### PR TITLE
Assert engine loop availability for stream callbacks

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -757,9 +757,11 @@ class InferenceEngine:
         self, req: _PendingRequest
     ) -> Optional[Callable[[StreamUpdate], None]]:
         queue = req.stream_queue
-        loop = self._loop
-        if queue is None or loop is None:
+        if queue is None:
             return None
+
+        loop = self._loop
+        assert loop is not None
 
         target_queue = queue
         target_loop = loop


### PR DESCRIPTION
## Summary
- replace defensive loop guard in `_build_stream_callback` with an assertion now that the engine loop is always initialized before streaming

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7117bec9c832b8ee29e576241ee8e