### PR TITLE
Ethan/md3 prompt fix

### DIFF
--- a/kestrel/skills/caption.py
+++ b/kestrel/skills/caption.py
@@ -58,9 +58,7 @@ class CaptionSkill(SkillSpec):
                 f"Unsupported caption length '{length_key}'. Expected one of: {valid}"
             )
         token_ids = templates[length_key]
-        tokens = []
-        if runtime.model_name == "moondream2":
-            tokens.append(TextToken(token_id=int(runtime.config.tokenizer.bos_id)))
+        tokens = [TextToken(token_id=int(runtime.config.tokenizer.bos_id))]
         tokens.extend(TextToken(token_id=int(tid)) for tid in token_ids)
         return tokens
 

--- a/kestrel/skills/detect.py
+++ b/kestrel/skills/detect.py
@@ -55,9 +55,7 @@ class DetectSkill(SkillSpec):
         prompt = request_context.object
         object_tokens = runtime.tokenizer.encode(" " + prompt).ids if prompt else []
         ids = [*prefix, *object_tokens, *suffix]
-        tokens = []
-        if runtime.model_name == "moondream2":
-            tokens.append(TextToken(token_id=int(runtime.config.tokenizer.bos_id)))
+        tokens = [TextToken(token_id=int(runtime.config.tokenizer.bos_id))]
         tokens.extend(TextToken(token_id=int(tid)) for tid in ids)
         return tokens
 

--- a/kestrel/skills/point.py
+++ b/kestrel/skills/point.py
@@ -54,9 +54,7 @@ class PointSkill(SkillSpec):
         prompt = request_context.object
         object_tokens = runtime.tokenizer.encode(" " + prompt).ids if prompt else []
         ids = [*prefix, *object_tokens, *suffix]
-        tokens = []
-        if runtime.model_name == "moondream2":
-            tokens.append(TextToken(token_id=int(runtime.config.tokenizer.bos_id)))
+        tokens = [TextToken(token_id=int(runtime.config.tokenizer.bos_id))]
         tokens.extend(TextToken(token_id=int(tid)) for tid in ids)
         return tokens
 

--- a/kestrel/skills/query.py
+++ b/kestrel/skills/query.py
@@ -56,15 +56,10 @@ class QuerySkill(SkillSpec):
         suffix: Sequence[int] = template["suffix"]
         encoded = runtime.tokenizer.encode(prompt).ids if prompt else []
         reasoning = request_context.reasoning
-        # The runtime's _prepare_full_prefill_inputs treats the first token as BOS
-        # (placed before the image). MD2's HF model prepends BOS (token 0) separately,
-        # so we must include it here. MD3 templates already start with the correct
-        # first-position token.
-        is_md2 = runtime.model_name == "moondream2"
+        # The runtime's _prepare_full_prefill_inputs places the first prompt token
+        # before image tokens, so prepend BOS explicitly.
         bos_id = runtime.config.tokenizer.bos_id
-        tokens: List[Token] = []
-        if is_md2:
-            tokens.append(TextToken(token_id=int(bos_id)))
+        tokens: List[Token] = [TextToken(token_id=int(bos_id))]
         tokens.extend(TextToken(token_id=int(tid)) for tid in prefix)
         tokens.extend(build_spatial_tokens(request_context.spatial_refs))
 

--- a/kestrel/skills/segment.py
+++ b/kestrel/skills/segment.py
@@ -67,10 +67,10 @@ class SegmentSkill(SkillSpec):
         object_tokens = runtime.tokenizer.encode(object_name).ids if object_name else []
 
         # Assemble tokens:
-        # [BOS (MD2 only)] <prefix> <spatial tokens> object <suffix>
-        tokens: List[Token] = []
-        if runtime.model_name == "moondream2":
-            tokens.append(TextToken(token_id=int(runtime.config.tokenizer.bos_id)))
+        # [BOS] <prefix> <spatial tokens> object <suffix>
+        tokens: List[Token] = [
+            TextToken(token_id=int(runtime.config.tokenizer.bos_id))
+        ]
         tokens.extend(TextToken(token_id=int(tid)) for tid in prefix)
         tokens.extend(build_spatial_tokens(request_context.spatial_refs))
 


### PR DESCRIPTION
When MD2 was added, a special gate was added to add the BOS token to the start of the prompt, citing MD2 hugging face behavior. The issue is that both MD2 and MD3 have the same behavior here in HF. This shows a bug in the MD3 kestrel logic, mode_id is being placed before the image, not BOS. This is as kestrel takes the first token in the prompt and places it behind the image, but in the MD3 path, there is no BOS being added, so that token is instead mode_id.

[MD2 Code](https://huggingface.co/vikhyatk/moondream2/blob/main/moondream.py#L569)
[MD3 Code](https://huggingface.co/moondream/moondream3-preview/blob/main/moondream.py#L656)

Note: this is deployed in staging, running the latest kestrel and kestrel-kernel.