### PR TITLE
Type the engine against the Runtime protocol

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -55,6 +55,7 @@ import torch
 from kestrel.config import RuntimeConfig
 from kestrel.device import set_device, synchronize
 from kestrel.moondream.runtime import MoondreamRuntime
+from kestrel.runtime import Runtime
 from kestrel.scheduler import (
     GenerationScheduler,
     GenerationRequest,
@@ -210,7 +211,7 @@ class _ReadyAdmission:
 class _AdmissionCoordinator:
     def __init__(
         self,
-        runtime: MoondreamRuntime,
+        runtime: Runtime,
         image_preprocessor: ImagePreprocessor,
         wake_event: threading.Event,
         fail_request: Callable[[_PendingRequest, BaseException], None],
@@ -314,7 +315,7 @@ class InferenceEngine:
         self._api_key = api_key
         self._api_base_url = api_base_url
 
-        self._runtime: Optional[MoondreamRuntime] = None
+        self._runtime: Optional[Runtime] = None
         self._queue: asyncio.Queue[Optional[_PendingRequest]] = asyncio.Queue()
         self._scheduler_queue: queue.Queue[_PendingRequest | None] = queue.Queue()
         self._scheduler_event = threading.Event()
@@ -343,7 +344,7 @@ class InferenceEngine:
         self._default_top_p = 0.9
 
     @property
-    def runtime(self) -> MoondreamRuntime:
+    def runtime(self) -> Runtime:
         if self._runtime is None:
             raise RuntimeError("InferenceEngine has not been started")
         return self._runtime
@@ -1325,7 +1326,7 @@ class InferenceEngine:
 
     def _build_generation_request(
         self,
-        runtime: MoondreamRuntime,
+        runtime: Runtime,
         req: _PendingRequest,
         image_crops: Optional[OverlapCropOutput],
     ) -> tuple[GenerationRequest, SkillState]:

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -1,17 +1,18 @@
-"""Protocol describing the scheduler↔runtime contract.
+"""Protocol describing the runtime contract used by engine + scheduler.
 
-The :class:`~kestrel.scheduler.scheduler.GenerationScheduler` is generic
-over runtime implementations: it manages admission, queues, prefill
+The :class:`~kestrel.engine.InferenceEngine` and
+:class:`~kestrel.scheduler.scheduler.GenerationScheduler` are generic
+over runtime implementations: they manage admission, queues, prefill
 batching, and decode pacing without knowing which model is actually
 running. Concrete runtimes (today: ``MoondreamRuntime``) implement the
 methods declared here.
 
 Some attributes are typed as ``Any`` because they expose model-specific
-state the scheduler currently reaches into directly (config, region,
-spatial decoding tables, prefill / decode slot containers). Tightening
-those — or refactoring the scheduler to stop reaching into them — is a
-follow-up; declaring them here keeps the protocol an honest record of
-the surface a runtime must satisfy today.
+state the engine + scheduler currently reach into directly (config,
+region, spatial decoding tables, prefix cache, slot containers).
+Tightening those — or refactoring callers to stop reaching into them —
+is a follow-up; declaring them here keeps the protocol an honest
+record of the surface a runtime must satisfy today.
 """
 
 from __future__ import annotations
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
 
 
 class Runtime(Protocol):
-    """Surface that :class:`GenerationScheduler` calls on a runtime."""
+    """Surface that the engine and scheduler call on a runtime."""
 
     # Capacity / shape
     max_batch_size: int
@@ -50,7 +51,11 @@ class Runtime(Protocol):
     decode_slots: Sequence[Any]
     active_sequences: Mapping[int, SequenceState]
 
-    # Model-specific state the scheduler reaches into today.
+    # Engine + scheduler infrastructure
+    prefix_cache: Any  # ``RadixPrefixCache | None`` on MoondreamRuntime
+    graph_capture_lock: Any  # context manager serializing CUDA-graph capture
+
+    # Model-specific state callers reach into today.
     # Narrowing these is a follow-up.
     config: Any
     region: Any

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -21,6 +21,7 @@ Behaviour:
 
 from __future__ import annotations
 
+import contextlib
 from typing import Any, Mapping, Sequence
 
 import torch
@@ -138,6 +139,10 @@ class FakeRuntime:
         self.region: Any = None
         self.spatial_tables: Any = None
         self.page_table = _FakePageTable(page_size=page_size)
+
+        # Engine + scheduler infrastructure
+        self.prefix_cache: Any = None
+        self.graph_capture_lock = contextlib.nullcontext()
 
         # Knobs
         self._prepare_exc = prepare_exc


### PR DESCRIPTION
## Summary

\`InferenceEngine\` still constructs \`MoondreamRuntime\` concretely (only the engine knows which runtime to instantiate today), but everywhere it *holds*, *returns*, or *accepts* a runtime reference is now typed against the \`Runtime\` protocol introduced in #48.

This is the engine-side counterpart to #48 (which did the scheduler) and lets us replace the engine's single-runtime hold-site with a multi-runtime registry in a follow-up without rewriting the type story.

## Changes

**\`kestrel/runtime/protocol.py\`** — adds two attributes the engine already reads on \`MoondreamRuntime\`:
- \`prefix_cache: Any\` — \`engine.py:234\` checks \`is not None\`
- \`graph_capture_lock: Any\` — \`engine.py:1274\` uses as a context manager

Both \`Any\` to avoid coupling the protocol to the \`RadixPrefixCache\` / \`threading.Lock\` concrete types — declaring them keeps the protocol an honest record of the surface a runtime must satisfy today.

**\`kestrel/engine.py\`** — annotation flips from \`MoondreamRuntime\` to \`Runtime\`:
- \`_AdmissionCoordinator.__init__\`'s \`runtime\` parameter
- \`InferenceEngine._runtime\` field
- \`InferenceEngine.runtime\` property return type
- \`_build_generation_request\`'s \`runtime\` parameter

The lone remaining \`MoondreamRuntime\` reference is the construction at \`engine.py:427\` — that's correct; the engine has to pick a concrete runtime to instantiate.

**\`tests/scheduler/_fake_runtime.py\`** — \`FakeRuntime\` gains the new attrs (\`prefix_cache=None\`, \`graph_capture_lock=contextlib.nullcontext()\`) so the conformance test in \`test_runtime_conformance.py\` still passes.

## Test plan
- [x] \`pyright -p . kestrel/engine.py kestrel/scheduler kestrel/runtime\` — 0 errors
- [x] \`pytest --ignore=tests/integration\` — 244 passed, 46 skipped, 0 changed
- [x] FakeRuntime conformance test (signature + attribute checks) still passes after adding the two new attrs