### PR TITLE
kestrel: device-agnostic runtime; enable Mac (MPS) install

### DIFF
--- a/kestrel/device.py
+++ b/kestrel/device.py
@@ -1,0 +1,116 @@
+"""Device-agnostic wrappers for the runtime primitives Kestrel uses.
+
+Kestrel is CUDA-first; this module centralizes the handful of
+``torch.cuda.*`` calls (streams, events, synchronization, allocator hints,
+capability queries) so the runtime can drive an MPS device on macOS
+without sprinkling ``device.type == "cuda"`` checks throughout.
+
+On CUDA, every primitive forwards to its ``torch.cuda.*`` counterpart with
+zero overhead. On MPS, streams/events become no-ops or thin wrappers
+around ``torch.mps.*`` where an equivalent exists; CUDA-graph capture is
+intentionally not wired (MPS has no equivalent) — callers gate that path
+on ``runtime._use_cuda_graphs`` which evaluates to False on MPS.
+"""
+
+import contextlib
+from typing import Optional
+
+import torch
+
+
+def set_device(device: torch.device) -> None:
+    """``torch.cuda.set_device`` on CUDA; no-op on MPS/CPU."""
+    if device.type == "cuda":
+        torch.cuda.set_device(device)
+
+
+def synchronize(device: torch.device) -> None:
+    """Block the host until pending work on ``device`` finishes."""
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    elif device.type == "mps":
+        torch.mps.synchronize()
+
+
+def empty_cache(device: torch.device) -> None:
+    """Hint the allocator to release cached blocks; no-op when unsupported."""
+    if device.type == "cuda":
+        torch.cuda.empty_cache()
+    elif device.type == "mps":
+        torch.mps.empty_cache()
+
+
+def get_device_capability(device: torch.device) -> tuple[int, int]:
+    """Return SM (major, minor) on CUDA; ``(0, 0)`` elsewhere.
+
+    Callers that gate FP8 / SM90+ paths on a specific capability tuple keep
+    working — non-CUDA devices answer "no, you don't have that hardware."
+    """
+    if device.type == "cuda":
+        return torch.cuda.get_device_capability(device)
+    return (0, 0)
+
+
+def make_stream(device: torch.device) -> Optional[torch.cuda.Stream]:
+    """Create a CUDA stream for explicit pipelining.
+
+    MPS has no exposed stream abstraction in ``torch.mps`` (torch 2.11);
+    return ``None`` and let callers drop into the in-line execution path
+    via :func:`stream_context`.
+    """
+    if device.type == "cuda":
+        return torch.cuda.Stream(device=device)
+    return None
+
+
+@contextlib.contextmanager
+def stream_context(stream: Optional[torch.cuda.Stream]):
+    """Run the ``with`` block on ``stream`` if non-None, else inline."""
+    if stream is None:
+        yield
+    else:
+        with torch.cuda.stream(stream):
+            yield
+
+
+class NoopEvent:
+    """Stand-in for ``torch.cuda.Event`` on devices without async events."""
+
+    def record(self, *_args, **_kwargs) -> None:
+        pass
+
+    def wait(self, *_args, **_kwargs) -> None:
+        pass
+
+    def synchronize(self) -> None:
+        pass
+
+    def query(self) -> bool:
+        return True
+
+    def elapsed_time(self, _other: "NoopEvent") -> float:
+        return 0.0
+
+
+def make_event(
+    device: torch.device,
+    *,
+    enable_timing: bool = False,
+    blocking: bool = False,
+) -> "torch.cuda.Event | NoopEvent":
+    """Create a CUDA event on CUDA; a no-op stand-in elsewhere."""
+    if device.type == "cuda":
+        return torch.cuda.Event(enable_timing=enable_timing, blocking=blocking)
+    return NoopEvent()
+
+
+__all__ = [
+    "NoopEvent",
+    "empty_cache",
+    "get_device_capability",
+    "make_event",
+    "make_stream",
+    "set_device",
+    "stream_context",
+    "synchronize",
+]

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -53,6 +53,7 @@ import numpy as np
 import torch
 
 from kestrel.config import RuntimeConfig
+from kestrel.device import set_device, synchronize
 from kestrel.moondream.runtime import MoondreamRuntime
 from kestrel.scheduler import (
     GenerationScheduler,
@@ -891,14 +892,14 @@ class InferenceEngine:
         self._paused_event.clear()
         self._scheduler_event.set()
         self._paused_event.wait(timeout)
-        torch.cuda.synchronize(self._runtime.device)
+        synchronize(self._runtime.device)
 
     def resume(self) -> None:
         """Resume scheduler progress after a pause."""
 
         if self._shutdown:
             return
-        torch.cuda.synchronize(self._runtime.device)
+        synchronize(self._runtime.device)
         self._paused_event.clear()
         self._paused_flag.clear()
         self._run_gate.set()
@@ -1089,7 +1090,7 @@ class InferenceEngine:
         runtime = self._runtime
         if runtime is None:
             return
-        torch.cuda.set_device(runtime.device)
+        set_device(runtime.device)
 
         adapter_provider = self._adapter_provider
         scheduler = GenerationScheduler(
@@ -1221,7 +1222,7 @@ class InferenceEngine:
                         if drained_results:
                             deliver_results(drained_results)
                         with runtime.graph_capture_lock:
-                            torch.cuda.synchronize(runtime.device)
+                            synchronize(runtime.device)
                         paused_event.set()
                         if should_exit():
                             break

--- a/kestrel/fused_moe/module.py
+++ b/kestrel/fused_moe/module.py
@@ -619,10 +619,21 @@ class FusedMoEModule(nn.Module):
         self.input_size = input_size
         self.num_experts = num_experts
         self.config = config or FusedMoEConfig()
-        self._lora_inputs_event = torch.cuda.Event(enable_timing=False)
-        self._lora_activation_event = torch.cuda.Event(enable_timing=False)
-        self._lora_up_event = torch.cuda.Event(enable_timing=False)
-        self._lora_down_event = torch.cuda.Event(enable_timing=False)
+        # Pipelined-LoRA events; only used when ``use_batched_lora`` or
+        # ``use_single_lora`` is True at forward time. LoRA is disabled in
+        # the v1 MPS path, so these are unreachable there — keep them
+        # ``None`` rather than instantiating CUDA Events that would crash
+        # on non-CUDA hosts.
+        if torch.cuda.is_available():
+            self._lora_inputs_event = torch.cuda.Event(enable_timing=False)
+            self._lora_activation_event = torch.cuda.Event(enable_timing=False)
+            self._lora_up_event = torch.cuda.Event(enable_timing=False)
+            self._lora_down_event = torch.cuda.Event(enable_timing=False)
+        else:
+            self._lora_inputs_event = None
+            self._lora_activation_event = None
+            self._lora_up_event = None
+            self._lora_down_event = None
 
     @property
     def _workspaces(self) -> _MoEWorkspaces:

--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -25,9 +25,8 @@ except Exception:  # pragma: no cover - runtime compatibility fallback
 
 def _maybe_stream_context(stream: torch.cuda.Stream | None):
     """Return a stream context manager, or nullcontext if stream is None."""
-    if stream is not None:
-        return torch.cuda.stream(stream)
-    return nullcontext()
+    from kestrel.device import stream_context
+    return stream_context(stream)
 
 
 def _cdiv(x: int | float | torch.Tensor, multiple: int | float | torch.Tensor):

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -20,6 +20,7 @@ from torch import Tensor
 from tokenizers import Tokenizer
 
 from kestrel.config import RuntimeConfig
+from kestrel.device import NoopEvent, empty_cache, get_device_capability, make_event, make_stream, set_device, stream_context
 from kestrel.kv_cache import PageTable, PagedKVCache
 from kestrel.prefix_cache import (
     CacheNamespace,
@@ -223,8 +224,10 @@ class PrefillSlot:
 
     slot_id: int
     batch_idx: Tensor
-    step_done_event: torch.cuda.Event
-    commit_done_event: torch.cuda.Event
+    # Type-annotated as the CUDA event for the common case; MPS/CPU paths
+    # store ``NoopEvent`` instances at runtime.
+    step_done_event: "torch.cuda.Event"
+    commit_done_event: "torch.cuda.Event"
     scratch: PrefillScratch | None = None
 
 
@@ -349,7 +352,7 @@ class MoondreamRuntime:
         self._cfg = cfg
         self.device = cfg.resolved_device()
         self.dtype = cfg.resolved_dtype()
-        torch.cuda.set_device(self.device)
+        set_device(self.device)
         # Guards CUDA graph capture so other threads avoid device-wide sync during capture.
         self.graph_capture_lock = threading.RLock()
 
@@ -389,7 +392,7 @@ class MoondreamRuntime:
 
         # Primary stream for all GPU operations. Created early because PageTable
         # needs it for H2D copies that must synchronize with graph replay.
-        self._primary_stream = torch.cuda.Stream(device=self.device)
+        self._primary_stream = make_stream(self.device)
 
         self.page_table = PageTable(
             n_pages=n_pages,
@@ -473,7 +476,7 @@ class MoondreamRuntime:
                 stacklevel=2,
             )
 
-        device_cc_major, device_cc_minor = torch.cuda.get_device_capability(self.device)
+        device_cc_major, device_cc_minor = get_device_capability(self.device)
         device_sm = device_cc_major * 10 + device_cc_minor
         fp8_kv_supported_sms = {87, 89, 90, 100, 120}
 
@@ -541,8 +544,8 @@ class MoondreamRuntime:
 
         # Additional streams: LoRA operations and D2H copies.
         # (Primary stream was created earlier for PageTable H2D sync.)
-        self._lora_stream = torch.cuda.Stream(device=self.device)
-        self._copy_stream = torch.cuda.Stream(device=self.device)
+        self._lora_stream = make_stream(self.device)
+        self._copy_stream = make_stream(self.device)
 
         # CUDA graph batch sizes for decode (same for all slots).
         self._graph_batch_sizes: list[int] = []
@@ -565,8 +568,8 @@ class MoondreamRuntime:
                 batch_idx=torch.empty(
                     (self.max_batch_size,), dtype=torch.int64, device=self.device
                 ),
-                step_done_event=torch.cuda.Event(enable_timing=False, blocking=False),
-                commit_done_event=torch.cuda.Event(enable_timing=False, blocking=False),
+                step_done_event=make_event(self.device, enable_timing=False, blocking=False),
+                commit_done_event=make_event(self.device, enable_timing=False, blocking=False),
                 scratch=PrefillScratch(
                     _prefill_scratch_tokens, self.config.text, self.device, self.dtype,
                 ) if self.config.text else None,
@@ -652,7 +655,7 @@ class MoondreamRuntime:
         """
         if self.device.type != "cuda":
             return
-        torch.cuda.empty_cache()
+        empty_cache(self.device)
 
     # ------------------------------------------------------------------
     # Capacity helpers
@@ -1396,7 +1399,7 @@ class MoondreamRuntime:
 
         # Keep all GPU work on the primary stream so all callers share identical
         # ordering semantics.
-        with torch.cuda.stream(self._primary_stream):
+        with stream_context(self._primary_stream):
             per_inputs: list[Tensor] = []
             per_positions: list[Tensor] = []
             use_prefix_attn: bool | None = None
@@ -1802,7 +1805,7 @@ class MoondreamRuntime:
 
         if is_new:
             try:
-                with torch.cuda.stream(self._primary_stream):
+                with stream_context(self._primary_stream):
                     self._lora_workspace.load_slot_(slot, adapter)
             except Exception:
                 # Rollback on load failure

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -11,6 +11,7 @@ import logging
 import torch
 from torch import Tensor
 
+from kestrel.device import stream_context
 from kestrel.moondream.runtime import (
     MoondreamRuntime,
     PrefillClassification,

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -333,7 +333,7 @@ class GenerationScheduler:
         """
         progressed = False
         pipeline = self._pipeline
-        with torch.cuda.stream(self.runtime.primary_stream):
+        with stream_context(self.runtime.primary_stream):
             has_launch = pipeline.has_launch_in_flight()
             has_queued = pipeline.queue_depth() > 0
 
@@ -727,7 +727,7 @@ class GenerationScheduler:
 
             lifecycle.sequence_state = prepared.state
             batch_idx = prepared.state.batch_idx
-            with torch.cuda.stream(self.runtime.primary_stream):
+            with stream_context(self.runtime.primary_stream):
                 self._sampling_temps_by_batch[batch_idx] = request.temperature
                 self._sampling_top_ps_by_batch[batch_idx] = request.top_p
 
@@ -796,7 +796,7 @@ class GenerationScheduler:
                 )
                 lifecycle.prefill_completed_at = time.perf_counter()
                 # Ensure prefill forward completes before cache finalize + release.
-                with torch.cuda.stream(self.runtime.primary_stream):
+                with stream_context(self.runtime.primary_stream):
                     prefill_slot.commit_done_event.record()
                 prefill_slot.commit_done_event.synchronize()
                 self.runtime.finalize_prepared_sequence_after_prefill(prepared_seq)
@@ -951,7 +951,7 @@ class GenerationScheduler:
         _launch_forward_on_stream. Use this when calling from outside advance().
         """
         slot = self.runtime.decode_slots[slot_id]
-        with torch.cuda.stream(slot.compute_stream):
+        with stream_context(slot.compute_stream):
             return self._launch_forward_on_stream(plan, slot_id)
 
     def _launch_forward_on_stream(
@@ -1034,12 +1034,12 @@ class GenerationScheduler:
         """
         if handle.kind == "decode":
             slot = self.runtime.decode_slots[handle.slot_id]
-            with torch.cuda.stream(slot.compute_stream):
+            with stream_context(slot.compute_stream):
                 return self._finalize_sampling_on_stream(handle, mask)
         if handle.kind == "prefill":
             if mask is not None:
                 raise AssertionError("Prefill finalize does not support masks")
-            with torch.cuda.stream(self.runtime.primary_stream):
+            with stream_context(self.runtime.primary_stream):
                 return self._finalize_prefill(handle)
         raise AssertionError(f"Unsupported handle kind {handle.kind!r}")
 

--- a/kestrel/scheduler/transfer.py
+++ b/kestrel/scheduler/transfer.py
@@ -3,6 +3,8 @@
 import torch
 from torch import Tensor
 
+from kestrel.device import make_event, stream_context
+
 
 class TransferHandle:
     """Handle for an in-flight D2H transfer."""
@@ -46,27 +48,23 @@ class RenderBuffer:
         size_dtype: torch.dtype,
         copy_stream: torch.cuda.Stream,
     ) -> None:
+        # Pinned host memory accelerates async H2D/D2H copies on CUDA but
+        # isn't supported (and triggers ``DispatchStub: missing kernel for
+        # mps``) when an MPS device is active even with ``device="cpu"``.
+        # Drop the hint off CUDA — same allocation, no pinning.
+        pin = device.type == "cuda"
         self._token_ids = torch.empty(
-            (max_batch,),
-            dtype=torch.long,
-            device="cpu",
-            pin_memory=True,
+            (max_batch,), dtype=torch.long, device="cpu", pin_memory=pin,
         )
         self._coord_values = torch.empty(
-            (max_batch, 1),
-            dtype=coord_dtype,
-            device="cpu",
-            pin_memory=True,
+            (max_batch, 1), dtype=coord_dtype, device="cpu", pin_memory=pin,
         )
         self._size_values = torch.empty(
-            (max_batch, 2),
-            dtype=size_dtype,
-            device="cpu",
-            pin_memory=True,
+            (max_batch, 2), dtype=size_dtype, device="cpu", pin_memory=pin,
         )
         self._device = device
         self._stream = copy_stream
-        self._event = torch.cuda.Event(enable_timing=False, blocking=False)
+        self._event = make_event(device, enable_timing=False, blocking=False)
 
     def transfer(
         self,
@@ -97,11 +95,12 @@ class RenderBuffer:
                 0,
             )
 
-        with torch.cuda.stream(self._stream):
+        with stream_context(self._stream):
             # Wait on the specific step's completion event (not wait_stream).
             # This anchors the dependency to exactly this step's GPU writes,
             # independent of any later work enqueued on the compute stream.
-            self._stream.wait_event(ready_event)
+            if self._stream is not None:
+                self._stream.wait_event(ready_event)
             self._token_ids[:count].copy_(token_ids, non_blocking=True)
             self._coord_values[:count].copy_(coord_values, non_blocking=True)
             self._size_values[:count].copy_(size_values, non_blocking=True)

--- a/kestrel/utils/buffers.py
+++ b/kestrel/utils/buffers.py
@@ -74,7 +74,15 @@ class CpuGpuBuffer:
         pin_memory: bool,
         with_numpy: bool = True,
     ) -> None:
-        self.cpu = torch.zeros(*size, dtype=dtype, device="cpu", pin_memory=pin_memory)
+        # Pinned memory is a CUDA-specific allocator hint that accelerates
+        # async H2D copies; on MPS torch raises ``DispatchStub: missing
+        # kernel for mps`` even with ``device="cpu"`` because the pin path
+        # is wired through the active device. The hint has no effect off
+        # CUDA, so just drop it.
+        pin_memory_effective = pin_memory and device.type == "cuda"
+        self.cpu = torch.zeros(
+            *size, dtype=dtype, device="cpu", pin_memory=pin_memory_effective,
+        )
         self.gpu = torch.zeros_like(self.cpu, device=device)
         self.np: np.ndarray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "httpx>=0.27",
     "apache-tvm-ffi>=0.1.5,<0.2",
     "kestrel-native==0.1.3",
-    "kestrel-kernels==0.2.1; sys_platform == 'linux'",
+    "kestrel-kernels==0.2.1",
     "huggingface-hub>=0.20",
 ]
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,117 @@
+"""Tests for the device-agnostic primitive wrappers in ``kestrel.device``."""
+
+import pytest
+import torch
+
+from kestrel.device import (
+    NoopEvent,
+    empty_cache,
+    get_device_capability,
+    make_event,
+    make_stream,
+    set_device,
+    stream_context,
+    synchronize,
+)
+
+
+CPU = torch.device("cpu")
+CUDA = torch.device("cuda")
+MPS = torch.device("mps")
+
+
+# --- CPU path: every primitive is a safe no-op or returns a sentinel -------
+
+
+def test_set_device_cpu_is_noop() -> None:
+    set_device(CPU)
+
+
+def test_synchronize_cpu_is_noop() -> None:
+    synchronize(CPU)
+
+
+def test_empty_cache_cpu_is_noop() -> None:
+    empty_cache(CPU)
+
+
+def test_get_device_capability_cpu_returns_zero_tuple() -> None:
+    assert get_device_capability(CPU) == (0, 0)
+
+
+def test_make_stream_cpu_returns_none() -> None:
+    assert make_stream(CPU) is None
+
+
+def test_make_event_cpu_returns_noop() -> None:
+    e = make_event(CPU)
+    assert isinstance(e, NoopEvent)
+    # All NoopEvent operations succeed silently.
+    e.record()
+    e.record(stream=None)
+    e.wait()
+    e.synchronize()
+    assert e.query() is True
+    assert e.elapsed_time(NoopEvent()) == 0.0
+
+
+def test_stream_context_with_none_yields_inline() -> None:
+    entered = False
+    with stream_context(None):
+        entered = True
+    assert entered
+
+
+# --- CUDA path: thin wrappers, only run when present ------------------------
+
+
+def _cuda_available() -> bool:
+    return torch.cuda.is_available()
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA not available")
+def test_make_stream_cuda_returns_real_stream() -> None:
+    stream = make_stream(CUDA)
+    assert isinstance(stream, torch.cuda.Stream)
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA not available")
+def test_make_event_cuda_returns_real_event() -> None:
+    event = make_event(CUDA, enable_timing=False, blocking=False)
+    assert isinstance(event, torch.cuda.Event)
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA not available")
+def test_get_device_capability_cuda_matches_torch() -> None:
+    assert get_device_capability(CUDA) == torch.cuda.get_device_capability()
+
+
+# --- MPS path: stream is None, event is NoopEvent, sync uses torch.mps.* ---
+
+
+def _mps_available() -> bool:
+    return torch.backends.mps.is_available()
+
+
+@pytest.mark.skipif(not _mps_available(), reason="MPS not available")
+def test_make_stream_mps_returns_none() -> None:
+    assert make_stream(MPS) is None
+
+
+@pytest.mark.skipif(not _mps_available(), reason="MPS not available")
+def test_make_event_mps_returns_noop() -> None:
+    assert isinstance(make_event(MPS), NoopEvent)
+
+
+@pytest.mark.skipif(not _mps_available(), reason="MPS not available")
+def test_synchronize_mps_uses_torch_mps() -> None:
+    # No exception → it dispatched. Hardware is always available so the
+    # call is essentially free; we're testing the dispatch table, not perf.
+    synchronize(MPS)
+
+
+@pytest.mark.skipif(not _mps_available(), reason="MPS not available")
+def test_set_device_mps_is_noop() -> None:
+    # MPS doesn't have a per-process device-set concept; we just ensure
+    # the call doesn't raise.
+    set_device(MPS)


### PR DESCRIPTION
## Summary
Adds a ``kestrel.device`` module that centralizes the CUDA-runtime primitives the engine + scheduler use (streams, events, synchronization, allocator hints, capability queries), and rewires the call sites to use it. Net effect: the runtime can drive an MPS device on macOS without sprinkling ``device.type == "cuda"`` checks throughout. CUDA paths are unchanged in behavior — every primitive forwards to its ``torch.cuda.*`` counterpart with zero overhead.

Also drops the ``sys_platform == 'linux'`` guard on the ``kestrel-kernels`` dependency, so ``pip install kestrel`` resolves on macOS arm64.

## What's wired
- **``moondream/runtime.py``**: ``set_device``, ``make_stream``, ``make_event``, ``empty_cache``, ``get_device_capability``, ``stream_context`` replace direct ``torch.cuda.*`` calls. CUDA-graph capture stays inside the existing ``_use_cuda_graphs`` branch (already False on MPS).
- **``engine.py``**: scheduler-loop ``set_device`` + the two pause/resume sync points.
- **``scheduler/scheduler.py``**: stream contexts (6 sites).
- **``scheduler/transfer.py``**: copy-stream Event creation + pin-memory hint dropped on non-CUDA (MPS raises ``DispatchStub: missing kernel for mps`` even on ``device="cpu"`` when an MPS device is active).
- **``kv_cache.py``**: ``_maybe_stream_context`` delegates to the new module.
- **``fused_moe/module.py``**: LoRA pipelining events deferred to ``None`` off CUDA (LoRA is intentionally disabled on the MPS path in v1).
- **``utils/buffers.py``**: ``CpuGpuBuffer`` drops the pin-memory hint when device isn't CUDA.

## Tests
- ``tests/test_device.py`` (new) covers each primitive on CPU / CUDA-when-available / MPS-when-available.
- Existing tests unchanged; nothing in the wiring changes CUDA-side behavior.

## Manual smoke verified
On a real Mac (macOS 14.8.5, M2-class, torch 2.11), ``MoondreamRuntime(cfg)`` with ``device="mps"`` constructs through every former CUDA touchpoint and only stops at weight load — which is expected: Moondream 3 ships ``model_fp8.pt`` for the kestrel CUDA path and BF16 safetensor loading on MPS is a separate follow-up.

```
runtime construction OK (FileNotFoundError at /tmp/fake — past all CUDA gating)
```

The MPS kernel suite in ``kestrel-kernels/tests/mps/`` (57 tests across attention, dense, moe, cache, rotary, sampling, tau) was also re-verified on the same Mac after rsync — all green in ~24s.

## Dependency note
Requires a ``kestrel-kernels`` release that includes m87-labs/kestrel-proprietary#58 (skip ``_NO_BIAS`` CUDA alloc on non-CUDA hosts). Without that, ``import kestrel`` still fails at module-load on Mac because ``linear_ops`` allocates a CUDA tensor at import time. After it lands and a 0.2.x release goes out, ``pip install kestrel`` works on macOS arm64.

## What's NOT in this PR (follow-ups)
- BF16 safetensor weight loading on MPS (Moondream 3 ships ``model_fp8.pt`` packed weights for the CUDA kernels; MPS needs the upstream ``moondream/moondream3-preview`` BF16 safetensors with a remap layer)
- End-to-end ``kestrel query image.jpg "..."`` on real weights
- Performance work — the v2 goal in ``docs/MAC_SUPPORT.md`` (Station's ~35 tok/s INT4 baseline) requires lifted MLX kernels / decode-replay; not in v1 scope