### PR TITLE
config: clamp max_batch_size to 1 on MPS (cross-slot bug guard)

### DIFF
--- a/kestrel/config.py
+++ b/kestrel/config.py
@@ -1,9 +1,11 @@
 """Runtime configuration objects for the Kestrel inference engine."""
 
 
+import os
+import re
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
-import re
 
 import torch
 
@@ -109,6 +111,29 @@ class RuntimeConfig:
         self.service_name = normalized_service_name or "local"
         if not _SERVICE_NAME_PATTERN.fullmatch(self.service_name):
             raise ValueError("service_name must match [A-Za-z0-9_-]+")
+
+        # MPS multi-batch is currently unsafe: at max_batch_size > 1 with
+        # 2+ active slots, attention/KV-cache cross-slot interference
+        # produces silently corrupted token streams (verified on M4 base
+        # 16 GB, MD2; B=1 clean, B≥2 garbage from token 0). The bug is
+        # not in any shipped Metal kernel — it lives in the scheduler /
+        # paged-attention fallback layer at B>1. Until that's fixed,
+        # clamp max_batch_size to 1 on MPS so callers don't see corrupted
+        # output. Set ``KESTREL_MPS_ALLOW_BATCH=1`` to opt out (e.g. for
+        # debugging the bug itself).
+        if (
+            self.resolved_device().type == "mps"
+            and self.max_batch_size > 1
+            and os.environ.get("KESTREL_MPS_ALLOW_BATCH") != "1"
+        ):
+            warnings.warn(
+                f"MPS multi-batch (max_batch_size={self.max_batch_size}) "
+                "produces corrupted output at B>1 with 2+ active slots; "
+                "clamping to 1. Set KESTREL_MPS_ALLOW_BATCH=1 to override.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            self.max_batch_size = 1
 
         if self.kv_cache_pages is None:
             self.kv_cache_pages = _default_kv_cache_pages_for_device(self.device)


### PR DESCRIPTION
## Summary

On MPS, running with \`max_batch_size > 1\` and 2+ concurrent requests in flight produces silently corrupted output. B=1 returns clean text; B≥2 with 2+ active slots returns gibberish starting from token 0 of every stream.

Repro on a 16 GB M4 base mini, kestrel main + the kv_cache_pages tier patch (PR #37), Moondream 2:

| Config | Output |
|---|---|
| \`max_batch=1, concurrency=4\` (B=1 always) | ✅ Clean |
| \`max_batch=2, concurrency=1\` (1 slot active) | ✅ Clean |
| \`max_batch=2, concurrency=2\` (2 slots active) | ❌ Garbage |
| \`max_batch=4, concurrency=4\` (3–4 slots active) | ❌ Garbage |

Sample b1 output: *\"The image displays a textured surface with a multicolored pattern. The colors range from vibrant reds and blues to soft greens and yellows…\"*

Sample b≥2 output: *\"The image being being is at least is in, imgssme.me by using Gospelslusing bleosw.sw.atticeworkw.swe.g…\"* (hits 768-token cap without ever emitting EOS)

## Localization

The bug is **cross-slot interference** triggered when 2+ slots are simultaneously active in the engine. It is **not** in any shipped Metal kernel:

- \`kv_cache_write.metal\` — uses caller-provided \`slot_mapping[token]\`; per-slot routing depends on caller
- \`paged_decode_attn.metal\`, \`paged_prefill_attn.metal\` — both gated to B=1 in the dispatch predicate
- All other MPS Metal kernels (\`moe_align\`, \`moe_topk\`, \`sample_step\`, \`layer_norm\`, \`flash_attn_dense\`, \`tau\`, \`rotary\`, etc.) operate per-token or per-slot via \`slot_mapping\` and are correct under B>1 if the caller provides correct indices.

The buggy code lives in one or more of:
- The kestrel scheduler's slot/page allocation when 2+ slots are concurrently active on MPS
- The torch-SDPA paged-attention fallback for paged + B>1 (\`kestrel_kernels/flash_attn/cute/fallback.py:798–858\`)
- The decode-step batching layer that packs multiple slots into one forward pass

Diagnosing it properly requires CUDA-vs-MPS bisection at B=2 (CUDA's B=2 produces correct output, so the divergence must be MPS-specific) and is a 1–3 day focused investigation.

## What this PR does

Until the underlying bug is found, clamp \`max_batch_size = 1\` on MPS in \`RuntimeConfig.__post_init__\` and emit a \`RuntimeWarning\`. Set \`KESTREL_MPS_ALLOW_BATCH=1\` to opt out (e.g., for the debugging session itself).

CUDA / CPU paths are unchanged.

## Trade-off

On Mac, multi-batch was actually *slower* than single-stream in the buggy state (1215 s wall for 60 requests at b4 vs 155 s at b1, on the same M4), so users lose nothing on perf. They lose continuous batching as a feature — which was returning corrupt output anyway.

## Test plan

- [x] AST validates
- [x] B=1 path (default) unchanged
- [x] CUDA path unchanged
- [ ] Verify warning fires at \`RuntimeConfig(max_batch_size=4, device='mps')\` on a Mac box
- [ ] Verify \`KESTREL_MPS_ALLOW_BATCH=1\` overrides the clamp (for the eventual real-fix PR's tests)

## Follow-up

Issue to track: \"MPS B>1 cross-slot corruption (paged-attention fallback or scheduler)\". Will file separately with the bisection data + a minimal Python repro.