### PR TITLE
Add a FakeRuntime that satisfies the Runtime protocol for scheduler tests

### DIFF
--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -1,0 +1,223 @@
+"""In-memory ``Runtime`` implementation for scheduler tests.
+
+The :class:`~kestrel.scheduler.scheduler.GenerationScheduler` is typed
+against the :class:`~kestrel.runtime.Runtime` protocol. ``FakeRuntime``
+gives the scheduler test suite a second consumer of that protocol so
+scheduler logic can be driven without instantiating ``MoondreamRuntime``
+(which requires real model weights, GPU resources, and vision/text
+encoders).
+
+Behaviour:
+- every Runtime method is implemented as a lightweight bookkeeping
+  call. Calls are recorded into public lists/dicts so tests can assert
+  ordering and arguments.
+- attributes default to small, plausible values (``max_batch_size=1``,
+  ``page_size=1``, etc.) but are mutable so individual tests can
+  override.
+- ``prepare_sequence`` and ``launch_prepared_batch`` accept a
+  pre-built return value or an exception so failure-path tests can
+  pin behaviour without constructing a real ``PreparedSequence``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+import torch
+
+from kestrel.runtime import (
+    PrefillClassification,
+    PreparedSequence,
+    SequenceState,
+)
+from kestrel.runtime.tokens import Token
+
+
+class _FakePageTable:
+    """Stand-in for :class:`kestrel.kv_cache.PageTable`.
+
+    Exposes the attributes the scheduler reads (``page_size``) plus a
+    ``commit_block_table`` no-op so decode-step tests can run.
+    """
+
+    def __init__(self, *, page_size: int = 1) -> None:
+        self.page_size = page_size
+        self.commit_block_table_calls: list[list[int] | None] = []
+
+    def commit_block_table(self, batch_indices: list[int] | None = None) -> None:
+        self.commit_block_table_calls.append(batch_indices)
+
+
+class FakeRuntime:
+    """Minimal :class:`Runtime` impl for scheduler tests."""
+
+    def __init__(
+        self,
+        *,
+        max_batch_size: int = 1,
+        max_batch_slots: int = 2,
+        max_seq_length: int = 1024,
+        image_prefix_length: int = 0,
+        device: torch.device | str = "cpu",
+        page_size: int = 1,
+        prepare_exc: Exception | None = None,
+        prepare_result: PreparedSequence | None = None,
+        launch_logits: torch.Tensor | None = None,
+    ) -> None:
+        # Capacity / shape
+        self.max_batch_size = max_batch_size
+        self.max_batch_slots = max_batch_slots
+        self.max_seq_length = max_seq_length
+        self.image_prefix_length = image_prefix_length
+
+        # Device + streams
+        self.device: torch.device = (
+            torch.device(device) if isinstance(device, str) else device
+        )
+        self.primary_stream: Any = None
+        self.copy_stream: Any = None
+
+        # Slot containers + sequence registry
+        self.prefill_slots: list[Any] = []
+        self.decode_slots: list[Any] = []
+        self.active_sequences: dict[int, SequenceState] = {}
+
+        # Model-specific surfaces — left as ``None``/empty for fake purposes;
+        # tests that need richer values assign attributes directly.
+        self.config: Any = None
+        self.region: Any = None
+        self.spatial_tables: Any = None
+        self.page_table = _FakePageTable(page_size=page_size)
+
+        # Knobs
+        self._prepare_exc = prepare_exc
+        self._prepare_result = prepare_result
+        self._launch_logits = launch_logits
+
+        # Call log
+        self.acquired_prefill_slots: list[int | None] = []
+        self.released_prefill_slots: list[Any] = []
+        self.acquired_adapter_slots: list[tuple[str, Any]] = []
+        self.released_adapter_slots: list[int] = []
+        self.classify_calls: list[Sequence[Token]] = []
+        self.prepare_calls: list[dict[str, Any]] = []
+        self.launch_calls: list[Sequence[PreparedSequence]] = []
+        self.finalized_prepared: list[PreparedSequence] = []
+        self.aborted_prepared: list[PreparedSequence] = []
+        self.released_sequences: list[SequenceState] = []
+        self.decode_calls: list[tuple[Any, int]] = []
+
+    # Capacity queries -------------------------------------------------
+    def can_reserve(self, total_length: int) -> bool:
+        return total_length <= self.max_seq_length
+
+    def prefill_budget(self) -> tuple[int, int]:
+        return (self.max_seq_length, self.max_batch_slots)
+
+    # Slot lifecycle ---------------------------------------------------
+    def acquire_prefill_slot(self, slot_id: int | None = None) -> Any:
+        self.acquired_prefill_slots.append(slot_id)
+        slot = object()
+        self.prefill_slots.append(slot)
+        return slot
+
+    def release_prefill_slot(self, slot: Any) -> None:
+        self.released_prefill_slots.append(slot)
+
+    def acquire_adapter_slot(self, adapter_id: str, adapter: Any) -> int:
+        self.acquired_adapter_slots.append((adapter_id, adapter))
+        return len(self.acquired_adapter_slots)
+
+    def release_adapter_slot(self, slot: int) -> None:
+        self.released_adapter_slots.append(slot)
+
+    # Prefill / decode -------------------------------------------------
+    def classify_prefill(
+        self,
+        prompt_tokens: Sequence[Token],
+        *,
+        has_image: bool,
+        image_hash: bytes | None,
+        adapter_id: str | None,
+    ) -> PrefillClassification:
+        self.classify_calls.append(prompt_tokens)
+        prompt_length = len(prompt_tokens) + (
+            self.image_prefix_length if has_image else 0
+        )
+        return PrefillClassification(
+            prompt_length=prompt_length,
+            skip_positions=0,
+            can_reuse=False,
+            use_prefix_attn=False,
+        )
+
+    def prepare_sequence(
+        self,
+        prompt_tokens: Sequence[Token],
+        *,
+        image: Any = None,
+        image_crops: Any = None,
+        max_new_tokens: int | None = None,
+        lora_slot: int = 0,
+        image_hash: bytes | None = None,
+        adapter_id: str | None = None,
+    ) -> PreparedSequence:
+        self.prepare_calls.append(
+            {
+                "prompt_tokens": prompt_tokens,
+                "image": image,
+                "image_crops": image_crops,
+                "max_new_tokens": max_new_tokens,
+                "lora_slot": lora_slot,
+                "image_hash": image_hash,
+                "adapter_id": adapter_id,
+            }
+        )
+        if self._prepare_exc is not None:
+            raise self._prepare_exc
+        if self._prepare_result is not None:
+            return self._prepare_result
+        raise AssertionError(
+            "prepare_sequence called but FakeRuntime has no prepare_result configured"
+        )
+
+    def launch_prepared_batch(
+        self,
+        prepared_sequences: Sequence[PreparedSequence],
+        prefill_slot: Any,
+        *,
+        images: Sequence[Any] | None = None,
+        image_crops_list: Sequence[Any] | None = None,
+    ) -> torch.Tensor:
+        self.launch_calls.append(prepared_sequences)
+        if self._launch_logits is not None:
+            return self._launch_logits
+        return torch.zeros(len(prepared_sequences), 1)
+
+    def finalize_prepared_sequence_after_prefill(
+        self, prepared: PreparedSequence
+    ) -> None:
+        self.finalized_prepared.append(prepared)
+
+    def abort_prepared_sequence(self, prepared: PreparedSequence) -> None:
+        self.aborted_prepared.append(prepared)
+
+    def release_sequence(self, state: SequenceState) -> None:
+        self.released_sequences.append(state)
+        self.active_sequences.pop(state.batch_idx, None)
+
+    def decode_with_slot(self, slot: Any, batch_size: int) -> None:
+        self.decode_calls.append((slot, batch_size))
+
+
+# Module-level type-check: FakeRuntime structurally satisfies Runtime.
+# (Performed as an import-time assignment so a missing/renamed Protocol
+# member surfaces as a TypeError before any test runs.)
+def _assert_conforms() -> None:
+    from kestrel.runtime import Runtime
+
+    fake: Runtime = FakeRuntime()
+    del fake
+
+
+_assert_conforms()

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -208,16 +208,3 @@ class FakeRuntime:
 
     def decode_with_slot(self, slot: Any, batch_size: int) -> None:
         self.decode_calls.append((slot, batch_size))
-
-
-# Module-level type-check: FakeRuntime structurally satisfies Runtime.
-# (Performed as an import-time assignment so a missing/renamed Protocol
-# member surfaces as a TypeError before any test runs.)
-def _assert_conforms() -> None:
-    from kestrel.runtime import Runtime
-
-    fake: Runtime = FakeRuntime()
-    del fake
-
-
-_assert_conforms()

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -25,6 +25,7 @@ from typing import Any, Mapping, Sequence
 
 import torch
 
+from kestrel.device import NoopEvent
 from kestrel.runtime import (
     PrefillClassification,
     PreparedSequence,
@@ -46,6 +47,38 @@ class _FakePageTable:
 
     def commit_block_table(self, batch_indices: list[int] | None = None) -> None:
         self.commit_block_table_calls.append(batch_indices)
+
+
+class _FakePrefillSlot:
+    """Minimal stand-in for a prefill slot.
+
+    Carries the attributes the scheduler reaches into during the
+    success path (``step_done_event`` / ``commit_done_event`` to
+    record + synchronize, ``batch_idx`` to slice). Moondream-specific
+    state like ``scratch`` is left as ``None``.
+    """
+
+    def __init__(self, *, slot_id: int, max_batch_size: int) -> None:
+        self.slot_id = slot_id
+        self.batch_idx = torch.zeros(max_batch_size, dtype=torch.int32)
+        self.step_done_event = NoopEvent()
+        self.commit_done_event = NoopEvent()
+        self.scratch = None
+
+
+class _FakeDecodeSlot:
+    """Minimal stand-in for a decode slot.
+
+    Carries the attributes the scheduler reaches into on the decode
+    success path (``step_done_event`` / ``commit_done_event``). Tests
+    that drive richer DecodeSlot state (``meta``, ``sampled_ids``,
+    etc.) should extend this stub.
+    """
+
+    def __init__(self, *, slot_id: int) -> None:
+        self.slot_id = slot_id
+        self.step_done_event = NoopEvent()
+        self.commit_done_event = NoopEvent()
 
 
 class FakeRuntime:
@@ -90,8 +123,13 @@ class FakeRuntime:
         decode_capacity = (
             n_decode_slots if n_decode_slots is not None else max_batch_slots
         )
-        self.prefill_slots: list[Any] = [object() for _ in range(prefill_capacity)]
-        self.decode_slots: list[Any] = [object() for _ in range(decode_capacity)]
+        self.prefill_slots: list[Any] = [
+            _FakePrefillSlot(slot_id=i, max_batch_size=max_batch_size)
+            for i in range(prefill_capacity)
+        ]
+        self.decode_slots: list[Any] = [
+            _FakeDecodeSlot(slot_id=i) for i in range(decode_capacity)
+        ]
         self.active_sequences: dict[int, SequenceState] = {}
 
         # Model-specific surfaces — left as ``None``/empty for fake purposes;

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -60,6 +60,8 @@ class FakeRuntime:
         image_prefix_length: int = 0,
         device: torch.device | str = "cpu",
         page_size: int = 1,
+        n_prefill_slots: int | None = None,
+        n_decode_slots: int | None = None,
         prepare_exc: Exception | None = None,
         prepare_result: PreparedSequence | None = None,
         launch_logits: torch.Tensor | None = None,
@@ -77,9 +79,19 @@ class FakeRuntime:
         self.primary_stream: Any = None
         self.copy_stream: Any = None
 
-        # Slot containers + sequence registry
-        self.prefill_slots: list[Any] = []
-        self.decode_slots: list[Any] = []
+        # Slot containers + sequence registry. The scheduler treats these
+        # as fixed-capacity arrays — sizing its staging pool from
+        # ``len(prefill_slots)`` and indexing ``decode_slots[slot_id]`` —
+        # so they must be pre-populated for the scheduler to construct
+        # against this fake at all.
+        prefill_capacity = (
+            n_prefill_slots if n_prefill_slots is not None else max_batch_slots
+        )
+        decode_capacity = (
+            n_decode_slots if n_decode_slots is not None else max_batch_slots
+        )
+        self.prefill_slots: list[Any] = [object() for _ in range(prefill_capacity)]
+        self.decode_slots: list[Any] = [object() for _ in range(decode_capacity)]
         self.active_sequences: dict[int, SequenceState] = {}
 
         # Model-specific surfaces — left as ``None``/empty for fake purposes;
@@ -117,9 +129,8 @@ class FakeRuntime:
     # Slot lifecycle ---------------------------------------------------
     def acquire_prefill_slot(self, slot_id: int | None = None) -> Any:
         self.acquired_prefill_slots.append(slot_id)
-        slot = object()
-        self.prefill_slots.append(slot)
-        return slot
+        index = 0 if slot_id is None else slot_id
+        return self.prefill_slots[index]
 
     def release_prefill_slot(self, slot: Any) -> None:
         self.released_prefill_slots.append(slot)

--- a/tests/scheduler/test_launch_prefill_step.py
+++ b/tests/scheduler/test_launch_prefill_step.py
@@ -11,6 +11,8 @@ from kestrel.scheduler.queues import RequestQueue, RunningQueue
 from kestrel.scheduler.scheduler import GenerationScheduler, _PrefillCandidate
 from kestrel.scheduler.types import GenerationRequest, RequestLifecycle, RequestPhase
 
+from tests.scheduler._fake_runtime import FakeRuntime
+
 
 @dataclass
 class _SkillStateStub:
@@ -20,29 +22,6 @@ class _SkillStateStub:
     def __post_init__(self) -> None:
         if self.tokens is None:
             self.tokens = []
-
-
-class _RuntimeStub:
-    def __init__(self, *, prepare_exc: Exception | None = None) -> None:
-        self.max_batch_slots = 2
-        self.max_batch_size = 1
-        self.prepare_exc = prepare_exc
-        self.released_prefill_slots: list[object] = []
-        self.released_adapter_slots: list[int] = []
-
-    def acquire_prefill_slot(self, slot_id: int) -> object:
-        return object()
-
-    def release_prefill_slot(self, slot: object) -> None:
-        self.released_prefill_slots.append(slot)
-
-    def prepare_sequence(self, **_: object) -> object:
-        if self.prepare_exc is not None:
-            raise self.prepare_exc
-        raise AssertionError("prepare_sequence should not succeed in this test")
-
-    def release_adapter_slot(self, slot: int) -> None:
-        self.released_adapter_slots.append(slot)
 
 
 def _make_request(*, request_id: int = 1, max_new_tokens: int = 8) -> GenerationRequest:
@@ -84,7 +63,7 @@ def _make_candidate(request: GenerationRequest) -> _PrefillCandidate:
 
 def _make_scheduler(
     request: GenerationRequest,
-    runtime: _RuntimeStub,
+    runtime: FakeRuntime,
 ) -> GenerationScheduler:
     scheduler = object.__new__(GenerationScheduler)
     scheduler.runtime = runtime
@@ -101,7 +80,7 @@ def test_launch_prefill_step_dequeues_requests_that_fail_to_bind(
     failure_stage: str,
 ) -> None:
     request = _make_request()
-    runtime = _RuntimeStub(
+    runtime = FakeRuntime(
         prepare_exc=RuntimeError("prepare failed") if failure_stage == "prepare" else None
     )
     scheduler = _make_scheduler(request, runtime)

--- a/tests/scheduler/test_runtime_conformance.py
+++ b/tests/scheduler/test_runtime_conformance.py
@@ -47,13 +47,27 @@ def test_fake_runtime_implements_every_protocol_member() -> None:
     )
 
 
+def _is_required(param: inspect.Parameter) -> bool:
+    """A param is "required" if it has no default and isn't variadic."""
+
+    if param.default is not inspect.Parameter.empty:
+        return False
+    return param.kind not in (
+        inspect.Parameter.VAR_POSITIONAL,
+        inspect.Parameter.VAR_KEYWORD,
+    )
+
+
 def test_fake_runtime_method_signatures_accept_protocol_calls() -> None:
     """Every Protocol method's parameter list is satisfied by the fake.
 
-    ``FakeRuntime`` may add extra optional parameters (Liskov-allowed),
-    but every parameter ``Runtime`` declares must be present on the fake
-    with the same kind and not be more restrictive (impl can't require
-    a parameter the Protocol marks optional).
+    ``FakeRuntime`` may add extra *optional* parameters
+    (Liskov-allowed), but:
+    - every parameter ``Runtime`` declares must be present on the fake
+      with the same kind, and the fake can't require a parameter the
+      Protocol marks optional;
+    - the fake can't add an extra required parameter the Protocol
+      doesn't declare — Protocol-valid calls would raise ``TypeError``.
     """
 
     mismatches: list[str] = []
@@ -79,12 +93,19 @@ def test_fake_runtime_method_signatures_accept_protocol_calls() -> None:
                     f"{name}: parameter {pname!r} kind mismatch "
                     f"(proto={proto_p.kind.name} fake={fake_p.kind.name})"
                 )
-            proto_required = proto_p.default is inspect.Parameter.empty
-            fake_required = fake_p.default is inspect.Parameter.empty
-            if not proto_required and fake_required:
+            if not _is_required(proto_p) and _is_required(fake_p):
                 mismatches.append(
                     f"{name}: parameter {pname!r} is optional in Runtime but "
                     "required in FakeRuntime"
+                )
+
+        for pname, fake_p in fake_params.items():
+            if pname in proto_params:
+                continue
+            if _is_required(fake_p):
+                mismatches.append(
+                    f"{name}: extra required parameter {pname!r} on "
+                    "FakeRuntime that Runtime doesn't declare"
                 )
 
     assert mismatches == [], (

--- a/tests/scheduler/test_runtime_conformance.py
+++ b/tests/scheduler/test_runtime_conformance.py
@@ -1,18 +1,22 @@
 """Pin the scheduler↔runtime surface against drift.
 
 If anyone adds a member to the ``Runtime`` protocol without updating
-``FakeRuntime``, this test catches it before the next scheduler test
-fails with a confusing ``AttributeError``.
+``FakeRuntime`` — or changes a method signature so the fake no longer
+accepts what the protocol promises — this test catches it before the
+next scheduler test fails with a confusing ``AttributeError`` /
+``TypeError``.
 """
 
 from __future__ import annotations
+
+import inspect
 
 from kestrel.runtime import Runtime
 
 from tests.scheduler._fake_runtime import FakeRuntime
 
 
-def _expected_members(protocol: type) -> set[str]:
+def _protocol_members(protocol: type) -> set[str]:
     """Names declared on ``protocol`` — annotations + non-special methods."""
 
     members = set(getattr(protocol, "__annotations__", {}))
@@ -24,12 +28,66 @@ def _expected_members(protocol: type) -> set[str]:
     return members
 
 
+def _params_excluding_self(func: object) -> list[inspect.Parameter]:
+    sig = inspect.signature(func)  # type: ignore[arg-type]
+    params = list(sig.parameters.values())
+    if params and params[0].name == "self":
+        params = params[1:]
+    return params
+
+
 def test_fake_runtime_implements_every_protocol_member() -> None:
     fake = FakeRuntime()
     missing = sorted(
-        name for name in _expected_members(Runtime) if not hasattr(fake, name)
+        name for name in _protocol_members(Runtime) if not hasattr(fake, name)
     )
     assert missing == [], (
         f"FakeRuntime is missing Runtime members: {missing}. "
         "Add them to tests/scheduler/_fake_runtime.py."
+    )
+
+
+def test_fake_runtime_method_signatures_accept_protocol_calls() -> None:
+    """Every Protocol method's parameter list is satisfied by the fake.
+
+    ``FakeRuntime`` may add extra optional parameters (Liskov-allowed),
+    but every parameter ``Runtime`` declares must be present on the fake
+    with the same kind and not be more restrictive (impl can't require
+    a parameter the Protocol marks optional).
+    """
+
+    mismatches: list[str] = []
+    for name in _protocol_members(Runtime):
+        proto_member = getattr(Runtime, name, None)
+        if not callable(proto_member):
+            continue
+        fake_member = getattr(FakeRuntime, name, None)
+        if not callable(fake_member):
+            mismatches.append(f"{name}: not callable on FakeRuntime")
+            continue
+
+        proto_params = {p.name: p for p in _params_excluding_self(proto_member)}
+        fake_params = {p.name: p for p in _params_excluding_self(fake_member)}
+
+        for pname, proto_p in proto_params.items():
+            fake_p = fake_params.get(pname)
+            if fake_p is None:
+                mismatches.append(f"{name}: missing parameter {pname!r}")
+                continue
+            if proto_p.kind != fake_p.kind:
+                mismatches.append(
+                    f"{name}: parameter {pname!r} kind mismatch "
+                    f"(proto={proto_p.kind.name} fake={fake_p.kind.name})"
+                )
+            proto_required = proto_p.default is inspect.Parameter.empty
+            fake_required = fake_p.default is inspect.Parameter.empty
+            if not proto_required and fake_required:
+                mismatches.append(
+                    f"{name}: parameter {pname!r} is optional in Runtime but "
+                    "required in FakeRuntime"
+                )
+
+    assert mismatches == [], (
+        "FakeRuntime signatures drifted from Runtime:\n  - "
+        + "\n  - ".join(mismatches)
     )

--- a/tests/scheduler/test_runtime_conformance.py
+++ b/tests/scheduler/test_runtime_conformance.py
@@ -1,0 +1,35 @@
+"""Pin the scheduler↔runtime surface against drift.
+
+If anyone adds a member to the ``Runtime`` protocol without updating
+``FakeRuntime``, this test catches it before the next scheduler test
+fails with a confusing ``AttributeError``.
+"""
+
+from __future__ import annotations
+
+from kestrel.runtime import Runtime
+
+from tests.scheduler._fake_runtime import FakeRuntime
+
+
+def _expected_members(protocol: type) -> set[str]:
+    """Names declared on ``protocol`` — annotations + non-special methods."""
+
+    members = set(getattr(protocol, "__annotations__", {}))
+    for name in dir(protocol):
+        if name.startswith("_"):
+            continue
+        if callable(getattr(protocol, name, None)):
+            members.add(name)
+    return members
+
+
+def test_fake_runtime_implements_every_protocol_member() -> None:
+    fake = FakeRuntime()
+    missing = sorted(
+        name for name in _expected_members(Runtime) if not hasattr(fake, name)
+    )
+    assert missing == [], (
+        f"FakeRuntime is missing Runtime members: {missing}. "
+        "Add them to tests/scheduler/_fake_runtime.py."
+    )


### PR DESCRIPTION
## Summary

The \`GenerationScheduler\` is now typed against \`kestrel.runtime.Runtime\` (introduced in #48), but the scheduler test suite only had a partial 4-method ad-hoc \`_RuntimeStub\`. This PR adds a complete \`FakeRuntime\` that satisfies the full protocol surface, plus a structural-conformance test that pins them together.

Running the fake gives the protocol a second consumer, validating that the surface in #48 is actually satisfiable by something other than \`MoondreamRuntime\`.

## What's added

**\`tests/scheduler/_fake_runtime.py\` — \`FakeRuntime\`**:
- attributes default to plausible test-shape values (\`max_batch_size=1\`, \`page_size=1\`, etc.); mutable so individual tests can override
- methods record their arguments into public lists (\`acquired_prefill_slots\`, \`released_sequences\`, \`launch_calls\`, …) so tests can assert ordering and arguments
- \`prepare_sequence\` and \`launch_prepared_batch\` accept a pre-built return value or an exception so failure-path tests can pin behaviour without constructing a real \`PreparedSequence\`
- \`_FakePageTable\` stand-in exposes \`page_size\` + \`commit_block_table\` no-op so decode-step tests can run

**\`tests/scheduler/test_runtime_conformance.py\`**:
- walks \`Runtime\`'s declared annotations + methods and asserts each one is present on \`FakeRuntime\`, so future protocol changes can't silently drift the fake out of sync

## What's migrated

\`tests/scheduler/test_launch_prefill_step.py\` previously defined a 4-method \`_RuntimeStub\` inline. Replaced with \`FakeRuntime\`; the parameterised test still passes.

## Test plan
- [x] \`pytest --ignore=tests/integration\` — 243 passed (was 242), 46 skipped, 0 changed
- [x] Scheduler tests specifically: 67 passed (was 66 — added the conformance test)
- [x] Manually verified conformance test fires on drift (removing an attribute from \`FakeRuntime\` causes the conformance test to fail with the missing name listed)