### PR TITLE
Scope prefix cache by runtime_id so multiple runtimes don't collide

### DIFF
--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -786,6 +786,7 @@ class MoondreamRuntime:
         # Build namespace
         image_hash_int = int.from_bytes(image_hash[:16], "big")
         namespace = CacheNamespace(
+            runtime_id=self.model_name,
             lora_id=adapter_id,
             image_hash=image_hash_int,
         )
@@ -819,6 +820,7 @@ class MoondreamRuntime:
                 )
             cache_tokens = self._build_cache_tokens(tokens_list, image_hash, image_kv_length)
             namespace = CacheNamespace(
+                runtime_id=self.model_name,
                 lora_id=adapter_id,
                 image_hash=(
                     int.from_bytes(image_hash[:16], "big") if image_hash is not None else None
@@ -886,6 +888,7 @@ class MoondreamRuntime:
             int.from_bytes(image_hash[:16], "big") if image_hash else None
         )
         namespace = CacheNamespace(
+            runtime_id=self.model_name,
             lora_id=adapter_id,
             image_hash=image_hash_int,
         )
@@ -1032,6 +1035,7 @@ class MoondreamRuntime:
         # Insert prompt into cache
         prompt_pages = self.page_table.get_pages(batch_idx, 0, prompt_len)
         namespace = CacheNamespace(
+            runtime_id=self.model_name,
             lora_id=adapter_id,
             image_hash=(
                 int.from_bytes(image_hash[:16], "big") if image_hash else None

--- a/kestrel/prefix_cache/namespace.py
+++ b/kestrel/prefix_cache/namespace.py
@@ -7,16 +7,22 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True, slots=True)
 class CacheNamespace:
-    """Namespace for cache isolation (LoRA adapters, image hashes).
+    """Namespace for cache isolation (runtime, LoRA adapters, image hashes).
 
     Frozen to be hashable for use as dict keys. Uses slots for memory efficiency.
 
     Attributes:
+        runtime_id: Stable identifier for the runtime that owns this cache
+            entry, or None for runtime-agnostic callers. When two runtimes
+            (e.g., different model variants) share one prefix cache,
+            ``runtime_id`` keeps their trees separate so a token-id sequence
+            valid in one model can't surface as a hit for the other.
         lora_id: LoRA adapter name, or None for base model. Uses the stable
             adapter identity (not slot index) to avoid cross-adapter cache hits
             when slots are reused.
         image_hash: 128-bit hash of image content, or None for text-only.
     """
 
+    runtime_id: str | None = None
     lora_id: str | None = None
     image_hash: int | None = None

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -35,6 +35,11 @@ if TYPE_CHECKING:
 class Runtime(Protocol):
     """Surface that the engine and scheduler call on a runtime."""
 
+    # Identity. Stable across the runtime's lifetime; used to scope
+    # prefix-cache entries and (later) to route requests in a
+    # multi-runtime engine.
+    model_name: str
+
     # Capacity / shape
     max_batch_size: int
     max_batch_slots: int

--- a/tests/prefix_cache/test_radix_cache.py
+++ b/tests/prefix_cache/test_radix_cache.py
@@ -628,6 +628,30 @@ class TestNamespace:
         assert result1.matched_kv_length == 1
         assert result2.matched_kv_length == 0
 
+    def test_runtime_id_namespace(self) -> None:
+        """Two runtimes sharing one prefix cache must not see each
+        other's entries — same token sequence under different
+        runtime_ids resolves to independent trees."""
+
+        cache = RadixPrefixCache()
+        md = CacheNamespace(runtime_id="moondream2")
+        other = CacheNamespace(runtime_id="other-model")
+
+        tokens = [MockToken(0)]
+        cache.insert(tokens, [0], namespace=md)
+        cache.insert(tokens, [1], namespace=other)
+
+        result_md = cache.match_prefix(tokens, namespace=md)
+        result_other = cache.match_prefix(tokens, namespace=other)
+
+        assert result_md.matched_pages == [0]
+        assert result_other.matched_pages == [1]
+
+        # And a runtime-tagged namespace must not collide with the
+        # default (runtime_id=None) namespace.
+        result_default = cache.match_prefix(tokens, namespace=CacheNamespace())
+        assert result_default.matched_kv_length == 0
+
     def test_match_prefix_does_not_create_namespace_root(self) -> None:
         """match_prefix() should not create namespace roots on miss."""
         cache = RadixPrefixCache()

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -88,6 +88,7 @@ class FakeRuntime:
     def __init__(
         self,
         *,
+        model_name: str = "fake",
         max_batch_size: int = 1,
         max_batch_slots: int = 2,
         max_seq_length: int = 1024,
@@ -100,6 +101,9 @@ class FakeRuntime:
         prepare_result: PreparedSequence | None = None,
         launch_logits: torch.Tensor | None = None,
     ) -> None:
+        # Identity
+        self.model_name = model_name
+
         # Capacity / shape
         self.max_batch_size = max_batch_size
         self.max_batch_slots = max_batch_slots

--- a/tests/test_page_table.py
+++ b/tests/test_page_table.py
@@ -24,11 +24,18 @@ class MockToken:
         return self._kv_len
 
 
+class _FakeRuntimeCfg:
+    """Minimal RuntimeConfig stub backing MoondreamRuntime.model_name."""
+
+    model = "test-model"
+
+
 def _make_runtime_for_cache(
     cache: RadixPrefixCache, page_table: PageTable
 ) -> runtime_mod.MoondreamRuntime:
     """Construct a minimal runtime instance for cache helper tests."""
     runtime = runtime_mod.MoondreamRuntime.__new__(runtime_mod.MoondreamRuntime)
+    runtime._cfg = _FakeRuntimeCfg()
     runtime.prefix_cache = cache
     runtime.page_table = page_table
     return runtime
@@ -908,7 +915,11 @@ class TestDuplicatePrefill:
         batch_a = page_table.allocate()
         pages_a = page_table.allocate_pages(prompt_len)
         page_table.map_pages(batch_a, 0, pages_a)
-        insert_a = cache.insert(tokens, pages_a)
+        # Insert A under the same runtime_id-scoped namespace
+        # _finalize_cache_after_prefill will use; otherwise B's finalize
+        # looks in a different tree and tries to insert a duplicate.
+        runtime_namespace = CacheNamespace(runtime_id="test-model")
+        insert_a = cache.insert(tokens, pages_a, namespace=runtime_namespace)
         cache.lock(insert_a.node)
         lock_ref_before = insert_a.node.lock_ref
 
@@ -960,17 +971,24 @@ class TestDuplicatePrefill:
         prefix_len = 3
         prefix_tokens = full_tokens[:prefix_len]
 
+        # All cache traffic in this test must use the same runtime_id-scoped
+        # namespace _finalize_cache_after_prefill will use; otherwise the
+        # finalize step looks at a different tree.
+        runtime_namespace = CacheNamespace(runtime_id="test-model")
+
         # Seed cache with prefix.
         batch_prefix = page_table.allocate()
         prefix_pages = page_table.allocate_pages(prefix_len)
         page_table.map_pages(batch_prefix, 0, prefix_pages)
-        prefix_insert = cache.insert(prefix_tokens, prefix_pages)
+        prefix_insert = cache.insert(
+            prefix_tokens, prefix_pages, namespace=runtime_namespace
+        )
         cache.lock(prefix_insert.node)
         cache.unlock(prefix_insert.node)
         page_table.erase(batch_prefix, cached_page_count=prefix_len)
 
         # Sequence B sees a partial hit and locks prefix.
-        match = cache.match_prefix(full_tokens)
+        match = cache.match_prefix(full_tokens, namespace=runtime_namespace)
         assert match.matched_kv_length == prefix_len
         temp_lock_node = match.last_node
         cache.lock_prefill(temp_lock_node)
@@ -988,6 +1006,7 @@ class TestDuplicatePrefill:
         insert_full = cache.insert(
             full_tokens,
             pages_a,
+            namespace=runtime_namespace,
             from_node=temp_lock_node,
             from_token_idx=prefix_len,
             from_page_idx=prefix_len,


### PR DESCRIPTION
## Summary

When two runtimes share one prefix cache (e.g., a multi-runtime engine hosting different model variants behind a shared cache), entries from different models must not surface as hits for each other — token-id sequences are model-specific, and a cross-model hit would return KV pages with incompatible shape and meaning.

Add a \`runtime_id\` field to \`CacheNamespace\` so the radix cache trees are per-runtime by default for runtime-scoped callers. Default \`None\` keeps every existing caller working unchanged.

## Changes

- **\`CacheNamespace\`** gains a \`runtime_id: str | None = None\` field. Two namespaces with different \`runtime_id\` values resolve to separate trees inside \`RadixPrefixCache\`.
- **\`Runtime\` protocol** gains \`model_name: str\`. Stable identity for the runtime; \`MoondreamRuntime.model_name\` already returns the configured model variant. The multi-runtime engine routing that lands next will read the same field.
- All four \`CacheNamespace(...)\` construction sites in \`MoondreamRuntime\` now pass \`runtime_id=self.model_name\`.
- **\`FakeRuntime\`** exposes \`model_name\` (defaulting to \`"fake"\`) so the conformance test still passes.

## Tests

- New \`test_runtime_id_namespace\` in \`tests/prefix_cache/test_radix_cache.py\` — exercises scope isolation across two runtime ids and against the default \`runtime_id=None\` namespace.
- \`tests/test_page_table.py\` duplicate-prefill tests construct a bare \`MoondreamRuntime\` via \`__new__\` and exercise \`_finalize_cache_after_prefill\`. Updated the helper to seed a \`_cfg\` stub backing \`model_name\`, and migrated the manual \`cache.insert\` / \`match_prefix\` calls to use the same \`runtime_id\`-scoped namespace the finalize path now uses.

## Test plan
- [x] \`pytest --ignore=tests/integration\` — 252 passed (was 249, +3), 47 skipped, 0 changed
- [x] \`pyright -p . kestrel/prefix_cache kestrel/runtime kestrel/moondream/runtime.py\` — 0 errors
- [x] Verified scope isolation: two namespaces with different \`runtime_id\` insert/match independently; same-tokens-different-runtime returns no match