### PR TITLE
Let InferenceEngine host an externally-built runtime

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -418,7 +418,6 @@ class InferenceEngine:
     async def _initialize(self) -> None:
         if self._initialized:
             return
-        self._initialized = True
         loop = asyncio.get_running_loop()
         self._loop = loop
         if self._runtime is None:
@@ -460,6 +459,10 @@ class InferenceEngine:
             )
             await self._photon_reporter.validate_api_key()
             self._photon_reporter.start()
+        # Flip the guard last so a failure partway through (runtime
+        # construction, warmup, photon) leaves the engine retry-able
+        # rather than wedged in a half-initialized state.
+        self._initialized = True
 
     async def _warmup_query_pipeline(self) -> None:
         """Ensure the high-level query path is exercised before serving traffic."""
@@ -986,7 +989,7 @@ class InferenceEngine:
         return future, req_id
 
     async def _ensure_started(self) -> None:
-        if self._runtime is None:
+        if not self._initialized:
             await self._initialize()
 
     async def _worker_loop(self) -> None:

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -326,14 +326,15 @@ class InferenceEngine:
         # An externally-built runtime is held from construction; otherwise
         # ``_initialize`` builds a MoondreamRuntime on first ``create``.
         self._runtime: Optional[Runtime] = runtime
-        # Two-phase init flags. ``_started`` flips once the scheduler
-        # thread + worker task are up so the warmup pipeline (which
-        # re-enters via ``query()`` → ``_ensure_started``) doesn't
-        # recurse back into ``_initialize``. ``_initialized`` flips at
-        # the very end so a partial failure (warmup, photon) can still
-        # be retried by another ``_initialize`` call.
-        self._started = False
+        # ``_initialized`` flips at the very end of ``_initialize`` so
+        # any partial failure (warmup, photon validation) leaves the
+        # engine retry-able. ``_initializing`` is held while
+        # ``_initialize`` runs so the warmup pipeline — which loops back
+        # through ``query()`` → ``_ensure_started`` — doesn't recurse,
+        # and so concurrent first-request callers don't both kick off
+        # the heavy init path.
         self._initialized = False
+        self._initializing = False
         self._queue: asyncio.Queue[Optional[_PendingRequest]] = asyncio.Queue()
         self._scheduler_queue: queue.Queue[_PendingRequest | None] = queue.Queue()
         self._scheduler_event = threading.Event()
@@ -423,58 +424,62 @@ class InferenceEngine:
         return engine
 
     async def _initialize(self) -> None:
-        if self._initialized:
+        if self._initialized or self._initializing:
             return
-        loop = asyncio.get_running_loop()
-        self._loop = loop
-        if self._runtime is None:
-            max_lora_rank = (
-                self._adapter_provider.config()["max_lora_rank"]
-                if self._adapter_provider is not None
-                else None
-            )
-            if max_lora_rank is not None:
-                from kestrel_kernels.moe_lora import TRITON_AVAILABLE
+        self._initializing = True
+        try:
+            loop = asyncio.get_running_loop()
+            self._loop = loop
+            if self._runtime is None:
+                max_lora_rank = (
+                    self._adapter_provider.config()["max_lora_rank"]
+                    if self._adapter_provider is not None
+                    else None
+                )
+                if max_lora_rank is not None:
+                    from kestrel_kernels.moe_lora import TRITON_AVAILABLE
 
-                if not TRITON_AVAILABLE:
-                    _LOGGER.warning(
-                        "MoE LoRA adapters require triton, which is not installed. "
-                        "Disabling LoRA — base model inference will still work, but "
-                        "adapter requests will be rejected. Contact contact@moondream.ai "
-                        "if LoRA support is needed on your platform."
-                    )
-                    max_lora_rank = None
-            self._runtime = await loop.run_in_executor(
-                None, lambda: MoondreamRuntime(self._runtime_cfg, max_lora_rank=max_lora_rank)
-            )
-        if self._scheduler_thread is None or not self._scheduler_thread.is_alive():
-            self._scheduler_thread = threading.Thread(
-                target=self._scheduler_loop,
-                name="kestrel-scheduler",
-                daemon=True,
-            )
-            self._scheduler_thread.start()
-        self._worker_task = asyncio.create_task(self._worker_loop())
-        # Scheduler + worker are now up. Flip ``_started`` so the warmup
-        # pipeline (which calls into ``query()`` and re-enters
-        # ``_ensure_started``) sees a started engine and doesn't recurse
-        # into ``_initialize``.
-        self._started = True
-        await self._warmup_query_pipeline()
-        if self._photon_reporter is None:
-            self._photon_reporter = PhotonReporter(
-                self._runtime_cfg,
-                self.runtime.device,
-                api_key=self._api_key,
-                api_base_url=self._api_base_url,
-                engine=self,
-            )
-            await self._photon_reporter.validate_api_key()
-            self._photon_reporter.start()
-        # Flip the guard last so a failure partway through (runtime
-        # construction, warmup, photon) leaves the engine retry-able
-        # rather than wedged in a half-initialized state.
-        self._initialized = True
+                    if not TRITON_AVAILABLE:
+                        _LOGGER.warning(
+                            "MoE LoRA adapters require triton, which is not installed. "
+                            "Disabling LoRA — base model inference will still work, but "
+                            "adapter requests will be rejected. Contact contact@moondream.ai "
+                            "if LoRA support is needed on your platform."
+                        )
+                        max_lora_rank = None
+                self._runtime = await loop.run_in_executor(
+                    None, lambda: MoondreamRuntime(self._runtime_cfg, max_lora_rank=max_lora_rank)
+                )
+            if self._scheduler_thread is None or not self._scheduler_thread.is_alive():
+                self._scheduler_thread = threading.Thread(
+                    target=self._scheduler_loop,
+                    name="kestrel-scheduler",
+                    daemon=True,
+                )
+                self._scheduler_thread.start()
+            if self._worker_task is None or self._worker_task.done():
+                self._worker_task = asyncio.create_task(self._worker_loop())
+            # Scheduler + worker are now up. The warmup pipeline below
+            # loops back through ``query()`` → ``_ensure_started``;
+            # ``_initializing`` keeps that recursive call from re-entering
+            # this body.
+            await self._warmup_query_pipeline()
+            if self._photon_reporter is None:
+                self._photon_reporter = PhotonReporter(
+                    self._runtime_cfg,
+                    self.runtime.device,
+                    api_key=self._api_key,
+                    api_base_url=self._api_base_url,
+                    engine=self,
+                )
+                await self._photon_reporter.validate_api_key()
+                self._photon_reporter.start()
+            # Flip the guard last so a failure partway through (runtime
+            # construction, warmup, photon) leaves the engine retry-able
+            # rather than wedged in a half-initialized state.
+            self._initialized = True
+        finally:
+            self._initializing = False
 
     async def _warmup_query_pipeline(self) -> None:
         """Ensure the high-level query path is exercised before serving traffic."""
@@ -1001,8 +1006,9 @@ class InferenceEngine:
         return future, req_id
 
     async def _ensure_started(self) -> None:
-        if not self._started:
-            await self._initialize()
+        if self._initialized or self._initializing:
+            return
+        await self._initialize()
 
     async def _worker_loop(self) -> None:
         shutdown_error = RuntimeError("Engine shut down")

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -305,17 +305,28 @@ class InferenceEngine:
         self,
         runtime_cfg: RuntimeConfig,
         *,
+        runtime: Optional[Runtime] = None,
         skills: Optional[SkillRegistry] = None,
         adapter_provider: Optional[AdapterProvider] = None,
         api_key: Optional[str] = None,
         api_base_url: str = _DEFAULT_API_BASE_URL,
     ) -> None:
+        if runtime is not None:
+            cfg_device = runtime_cfg.resolved_device()
+            if runtime.device != cfg_device:
+                raise ValueError(
+                    f"runtime.device ({runtime.device}) does not match "
+                    f"runtime_cfg.resolved_device() ({cfg_device})"
+                )
         self._runtime_cfg = runtime_cfg
         self._adapter_provider = adapter_provider
         self._api_key = api_key
         self._api_base_url = api_base_url
 
-        self._runtime: Optional[Runtime] = None
+        # An externally-built runtime is held from construction; otherwise
+        # ``_initialize`` builds a MoondreamRuntime on first ``create``.
+        self._runtime: Optional[Runtime] = runtime
+        self._initialized = False
         self._queue: asyncio.Queue[Optional[_PendingRequest]] = asyncio.Queue()
         self._scheduler_queue: queue.Queue[_PendingRequest | None] = queue.Queue()
         self._scheduler_event = threading.Event()
@@ -368,6 +379,7 @@ class InferenceEngine:
         cls,
         runtime_cfg: RuntimeConfig,
         *,
+        runtime: Optional[Runtime] = None,
         skills: Optional[SkillRegistry] = None,
         adapter_provider: Optional[AdapterProvider] = None,
         api_key: Optional[str] = None,
@@ -394,6 +406,7 @@ class InferenceEngine:
 
         engine = cls(
             runtime_cfg,
+            runtime=runtime,
             skills=skills,
             adapter_provider=adapter_provider,
             api_key=api_key,
@@ -403,29 +416,31 @@ class InferenceEngine:
         return engine
 
     async def _initialize(self) -> None:
-        if self._runtime is not None:
+        if self._initialized:
             return
+        self._initialized = True
         loop = asyncio.get_running_loop()
         self._loop = loop
-        max_lora_rank = (
-            self._adapter_provider.config()["max_lora_rank"]
-            if self._adapter_provider is not None
-            else None
-        )
-        if max_lora_rank is not None:
-            from kestrel_kernels.moe_lora import TRITON_AVAILABLE
+        if self._runtime is None:
+            max_lora_rank = (
+                self._adapter_provider.config()["max_lora_rank"]
+                if self._adapter_provider is not None
+                else None
+            )
+            if max_lora_rank is not None:
+                from kestrel_kernels.moe_lora import TRITON_AVAILABLE
 
-            if not TRITON_AVAILABLE:
-                _LOGGER.warning(
-                    "MoE LoRA adapters require triton, which is not installed. "
-                    "Disabling LoRA — base model inference will still work, but "
-                    "adapter requests will be rejected. Contact contact@moondream.ai "
-                    "if LoRA support is needed on your platform."
-                )
-                max_lora_rank = None
-        self._runtime = await loop.run_in_executor(
-            None, lambda: MoondreamRuntime(self._runtime_cfg, max_lora_rank=max_lora_rank)
-        )
+                if not TRITON_AVAILABLE:
+                    _LOGGER.warning(
+                        "MoE LoRA adapters require triton, which is not installed. "
+                        "Disabling LoRA — base model inference will still work, but "
+                        "adapter requests will be rejected. Contact contact@moondream.ai "
+                        "if LoRA support is needed on your platform."
+                    )
+                    max_lora_rank = None
+            self._runtime = await loop.run_in_executor(
+                None, lambda: MoondreamRuntime(self._runtime_cfg, max_lora_rank=max_lora_rank)
+            )
         if self._scheduler_thread is None or not self._scheduler_thread.is_alive():
             self._scheduler_thread = threading.Thread(
                 target=self._scheduler_loop,

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -481,6 +481,9 @@ class InferenceEngine:
         # construction, warmup, photon) leaves the engine retry-able
         # rather than wedged in a half-initialized state.
         self._initialized = True
+        # Drop the reference to the completed init task so its
+        # captured locals can be garbage-collected.
+        self._init_task = None
 
     async def _warmup_query_pipeline(self) -> None:
         """Ensure the high-level query path is exercised before serving traffic."""

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -326,6 +326,13 @@ class InferenceEngine:
         # An externally-built runtime is held from construction; otherwise
         # ``_initialize`` builds a MoondreamRuntime on first ``create``.
         self._runtime: Optional[Runtime] = runtime
+        # Two-phase init flags. ``_started`` flips once the scheduler
+        # thread + worker task are up so the warmup pipeline (which
+        # re-enters via ``query()`` → ``_ensure_started``) doesn't
+        # recurse back into ``_initialize``. ``_initialized`` flips at
+        # the very end so a partial failure (warmup, photon) can still
+        # be retried by another ``_initialize`` call.
+        self._started = False
         self._initialized = False
         self._queue: asyncio.Queue[Optional[_PendingRequest]] = asyncio.Queue()
         self._scheduler_queue: queue.Queue[_PendingRequest | None] = queue.Queue()
@@ -448,6 +455,11 @@ class InferenceEngine:
             )
             self._scheduler_thread.start()
         self._worker_task = asyncio.create_task(self._worker_loop())
+        # Scheduler + worker are now up. Flip ``_started`` so the warmup
+        # pipeline (which calls into ``query()`` and re-enters
+        # ``_ensure_started``) sees a started engine and doesn't recurse
+        # into ``_initialize``.
+        self._started = True
         await self._warmup_query_pipeline()
         if self._photon_reporter is None:
             self._photon_reporter = PhotonReporter(
@@ -989,7 +1001,7 @@ class InferenceEngine:
         return future, req_id
 
     async def _ensure_started(self) -> None:
-        if not self._initialized:
+        if not self._started:
             await self._initialize()
 
     async def _worker_loop(self) -> None:

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -328,13 +328,14 @@ class InferenceEngine:
         self._runtime: Optional[Runtime] = runtime
         # ``_initialized`` flips at the very end of ``_initialize`` so
         # any partial failure (warmup, photon validation) leaves the
-        # engine retry-able. ``_initializing`` is held while
-        # ``_initialize`` runs so the warmup pipeline — which loops back
-        # through ``query()`` → ``_ensure_started`` — doesn't recurse,
-        # and so concurrent first-request callers don't both kick off
-        # the heavy init path.
+        # engine retry-able. ``_init_task`` is the asyncio task that's
+        # currently running ``_initialize``; concurrent callers await
+        # it instead of racing each other, and the warmup pipeline
+        # (which loops back through ``query()`` → ``_ensure_started``)
+        # detects via ``asyncio.current_task() is self._init_task``
+        # that it's already inside init and bails without recursing.
         self._initialized = False
-        self._initializing = False
+        self._init_task: Optional[asyncio.Task[None]] = None
         self._queue: asyncio.Queue[Optional[_PendingRequest]] = asyncio.Queue()
         self._scheduler_queue: queue.Queue[_PendingRequest | None] = queue.Queue()
         self._scheduler_event = threading.Event()
@@ -424,62 +425,62 @@ class InferenceEngine:
         return engine
 
     async def _initialize(self) -> None:
-        if self._initialized or self._initializing:
+        if self._initialized:
             return
-        self._initializing = True
-        try:
-            loop = asyncio.get_running_loop()
-            self._loop = loop
-            if self._runtime is None:
-                max_lora_rank = (
-                    self._adapter_provider.config()["max_lora_rank"]
-                    if self._adapter_provider is not None
-                    else None
-                )
-                if max_lora_rank is not None:
-                    from kestrel_kernels.moe_lora import TRITON_AVAILABLE
+        loop = asyncio.get_running_loop()
+        self._loop = loop
+        if self._runtime is None:
+            max_lora_rank = (
+                self._adapter_provider.config()["max_lora_rank"]
+                if self._adapter_provider is not None
+                else None
+            )
+            if max_lora_rank is not None:
+                from kestrel_kernels.moe_lora import TRITON_AVAILABLE
 
-                    if not TRITON_AVAILABLE:
-                        _LOGGER.warning(
-                            "MoE LoRA adapters require triton, which is not installed. "
-                            "Disabling LoRA — base model inference will still work, but "
-                            "adapter requests will be rejected. Contact contact@moondream.ai "
-                            "if LoRA support is needed on your platform."
-                        )
-                        max_lora_rank = None
-                self._runtime = await loop.run_in_executor(
-                    None, lambda: MoondreamRuntime(self._runtime_cfg, max_lora_rank=max_lora_rank)
-                )
-            if self._scheduler_thread is None or not self._scheduler_thread.is_alive():
-                self._scheduler_thread = threading.Thread(
-                    target=self._scheduler_loop,
-                    name="kestrel-scheduler",
-                    daemon=True,
-                )
-                self._scheduler_thread.start()
-            if self._worker_task is None or self._worker_task.done():
-                self._worker_task = asyncio.create_task(self._worker_loop())
-            # Scheduler + worker are now up. The warmup pipeline below
-            # loops back through ``query()`` → ``_ensure_started``;
-            # ``_initializing`` keeps that recursive call from re-entering
-            # this body.
-            await self._warmup_query_pipeline()
-            if self._photon_reporter is None:
-                self._photon_reporter = PhotonReporter(
-                    self._runtime_cfg,
-                    self.runtime.device,
-                    api_key=self._api_key,
-                    api_base_url=self._api_base_url,
-                    engine=self,
-                )
-                await self._photon_reporter.validate_api_key()
-                self._photon_reporter.start()
-            # Flip the guard last so a failure partway through (runtime
-            # construction, warmup, photon) leaves the engine retry-able
-            # rather than wedged in a half-initialized state.
-            self._initialized = True
-        finally:
-            self._initializing = False
+                if not TRITON_AVAILABLE:
+                    _LOGGER.warning(
+                        "MoE LoRA adapters require triton, which is not installed. "
+                        "Disabling LoRA — base model inference will still work, but "
+                        "adapter requests will be rejected. Contact contact@moondream.ai "
+                        "if LoRA support is needed on your platform."
+                    )
+                    max_lora_rank = None
+            self._runtime = await loop.run_in_executor(
+                None, lambda: MoondreamRuntime(self._runtime_cfg, max_lora_rank=max_lora_rank)
+            )
+        if self._scheduler_thread is None or not self._scheduler_thread.is_alive():
+            self._scheduler_thread = threading.Thread(
+                target=self._scheduler_loop,
+                name="kestrel-scheduler",
+                daemon=True,
+            )
+            self._scheduler_thread.start()
+        if self._worker_task is None or self._worker_task.done():
+            self._worker_task = asyncio.create_task(self._worker_loop())
+        # Scheduler + worker are now up. The warmup pipeline below
+        # loops back through ``query()`` → ``_ensure_started``; the
+        # ``_init_task is current_task`` check there keeps that
+        # recursive call from re-entering this body.
+        await self._warmup_query_pipeline()
+        if self._photon_reporter is None:
+            reporter = PhotonReporter(
+                self._runtime_cfg,
+                self.runtime.device,
+                api_key=self._api_key,
+                api_base_url=self._api_base_url,
+                engine=self,
+            )
+            await reporter.validate_api_key()
+            reporter.start()
+            # Only commit a successfully-validated, started reporter.
+            # If ``validate_api_key`` raises, the next ``_initialize``
+            # call will retry the build + validate.
+            self._photon_reporter = reporter
+        # Flip the guard last so a failure partway through (runtime
+        # construction, warmup, photon) leaves the engine retry-able
+        # rather than wedged in a half-initialized state.
+        self._initialized = True
 
     async def _warmup_query_pipeline(self) -> None:
         """Ensure the high-level query path is exercised before serving traffic."""
@@ -1006,9 +1007,29 @@ class InferenceEngine:
         return future, req_id
 
     async def _ensure_started(self) -> None:
-        if self._initialized or self._initializing:
+        if self._initialized:
             return
-        await self._initialize()
+
+        # If init is already in flight on the current task (warmup
+        # pipeline calling back through ``query()``), bail without
+        # awaiting — awaiting our own task deadlocks.
+        current = asyncio.current_task()
+        if self._init_task is not None and self._init_task is current:
+            return
+
+        # If another caller has init in flight, wait for it.
+        if self._init_task is not None and not self._init_task.done():
+            await asyncio.shield(self._init_task)
+            if self._initialized:
+                return
+            # Init failed; fall through to retry below.
+
+        if self._init_task is None or self._init_task.done():
+            # Run ``_initialize`` as a Task so concurrent callers can
+            # wait on the same object (and ``current_task() is
+            # self._init_task`` catches the warmup recursion above).
+            self._init_task = asyncio.create_task(self._initialize())
+        await asyncio.shield(self._init_task)
 
     async def _worker_loop(self) -> None:
         shutdown_error = RuntimeError("Engine shut down")

--- a/tests/test_engine_runtime_injection.py
+++ b/tests/test_engine_runtime_injection.py
@@ -1,0 +1,47 @@
+"""Verify ``InferenceEngine`` accepts an externally-built runtime.
+
+Lets two engines (e.g., different model variants) coexist behind one
+``KVMemoryPool``: the caller builds each runtime with the shared pool,
+then hands the runtime to its engine instead of letting the engine
+construct ``MoondreamRuntime`` internally.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kestrel.config import RuntimeConfig
+from kestrel.engine import InferenceEngine
+
+from tests.scheduler._fake_runtime import FakeRuntime
+
+
+def _cpu_cfg() -> RuntimeConfig:
+    return RuntimeConfig(device="cpu", model="moondream2")
+
+
+def test_engine_holds_injected_runtime() -> None:
+    """An injected runtime is exposed via ``engine.runtime`` immediately,
+    without having to ``await create``."""
+
+    runtime = FakeRuntime(model_name="injected", device="cpu")
+    engine = InferenceEngine(_cpu_cfg(), runtime=runtime)
+    assert engine.runtime is runtime
+
+
+def test_engine_rejects_runtime_with_mismatched_device() -> None:
+    """Catch wrong-pool wiring at construction rather than at the first
+    GPU call."""
+
+    runtime = FakeRuntime(model_name="injected", device="meta")
+    with pytest.raises(ValueError, match="does not match"):
+        InferenceEngine(_cpu_cfg(), runtime=runtime)
+
+
+def test_engine_without_runtime_still_unbuilt_at_construction() -> None:
+    """Without the kwarg the engine still defers MoondreamRuntime
+    construction to ``_initialize`` (current behaviour)."""
+
+    engine = InferenceEngine(_cpu_cfg())
+    with pytest.raises(RuntimeError, match="not been started"):
+        _ = engine.runtime


### PR DESCRIPTION
## Summary

The engine has been the only place that constructs \`MoondreamRuntime\`, which forced a 1:1 binding between engines and a single runtime class. This PR lets the caller build the runtime themselves and hand it to the engine, so **two engines (different model variants) can coexist in one process behind a shared \`KVMemoryPool\`** — each engine still owns its own scheduler thread and request queue, but the GPU's KV budget is common.

The expected wiring:

\`\`\`python
shared_pool = KVMemoryPool(device="cuda", budget_bytes=...)
md_runtime = MoondreamRuntime(md_cfg, kv_pool=shared_pool)
other_runtime = SomeOtherRuntime(other_cfg, kv_pool=shared_pool)

md_engine    = InferenceEngine(md_cfg,    runtime=md_runtime)
other_engine = InferenceEngine(other_cfg, runtime=other_runtime)
\`\`\`

## Changes

- \`InferenceEngine.__init__\` gains \`runtime: Runtime | None = None\`, plumbed through \`create()\`. When provided, \`_initialize\` skips the internal \`MoondreamRuntime\` construction.
- \`RuntimeConfig\` is still required (PhotonReporter telemetry uses it).
- Validates \`runtime.device == runtime_cfg.resolved_device()\` at construction so wrong-pool wiring fails immediately.
- Decouples the "already initialized" guard from the "runtime exists" check by introducing \`self._initialized\`. An injected runtime no longer short-circuits warmup or scheduler-thread setup.

## Test plan
- [x] \`pytest --ignore=tests/integration\` — 255 passed (was 252, +3), 47 skipped, 0 changed
- [x] New tests cover: injected runtime visible immediately on \`engine.runtime\`; device mismatch raises at construction; un-injected engine still raises on \`engine.runtime\` until \`_initialize\` runs
- [x] \`pyright -p . kestrel/engine.py\` — 0 errors