### PR TITLE
kestrel: route decode-slot events through kestrel.device (MPS fix)

### DIFF
--- a/kestrel/moondream/decode_slot.py
+++ b/kestrel/moondream/decode_slot.py
@@ -25,6 +25,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 
+from kestrel.device import make_event
 from kestrel.utils import CpuGpuBuffer
 
 
@@ -252,7 +253,6 @@ def create_decode_slot(
     # Pre-allocated events for decode-step synchronization. ``make_event``
     # returns a real ``torch.cuda.Event`` on CUDA, a no-op stand-in on MPS
     # (where the decode path serializes via the single implicit stream).
-    from kestrel.device import make_event
     step_done_event = make_event(device)
     commit_done_event = make_event(device)
 

--- a/kestrel/moondream/decode_slot.py
+++ b/kestrel/moondream/decode_slot.py
@@ -249,9 +249,12 @@ def create_decode_slot(
         device=device,
     )
 
-    # Pre-allocated events for decode-step synchronization
-    step_done_event = torch.cuda.Event()
-    commit_done_event = torch.cuda.Event()
+    # Pre-allocated events for decode-step synchronization. ``make_event``
+    # returns a real ``torch.cuda.Event`` on CUDA, a no-op stand-in on MPS
+    # (where the decode path serializes via the single implicit stream).
+    from kestrel.device import make_event
+    step_done_event = make_event(device)
+    commit_done_event = make_event(device)
 
     return DecodeSlot(
         slot_id=slot_id,


### PR DESCRIPTION
## Summary
- ``create_decode_slot`` instantiated ``torch.cuda.Event()`` unconditionally, which crashes on MPS (*\"Tried to instantiate dummy base class Event\"*) during runtime construction.
- Route through ``kestrel.device.make_event`` so CUDA still gets a real ``torch.cuda.Event`` and MPS gets the ``NoopEvent`` shim that #26 already introduced.

Caught running a real ``InferenceEngine.create(model=\"moondream2\", device=\"mps\")`` on the Mac box — the rest of the #26 work brings us past scheduler construction, and this was the next ``torch.cuda.*`` touchpoint still unguarded.

## Test plan
- [x] ``MoondreamRuntime(cfg_mps)`` constructs cleanly on MPS (previously threw at line 253).
- [ ] CI (existing ``test_device.py`` already covers ``make_event(MPS) → NoopEvent``).