### PR TITLE
Centralize per-layer KV allocation behind a KVMemoryPool

### DIFF
--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -129,10 +129,12 @@ class PagedKVCache(torch.nn.Module):
             self.k_scale = 1.0
             self.v_scale = 1.0
         self.register_buffer(
-            "k_scale_tensor", torch.tensor(self.k_scale, dtype=torch.float32)
+            "k_scale_tensor",
+            torch.tensor(self.k_scale, dtype=torch.float32, device=pool.device),
         )
         self.register_buffer(
-            "v_scale_tensor", torch.tensor(self.v_scale, dtype=torch.float32)
+            "v_scale_tensor",
+            torch.tensor(self.v_scale, dtype=torch.float32, device=pool.device),
         )
 
     def update(

--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -60,6 +60,40 @@ def _build_fa3_decode_metadata_torch(
     out_seqused_k[:batch_size].copy_(seqlen.to(dtype=torch.int32))
 
 
+class KVMemoryPool:
+    """Allocator for paged KV cache storage.
+
+    Funnels every per-layer K/V buffer allocation through a single
+    accounting layer. Today the pool just allocates each layer's
+    ``(k, v)`` pair on demand via ``torch.zeros``; the abstraction exists
+    so multiple :class:`PagedKVCache` instances — and ultimately multiple
+    runtimes that share the GPU's KV budget — can be backed by one
+    allocation strategy without touching call sites.
+
+    ``allocated_bytes`` tracks the total K + V bytes handed out for
+    diagnostics and capacity planning.
+    """
+
+    def __init__(self, *, device: torch.device | str):
+        self.device = torch.device(device) if isinstance(device, str) else device
+        self.allocated_bytes = 0
+
+    def allocate_layer_kv(
+        self,
+        *,
+        n_pages: int,
+        n_heads: int,
+        page_size: int,
+        head_dim: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        cache_shape = (n_pages, n_heads, page_size, head_dim)
+        k = torch.zeros(cache_shape, dtype=dtype, device=self.device)
+        v = torch.zeros(cache_shape, dtype=dtype, device=self.device)
+        self.allocated_bytes += 2 * k.numel() * k.element_size()
+        return k, v
+
+
 class PagedKVCache(torch.nn.Module):
     def __init__(
         self,
@@ -67,19 +101,21 @@ class PagedKVCache(torch.nn.Module):
         n_heads,
         head_dim,
         dtype,
+        pool: KVMemoryPool,
         *,
         k_scale: float | None = None,
         v_scale: float | None = None,
     ):
         super().__init__()
-        cache_shape = (
-            page_table.n_pages,
-            n_heads,
-            page_table.page_size,
-            head_dim,
+        k_cache, v_cache = pool.allocate_layer_kv(
+            n_pages=page_table.n_pages,
+            n_heads=n_heads,
+            page_size=page_table.page_size,
+            head_dim=head_dim,
+            dtype=dtype,
         )
-        self.register_buffer("k_cache", torch.zeros(cache_shape, dtype=dtype))
-        self.register_buffer("v_cache", torch.zeros(cache_shape, dtype=dtype))
+        self.register_buffer("k_cache", k_cache)
+        self.register_buffer("v_cache", v_cache)
 
         self.page_table = page_table
         self.quantized = dtype == torch.float8_e4m3fn

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -268,7 +268,7 @@ class MoondreamRuntime:
             prefix_cache=self.prefix_cache,
             h2d_stream=self._primary_stream,
         )
-        self.kv_pool = KVMemoryPool(device=self.device)
+        self._kv_pool = KVMemoryPool(device=self.device)
 
         construction_device = torch.device("meta")
         with _disable_parameter_initialization():
@@ -395,7 +395,7 @@ class MoondreamRuntime:
                 n_kv_heads=self.config.text.n_kv_heads,
                 head_dim=head_dim,
                 dtype=self.kv_cache_dtype,
-                pool=self.kv_pool,
+                pool=self._kv_pool,
                 k_scale=k_scale,
                 v_scale=v_scale,
             )

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -21,7 +21,7 @@ from tokenizers import Tokenizer
 
 from kestrel.config import RuntimeConfig
 from kestrel.device import NoopEvent, empty_cache, get_device_capability, make_event, make_stream, set_device, stream_context
-from kestrel.kv_cache import PageTable, PagedKVCache
+from kestrel.kv_cache import KVMemoryPool, PageTable, PagedKVCache
 from kestrel.prefix_cache import (
     CacheNamespace,
     CacheToken,
@@ -157,7 +157,7 @@ class _LayerPagedCache(torch.nn.Module):
         n_kv_heads: int,
         head_dim: int,
         dtype: torch.dtype,
-        device: torch.device,
+        pool: KVMemoryPool,
         *,
         k_scale: float | None = None,
         v_scale: float | None = None,
@@ -168,9 +168,10 @@ class _LayerPagedCache(torch.nn.Module):
             n_heads=n_kv_heads,
             head_dim=head_dim,
             dtype=dtype,
+            pool=pool,
             k_scale=k_scale,
             v_scale=v_scale,
-        ).to(device)
+        )
 
     def update(
         self,
@@ -267,6 +268,7 @@ class MoondreamRuntime:
             prefix_cache=self.prefix_cache,
             h2d_stream=self._primary_stream,
         )
+        self.kv_pool = KVMemoryPool(device=self.device)
 
         construction_device = torch.device("meta")
         with _disable_parameter_initialization():
@@ -393,7 +395,7 @@ class MoondreamRuntime:
                 n_kv_heads=self.config.text.n_kv_heads,
                 head_dim=head_dim,
                 dtype=self.kv_cache_dtype,
-                device=self.device,
+                pool=self.kv_pool,
                 k_scale=k_scale,
                 v_scale=v_scale,
             )


### PR DESCRIPTION
## Summary

Funnel every \`PagedKVCache\` K/V buffer allocation through a new \`KVMemoryPool\` so storage isn't bound to \`PagedKVCache.__init__\`. The pool is currently a thin wrapper around \`torch.zeros\` that also reports \`allocated_bytes\` for diagnostics; the abstraction exists so:

- future revisions can share an underlying buffer or implement compaction without touching call sites
- the engine can eventually host multiple runtimes that share the GPU's KV budget
- KV memory accounting has a single chokepoint today

## Changes

- New \`KVMemoryPool\` in \`kestrel/kv_cache.py\`. Constructed with a \`device\`; exposes \`allocate_layer_kv(n_pages, n_heads, page_size, head_dim, dtype) -> (k, v)\` and tracks total bytes in \`allocated_bytes\`.
- \`PagedKVCache\` now requires a \`pool\` parameter; it asks the pool for its K and V buffers instead of calling \`torch.zeros\` directly.
- \`MoondreamRuntime\` constructs one \`KVMemoryPool\` per runtime instance and passes it to every \`_LayerPagedCache\`. \`_LayerPagedCache\` no longer takes \`device\` (the pool already knows it), and the redundant \`.to(device)\` on the inner \`PagedKVCache\` is gone.

## Test plan
- [x] \`pytest --ignore=tests/integration\` — 242 passed, 46 skipped, 0 changed
- [x] Smoke-tested pool wiring: \`PagedKVCache\` allocations land on the pool's device; \`allocated_bytes\` matches \`2 × n_pages × n_heads × page_size × head_dim × element_size\` exactly.
- [x] No new GPU allocations vs. baseline — same per-layer \`torch.zeros\` calls, just routed through \`KVMemoryPool\`.