### PR TITLE
Ethan/set device

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -852,8 +852,7 @@ class InferenceEngine:
         runtime = self._runtime
         if runtime is None:
             return
-        if runtime.device.type == "cuda":
-            torch.cuda.set_device(runtime.device)
+        torch.cuda.set_device(runtime.device)
 
         scheduler = GenerationScheduler(
             runtime,

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -852,6 +852,8 @@ class InferenceEngine:
         runtime = self._runtime
         if runtime is None:
             return
+        if runtime.device.type == "cuda":
+            torch.cuda.set_device(runtime.device)
 
         scheduler = GenerationScheduler(
             runtime,

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -203,8 +203,7 @@ class MoondreamRuntime:
         self._cfg = cfg
         self.device = cfg.resolved_device()
         self.dtype = cfg.resolved_dtype()
-        if self.device.type == "cuda":
-            torch.cuda.set_device(self.device)
+        torch.cuda.set_device(self.device)
 
         if cfg.model_paths.config_json:
             with Path(cfg.model_paths.config_json).open("r", encoding="utf-8") as fp:

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -203,6 +203,8 @@ class MoondreamRuntime:
         self._cfg = cfg
         self.device = cfg.resolved_device()
         self.dtype = cfg.resolved_dtype()
+        if self.device.type == "cuda":
+            torch.cuda.set_device(self.device)
 
         if cfg.model_paths.config_json:
             with Path(cfg.model_paths.config_json).open("r", encoding="utf-8") as fp:


### PR DESCRIPTION
I was trying to fire up multiple instances of kestrel from an eval and kept running into an illegal access. Even though the rank of the process was not 0, the Kestrel engine was always trying to run on rank 0.  It looks like the engine and runtime use different threads which conflicts with Cuda device being thread local, so if it is not set it will default to 0.

To fix this I just set the device in engine and runtime. 

To rule out my eval code I tested a [simple script](https://gist.github.com/EthanReid/d94edf22d45199e2c6d688d514d14574) that just boots up kestrel on two separate devices. 

Here is the traceback I was facing:
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/ephemeral/vixtral-train/scripts/test_kestrel_multi.py", line 55, in <module>
    main()
  File "/ephemeral/vixtral-train/scripts/test_kestrel_multi.py", line 51, in main
    asyncio.run(_run(args))
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/ephemeral/vixtral-train/scripts/test_kestrel_multi.py", line 32, in _run
    engine = await InferenceEngine.create(cfg)
  File "/ephemeral/vixtral-train/.venv/lib/python3.10/site-packages/kestrel/engine.py", line 244, in create
    await engine._initialize()
  File "/ephemeral/vixtral-train/.venv/lib/python3.10/site-packages/kestrel/engine.py", line 252, in _initialize
    self._runtime = await loop.run_in_executor(
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/ephemeral/vixtral-train/.venv/lib/python3.10/site-packages/kestrel/moondream/runtime.py", line 413, in __init__
    self._ensure_cuda_graphs_ready()
  File "/ephemeral/vixtral-train/.venv/lib/python3.10/site-packages/kestrel/moondream/runtime.py", line 1031, in _ensure_cuda_graphs_ready
    self._capture_decode_graphs()
  File "/ephemeral/vixtral-train/.venv/lib/python3.10/site-packages/kestrel/moondream/runtime.py", line 1106, in _capture_decode_graphs
    metadata = self._build_flashinfer_metadata(
  File "/ephemeral/vixtral-train/.venv/lib/python3.10/site-packages/kestrel/moondream/runtime.py", line 882, in _build_flashinfer_metadata
    self.page_table.populate_flashinfer_kv_indices(
  File "/ephemeral/vixtral-train/.venv/lib/python3.10/site-packages/kestrel/kv_cache.py", line 375, in populate_flashinfer_kv_indices
    _copy_page_indices_kernel[grid](
  File "/ephemeral/vixtral-train/.venv/lib/python3.10/site-packages/triton/runtime/jit.py", line 390, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
  File "/ephemeral/vixtral-train/.venv/lib/python3.10/site-packages/triton/runtime/jit.py", line 617, in run
    kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
  File "/ephemeral/vixtral-train/.venv/lib/python3.10/site-packages/triton/backends/nvidia/driver.py", line 708, in __call__
    self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu tensor?)