### PR TITLE
Set max LoRA rank to 32

### DIFF
--- a/kestrel/cloud/adapter_provider.py
+++ b/kestrel/cloud/adapter_provider.py
@@ -39,7 +39,7 @@ class MoondreamAdapterProvider:
         *,
         api_key: str,
         api_base_url: str = "https://api.moondream.ai",
-        max_lora_rank: int = 16,
+        max_lora_rank: int = 32,
         cache_size: int = 32,
         device: torch.device = torch.device("cpu"),
         dtype: torch.dtype = torch.bfloat16,


### PR DESCRIPTION
Updates the Moondream adapter provider default `max_lora_rank` from 16 to 32 so rank-32 adapters are admitted.