### PR TITLE
Route MoE router TopK through the kernel runtime

### DIFF
--- a/kestrel/moondream/layers.py
+++ b/kestrel/moondream/layers.py
@@ -20,6 +20,7 @@ from kestrel_kernels import get_runtime
 
 _KERNELS = get_runtime()
 _layernorm_bias = _KERNELS.dense.layernorm_bias  # cross-arch (.so on CUDA, Metal on MPS)
+_moe_topk_fwd = _KERNELS.moe.topk_fwd
 
 # Re-export LoRA for convenience
 from .lora import LoRA, MoEMLPLoRA, DenseMLPLoRA  # noqa: F401
@@ -165,9 +166,11 @@ def moe_mlp(
     fused_mlp = mlp_module["mlp"]
 
     router_logits = _KERNELS.linear.linear(x_flat, router.weight, router.bias)
-    topk_weights, topk_idxs = torch.topk(router_logits, experts_per_token, dim=-1)
-    topk_weights = F.softmax(topk_weights, dim=-1)
-    topk_idxs = topk_idxs.to(torch.int32)
+    topk_weights, topk_idxs = _moe_topk_fwd(
+        router_logits,
+        experts_per_token,
+        softmax=True,
+    )
 
     # Expand slot IDs for all tokens if we have a sequence length > 1
     expanded_slot_ids = None


### PR DESCRIPTION
## Summary

- Replace the app-side `torch.topk` + `F.softmax` MoE router path with `_KERNELS.moe.topk_fwd`.
- Cache the runtime callable at module import, matching the existing layernorm runtime pattern.

## Dependency

Depends on m87-labs/kestrel-proprietary#93, which exposes `moe.topk_fwd` through the stable kernel runtime and owns fallback behavior there.

## Validation

- `python -m py_compile kestrel/moondream/layers.py scripts/chartqa_eval.py`
- L4 ChartQA comparisons were run through Modal. The TopK microbench is faster, but the paired end-to-end ChartQA runs were noise-level after accounting for order and remaining MoE JIT artifacts:
  - cold-first: patched `2.36 RPS`, baseline `2.49 RPS`
  - warm-second: patched `6.69 RPS`, baseline `6.61 RPS`