### PR TITLE
Stop passing dead expert_map args to MoE routing kernels

### DIFF
--- a/kestrel/fused_moe/routing.py
+++ b/kestrel/fused_moe/routing.py
@@ -69,11 +69,6 @@ def moe_align_block_size(
     )
     num_tokens_post_pad = torch.empty((1,), dtype=torch.int32, device=topk_ids.device)
 
-    if expert_map is None or not ignore_invalid_experts:
-        expert_map_arg = torch.empty((0,), dtype=torch.int32, device=topk_ids.device)
-    else:
-        expert_map_arg = expert_map
-
     moe_align_block_size_cute(
         topk_ids,
         num_experts,
@@ -81,7 +76,6 @@ def moe_align_block_size(
         sorted_ids,
         expert_ids,
         num_tokens_post_pad,
-        expert_map_arg,
     )
 
     if expert_map is not None and not ignore_invalid_experts:
@@ -172,7 +166,6 @@ def moe_lora_align_block_size(
         sorted_ids,
         expert_ids,
         num_tokens_post_pad,
-        expert_map=expert_map,
     )
 
     return sorted_ids, expert_ids, num_tokens_post_pad


### PR DESCRIPTION
## Summary
- stop passing the empty `expert_map` placeholder into `moe_align_block_size_cute`
- stop forwarding `expert_map` through the LoRA routing helper as well
- keep the outer routing API unchanged

## Why
- the current `kestrel-kernels` moe_align entry points do not consume this argument
- the signature skew surfaced immediately during the RTX PRO 6000 ChartQA baseline bring-up

## Testing
- `python -m py_compile kestrel/fused_moe/routing.py`
- reran the ChartQA baseline on Modal RTX PRO 6000 against the local `kestrel-kernels` source install after applying this routing change