### PR TITLE
Drop the image_regions plumbing left behind in prepare_sequence

### DIFF
--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -1136,19 +1136,6 @@ class MoondreamRuntime:
         image_kv_length = self.image_prefix_length if has_image else 0
         prompt_len = len(tokens_list) + image_kv_length
 
-        # Build image_regions for attention masking. Until multi-image support,
-        # this must be either [] (no image) or [(1, 1+image_kv_length)] (single image).
-        if has_image:
-            image_regions: list[tuple[int, int]] = [(1, 1 + image_kv_length)]
-            # Validate single-image invariant
-            assert len(image_regions) == 1, "Multi-image not yet supported"
-            expected_region = (1, 1 + self.image_prefix_length)
-            assert image_regions[0] == expected_region, (
-                f"Unexpected image region {image_regions[0]}, expected {expected_region}"
-            )
-        else:
-            image_regions = []
-
         max_new = max_new_tokens or DEFAULT_MAX_TOKENS
         target_length = prompt_len + max_new
         if target_length > self.max_seq_length:
@@ -1198,7 +1185,6 @@ class MoondreamRuntime:
             # Treat mapped prefix pages as cache-owned so we never free them by accident.
             cache_owned_page_count=cache_result.skip_positions,
             reused_page_count=cache_result.skip_positions,
-            image_regions=image_regions if image_regions else None,
         )
 
         return PreparedSequence(


### PR DESCRIPTION
## Summary

Follow-up to #52, which dropped the unused \`image_regions\` field from \`SequenceState\` but missed that \`MoondreamRuntime.prepare_sequence\` still computed an \`image_regions\` list and passed it to the \`SequenceState\` constructor.

The unit tests don't construct sequences via \`prepare_sequence\` on a real runtime, so this regression slipped through. Running the ChartQA eval surfaced it on the first request:

\`\`\`
TypeError: SequenceState.__init__() got an unexpected keyword argument 'image_regions'
\`\`\`

## Fix

Delete the now-dead \`image_regions\` computation block in \`prepare_sequence\` and the \`image_regions=\` kwarg on the \`SequenceState\` construction. The block's only purpose was to populate that field, so removing it cleans up the regression and the unused intermediate variable in one go.

## Test plan
- [x] \`pytest --ignore=tests/integration\` — 255 passed, 47 skipped, 0 changed
- [x] \`grep -rn image_regions\` returns no matches anywhere in the repo