### PR TITLE
Avoid redundant prefill seqused_q

### DIFF
--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -1426,7 +1426,8 @@ class MoondreamRuntime:
 
             assert use_prefix_attn is not None
             hidden_dim = self.bos_embed.shape[-1]
-            max_seq_len = max(t.shape[1] for t in per_inputs)
+            seq_lens = [int(t.shape[1]) for t in per_inputs]
+            max_seq_len = max(seq_lens)
             inputs_embeds = torch.zeros(
                 (batch_size, max_seq_len, hidden_dim),
                 dtype=self.dtype,
@@ -1441,8 +1442,11 @@ class MoondreamRuntime:
             last_token_positions = torch.empty(
                 (batch_size,), dtype=torch.long, device=self.device
             )
-            fa3_seqused_q = torch.empty(
-                (batch_size,), dtype=torch.int32, device=self.device
+            q_is_padded = any(seq_len != max_seq_len for seq_len in seq_lens)
+            fa3_seqused_q = (
+                torch.empty((batch_size,), dtype=torch.int32, device=self.device)
+                if q_is_padded
+                else None
             )
             fa3_seqused_k = torch.tensor(
                 [
@@ -1456,10 +1460,9 @@ class MoondreamRuntime:
             row_batch_idx = prefill_slot.batch_idx[:batch_size]
             batch_indices: list[int] = []
 
-            for row, (prepared, embed_row, pos_row) in enumerate(
-                zip(prepared_sequences, per_inputs, per_positions)
+            for row, (prepared, embed_row, pos_row, seq_len) in enumerate(
+                zip(prepared_sequences, per_inputs, per_positions, seq_lens)
             ):
-                seq_len = int(embed_row.shape[1])
                 prompt_len = int(prepared.state.prompt_length or prepared.state.length)
                 if seq_len > prompt_len:
                     raise AssertionError(
@@ -1473,7 +1476,8 @@ class MoondreamRuntime:
                 # Route padded tokens to reserved batch row 0 so they never write
                 # into real sequence KV slots.
                 slot_batch_idx[row, :seq_len].fill_(batch_idx)
-                fa3_seqused_q[row] = seq_len
+                if fa3_seqused_q is not None:
+                    fa3_seqused_q[row] = seq_len
                 last_token_positions[row] = seq_len - 1
 
             # Commit page table rows for all batch indices before forward pass.
@@ -1558,7 +1562,7 @@ class MoondreamRuntime:
         lora_slot: int = 0,
         *,
         use_prefix_attn: bool,
-        fa3_seqused_q: Tensor,
+        fa3_seqused_q: Tensor | None,
         fa3_seqused_k: Tensor,
         last_token_positions: Tensor,
     ) -> tuple[Tensor, Tensor]:

--- a/tests/moondream/test_runtime_prefill.py
+++ b/tests/moondream/test_runtime_prefill.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import torch
+
+from kestrel.moondream import runtime as runtime_mod
+
+
+class _FakePageTable:
+    def __init__(self) -> None:
+        self.committed: list[int] | None = None
+
+    def commit_block_table(self, batch_indices: list[int]) -> None:
+        self.committed = list(batch_indices)
+
+
+def _make_prepared(batch_idx: int, prompt_len: int) -> runtime_mod.PreparedSequence:
+    state = runtime_mod.SequenceState(
+        batch_idx=batch_idx,
+        length=prompt_len,
+        max_length=prompt_len + 8,
+        prompt_length=prompt_len,
+    )
+    return runtime_mod.PreparedSequence(
+        state=state,
+        tokens_list=[runtime_mod.TextToken(i) for i in range(prompt_len)],
+        cache_tokens=[],
+        cache_result=None,  # type: ignore[arg-type]
+        adapter_id=None,
+        image_hash=None,
+    )
+
+
+def _make_runtime(seq_lens: dict[int, int]) -> tuple[runtime_mod.MoondreamRuntime, dict]:
+    captured: dict = {}
+    runtime = runtime_mod.MoondreamRuntime.__new__(runtime_mod.MoondreamRuntime)
+    runtime.max_batch_size = 8
+    runtime.device = torch.device("cpu")
+    runtime.dtype = torch.float32
+    runtime.bos_embed = torch.empty(1, 4)
+    runtime._primary_stream = None
+    runtime.page_table = _FakePageTable()
+
+    def build_inputs(prepared, *, image, image_crops):
+        del image, image_crops
+        seq_len = seq_lens[prepared.state.batch_idx]
+        hidden = torch.full((1, seq_len, 4), float(prepared.state.batch_idx))
+        positions = torch.arange(seq_len, dtype=torch.long).view(1, seq_len)
+        return hidden, positions, False
+
+    def prefill_impl(
+        inputs_embeds,
+        attn_mask,
+        position_ids,
+        batch_idx,
+        lora_slot=0,
+        *,
+        use_prefix_attn,
+        fa3_seqused_q,
+        fa3_seqused_k,
+        last_token_positions,
+    ):
+        del attn_mask, position_ids, batch_idx, lora_slot, use_prefix_attn
+        captured["fa3_seqused_q"] = fa3_seqused_q
+        captured["fa3_seqused_k"] = fa3_seqused_k
+        captured["last_token_positions"] = last_token_positions
+        batch_size = inputs_embeds.shape[0]
+        return inputs_embeds, torch.zeros((batch_size, 8), dtype=inputs_embeds.dtype)
+
+    runtime._build_prefill_inputs_for_prepared = build_inputs
+    runtime._prefill_impl = prefill_impl
+    return runtime, captured
+
+
+def test_launch_prepared_batch_omits_seqused_q_for_uniform_q_lengths() -> None:
+    runtime, captured = _make_runtime({1: 3, 2: 3})
+    slot = runtime_mod.PrefillSlot(
+        slot_id=0,
+        batch_idx=torch.zeros(2, dtype=torch.int64),
+        step_done_event=None,  # type: ignore[arg-type]
+        commit_done_event=None,  # type: ignore[arg-type]
+    )
+
+    logits = runtime.launch_prepared_batch(
+        [_make_prepared(1, 10), _make_prepared(2, 11)],
+        slot,
+    )
+
+    assert logits.shape == (2, 8)
+    assert captured["fa3_seqused_q"] is None
+    torch.testing.assert_close(
+        captured["fa3_seqused_k"],
+        torch.tensor([10, 11], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        captured["last_token_positions"],
+        torch.tensor([2, 2], dtype=torch.long),
+    )
+
+
+def test_launch_prepared_batch_omits_seqused_q_for_single_token_append() -> None:
+    runtime, captured = _make_runtime({1: 1, 2: 1})
+    slot = runtime_mod.PrefillSlot(
+        slot_id=0,
+        batch_idx=torch.zeros(2, dtype=torch.int64),
+        step_done_event=None,  # type: ignore[arg-type]
+        commit_done_event=None,  # type: ignore[arg-type]
+    )
+
+    logits = runtime.launch_prepared_batch(
+        [_make_prepared(1, 10), _make_prepared(2, 11)],
+        slot,
+    )
+
+    assert logits.shape == (2, 8)
+    assert captured["fa3_seqused_q"] is None
+    torch.testing.assert_close(
+        captured["last_token_positions"],
+        torch.tensor([0, 0], dtype=torch.long),
+    )
+
+
+def test_launch_prepared_batch_keeps_seqused_q_for_padded_q_lengths() -> None:
+    runtime, captured = _make_runtime({1: 1, 2: 3})
+    slot = runtime_mod.PrefillSlot(
+        slot_id=0,
+        batch_idx=torch.zeros(2, dtype=torch.int64),
+        step_done_event=None,  # type: ignore[arg-type]
+        commit_done_event=None,  # type: ignore[arg-type]
+    )
+
+    logits = runtime.launch_prepared_batch(
+        [_make_prepared(1, 10), _make_prepared(2, 11)],
+        slot,
+    )
+
+    assert logits.shape == (2, 8)
+    torch.testing.assert_close(
+        captured["fa3_seqused_q"],
+        torch.tensor([1, 3], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        captured["last_token_positions"],
+        torch.tensor([0, 2], dtype=torch.long),
+    )


### PR DESCRIPTION
## Summary

Only pass `fa3_seqused_q` from runtime prefill when the Q batch is actually padded. Uniform-Q prefill, including the single-token prefix-cache append case, now passes `None` so the existing fixed-Q/paged fast paths can dispatch normally.

This keeps `seqused_q` reserved for its intended meaning: per-row valid Q lengths for a padded varlen-Q batch.

## Why

The full ChartQA dispatch probe showed one warmup/cache-reuse text forward falling through to torch SDPA on L40S/SM89. Root cause: runtime passed `seqused_q=[1]` for a single-token append prefill. That redundant varlen marker blocked the existing fast path even though every row had the full Q length.

## Validation

- `python -m py_compile kestrel/moondream/runtime.py tests/moondream/test_runtime_prefill.py`
- `.venv/bin/python -m pytest tests/moondream/test_runtime_prefill.py` -> `3 passed`
- `git diff --check`
- Modal L40S / SM89 `ap-3fEIT8u3JPoYfzJsJTjW3I`, Moondream 2 ChartQA `--limit 1`: completed successfully with dispatch counts `{"decode_persistent_split_fused": 48, "sm89_decode": 744, "sm89_paged_prefill": 24, "sm89_prefill": 48}` and no `torch_sdpa_fallback`.