### PR TITLE
MD2 Reasoning Bug

### DIFF
--- a/kestrel/skills/query.py
+++ b/kestrel/skills/query.py
@@ -69,10 +69,6 @@ class QuerySkill(SkillSpec):
         tokens.extend(build_spatial_tokens(request_context.spatial_refs))
 
         tokens.extend(TextToken(token_id=int(tid)) for tid in encoded)
-        # MD2 HF model adds suffix before thinking_id or doubles suffix for non-reasoning
-        is_md2 = runtime.model_name == "moondream2"
-        if is_md2:
-            tokens.extend(TextToken(token_id=int(tid)) for tid in suffix)
         if reasoning:
             thinking_id = runtime.config.tokenizer.thinking_id
             tokens.append(TextToken(token_id=int(thinking_id)))


### PR DESCRIPTION
In the [MD2 HF code there is a bug](https://huggingface.co/vikhyatk/moondream2/blob/main/moondream.py#L604) which causes the suffix to be double added. This bug was discovered right before we launched MD3, so the MD3 code does not have this issue.  We used the same reasoning format when training MD2 and MD3.

Before (reasoning = false):
[BOS] + [QUERY_PREFIX] + [SPATIAL_TOKENS] + [QUESTION_TOKENS] + [QUERY_SUFFIX] + [QUERY_SUFFIX]

After (reasoning = false):
[BOS] + [QUERY_PREFIX] + [SPATIAL_TOKENS] + [QUESTION_TOKENS] + [QUERY_SUFFIX]

I have not tested this.