### PR TITLE
Run Moondream in fp16 on MPS

### DIFF
--- a/kestrel/config.py
+++ b/kestrel/config.py
@@ -71,8 +71,20 @@ class RuntimeConfig:
             self.model_path = ensure_model_weights(self.model)
 
     def resolved_dtype(self) -> torch.dtype:
-        """Return the torch dtype to use for the runtime."""
+        """Return the torch dtype to use for the runtime.
 
+        On MPS we override the default ``bfloat16`` to ``float16``:
+        Apple Silicon's matmul + SDPA throughput is consistently
+        higher in fp16, fp16's 10-bit mantissa is a precision
+        *upgrade* over bf16's 7-bit on the activation range Moondream
+        occupies, and Moondream's bf16-trained weights round to fp16
+        without saturating fp16's 65504 dynamic-range cap. Users who
+        explicitly want fp32 on MPS still get fp32 — only the bf16
+        default is overridden.
+        """
+
+        if self.dtype == torch.bfloat16 and self.resolved_device().type == "mps":
+            return torch.float16
         return self.dtype
 
     def resolved_device(self) -> torch.device:


### PR DESCRIPTION
## Summary
Single-file switch: when device is MPS, resolve the runtime dtype to ``float16`` instead of the ``bfloat16`` default. Apple Silicon's matmul + SDPA throughput is consistently higher in fp16 across every kernel we ship, and fp16's 10-bit mantissa is a precision *upgrade* over bf16's 7-bit on the activation range Moondream occupies. CUDA path unchanged.

This PR replaces the earlier vision-only fp16 plumbing — when the *whole* pipeline runs in fp16, the ``vision_dtype != dtype`` boundary cast becomes unnecessary, and the diff drops from 34 lines / 2 files to 14 lines / 1 file.

## Why this is safe
- Bf16-trained weights round into fp16 without saturation (max activation observed in vision encoder + text decoder stays under 1e3 vs fp16's 65504 cap).
- Reductions that actually matter (softmax, LayerNorm, matmul accumulate) are fp32 inside the kernels regardless of input dtype — flash_attn_dense uses ``AccumType=float``, layer_norm uses fp32 accum, the linear path uses fp32 SGEMM-style accumulation.
- All kestrel-kernels MPS ops (LayerNorm, RoPE, tau, flash_attn_dense) ship fp16 variants; nothing falls back to torch.
- Users who explicitly pass a non-bf16 dtype (``torch.float32`` for testing, etc.) get exactly that — only the bf16 default is overridden.

## ChartQA on M2 (--limit 30 → 60 q-variants, --max-batch-size 1, --kv-cache-pages 1024, default prefix cache)

| metric | bf16 (vision-attn Metal baseline) | **fp16** | Δ |
|---|---|---|---|
| Accuracy | 31/60 (51.67%) | **31/60 (51.67%)** | unchanged |
| Prefill | 250.75 tok/s | **397.02** | **+58%** |
| Decode | 0.89 tok/s | **1.39** | **+56%** |
| Requests/s | 0.33 | **0.52** | **+58%** |
| P50 latency | 2892 ms | **2037** | **−30%** |
| P90 latency | 5902 ms | **3844** | **−35%** |
| P99 latency | 6603 ms | **4311** | **−35%** |

Cumulative MPS speedup over the past few weeks (LayerNorm + RoPE + tau + flash_attn_dense + fp16): **prefill +182%, decode +184%, P99 −74%, accuracy preserved.**

## Changes
- ``RuntimeConfig.resolved_dtype()``: on MPS with ``self.dtype == bfloat16``, return ``float16``. Otherwise return ``self.dtype``.

That's the entire diff.

## Test plan
- [x] ChartQA --limit 30 end-to-end on M2 — accuracy 31/60 matches the original baseline 31/60 (within sampling noise of the 30/60 we saw at vision-only fp16; the LLM-fp16 path bounces it back).
- [x] Output finite, no NaN/Inf in any decode step.
- [x] No fallback warnings beyond the expected paged/causal + paged/prefix_lm_730 (still on torch SDPA pending native paged attention kernels).
- [ ] Larger ChartQA (--limit 100+) when GPU is free.

## Pairing
Requires kestrel-kernels #76 (fp16 ``flash_attn_dense_into`` instantiation) on the kernels side; that PR is approved/merging.