### PR TITLE
engine: warn once when sampling settings exit the MPS kernel envelope

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -88,6 +88,11 @@ from kestrel.utils.spatial_refs import normalize_spatial_refs
 
 
 _LOGGER = logging.getLogger(__name__)
+
+# PR landing this warning + the kernel envelope it documents. Update if
+# the canonical docs move.
+_MPS_SAMPLER_DOCS_URL = "https://github.com/m87-labs/kestrel/pull/33"
+
 _DEFAULT_API_BASE_URL = "https://api.moondream.ai"
 _ALLOWED_API_BASE_URLS = (
     "https://api-staging.moondream.ai",
@@ -942,6 +947,9 @@ class InferenceEngine:
 
         prompt_str = self._extract_prompt_text(skill_spec, request_context)
         tokens = list(skill_spec.build_prompt_tokens(self.runtime, request_context))
+        norm_temperature = self._normalize_temperature(temperature)
+        norm_top_p = self._normalize_top_p(top_p)
+        self._warn_if_outside_mps_sampler_envelope(norm_temperature, norm_top_p)
         payload = _PendingRequest(
             request_id=req_id,
             prompt=prompt_str,
@@ -949,8 +957,8 @@ class InferenceEngine:
             image=image_obj,
             image_hash=None,  # Computed in scheduler thread if prefix cache enabled
             max_new_tokens=max_new_tokens,
-            temperature=self._normalize_temperature(temperature),
-            top_p=self._normalize_top_p(top_p),
+            temperature=norm_temperature,
+            top_p=norm_top_p,
             submitted_at=time.perf_counter(),
             future=future,
             stream_queue=stream_queue,
@@ -997,6 +1005,41 @@ class InferenceEngine:
         if top_p <= 0.0 or top_p > 1.0:
             raise ValueError("top_p must be in the range (0, 1]")
         return top_p
+
+    # Settings outside this envelope cause the MPS fused sampler to
+    # silently bias outputs (top-K=64 may not span the nucleus). Logged
+    # once per (temperature, top_p) tuple seen so a chat session with
+    # a warm prompt doesn't spam.
+    _MPS_SAMPLER_TOP_P_MAX = 0.95
+    _MPS_SAMPLER_TEMP_MAX = 1.0
+    _mps_sampler_warned: set[Tuple[float, float]] = set()
+
+    def _warn_if_outside_mps_sampler_envelope(
+        self, temperature: float, top_p: float,
+    ) -> None:
+        runtime = self._runtime
+        if runtime is None or runtime.device.type != "mps":
+            return
+        if (
+            temperature <= self._MPS_SAMPLER_TEMP_MAX
+            and top_p <= self._MPS_SAMPLER_TOP_P_MAX
+        ):
+            return
+        key = (temperature, top_p)
+        if key in self._mps_sampler_warned:
+            return
+        self._mps_sampler_warned.add(key)
+        _LOGGER.warning(
+            "MPS sampler may produce biased outputs for "
+            "temperature=%.3g, top_p=%.3g. The fused Metal kernel only "
+            "inspects the top-K=64 candidates and is calibrated for "
+            "top_p ≤ %.2f / temperature ≤ %.1f; settings outside that "
+            "envelope can sample from a truncated nucleus. See %s for "
+            "details.",
+            temperature, top_p,
+            self._MPS_SAMPLER_TOP_P_MAX, self._MPS_SAMPLER_TEMP_MAX,
+            _MPS_SAMPLER_DOCS_URL,
+        )
 
     def _normalize_adapter_id(self, value: Optional[str]) -> Optional[str]:
         if value is None:

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -1017,8 +1017,15 @@ class InferenceEngine:
     def _warn_if_outside_mps_sampler_envelope(
         self, temperature: float, top_p: float,
     ) -> None:
-        runtime = self._runtime
-        if runtime is None or runtime.device.type != "mps":
+        # _submit_request awaits _ensure_started before calling us, so
+        # _runtime is set by here.
+        if self._runtime.device.type != "mps":
+            return
+        # Greedy decoding (``temperature == 0``) hits the scheduler's
+        # ``torch.argmax`` short-circuit and never reaches the fused
+        # MPS sampler — top_p is irrelevant. ``detect`` / ``point`` /
+        # ``segment`` defaults sit here, so warning would be noise.
+        if temperature <= 0.0:
             return
         if (
             temperature <= self._MPS_SAMPLER_TEMP_MAX


### PR DESCRIPTION
## Summary

The MPS fused ``sample_step`` kernel (kestrel-proprietary #84) only
inspects the top-K=64 candidates and is calibrated for ``top_p ≤
0.95`` / ``temperature ≤ 1.0``. Settings outside that envelope can
produce biased samples:

- **High top_p (≥ 0.95)**: the kernel truncates at K=64 even when
  the true cumulative-mass crossing is later, biasing the nucleus
  toward the head.
- **High temperature (> 1.0)**: the post-temp distribution flattens
  enough that K=64 may not span the support.

We accept the trade-off (full kernel speed — ~5× the torch chain
on V=51200) but surface a **one-time per-process** warning the
first time a request with out-of-envelope settings is admitted on
an MPS runtime. Users running with non-default sampling settings
know their output distribution will diverge from the CUDA / torch
reference.

CUDA / CPU runtimes are unaffected — the warning gate keys on
``runtime.device.type == "mps"``.

## Implementation

- ``InferenceEngine._warn_if_outside_mps_sampler_envelope`` — gates
  on ``runtime.device.type``, dedupes via a class-level
  ``set[(temp, top_p)]`` so a long chat session doesn't spam.
- Called from ``_submit_request`` right after the existing
  ``_normalize_temperature`` / ``_normalize_top_p`` validation, so
  every entry point (query, caption, detect, ask, raw submit) is
  covered.

## Test plan

- [x] Syntax check
- [ ] Manual: on Mac, run with ``settings={'top_p': 0.99}`` and
      verify the warning fires once
- [ ] Manual: same call again with same settings → no second
      warning