### PR TITLE
Let multiple runtimes share a KVMemoryPool with a budget cap

### DIFF
--- a/kestrel/config.py
+++ b/kestrel/config.py
@@ -7,6 +7,8 @@ import re
 
 import torch
 
+from kestrel.device import resolve_device
+
 
 _SMALL_VRAM_THRESHOLD_BYTES = 24 * 1024**3
 _KV_CACHE_PAGES_SMALL_VRAM = 16384
@@ -142,11 +144,7 @@ class RuntimeConfig:
     def resolved_device(self) -> torch.device:
         """Return the torch device requested for inference."""
 
-        device = torch.device(self.device)
-        # Ensure CUDA devices have an explicit index for torch.cuda.set_device()
-        if device.type == "cuda" and device.index is None:
-            device = torch.device("cuda", torch.cuda.current_device())
-        return device
+        return resolve_device(self.device)
 
     def _validate_device_available(self) -> None:
         """Raise a clear error if the requested device isn't usable.

--- a/kestrel/device.py
+++ b/kestrel/device.py
@@ -18,6 +18,22 @@ from typing import Optional
 import torch
 
 
+def resolve_device(device: torch.device | str) -> torch.device:
+    """Canonicalize a device spec to a fully-qualified ``torch.device``.
+
+    Strings are parsed via ``torch.device(...)``. CUDA devices without an
+    explicit index resolve to the current CUDA device, so a value
+    constructed as ``"cuda"`` compares equal to one built as ``"cuda:N"``
+    against ``torch.cuda.current_device()``. Other device types
+    (CPU, MPS, …) are returned untouched.
+    """
+
+    out = torch.device(device) if isinstance(device, str) else device
+    if out.type == "cuda" and out.index is None:
+        out = torch.device("cuda", torch.cuda.current_device())
+    return out
+
+
 def set_device(device: torch.device) -> None:
     """``torch.cuda.set_device`` on CUDA; no-op on MPS/CPU."""
     if device.type == "cuda":

--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -14,6 +14,7 @@ except ImportError:  # pragma: no cover - optional on aarch64/Jetson
 
 from kestrel_kernels import get_runtime
 
+from kestrel.device import resolve_device
 from kestrel.utils import CpuGpuBuffer
 
 try:
@@ -87,7 +88,7 @@ class KVMemoryPool:
             raise ValueError(
                 f"budget_bytes must be non-negative, got {budget_bytes}"
             )
-        self.device = torch.device(device) if isinstance(device, str) else device
+        self.device = resolve_device(device)
         self.budget_bytes = budget_bytes
         self.allocated_bytes = 0
 

--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -1,4 +1,6 @@
 
+import threading
+import weakref
 from contextlib import nullcontext
 from typing import Optional
 
@@ -91,6 +93,11 @@ class KVMemoryPool:
         self.device = resolve_device(device)
         self.budget_bytes = budget_bytes
         self.allocated_bytes = 0
+        # Serializes the budget check + reservation + counter update so two
+        # threads sharing one pool can't both pass the precheck and bust
+        # the cap. Also guards the rollback path (weakref finalizer + the
+        # try/except around torch.zeros).
+        self._lock = threading.Lock()
 
     def allocate_layer_kv(
         self,
@@ -103,21 +110,44 @@ class KVMemoryPool:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         cache_shape = (n_pages, n_heads, page_size, head_dim)
         element_size = torch.empty((), dtype=dtype).element_size()
-        layer_bytes = (
-            2 * n_pages * n_heads * page_size * head_dim * element_size
-        )
-        if (
-            self.budget_bytes is not None
-            and self.allocated_bytes + layer_bytes > self.budget_bytes
-        ):
-            raise MemoryError(
-                f"KVMemoryPool budget exceeded: requested {layer_bytes} bytes, "
-                f"already used {self.allocated_bytes} of {self.budget_bytes}"
-            )
-        k = torch.zeros(cache_shape, dtype=dtype, device=self.device)
-        v = torch.zeros(cache_shape, dtype=dtype, device=self.device)
-        self.allocated_bytes += layer_bytes
+        per_tensor_bytes = n_pages * n_heads * page_size * head_dim * element_size
+        layer_bytes = 2 * per_tensor_bytes
+
+        # Reserve the bytes atomically so concurrent callers can't both
+        # pass the precheck against the same counter value.
+        with self._lock:
+            if (
+                self.budget_bytes is not None
+                and self.allocated_bytes + layer_bytes > self.budget_bytes
+            ):
+                raise MemoryError(
+                    f"KVMemoryPool budget exceeded: requested {layer_bytes} "
+                    f"bytes, already used {self.allocated_bytes} of "
+                    f"{self.budget_bytes}"
+                )
+            self.allocated_bytes += layer_bytes
+
+        try:
+            k = torch.zeros(cache_shape, dtype=dtype, device=self.device)
+            v = torch.zeros(cache_shape, dtype=dtype, device=self.device)
+        except Exception:
+            # Release the reservation we just took so a failing
+            # ``torch.zeros`` doesn't leave the pool over-counted.
+            self._release_bytes(layer_bytes)
+            raise
+
+        # Auto-rollback when the tensors are garbage-collected. Covers
+        # the partial-init-failure case: if a runtime allocates layers
+        # 0..N successfully then layer N+1 raises and the runtime is
+        # discarded, GC of the prior layer caches releases their bytes
+        # back to the pool.
+        weakref.finalize(k, self._release_bytes, per_tensor_bytes)
+        weakref.finalize(v, self._release_bytes, per_tensor_bytes)
         return k, v
+
+    def _release_bytes(self, n: int) -> None:
+        with self._lock:
+            self.allocated_bytes = max(0, self.allocated_bytes - n)
 
 
 class PagedKVCache(torch.nn.Module):

--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -64,18 +64,31 @@ class KVMemoryPool:
     """Allocator for paged KV cache storage.
 
     Funnels every per-layer K/V buffer allocation through a single
-    accounting layer. Today the pool just allocates each layer's
-    ``(k, v)`` pair on demand via ``torch.zeros``; the abstraction exists
-    so multiple :class:`PagedKVCache` instances — and ultimately multiple
-    runtimes that share the GPU's KV budget — can be backed by one
-    allocation strategy without touching call sites.
+    accounting layer so multiple :class:`PagedKVCache` instances — and
+    multiple runtimes — can share one budget. Today the pool allocates
+    each layer's ``(k, v)`` pair on demand via ``torch.zeros``; the
+    abstraction exists so a future revision can serve allocations from
+    one underlying buffer without touching call sites.
 
-    ``allocated_bytes`` tracks the total K + V bytes handed out for
-    diagnostics and capacity planning.
+    Pass ``budget_bytes`` to cap the total KV memory the pool may hand
+    out across all callers; ``allocate_layer_kv`` raises
+    :class:`MemoryError` when an allocation would exceed it. Without a
+    budget the pool tracks ``allocated_bytes`` for diagnostics only and
+    never refuses an allocation.
     """
 
-    def __init__(self, *, device: torch.device | str):
+    def __init__(
+        self,
+        *,
+        device: torch.device | str,
+        budget_bytes: int | None = None,
+    ):
+        if budget_bytes is not None and budget_bytes < 0:
+            raise ValueError(
+                f"budget_bytes must be non-negative, got {budget_bytes}"
+            )
         self.device = torch.device(device) if isinstance(device, str) else device
+        self.budget_bytes = budget_bytes
         self.allocated_bytes = 0
 
     def allocate_layer_kv(
@@ -88,9 +101,21 @@ class KVMemoryPool:
         dtype: torch.dtype,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         cache_shape = (n_pages, n_heads, page_size, head_dim)
+        element_size = torch.empty((), dtype=dtype).element_size()
+        layer_bytes = (
+            2 * n_pages * n_heads * page_size * head_dim * element_size
+        )
+        if (
+            self.budget_bytes is not None
+            and self.allocated_bytes + layer_bytes > self.budget_bytes
+        ):
+            raise MemoryError(
+                f"KVMemoryPool budget exceeded: requested {layer_bytes} bytes, "
+                f"already used {self.allocated_bytes} of {self.budget_bytes}"
+            )
         k = torch.zeros(cache_shape, dtype=dtype, device=self.device)
         v = torch.zeros(cache_shape, dtype=dtype, device=self.device)
-        self.allocated_bytes += 2 * k.numel() * k.element_size()
+        self.allocated_bytes += layer_bytes
         return k, v
 
 

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -214,6 +214,7 @@ class MoondreamRuntime:
         cfg: RuntimeConfig,
         *,
         max_lora_rank: int | None = None,
+        kv_pool: KVMemoryPool | None = None,
     ) -> None:
         self._cfg = cfg
         self.device = cfg.resolved_device()
@@ -268,7 +269,14 @@ class MoondreamRuntime:
             prefix_cache=self.prefix_cache,
             h2d_stream=self._primary_stream,
         )
-        self._kv_pool = KVMemoryPool(device=self.device)
+        self._kv_pool = kv_pool if kv_pool is not None else KVMemoryPool(
+            device=self.device
+        )
+        if self._kv_pool.device != self.device:
+            raise ValueError(
+                f"kv_pool.device ({self._kv_pool.device}) must match runtime "
+                f"device ({self.device})"
+            )
 
         construction_device = torch.device("meta")
         with _disable_parameter_initialization():

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -72,3 +72,17 @@ def test_pool_rejects_negative_budget() -> None:
 def test_pool_normalizes_string_device() -> None:
     pool = KVMemoryPool(device="cpu")
     assert pool.device == torch.device("cpu")
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+def test_pool_canonicalizes_indexless_cuda_device() -> None:
+    """``KVMemoryPool(device='cuda')`` must compare equal to the same
+    device built from ``RuntimeConfig`` so shared-pool wiring doesn't
+    raise on default single-GPU setups."""
+
+    pool = KVMemoryPool(device="cuda")
+    assert pool.device.type == "cuda"
+    assert pool.device.index == torch.cuda.current_device()
+    assert pool.device == torch.device("cuda", torch.cuda.current_device())

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -1,0 +1,74 @@
+"""Tests for :class:`kestrel.kv_cache.KVMemoryPool`.
+
+Exercises both the diagnostics-only (unbudgeted) path and the
+budget-enforcing path that lets multiple consumers share one pool
+without exceeding a total cap.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from kestrel.kv_cache import KVMemoryPool, PageTable, PagedKVCache
+
+
+def _make_page_table(*, page_size: int = 1, n_pages: int = 4) -> PageTable:
+    return PageTable(
+        n_pages=n_pages,
+        page_size=page_size,
+        max_batch_size=2,
+        device="cpu",
+    )
+
+
+def test_pool_tracks_allocated_bytes_without_budget() -> None:
+    pool = KVMemoryPool(device="cpu")
+    page_table = _make_page_table()
+    cache = PagedKVCache(
+        page_table,
+        n_heads=2,
+        head_dim=8,
+        dtype=torch.float32,
+        pool=pool,
+    )
+    expected = 2 * 4 * 2 * 1 * 8 * 4  # 2x for K+V, fp32 = 4 bytes
+    assert pool.allocated_bytes == expected
+    assert tuple(cache.k_cache.shape) == (4, 2, 1, 8)
+
+
+def test_pool_serves_multiple_caches_against_one_budget() -> None:
+    """Two caches sharing one pool count against the same allocated_bytes."""
+
+    pool = KVMemoryPool(device="cpu", budget_bytes=10_000)
+    page_table = _make_page_table()
+    PagedKVCache(page_table, n_heads=2, head_dim=8, dtype=torch.float32, pool=pool)
+    after_first = pool.allocated_bytes
+    PagedKVCache(page_table, n_heads=2, head_dim=8, dtype=torch.float32, pool=pool)
+    assert pool.allocated_bytes == 2 * after_first
+    assert pool.allocated_bytes <= pool.budget_bytes  # type: ignore[operator]
+
+
+def test_pool_raises_when_budget_exceeded() -> None:
+    pool = KVMemoryPool(device="cpu", budget_bytes=128)
+    page_table = _make_page_table()
+    with pytest.raises(MemoryError, match="budget exceeded"):
+        PagedKVCache(
+            page_table,
+            n_heads=4,
+            head_dim=16,
+            dtype=torch.float32,
+            pool=pool,
+        )
+    # A failed allocation must not advance the counter.
+    assert pool.allocated_bytes == 0
+
+
+def test_pool_rejects_negative_budget() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        KVMemoryPool(device="cpu", budget_bytes=-1)
+
+
+def test_pool_normalizes_string_device() -> None:
+    pool = KVMemoryPool(device="cpu")
+    assert pool.device == torch.device("cpu")

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -86,3 +86,60 @@ def test_pool_canonicalizes_indexless_cuda_device() -> None:
     assert pool.device.type == "cuda"
     assert pool.device.index == torch.cuda.current_device()
     assert pool.device == torch.device("cuda", torch.cuda.current_device())
+
+
+def test_pool_releases_bytes_when_tensors_are_collected() -> None:
+    """Discarding a cache must return its bytes to the pool so a
+    partial-init failure of one runtime doesn't permanently shrink the
+    budget for other runtimes sharing the same pool."""
+
+    import gc
+
+    pool = KVMemoryPool(device="cpu")
+    page_table = _make_page_table()
+    cache = PagedKVCache(
+        page_table, n_heads=2, head_dim=8, dtype=torch.float32, pool=pool
+    )
+    assert pool.allocated_bytes > 0
+
+    del cache
+    gc.collect()
+
+    assert pool.allocated_bytes == 0
+
+
+def test_pool_budget_serializes_concurrent_allocations() -> None:
+    """Two threads sharing one pool must not both pass the precheck and
+    bust the cap. Exactly one allocation may succeed when the budget
+    only fits one."""
+
+    import threading
+
+    layer_bytes = 4 * 2 * 1 * 8 * 4  # n_pages=4 n_heads=2 page=1 head_dim=8 fp32
+    layer_total = 2 * layer_bytes  # K + V
+    pool = KVMemoryPool(device="cpu", budget_bytes=layer_total)
+    page_table = _make_page_table()
+
+    successes: list[PagedKVCache] = []
+    failures: list[Exception] = []
+    barrier = threading.Barrier(2)
+
+    def alloc() -> None:
+        barrier.wait()
+        try:
+            cache = PagedKVCache(
+                page_table, n_heads=2, head_dim=8, dtype=torch.float32, pool=pool
+            )
+            successes.append(cache)
+        except MemoryError as exc:
+            failures.append(exc)
+
+    threads = [threading.Thread(target=alloc) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(successes) == 1
+    assert len(failures) == 1
+    assert pool.allocated_bytes == layer_total


### PR DESCRIPTION
## Summary

Two changes that together let one process host more than one runtime behind a single KV memory budget:

1. **\`KVMemoryPool\` gains an optional \`budget_bytes\` parameter.** \`allocate_layer_kv\` raises \`MemoryError\` when an allocation would push the cumulative \`allocated_bytes\` past the cap. Existing unbudgeted construction stays a pure accounting layer with no enforcement, so current callers don't change behaviour.
2. **\`MoondreamRuntime\` accepts an optional \`kv_pool\` constructor kwarg.** When \`None\` it builds a private pool (current behaviour); otherwise it borrows the caller-supplied pool. A device mismatch raises immediately so wrong-pool wiring fails at construction rather than at first allocation.

Together these let a caller construct one pool with a total budget and pass it to multiple runtime instances. The pool counts every \`(k, v)\` allocation against the same cap, so neither runtime can over-allocate against the other.

## Implementation notes

- The pool now computes layer byte count from \`element_size(dtype)\` directly (no temporary tensor) so the precondition check happens before any allocation.
- A failed budget check leaves \`allocated_bytes\` unchanged so a caller can retry against a different pool / smaller cache without leaking state. New tests pin this.

## Test plan
- [x] \`pytest --ignore=tests/integration\` — 249 passed (was 244, +5 from \`tests/test_kv_pool.py\`), 46 skipped, 0 changed
- [x] New tests cover: unbudgeted accounting, multiple caches sharing one budget, budget exhaustion raises and doesn't advance counter, negative budget rejected, string device normalization
- [x] \`pyright -p . kestrel/kv_cache.py kestrel/moondream/runtime.py\` — 0 errors (2 unrelated pre-existing warnings)