### PR TITLE
moondream/runtime: enable FP8 KV cache on sm_110 (Jetson Thor)

### DIFF
--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -478,7 +478,7 @@ class MoondreamRuntime:
 
         device_cc_major, device_cc_minor = get_device_capability(self.device)
         device_sm = device_cc_major * 10 + device_cc_minor
-        fp8_kv_supported_sms = {87, 89, 90, 100, 120}
+        fp8_kv_supported_sms = {87, 89, 90, 100, 110, 120}
 
         if (
             self._kv_layer_k_scales is not None


### PR DESCRIPTION
## Summary
- One-line whitelist fix in \`MoondreamRuntime\`: add \`110\` to \`fp8_kv_supported_sms\` so Thor uses FP8 KV cache when the checkpoint carries scales (Moondream 3).

## Context
Pairs with kestrel-kernels#112, which ships the underlying \`decode_sm90_*_fp8_e4m3_*\` and \`persistent_split_fused_*_fp8_e4m3_*\` cubins for sm_110. Without this, Thor was emitting:

\`\`\`
UserWarning: KV scales found in checkpoint but FP8 KV cache currently requires SM87/SM89/SM90/SM100/SM120 decode kernels; falling back to standard KV cache.
\`\`\`

…and silently dropping FP8 KV compression — losing ~50% of KV-cache memory + the FP8-decode bandwidth win.

## Test plan
- [ ] On Thor with the kestrel-kernels#112 wheel installed: rerun \`scripts/chartqa_eval.py --model moondream3-preview --max-batch-size 1 --limit 30\` and confirm no \`falling back to standard KV cache\` warning.
- [ ] Other GPUs (B200 sm_100, RTX-PRO-6000 sm_120, H100 sm_90, L40S sm_89) unchanged — \`fp8_kv_supported_sms\` is union-only.