### PR TITLE
Enable FP8 KV cache on SM120

### DIFF
--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -475,7 +475,7 @@ class MoondreamRuntime:
 
         device_cc_major, device_cc_minor = torch.cuda.get_device_capability(self.device)
         device_sm = device_cc_major * 10 + device_cc_minor
-        fp8_kv_supported_sms = {87, 89, 90, 100}
+        fp8_kv_supported_sms = {87, 89, 90, 100, 120}
 
         if (
             self._kv_layer_k_scales is not None


### PR DESCRIPTION
## Summary

- Enable FP8 KV cache on SM120 / RTX PRO 6000 Blackwell now that the SM120 FP8 decode path is available.

## Validation

- Modal RTX PRO 6000 smoke: runtime cache dtype is `torch.float8_e4m3fn` and direct FP8 decode reports `sm120_decode`.
- CUDA-event decode microbench, batch 64 / seq 768: BF16 decode `0.271 ms`, FP8 decode `0.142 ms`.
- Full ChartQA RTX PRO 6000 batch 64: `26.04 req/s`, `83.68%` accuracy.
