### PR TITLE
spatial query

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -408,8 +408,8 @@ class InferenceEngine:
         normalized_question = question.strip()
         if not normalized_question:
             raise ValueError("question must be a non-empty string")
-        if spatial_refs is not None:
-            raise ValueError("spatial_refs are not supported")
+        if spatial_refs and image is None:
+            raise ValueError("spatial_refs can only be used with an image")
 
         temperature = self._default_temperature
         top_p = self._default_top_p
@@ -438,6 +438,7 @@ class InferenceEngine:
         if max_tokens <= 0:
             raise ValueError("max_tokens must be positive")
 
+        normalized_refs = self._normalize_spatial_refs(spatial_refs)
         request = QueryRequest(
             question=normalized_question,
             image=image,
@@ -448,6 +449,7 @@ class InferenceEngine:
                 top_p=top_p,
                 max_tokens=max_tokens,
             ),
+            spatial_refs=normalized_refs,
         )
         if stream:
             return await self.submit_streaming(
@@ -679,30 +681,7 @@ class InferenceEngine:
         if max_tokens <= 0:
             raise ValueError("max_tokens must be positive")
 
-        normalized_refs: Optional[List[Tuple[float, ...]]] = None
-        if spatial_refs is not None:
-            normalized_refs = []
-            for idx, ref in enumerate(spatial_refs):
-                if len(ref) not in (2, 4):
-                    raise ValueError(
-                        f"spatial_refs[{idx}] must contain 2 (point) or 4 (bbox) values"
-                    )
-                converted = [float(value) for value in ref]
-                if not all(math.isfinite(value) for value in converted):
-                    raise ValueError(
-                        f"spatial_refs[{idx}] contains non-finite values"
-                    )
-                if not all(0.0 <= value <= 1.0 for value in converted):
-                    raise ValueError(
-                        f"spatial_refs[{idx}] values must be normalised to [0, 1]"
-                    )
-                if len(converted) == 4:
-                    x_min, y_min, x_max, y_max = converted
-                    if x_min > x_max or y_min > y_max:
-                        raise ValueError(
-                            f"spatial_refs[{idx}] bbox must satisfy x_min<=x_max and y_min<=y_max"
-                        )
-                normalized_refs.append(tuple(converted))
+        normalized_refs = self._normalize_spatial_refs(spatial_refs)
 
         request = SegmentRequest(
             object=normalized_object,
@@ -713,7 +692,7 @@ class InferenceEngine:
                 top_p=top_p,
                 max_tokens=max_tokens,
             ),
-            spatial_refs=tuple(normalized_refs) if normalized_refs else None,
+            spatial_refs=normalized_refs,
         )
 
         return await self.submit(
@@ -879,6 +858,35 @@ class InferenceEngine:
         if not normalized:
             raise ValueError("adapter must be a non-empty string")
         return normalized
+
+    def _normalize_spatial_refs(
+        self, spatial_refs: Optional[Sequence[Sequence[float]]]
+    ) -> Optional[Tuple[Tuple[float, ...], ...]]:
+        if spatial_refs is None:
+            return None
+        normalized_refs: List[Tuple[float, ...]] = []
+        for idx, ref in enumerate(spatial_refs):
+            if len(ref) not in (2, 4):
+                raise ValueError(
+                    f"spatial_refs[{idx}] must contain 2 (point) or 4 (bbox) values"
+                )
+            converted = [float(value) for value in ref]
+            if not all(math.isfinite(value) for value in converted):
+                raise ValueError(
+                    f"spatial_refs[{idx}] contains non-finite values"
+                )
+            if not all(0.0 <= value <= 1.0 for value in converted):
+                raise ValueError(
+                    f"spatial_refs[{idx}] values must be normalised to [0, 1]"
+                )
+            if len(converted) == 4:
+                x_min, y_min, x_max, y_max = converted
+                if x_min > x_max or y_min > y_max:
+                    raise ValueError(
+                        f"spatial_refs[{idx}] bbox must satisfy x_min<=x_max and y_min<=y_max"
+                    )
+            normalized_refs.append(tuple(converted))
+        return tuple(normalized_refs) if normalized_refs else None
 
     def _extract_adapter_id(
         self, settings: Optional[Mapping[str, object]]

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -438,7 +438,7 @@ class InferenceEngine:
         if max_tokens <= 0:
             raise ValueError("max_tokens must be positive")
 
-        normalized_refs = self._normalize_spatial_refs(spatial_refs)
+        normalized_refs = normalize_spatial_refs(spatial_refs)
         request = QueryRequest(
             question=normalized_question,
             image=image,
@@ -681,7 +681,7 @@ class InferenceEngine:
         if max_tokens <= 0:
             raise ValueError("max_tokens must be positive")
 
-        normalized_refs = self._normalize_spatial_refs(spatial_refs)
+        normalized_refs = normalize_spatial_refs(spatial_refs)
 
         request = SegmentRequest(
             object=normalized_object,
@@ -858,11 +858,6 @@ class InferenceEngine:
         if not normalized:
             raise ValueError("adapter must be a non-empty string")
         return normalized
-
-    def _normalize_spatial_refs(
-        self, spatial_refs: Optional[Sequence[Sequence[float]]]
-    ) -> Optional[Tuple[Tuple[float, ...], ...]]:
-        return normalize_spatial_refs(spatial_refs)
 
     def _extract_adapter_id(
         self, settings: Optional[Mapping[str, object]]

--- a/kestrel/server/http.py
+++ b/kestrel/server/http.py
@@ -132,6 +132,8 @@ class _ServerState:
             else:
                 raise ValueError("Field 'settings' must be an object if provided")
 
+            spatial_refs = _parse_spatial_refs(payload.get("spatial_refs"))
+
             image_data = payload.get("image_url")
             if image_data is None:
                 image: Optional[pyvips.Image | np.ndarray] = None
@@ -139,6 +141,8 @@ class _ServerState:
                 image = load_vips_from_base64(image_data)
             else:
                 raise ValueError("Field 'image_url' must be a string if provided")
+            if spatial_refs and image is None:
+                raise ValueError("Field 'spatial_refs' requires image_url")
         except ValueError as exc:
             return JSONResponse({"error": str(exc)}, status_code=400)
 
@@ -162,6 +166,7 @@ class _ServerState:
                     image=image,
                     question=question,
                     reasoning=reasoning,
+                    spatial_refs=spatial_refs,
                     stream=True,
                     settings=settings_dict,
                 )
@@ -221,6 +226,7 @@ class _ServerState:
                 image=image,
                 question=question,
                 reasoning=reasoning,
+                spatial_refs=spatial_refs,
                 stream=False,
                 settings=settings_dict,
             )

--- a/kestrel/skills/query.py
+++ b/kestrel/skills/query.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 import pyvips
 import numpy as np
 
-from kestrel.moondream.runtime import CoordToken, TextToken, Token
+from kestrel.moondream.runtime import CoordToken, SizeToken, TextToken, Token
 
 from .base import DecodeStep, SkillFinalizeResult, SkillSpec, SkillState
 
@@ -34,6 +34,7 @@ class QueryRequest:
     reasoning: bool
     stream: bool
     settings: QuerySettings
+    spatial_refs: Optional[Sequence[Sequence[float]]] = None
 
 
 class QuerySkill(SkillSpec):
@@ -55,12 +56,49 @@ class QuerySkill(SkillSpec):
         suffix: Sequence[int] = template["suffix"]
         encoded = runtime.tokenizer.encode(prompt).ids if prompt else []
         reasoning = request_context.reasoning
+        tokens: List[Token] = [TextToken(token_id=int(tid)) for tid in prefix]
+
+        refs = request_context.spatial_refs
+        if refs:
+            for ref in refs:
+                n = len(ref)
+                if n == 2:
+                    x, y = float(ref[0]), float(ref[1])
+                    x = min(max(x, 0.0), 1.0)
+                    y = min(max(y, 0.0), 1.0)
+                    tokens.extend([CoordToken(pos=x), CoordToken(pos=y)])
+                elif n == 4:
+                    x_min, y_min, x_max, y_max = map(float, ref)
+                    if not (
+                        0.0 <= x_min <= x_max <= 1.0
+                        and 0.0 <= y_min <= y_max <= 1.0
+                    ):
+                        raise ValueError(
+                            "bbox spatial_ref must satisfy 0<=x_min<=x_max<=1 and 0<=y_min<=y_max<=1"
+                        )
+                    x_c = (x_min + x_max) / 2.0
+                    y_c = (y_min + y_max) / 2.0
+                    width = x_max - x_min
+                    height = y_max - y_min
+                    tokens.extend(
+                        [
+                            CoordToken(pos=x_c),
+                            CoordToken(pos=y_c),
+                            SizeToken(width=width, height=height),
+                        ]
+                    )
+                else:
+                    raise ValueError(
+                        "Each spatial_ref must contain 2 (point) or 4 (bbox) values"
+                    )
+
+        tokens.extend(TextToken(token_id=int(tid)) for tid in encoded)
         if reasoning:
             thinking_id = runtime.config.tokenizer.thinking_id
-            ids = [*prefix, *encoded, thinking_id]
+            tokens.append(TextToken(token_id=int(thinking_id)))
         else:
-            ids = [*prefix, *encoded, *suffix]
-        return [TextToken(token_id=int(tid)) for tid in ids]
+            tokens.extend(TextToken(token_id=int(tid)) for tid in suffix)
+        return tokens
 
     def create_state(
         self,

--- a/kestrel/skills/segment.py
+++ b/kestrel/skills/segment.py
@@ -10,6 +10,7 @@ import pyvips
 import numpy as np
 
 from kestrel.moondream.runtime import CoordToken, SizeToken, TextToken, Token
+from kestrel.utils.spatial_refs import build_spatial_tokens
 from kestrel.utils.svg import (
     decode_svg_token_strings,
     parse_svg_tokens,
@@ -69,37 +70,7 @@ class SegmentSkill(SkillSpec):
         # Assemble tokens in vixtral order:
         # <prefix> <spatial tokens> object <suffix>
         tokens: List[Token] = [TextToken(token_id=int(tid)) for tid in prefix]
-
-        refs = request_context.spatial_refs
-        if refs:
-            for ref in refs:
-                n = len(ref)
-                if n == 2:
-                    x, y = float(ref[0]), float(ref[1])
-                    x = min(max(x, 0.0), 1.0)
-                    y = min(max(y, 0.0), 1.0)
-                    tokens.extend([CoordToken(pos=x), CoordToken(pos=y)])
-                elif n == 4:
-                    x_min, y_min, x_max, y_max = map(float, ref)
-                    if not (0.0 <= x_min <= x_max <= 1.0 and 0.0 <= y_min <= y_max <= 1.0):
-                        raise ValueError(
-                            "bbox spatial_ref must satisfy 0<=x_min<=x_max<=1 and 0<=y_min<=y_max<=1"
-                        )
-                    x_c = (x_min + x_max) / 2.0
-                    y_c = (y_min + y_max) / 2.0
-                    width = x_max - x_min
-                    height = y_max - y_min
-                    tokens.extend(
-                        [
-                            CoordToken(pos=x_c),
-                            CoordToken(pos=y_c),
-                            SizeToken(width=width, height=height),
-                        ]
-                    )
-                else:
-                    raise ValueError(
-                        "Each spatial_ref must contain 2 (point) or 4 (bbox) values"
-                    )
+        tokens.extend(build_spatial_tokens(request_context.spatial_refs))
 
         tokens.extend(TextToken(token_id=int(tid)) for tid in object_tokens)
         tokens.extend(TextToken(token_id=int(tid)) for tid in suffix)

--- a/kestrel/utils/spatial_refs.py
+++ b/kestrel/utils/spatial_refs.py
@@ -1,0 +1,61 @@
+"""Spatial reference validation and token helpers."""
+
+import math
+from typing import List, Optional, Sequence, Tuple
+
+from kestrel.moondream.runtime import CoordToken, SizeToken, Token
+
+
+def normalize_spatial_refs(
+    spatial_refs: Optional[Sequence[Sequence[float]]],
+) -> Optional[Tuple[Tuple[float, ...], ...]]:
+    if spatial_refs is None:
+        return None
+    normalized_refs: List[Tuple[float, ...]] = []
+    for idx, ref in enumerate(spatial_refs):
+        if len(ref) not in (2, 4):
+            raise ValueError(
+                f"spatial_refs[{idx}] must contain 2 (point) or 4 (bbox) values"
+            )
+        converted = [float(value) for value in ref]
+        if not all(math.isfinite(value) for value in converted):
+            raise ValueError(f"spatial_refs[{idx}] contains non-finite values")
+        if not all(0.0 <= value <= 1.0 for value in converted):
+            raise ValueError(
+                f"spatial_refs[{idx}] values must be normalised to [0, 1]"
+            )
+        if len(converted) == 4:
+            x_min, y_min, x_max, y_max = converted
+            if x_min > x_max or y_min > y_max:
+                raise ValueError(
+                    f"spatial_refs[{idx}] bbox must satisfy x_min<=x_max and y_min<=y_max"
+                )
+        normalized_refs.append(tuple(converted))
+    return tuple(normalized_refs) if normalized_refs else None
+
+
+def build_spatial_tokens(
+    spatial_refs: Optional[Sequence[Sequence[float]]],
+) -> List[Token]:
+    refs = normalize_spatial_refs(spatial_refs)
+    if not refs:
+        return []
+    tokens: List[Token] = []
+    for ref in refs:
+        if len(ref) == 2:
+            x, y = ref
+            tokens.extend([CoordToken(pos=float(x)), CoordToken(pos=float(y))])
+        else:
+            x_min, y_min, x_max, y_max = ref
+            x_c = (x_min + x_max) / 2.0
+            y_c = (y_min + y_max) / 2.0
+            width = x_max - x_min
+            height = y_max - y_min
+            tokens.extend(
+                [
+                    CoordToken(pos=x_c),
+                    CoordToken(pos=y_c),
+                    SizeToken(width=width, height=height),
+                ]
+            )
+    return tokens


### PR DESCRIPTION
Spatial Query was missing from Kestrel.

Added spatial query support by accepting `spatial_refs` on the query API/engine path, validating them alongside the image requirement, and threading them into the QuerySkill request. Query prompt construction now inserts Coord/Size tokens for point and bbox refs in front of the question text using the same format as segment.

This is a cleaned up version of what I have been using for my spatial fine tunes. I tested this PR by running some bbox and point queries. 