### PR TITLE
Streaming Concurrency Fix

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -316,8 +316,7 @@ class InferenceEngine:
         spatial_refs: Optional[Sequence[Sequence[float]]] = ...,
         stream: Literal[True] = ...,
         settings: Optional[Mapping[str, object]] = ...,
-    ) -> "EngineStream":
-        ...
+    ) -> "EngineStream": ...
 
     @overload
     async def query(
@@ -328,8 +327,7 @@ class InferenceEngine:
         spatial_refs: Optional[Sequence[Sequence[float]]] = ...,
         stream: Literal[False] = ...,
         settings: Optional[Mapping[str, object]] = ...,
-    ) -> EngineResult:
-        ...
+    ) -> EngineResult: ...
 
     @overload
     async def query(
@@ -340,8 +338,7 @@ class InferenceEngine:
         spatial_refs: Optional[Sequence[Sequence[float]]] = None,
         stream: bool = False,
         settings: Optional[Mapping[str, object]] = None,
-    ) -> Union[EngineResult, EngineStream]:
-        ...
+    ) -> Union[EngineResult, EngineStream]: ...
 
     async def query(
         self,
@@ -460,8 +457,7 @@ class InferenceEngine:
         length: str = ...,
         stream: Literal[True],
         settings: Optional[Mapping[str, object]] = ...,
-    ) -> "EngineStream":
-        ...
+    ) -> "EngineStream": ...
 
     @overload
     async def caption(
@@ -471,8 +467,7 @@ class InferenceEngine:
         length: str = ...,
         stream: Literal[False] = ...,
         settings: Optional[Mapping[str, object]] = ...,
-    ) -> EngineResult:
-        ...
+    ) -> EngineResult: ...
 
     @overload
     async def caption(
@@ -482,8 +477,7 @@ class InferenceEngine:
         length: str = ...,
         stream: bool = ...,
         settings: Optional[Mapping[str, object]] = ...,
-    ) -> Union[EngineResult, EngineStream]:
-        ...
+    ) -> Union[EngineResult, EngineStream]: ...
 
     async def caption(
         self,
@@ -787,7 +781,7 @@ class InferenceEngine:
             return
         req.stream_queue = None
         completion = _StreamCompletion(result=result, error=error)
-        queue.put_nowait(completion)
+        self._loop.call_soon_threadsafe(queue.put_nowait, completion)
 
     def _fail_request(self, req: _PendingRequest, error: BaseException) -> None:
         future = req.future


### PR DESCRIPTION
There was a bug where the queue would get cut short, resulting in an incomplete responses. Shown in this example, the first response gets cut short.

<img width="865" height="496" alt="Screenshot 2025-10-08 at 6 23 33 PM" src="https://github.com/user-attachments/assets/d9ca1a31-3052-40e6-92f8-b15390437fec" />


Note: My editor **black** formatted it.
Note: Codex PR: https://github.com/m87-labs/kestrel/pull/1/files#diff-30ceeddb13c733eb9f102ff78c4089be30a8fdd5630198424782cb1b8c42720b
