### PR TITLE
Add opt-in token logprobs to engine results

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -540,7 +540,7 @@ class InferenceEngine:
         image: Optional[np.ndarray | bytes] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
-        _return_logprobs: Optional[bool] = None,
+        _logprobs: Optional[bool] = None,
     ) -> EngineResult:
         future, _ = await self._submit_request(
             max_new_tokens=max_new_tokens,
@@ -549,7 +549,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
-            return_logprobs=_return_logprobs,
+            return_logprobs=_logprobs,
             stream_queue=None,
             skill=skill,
         )
@@ -609,7 +609,7 @@ class InferenceEngine:
         top_p = self._default_top_p
         max_tokens = self._default_max_new_tokens
         adapter: Optional[str] = None
-        return_logprobs = self._extract_return_logprobs(settings)
+        return_logprobs = self._extract_logprobs(settings)
         if settings is not None:
             if "temperature" in settings:
                 temperature = float(settings["temperature"])
@@ -654,7 +654,7 @@ class InferenceEngine:
                 image=image,
                 temperature=temperature,
                 top_p=top_p,
-                _return_logprobs=return_logprobs,
+                _logprobs=return_logprobs,
                 skill="query",
             )
         return await self.submit(
@@ -664,7 +664,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
-            _return_logprobs=return_logprobs,
+            _logprobs=return_logprobs,
             skill="query",
         )
 
@@ -679,7 +679,7 @@ class InferenceEngine:
             raise ValueError("object must be a non-empty string")
 
         adapter = self._extract_adapter_id(settings)
-        return_logprobs = self._extract_return_logprobs(settings)
+        return_logprobs = self._extract_logprobs(settings)
         max_tokens = self._default_max_new_tokens
         max_objects = None
         temperature = 0.0
@@ -713,7 +713,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
-            _return_logprobs=return_logprobs,
+            _logprobs=return_logprobs,
             skill="point",
         )
 
@@ -763,7 +763,7 @@ class InferenceEngine:
             raise ValueError(f"length must be one of: {valid}")
 
         adapter = self._extract_adapter_id(settings)
-        return_logprobs = self._extract_return_logprobs(settings)
+        return_logprobs = self._extract_logprobs(settings)
         temperature = self._default_temperature
         top_p = self._default_top_p
         max_tokens = self._default_max_new_tokens
@@ -796,7 +796,7 @@ class InferenceEngine:
                 image=image,
                 temperature=temperature,
                 top_p=top_p,
-                _return_logprobs=return_logprobs,
+                _logprobs=return_logprobs,
                 skill="caption",
             )
         return await self.submit(
@@ -806,7 +806,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
-            _return_logprobs=return_logprobs,
+            _logprobs=return_logprobs,
             skill="caption",
         )
 
@@ -821,7 +821,7 @@ class InferenceEngine:
             raise ValueError("object must be a non-empty string")
 
         adapter = self._extract_adapter_id(settings)
-        return_logprobs = self._extract_return_logprobs(settings)
+        return_logprobs = self._extract_logprobs(settings)
         max_objects = 50
         temperature = 0.0
         top_p = 1.0
@@ -850,7 +850,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
-            _return_logprobs=return_logprobs,
+            _logprobs=return_logprobs,
             skill="detect",
         )
 
@@ -867,7 +867,7 @@ class InferenceEngine:
             raise ValueError("object must be a non-empty string")
 
         adapter = self._extract_adapter_id(settings)
-        return_logprobs = self._extract_return_logprobs(settings)
+        return_logprobs = self._extract_logprobs(settings)
         temperature = 0.0
         top_p = 1.0
         max_tokens = self._default_max_new_tokens
@@ -907,7 +907,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
-            _return_logprobs=return_logprobs,
+            _logprobs=return_logprobs,
             skill="segment",
         )
 
@@ -921,7 +921,7 @@ class InferenceEngine:
         image: Optional[np.ndarray | bytes] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
-        _return_logprobs: Optional[bool] = None,
+        _logprobs: Optional[bool] = None,
     ) -> EngineStream:
         queue: _StreamQueue = asyncio.Queue()
         future, request_id = await self._submit_request(
@@ -931,7 +931,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
-            return_logprobs=_return_logprobs,
+            return_logprobs=_logprobs,
             stream_queue=queue,
             skill=skill,
         )
@@ -1149,16 +1149,16 @@ class InferenceEngine:
             raise TypeError("settings.adapter must be a string or None")
         return self._normalize_adapter_id(raw)
 
-    def _extract_return_logprobs(
+    def _extract_logprobs(
         self, settings: Optional[Mapping[str, object]]
     ) -> Optional[bool]:
-        if settings is None or "_return_logprobs" not in settings:
+        if settings is None or "_logprobs" not in settings:
             return None
-        raw = settings["_return_logprobs"]
+        raw = settings["_logprobs"]
         if raw is None:
             return None
         if not isinstance(raw, bool):
-            raise TypeError("settings._return_logprobs must be a bool or None")
+            raise TypeError("settings._logprobs must be a bool or None")
         return raw
 
     def _build_stream_callback(

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -122,6 +122,7 @@ class EngineResult:
     finish_reason: str
     metrics: EngineMetrics
     output: Dict[str, object]
+    logprobs: Optional[List[float]] = None
 
 
 @dataclass(slots=True)
@@ -199,6 +200,7 @@ class _PendingRequest:
     request_context: object
     adapter: Optional[str] = None
     lora_slot: int = 0  # Always 0 here; scheduler assigns actual slot at admission
+    return_logprobs: Optional[bool] = None
 
 
 @dataclass(slots=True)
@@ -538,6 +540,7 @@ class InferenceEngine:
         image: Optional[np.ndarray | bytes] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
+        _return_logprobs: Optional[bool] = None,
     ) -> EngineResult:
         future, _ = await self._submit_request(
             max_new_tokens=max_new_tokens,
@@ -546,6 +549,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
+            return_logprobs=_return_logprobs,
             stream_queue=None,
             skill=skill,
         )
@@ -605,6 +609,7 @@ class InferenceEngine:
         top_p = self._default_top_p
         max_tokens = self._default_max_new_tokens
         adapter: Optional[str] = None
+        return_logprobs = self._extract_return_logprobs(settings)
         if settings is not None:
             if "temperature" in settings:
                 temperature = float(settings["temperature"])
@@ -649,6 +654,7 @@ class InferenceEngine:
                 image=image,
                 temperature=temperature,
                 top_p=top_p,
+                _return_logprobs=return_logprobs,
                 skill="query",
             )
         return await self.submit(
@@ -658,6 +664,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
+            _return_logprobs=return_logprobs,
             skill="query",
         )
 
@@ -672,6 +679,7 @@ class InferenceEngine:
             raise ValueError("object must be a non-empty string")
 
         adapter = self._extract_adapter_id(settings)
+        return_logprobs = self._extract_return_logprobs(settings)
         max_tokens = self._default_max_new_tokens
         max_objects = None
         temperature = 0.0
@@ -705,6 +713,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
+            _return_logprobs=return_logprobs,
             skill="point",
         )
 
@@ -754,6 +763,7 @@ class InferenceEngine:
             raise ValueError(f"length must be one of: {valid}")
 
         adapter = self._extract_adapter_id(settings)
+        return_logprobs = self._extract_return_logprobs(settings)
         temperature = self._default_temperature
         top_p = self._default_top_p
         max_tokens = self._default_max_new_tokens
@@ -786,6 +796,7 @@ class InferenceEngine:
                 image=image,
                 temperature=temperature,
                 top_p=top_p,
+                _return_logprobs=return_logprobs,
                 skill="caption",
             )
         return await self.submit(
@@ -795,6 +806,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
+            _return_logprobs=return_logprobs,
             skill="caption",
         )
 
@@ -809,6 +821,7 @@ class InferenceEngine:
             raise ValueError("object must be a non-empty string")
 
         adapter = self._extract_adapter_id(settings)
+        return_logprobs = self._extract_return_logprobs(settings)
         max_objects = 50
         temperature = 0.0
         top_p = 1.0
@@ -837,6 +850,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
+            _return_logprobs=return_logprobs,
             skill="detect",
         )
 
@@ -853,6 +867,7 @@ class InferenceEngine:
             raise ValueError("object must be a non-empty string")
 
         adapter = self._extract_adapter_id(settings)
+        return_logprobs = self._extract_return_logprobs(settings)
         temperature = 0.0
         top_p = 1.0
         max_tokens = self._default_max_new_tokens
@@ -892,6 +907,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
+            _return_logprobs=return_logprobs,
             skill="segment",
         )
 
@@ -905,6 +921,7 @@ class InferenceEngine:
         image: Optional[np.ndarray | bytes] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
+        _return_logprobs: Optional[bool] = None,
     ) -> EngineStream:
         queue: _StreamQueue = asyncio.Queue()
         future, request_id = await self._submit_request(
@@ -914,6 +931,7 @@ class InferenceEngine:
             image=image,
             temperature=temperature,
             top_p=top_p,
+            return_logprobs=_return_logprobs,
             stream_queue=queue,
             skill=skill,
         )
@@ -959,6 +977,7 @@ class InferenceEngine:
         image: Optional[np.ndarray | bytes],
         temperature: Optional[float],
         top_p: Optional[float],
+        return_logprobs: Optional[bool],
         stream_queue: Optional[_StreamQueue],
         skill: str,
     ) -> Tuple[asyncio.Future[EngineResult], int]:
@@ -1005,6 +1024,7 @@ class InferenceEngine:
             skill=skill_spec,
             request_context=request_context,
             adapter=adapter_id,
+            return_logprobs=return_logprobs,
         )
         await self._queue.put(payload)
         return future, req_id
@@ -1128,6 +1148,18 @@ class InferenceEngine:
         if not isinstance(raw, str):
             raise TypeError("settings.adapter must be a string or None")
         return self._normalize_adapter_id(raw)
+
+    def _extract_return_logprobs(
+        self, settings: Optional[Mapping[str, object]]
+    ) -> Optional[bool]:
+        if settings is None or "_return_logprobs" not in settings:
+            return None
+        raw = settings["_return_logprobs"]
+        if raw is None:
+            return None
+        if not isinstance(raw, bool):
+            raise TypeError("settings._return_logprobs must be a bool or None")
+        return raw
 
     def _build_stream_callback(
         self, req: _PendingRequest
@@ -1415,6 +1447,7 @@ class InferenceEngine:
             request_context=req.request_context,
             adapter=adapter,
             lora_slot=req.lora_slot,
+            return_logprobs=req.return_logprobs,
         )
         limit = runtime.max_seq_length
         target_total = request_obj.target_length
@@ -1449,6 +1482,7 @@ class InferenceEngine:
             finish_reason=result.finish_reason,
             metrics=metrics,
             output=result.output,
+            logprobs=result.logprobs,
         )
 
     def _fail_all_pending(

--- a/kestrel/moondream/decode_slot.py
+++ b/kestrel/moondream/decode_slot.py
@@ -73,6 +73,7 @@ class DecodeSlot:
 
         # GPU staging buffers for sampled outputs (per-slot to avoid clobbering)
         sampled_ids: GPU buffer for sampled token IDs.
+        sampled_logprobs: GPU buffer for sampled token logprobs.
         coord_staging: GPU buffer for decoded coord values.
         size_staging: GPU buffer for decoded size values.
 
@@ -101,6 +102,7 @@ class DecodeSlot:
 
     # GPU staging for sampled outputs
     sampled_ids: Tensor
+    sampled_logprobs: Tensor
     coord_staging: Tensor
     size_staging: Tensor
 
@@ -210,6 +212,11 @@ def create_decode_slot(
         dtype=torch.long,
         device=device,
     )
+    sampled_logprobs = torch.empty(
+        (max_batch_slots,),
+        dtype=torch.float32,
+        device=device,
+    )
     coord_staging = torch.empty(
         (max_batch_slots, 1),
         dtype=coord_dtype,
@@ -264,6 +271,7 @@ def create_decode_slot(
         fa3_page_table=fa3_page_table,
         fa3_seqused_k=fa3_seqused_k,
         sampled_ids=sampled_ids,
+        sampled_logprobs=sampled_logprobs,
         coord_staging=coord_staging,
         size_staging=size_staging,
         logits=logits,

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1259,8 +1259,7 @@ class GenerationScheduler:
         """
         batch = len(sequences)
         if batch == 0:
-            empty_logprobs = None if logprobs_out is None else logprobs_out[:0]
-            return out[:0], None, None, empty_logprobs
+            return out[:0], None, None, None
 
         allowed_tokens: list[Optional[Sequence[int]]] = []
         restrict = False
@@ -1300,21 +1299,26 @@ class GenerationScheduler:
             and any(seq.request.return_logprobs is True for seq in sequences)
         )
         logprobs = logprobs_out[:batch] if want_logprobs else None
-
-        if all(seq.request.temperature <= 0.0 for seq in sequences):
-            torch.argmax(logits, dim=-1, out=out[:batch])
-            if logprobs is not None:
-                logprobs.zero_()
-            return out[:batch], None, None, logprobs
-
-        if batch_idx is None:
-            raise AssertionError("batch_idx is required for non-greedy sampling")
-        batch_idx = batch_idx.view(-1)[:batch]
-        temps = self._sampling_temps[:batch]
-        top_ps = self._sampling_top_ps[:batch]
-        torch.index_select(self._sampling_temps_by_batch, 0, batch_idx, out=temps)
-        torch.index_select(self._sampling_top_ps_by_batch, 0, batch_idx, out=top_ps)
         out_view = out[:batch]
+
+        all_greedy = all(seq.request.temperature <= 0.0 for seq in sequences)
+        if all_greedy:
+            if logprobs is None:
+                torch.argmax(logits, dim=-1, out=out_view)
+                return out_view, None, None, None
+            temps = self._sampling_temps[:batch]
+            top_ps = self._sampling_top_ps[:batch]
+            temps.zero_()
+            top_ps.fill_(1.0)
+        else:
+            if batch_idx is None:
+                raise AssertionError("batch_idx is required for non-greedy sampling")
+            batch_idx = batch_idx.view(-1)[:batch]
+            temps = self._sampling_temps[:batch]
+            top_ps = self._sampling_top_ps[:batch]
+            torch.index_select(self._sampling_temps_by_batch, 0, batch_idx, out=temps)
+            torch.index_select(self._sampling_top_ps_by_batch, 0, batch_idx, out=top_ps)
+
         sample_kwargs = {
             "out": out_view,
             "generator": self._sampling_rng,
@@ -1412,14 +1416,16 @@ class GenerationScheduler:
             )
             tokens = finalize.tokens
             output = finalize.output
+            finalization_failed = False
         except Exception as exc:  # pragma: no cover - defensive
             _LOGGER.exception("Failed to finalize sequence %s", seq.request.request_id)
             finish_reason = "error"
             tokens = []
             output = {"error": str(exc)}
+            finalization_failed = True
 
         logprobs = None
-        if seq.request.return_logprobs is True:
+        if seq.request.return_logprobs is True and not finalization_failed:
             logprobs = list(seq.logprobs)
             if len(logprobs) != len(tokens):
                 _LOGGER.error(

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -62,6 +62,7 @@ class PrefillStaging:
     """Per-prefill staging buffers and RenderBuffer for D2H."""
 
     sampled_ids: Tensor
+    sampled_logprobs: Tensor
     coord_staging: Tensor
     size_staging: Tensor
     render: RenderBuffer
@@ -262,6 +263,11 @@ class GenerationScheduler:
                     sampled_ids=torch.empty(
                         (runtime.max_batch_size,),
                         dtype=torch.long,
+                        device=runtime.device,
+                    ),
+                    sampled_logprobs=torch.empty(
+                        (runtime.max_batch_size,),
+                        dtype=torch.float32,
                         device=runtime.device,
                     ),
                     coord_staging=torch.empty(
@@ -557,11 +563,12 @@ class GenerationScheduler:
         if batch_size == 0:
             raise AssertionError("Prefill finalize requires at least one sequence")
 
-        sampled_ids, temps, top_ps = self._sample_batch(
+        sampled_ids, temps, top_ps, sampled_logprobs = self._sample_batch(
             logits,
             sequences,
             staging.sampled_ids,
             batch_idx=prefill_slot.batch_idx[:batch_size],
+            logprobs_out=staging.sampled_logprobs[:batch_size],
         )
         hidden_rows: list[Tensor] = []
         for seq in sequences:
@@ -579,6 +586,9 @@ class GenerationScheduler:
             self.runtime.spatial_tables,
             temperatures=temps,
             top_ps=top_ps,
+            token_logprobs=sampled_logprobs,
+            coord_id=self._coord_id,
+            size_id=self._size_id,
             out_coord=coord_out,
             out_size=size_out,
             rng=self._sampling_rng,
@@ -596,7 +606,11 @@ class GenerationScheduler:
             self.running.push(seq)
 
         transfer = staging.render.transfer(
-            sampled_ids, coord_decode, size_decode, ready_event=prefill_slot.step_done_event
+            sampled_ids,
+            coord_decode,
+            size_decode,
+            ready_event=prefill_slot.step_done_event,
+            logprobs=sampled_logprobs,
         )
         return PendingCommit(
             kind="prefill",
@@ -610,8 +624,10 @@ class GenerationScheduler:
             ),
         )
 
-    def _commit_prefill(self, step: PendingCommit) -> list[Token]:
-        """Commit a prefill PendingCommit and return the first tokens."""
+    def _commit_prefill(
+        self, step: PendingCommit
+    ) -> tuple[list[Token], Tensor | None]:
+        """Commit a prefill PendingCommit and return first tokens/logprobs."""
         if step.kind != "prefill":
             raise AssertionError("prefill commit requires a prefill pending commit")
         payload = step.payload
@@ -621,7 +637,7 @@ class GenerationScheduler:
         prepared_sequences = payload.prepared_sequences
         prefill_slot = payload.prefill_slot
         try:
-            token_ids_cpu, coord_cpu, size_cpu = step.transfer.wait()
+            token_ids_cpu, coord_cpu, size_cpu, logprobs_cpu = step.transfer.wait()
             prefill_slot.commit_done_event.synchronize()
             for prepared in prepared_sequences:
                 self.runtime.finalize_prepared_sequence_after_prefill(prepared)
@@ -635,7 +651,7 @@ class GenerationScheduler:
         finally:
             self._release_prefill_staging(staging)
             self.runtime.release_prefill_slot(prefill_slot)
-        return tokens
+        return tokens, logprobs_cpu
 
     def _launch_prefill_step(self, pipeline: PipelineState) -> bool:
         """Launch a prefill forward and enqueue it into the shared pipeline.
@@ -1073,8 +1089,12 @@ class GenerationScheduler:
 
         # Sample tokens directly into per-slot staging buffer for D2H.
         # This prevents race with next step's sampling writing to shared buffer.
-        sampled_ids, temps, top_ps = self._sample_batch(
-            logits, sequences, slot.sampled_ids, batch_idx=batch_idx
+        sampled_ids, temps, top_ps, sampled_logprobs = self._sample_batch(
+            logits,
+            sequences,
+            slot.sampled_ids,
+            batch_idx=batch_idx,
+            logprobs_out=slot.sampled_logprobs[:batch_size],
         )
 
         # Compute spatial values into slot's staging buffers
@@ -1087,6 +1107,9 @@ class GenerationScheduler:
             self.runtime.spatial_tables,
             temperatures=temps,
             top_ps=top_ps,
+            token_logprobs=sampled_logprobs,
+            coord_id=self._coord_id,
+            size_id=self._size_id,
             out_coord=coord_staging,
             out_size=size_staging,
             rng=self._sampling_rng,
@@ -1117,6 +1140,7 @@ class GenerationScheduler:
             coord_staging,
             size_staging,
             ready_event=slot.step_done_event,
+            logprobs=sampled_logprobs,
         )
 
         return PendingCommit(
@@ -1138,14 +1162,15 @@ class GenerationScheduler:
         at commit time and released when their last step completes.
         """
         if step.kind == "prefill":
-            tokens = self._commit_prefill(step)
+            tokens, logprobs_cpu = self._commit_prefill(step)
             if len(tokens) != len(step.sequences):
                 raise RuntimeError(
                     "Prefill token count mismatch: "
                     f"{len(tokens)} token(s) for {len(step.sequences)} sequence(s)"
                 )
-            for seq, token in zip(step.sequences, tokens):
-                seq.stage_token(self.runtime, token)
+            logprobs = self._logprobs_for_sequences(step.sequences, logprobs_cpu)
+            for seq, token, logprob in zip(step.sequences, tokens, logprobs):
+                seq.stage_token(self.runtime, token, logprob=logprob)
                 seq.uncommitted_prefill_token = False
                 if self._mark_finished_if_needed(seq):
                     seq.finalized = True
@@ -1161,7 +1186,7 @@ class GenerationScheduler:
             raise AssertionError(f"Unsupported commit kind {step.kind!r}")
 
         # Wait for D2H transfer
-        token_ids_cpu, coord_cpu, size_cpu = step.transfer.wait()
+        token_ids_cpu, coord_cpu, size_cpu, logprobs_cpu = step.transfer.wait()
 
         # Ensure `_pending_*` writes for this step have completed before we release
         # or reuse any batch indices (these writes intentionally do not gate D2H).
@@ -1173,9 +1198,10 @@ class GenerationScheduler:
             token_ids_cpu, coord_cpu, size_cpu,
             coord_id=self._coord_id, size_id=self._size_id,
         )
+        logprobs = self._logprobs_for_sequences(step.sequences, logprobs_cpu)
 
         # Commit each sequence
-        for seq, token in zip(step.sequences, tokens):
+        for seq, token, logprob in zip(step.sequences, tokens, logprobs):
             seq.inflight_refs -= 1
 
             # Skip zombies (already finalized in a previous step)
@@ -1186,7 +1212,7 @@ class GenerationScheduler:
                 continue
 
             # Stage token (calls consume_step, emits streaming)
-            seq.stage_token(self.runtime, token)
+            seq.stage_token(self.runtime, token, logprob=logprob)
 
             # Check for termination
             if self._mark_finished_if_needed(seq):
@@ -1214,7 +1240,8 @@ class GenerationScheduler:
         out: Tensor,
         *,
         batch_idx: Tensor | None = None,
-    ) -> tuple[Tensor, Tensor | None, Tensor | None]:
+        logprobs_out: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor | None, Tensor | None, Tensor | None]:
         """Sample tokens from logits into the provided output buffer.
 
         Args:
@@ -1226,12 +1253,14 @@ class GenerationScheduler:
                 shape [batch] or larger, dtype long.
 
         Returns:
-            Tuple of (sampled_ids, temps, top_ps). sampled_ids is a view of
-            out[:batch].
+            Tuple of (sampled_ids, temps, top_ps, logprobs). sampled_ids is a
+            view of out[:batch]. logprobs is a view of logprobs_out[:batch]
+            when at least one sequence requested logprobs, otherwise None.
         """
         batch = len(sequences)
         if batch == 0:
-            return out[:0], None, None
+            empty_logprobs = None if logprobs_out is None else logprobs_out[:0]
+            return out[:0], None, None, empty_logprobs
 
         allowed_tokens: list[Optional[Sequence[int]]] = []
         restrict = False
@@ -1266,9 +1295,17 @@ class GenerationScheduler:
                 idx = torch.tensor(suppressed, device=logits.device, dtype=torch.long)
                 logits[i, idx] = float("-inf")
 
+        want_logprobs = (
+            logprobs_out is not None
+            and any(seq.request.return_logprobs is True for seq in sequences)
+        )
+        logprobs = logprobs_out[:batch] if want_logprobs else None
+
         if all(seq.request.temperature <= 0.0 for seq in sequences):
             torch.argmax(logits, dim=-1, out=out[:batch])
-            return out[:batch], None, None
+            if logprobs is not None:
+                logprobs.zero_()
+            return out[:batch], None, None, logprobs
 
         if batch_idx is None:
             raise AssertionError("batch_idx is required for non-greedy sampling")
@@ -1277,9 +1314,34 @@ class GenerationScheduler:
         top_ps = self._sampling_top_ps[:batch]
         torch.index_select(self._sampling_temps_by_batch, 0, batch_idx, out=temps)
         torch.index_select(self._sampling_top_ps_by_batch, 0, batch_idx, out=top_ps)
-        sampled_raw = sample_step_from_logits(logits, temps, top_ps, generator=self._sampling_rng)
-        out[:batch].copy_(sampled_raw)
-        return out[:batch], temps, top_ps
+        out_view = out[:batch]
+        sample_kwargs = {
+            "out": out_view,
+            "generator": self._sampling_rng,
+        }
+        if logprobs is not None:
+            sample_kwargs["logprobs_out"] = logprobs
+        sampled_raw = sample_step_from_logits(
+            logits,
+            temps,
+            top_ps,
+            **sample_kwargs,
+        )
+        if sampled_raw is not out_view:
+            out_view.copy_(sampled_raw)
+        return out_view, temps, top_ps, logprobs
+
+    def _logprobs_for_sequences(
+        self,
+        sequences: Sequence[RequestLifecycle],
+        logprobs_cpu: Tensor | None,
+    ) -> list[float | None]:
+        if logprobs_cpu is None:
+            return [None] * len(sequences)
+        return [
+            float(logprobs_cpu[i].item()) if seq.request.return_logprobs is True else None
+            for i, seq in enumerate(sequences)
+        ]
 
     def _mark_finished_if_needed(self, seq: RequestLifecycle) -> bool:
         last_token = seq.last_token
@@ -1364,4 +1426,5 @@ class GenerationScheduler:
             finish_reason=finish_reason,
             metrics=metrics,
             output=output,
+            logprobs=list(seq.logprobs) if seq.request.return_logprobs is True else None,
         )

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1418,6 +1418,24 @@ class GenerationScheduler:
             tokens = []
             output = {"error": str(exc)}
 
+        logprobs = None
+        if seq.request.return_logprobs is True:
+            logprobs = list(seq.logprobs)
+            if len(logprobs) != len(tokens):
+                _LOGGER.error(
+                    "Logprob/token count mismatch for request %s: "
+                    "%s logprob(s) for %s token(s)",
+                    seq.request.request_id,
+                    len(logprobs),
+                    len(tokens),
+                )
+                finish_reason = "error"
+                tokens = []
+                output = {
+                    "error": "Internal logprobs/token alignment mismatch"
+                }
+                logprobs = None
+
         decode_tokens = len(tokens) if tokens else len(seq.skill_state.tokens)
         metrics = seq.build_metrics(decode_tokens=decode_tokens)
         return SchedulerResult(
@@ -1426,5 +1444,5 @@ class GenerationScheduler:
             finish_reason=finish_reason,
             metrics=metrics,
             output=output,
-            logprobs=list(seq.logprobs) if seq.request.return_logprobs is True else None,
+            logprobs=logprobs,
         )

--- a/kestrel/scheduler/spatial.py
+++ b/kestrel/scheduler/spatial.py
@@ -22,6 +22,9 @@ def compute_spatial_values(
     *,
     temperatures: Tensor | None = None,
     top_ps: Tensor | None = None,
+    token_logprobs: Tensor | None = None,
+    coord_id: int | None = None,
+    size_id: int | None = None,
     out_coord: Tensor,
     out_size: Tensor,
     rng: Optional[torch.Generator] = None,
@@ -35,6 +38,9 @@ def compute_spatial_values(
         spatial_tables: Precomputed spatial decode tables.
         temperatures: Per-request temperatures [batch] (optional).
         top_ps: Per-request top_p values [batch] (optional).
+        token_logprobs: Optional per-token logprob buffer to update in-place.
+        coord_id: Vocabulary id for coord tokens when token_logprobs is provided.
+        size_id: Vocabulary id for size tokens when token_logprobs is provided.
         out_coord: Output buffer for coord values [batch, 1].
         out_size: Output buffer for size values [batch, 2].
         rng: Random generator for sampling (if None, uses greedy decoding).
@@ -50,6 +56,10 @@ def compute_spatial_values(
         coord_decode = torch.empty((0, 1), device=device, dtype=out_coord.dtype)
         size_decode = torch.empty((0, 2), device=device, dtype=out_size.dtype)
         return coord_decode, size_decode
+    if token_logprobs is not None and (coord_id is None or size_id is None):
+        raise AssertionError(
+            "coord_id and size_id are required when token_logprobs is provided"
+        )
 
     hidden = hidden_last.unsqueeze(0) if hidden_last.ndim == 1 else hidden_last
 
@@ -67,8 +77,19 @@ def compute_spatial_values(
         height_bins = torch.argmax(height_logits, dim=-1)
     else:
         assert temperatures is not None and top_ps is not None
+        coord_logprobs = (
+            torch.empty((batch,), dtype=torch.float32, device=hidden.device)
+            if token_logprobs is not None
+            else None
+        )
+        coord_kwargs = {"generator": rng}
+        if coord_logprobs is not None:
+            coord_kwargs["logprobs_out"] = coord_logprobs
         coord_bins_raw = sample_step_from_logits(
-            coord_logits, temperatures, top_ps, generator=rng
+            coord_logits,
+            temperatures,
+            top_ps,
+            **coord_kwargs,
         )
         # Ensure long dtype for indexing
         if coord_bins_raw.dtype == torch.long:
@@ -77,11 +98,19 @@ def compute_spatial_values(
             coord_bins = coord_bins_raw.to(torch.long)
 
         logits_2 = torch.cat((width_logits, height_logits), dim=0)
+        size_logprobs = (
+            torch.empty((batch * 2,), dtype=torch.float32, device=hidden.device)
+            if token_logprobs is not None
+            else None
+        )
+        size_kwargs = {"generator": rng}
+        if size_logprobs is not None:
+            size_kwargs["logprobs_out"] = size_logprobs
         bins_2_raw = sample_step_from_logits(
             logits_2,
             temperatures.repeat(2),
             top_ps.repeat(2),
-            generator=rng,
+            **size_kwargs,
         )
         if bins_2_raw.dtype == torch.long:
             bins_2 = bins_2_raw
@@ -89,6 +118,29 @@ def compute_spatial_values(
             bins_2 = bins_2_raw.to(torch.long)
         width_bins = bins_2[:batch]
         height_bins = bins_2[batch:]
+        if token_logprobs is not None:
+            assert coord_id is not None and size_id is not None
+            assert coord_logprobs is not None and size_logprobs is not None
+            row_token_ids = token_ids.view(-1)[:batch]
+            coord_mask = row_token_ids == int(coord_id)
+            size_mask = row_token_ids == int(size_id)
+            token_logprobs[:batch].add_(
+                torch.where(
+                    coord_mask,
+                    coord_logprobs,
+                    torch.zeros_like(coord_logprobs),
+                )
+            )
+            width_logprobs = size_logprobs[:batch]
+            height_logprobs = size_logprobs[batch:]
+            size_token_logprobs = width_logprobs + height_logprobs
+            token_logprobs[:batch].add_(
+                torch.where(
+                    size_mask,
+                    size_token_logprobs,
+                    torch.zeros_like(size_token_logprobs),
+                )
+            )
 
     coord_out = out_coord[:batch]
     size_out = out_size[:batch]

--- a/kestrel/scheduler/spatial.py
+++ b/kestrel/scheduler/spatial.py
@@ -14,6 +14,10 @@ from kestrel.scheduler.types import GenerationRequest
 from kestrel_kernels.sampling import sample_step_from_logits
 
 
+def _as_long_bins(raw: Tensor) -> Tensor:
+    return raw if raw.dtype == torch.long else raw.to(torch.long)
+
+
 def compute_spatial_values(
     token_ids: Tensor,
     hidden_last: Tensor,
@@ -71,17 +75,30 @@ def compute_spatial_values(
         hidden, spatial_tables
     )
 
-    if not do_sample:
+    if not do_sample and token_logprobs is None:
         coord_bins = torch.argmax(coord_logits, dim=-1)
         width_bins = torch.argmax(width_logits, dim=-1)
         height_bins = torch.argmax(height_logits, dim=-1)
+        coord_logprobs = size_logprobs = None
     else:
-        assert temperatures is not None and top_ps is not None
         coord_logprobs = (
             torch.empty((batch,), dtype=torch.float32, device=hidden.device)
             if token_logprobs is not None
             else None
         )
+        size_logprobs = (
+            torch.empty((batch * 2,), dtype=torch.float32, device=hidden.device)
+            if token_logprobs is not None
+            else None
+        )
+        if do_sample:
+            assert temperatures is not None and top_ps is not None
+        elif temperatures is None or top_ps is None:
+            temperatures = torch.zeros(
+                (batch,), dtype=torch.float32, device=hidden.device
+            )
+            top_ps = torch.ones((batch,), dtype=torch.float32, device=hidden.device)
+
         coord_kwargs = {"generator": rng}
         if coord_logprobs is not None:
             coord_kwargs["logprobs_out"] = coord_logprobs
@@ -91,18 +108,9 @@ def compute_spatial_values(
             top_ps,
             **coord_kwargs,
         )
-        # Ensure long dtype for indexing
-        if coord_bins_raw.dtype == torch.long:
-            coord_bins = coord_bins_raw
-        else:
-            coord_bins = coord_bins_raw.to(torch.long)
+        coord_bins = _as_long_bins(coord_bins_raw)
 
         logits_2 = torch.cat((width_logits, height_logits), dim=0)
-        size_logprobs = (
-            torch.empty((batch * 2,), dtype=torch.float32, device=hidden.device)
-            if token_logprobs is not None
-            else None
-        )
         size_kwargs = {"generator": rng}
         if size_logprobs is not None:
             size_kwargs["logprobs_out"] = size_logprobs
@@ -112,35 +120,20 @@ def compute_spatial_values(
             top_ps.repeat(2),
             **size_kwargs,
         )
-        if bins_2_raw.dtype == torch.long:
-            bins_2 = bins_2_raw
-        else:
-            bins_2 = bins_2_raw.to(torch.long)
+        bins_2 = _as_long_bins(bins_2_raw)
         width_bins = bins_2[:batch]
         height_bins = bins_2[batch:]
-        if token_logprobs is not None:
-            assert coord_id is not None and size_id is not None
-            assert coord_logprobs is not None and size_logprobs is not None
-            row_token_ids = token_ids.view(-1)[:batch]
-            coord_mask = row_token_ids == int(coord_id)
-            size_mask = row_token_ids == int(size_id)
-            token_logprobs[:batch].add_(
-                torch.where(
-                    coord_mask,
-                    coord_logprobs,
-                    torch.zeros_like(coord_logprobs),
-                )
-            )
-            width_logprobs = size_logprobs[:batch]
-            height_logprobs = size_logprobs[batch:]
-            size_token_logprobs = width_logprobs + height_logprobs
-            token_logprobs[:batch].add_(
-                torch.where(
-                    size_mask,
-                    size_token_logprobs,
-                    torch.zeros_like(size_token_logprobs),
-                )
-            )
+
+    if token_logprobs is not None:
+        assert coord_id is not None and size_id is not None
+        assert coord_logprobs is not None and size_logprobs is not None
+        row_token_ids = token_ids.view(-1)[:batch]
+        coord_mask = row_token_ids == int(coord_id)
+        size_mask = row_token_ids == int(size_id)
+        token_logprobs[:batch].add_(coord_logprobs * coord_mask)
+        width_logprobs = size_logprobs[:batch]
+        height_logprobs = size_logprobs[batch:]
+        token_logprobs[:batch].add_((width_logprobs + height_logprobs) * size_mask)
 
     coord_out = out_coord[:batch]
     size_out = out_size[:batch]

--- a/kestrel/scheduler/transfer.py
+++ b/kestrel/scheduler/transfer.py
@@ -15,24 +15,31 @@ class TransferHandle:
         token_ids: Tensor,
         coord_values: Tensor,
         size_values: Tensor,
+        logprobs: Tensor | None,
         count: int,
     ) -> None:
         self._event = event
         self._token_ids = token_ids
         self._coord_values = coord_values
         self._size_values = size_values
+        self._logprobs = logprobs
         self._count = count
 
-    def wait(self) -> tuple[Tensor, Tensor, Tensor]:
+    def wait(self) -> tuple[Tensor, Tensor, Tensor, Tensor | None]:
         """Block until D2H transfer completes and return the CPU tensors."""
         if self._count == 0:
             empty = self._token_ids[:0]
-            return empty, self._coord_values[:0], self._size_values[:0]
+            logprobs = None if self._logprobs is None else self._logprobs[:0]
+            return empty, self._coord_values[:0], self._size_values[:0], logprobs
         self._event.synchronize()
+        logprobs = None
+        if self._logprobs is not None:
+            logprobs = self._logprobs[: self._count]
         return (
             self._token_ids[: self._count],
             self._coord_values[: self._count],
             self._size_values[: self._count],
+            logprobs,
         )
 
 
@@ -62,6 +69,9 @@ class RenderBuffer:
         self._size_values = torch.empty(
             (max_batch, 2), dtype=size_dtype, device="cpu", pin_memory=pin,
         )
+        self._logprobs = torch.empty(
+            (max_batch,), dtype=torch.float32, device="cpu", pin_memory=pin,
+        )
         self._device = device
         self._stream = copy_stream
         self._event = make_event(device, enable_timing=False, blocking=False)
@@ -73,6 +83,7 @@ class RenderBuffer:
         size_values: Tensor,
         *,
         ready_event: torch.cuda.Event,
+        logprobs: Tensor | None = None,
     ) -> TransferHandle:
         """Start a D2H transfer and return a handle to wait on completion.
 
@@ -80,6 +91,7 @@ class RenderBuffer:
             token_ids: GPU tensor of sampled token IDs (from per-slot staging buffer).
             coord_values: GPU tensor of coord values (from per-slot staging buffer).
             size_values: GPU tensor of size values (from per-slot staging buffer).
+            logprobs: Optional GPU tensor of sampled token logprobs.
             ready_event: Event recorded on compute stream after all GPU writes complete.
                 The copy stream will wait on this event before starting D2H copies.
                 This ensures correct ordering without capturing dependencies on
@@ -92,6 +104,7 @@ class RenderBuffer:
                 self._token_ids,
                 self._coord_values,
                 self._size_values,
+                self._logprobs if logprobs is not None else None,
                 0,
             )
 
@@ -104,7 +117,14 @@ class RenderBuffer:
             self._token_ids[:count].copy_(token_ids, non_blocking=True)
             self._coord_values[:count].copy_(coord_values, non_blocking=True)
             self._size_values[:count].copy_(size_values, non_blocking=True)
+            if logprobs is not None:
+                self._logprobs[:count].copy_(logprobs, non_blocking=True)
             self._event.record(self._stream)
         return TransferHandle(
-            self._event, self._token_ids, self._coord_values, self._size_values, count
+            self._event,
+            self._token_ids,
+            self._coord_values,
+            self._size_values,
+            self._logprobs if logprobs is not None else None,
+            count,
         )

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -113,17 +113,17 @@ class RequestLifecycle:
             RequestPhase.COMPLETED,
         ):
             self.transition(RequestPhase.RUNNING)
+        step = DecodeStep(
+            token=token,
+            position=self.skill_state.token_count,
+        )
+        self.skill_state.consume_step(runtime, step)
         if self.request.return_logprobs is True:
             if logprob is None:
                 raise RuntimeError(
                     "Missing token logprob for request that asked for logprobs"
                 )
             self.logprobs.append(float(logprob))
-        step = DecodeStep(
-            token=token,
-            position=self.skill_state.token_count,
-        )
-        self.skill_state.consume_step(runtime, step)
         callback = self.request.stream_callback
         if callback is not None:
             delta = self.skill_state.pop_stream_delta(runtime)

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -54,6 +54,7 @@ class RequestLifecycle:
     # Output
     finish_reason: Optional[str] = None
     error: Optional[BaseException] = None
+    logprobs: List[float] = field(default_factory=list)
 
     def transition(self, phase: RequestPhase) -> None:
         """Update phase with minimal bookkeeping."""
@@ -101,6 +102,8 @@ class RequestLifecycle:
         self,
         runtime: Runtime,
         token: Token,
+        *,
+        logprob: float | None = None,
     ) -> None:
         if self.first_token_time is None:
             self.first_token_time = time.perf_counter()
@@ -110,6 +113,12 @@ class RequestLifecycle:
             RequestPhase.COMPLETED,
         ):
             self.transition(RequestPhase.RUNNING)
+        if self.request.return_logprobs is True:
+            if logprob is None:
+                raise RuntimeError(
+                    "Missing token logprob for request that asked for logprobs"
+                )
+            self.logprobs.append(float(logprob))
         step = DecodeStep(
             token=token,
             position=self.skill_state.token_count,
@@ -167,6 +176,7 @@ class GenerationRequest:
     lifecycle: RequestLifecycle = field(init=False, repr=False)
     adapter: Optional[str] = None
     lora_slot: int = 0  # Slot in workspace; 0 = no LoRA
+    return_logprobs: Optional[bool] = None
 
     prompt_length: int = field(init=False)
 
@@ -197,6 +207,7 @@ class SchedulerResult:
     finish_reason: str
     metrics: "RequestMetrics"
     output: Dict[str, object]
+    logprobs: Optional[List[float]] = None
 
 
 @dataclass

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -75,6 +75,21 @@ def test_scheduler_result_returns_requested_token_logprobs() -> None:
     assert result.logprobs == [-1.25, -0.5]
 
 
+def test_scheduler_result_rejects_misaligned_logprobs() -> None:
+    seq = _make_lifecycle(return_logprobs=True)
+    seq.stage_token(SimpleNamespace(), TextToken(10), logprob=-1.25)
+    seq.logprobs.append(-0.5)
+
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = SimpleNamespace()
+    result = GenerationScheduler._build_result(scheduler, seq)
+
+    assert result.tokens == []
+    assert result.logprobs is None
+    assert result.finish_reason == "error"
+    assert result.output == {"error": "Internal logprobs/token alignment mismatch"}
+
+
 def test_requested_logprobs_require_sampling_result() -> None:
     seq = _make_lifecycle(return_logprobs=True)
 

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from kestrel.moondream.region import SpatialDecodeTables
+from kestrel.moondream.runtime import TextToken
+from kestrel.scheduler.scheduler import GenerationScheduler
+from kestrel.scheduler.spatial import compute_spatial_values
+from kestrel.scheduler.types import GenerationRequest, RequestLifecycle
+from kestrel.skills import DecodeStep, SkillFinalizeResult, SkillState
+
+
+@dataclass(frozen=True)
+class _SkillSpecStub:
+    name: str = "stub"
+
+
+class _SkillStateStub(SkillState):
+    def __init__(self, request: GenerationRequest) -> None:
+        super().__init__(_SkillSpecStub(), request)  # type: ignore[arg-type]
+
+    def consume_step(self, runtime: object, step: DecodeStep) -> None:
+        self.append_token(step.token)
+
+    def finalize(self, runtime: object, *, reason: str) -> SkillFinalizeResult:
+        return SkillFinalizeResult(
+            text="",
+            tokens=list(self.tokens),
+            output={},
+        )
+
+
+def _make_lifecycle(*, return_logprobs: bool | None) -> RequestLifecycle:
+    request = GenerationRequest(
+        request_id=7,
+        prompt="prompt",
+        prompt_tokens=[TextToken(1)],
+        max_new_tokens=4,
+        skill=_SkillSpecStub(),  # type: ignore[arg-type]
+        request_context=object(),
+        return_logprobs=return_logprobs,
+    )
+    state = _SkillStateStub(request)
+    lifecycle = RequestLifecycle(request=request, skill_state=state)
+    request.lifecycle = lifecycle
+    return lifecycle
+
+
+def test_scheduler_result_omits_logprobs_by_default() -> None:
+    seq = _make_lifecycle(return_logprobs=None)
+    seq.stage_token(SimpleNamespace(), TextToken(10))
+
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = SimpleNamespace()
+    result = GenerationScheduler._build_result(scheduler, seq)
+
+    assert result.tokens == [TextToken(10)]
+    assert result.logprobs is None
+
+
+def test_scheduler_result_returns_requested_token_logprobs() -> None:
+    seq = _make_lifecycle(return_logprobs=True)
+    seq.stage_token(SimpleNamespace(), TextToken(10), logprob=-1.25)
+    seq.stage_token(SimpleNamespace(), TextToken(11), logprob=-0.5)
+
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = SimpleNamespace()
+    result = GenerationScheduler._build_result(scheduler, seq)
+
+    assert result.tokens == [TextToken(10), TextToken(11)]
+    assert result.logprobs == [-1.25, -0.5]
+
+
+def test_requested_logprobs_require_sampling_result() -> None:
+    seq = _make_lifecycle(return_logprobs=True)
+
+    with pytest.raises(RuntimeError, match="Missing token logprob"):
+        seq.stage_token(SimpleNamespace(), TextToken(10))
+
+
+def test_sample_batch_omits_logprob_keyword_without_opt_in(monkeypatch) -> None:
+    def fake_sample_step_from_logits(
+        logits: torch.Tensor,
+        temperatures: torch.Tensor,
+        top_p: torch.Tensor,
+        *,
+        out: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        sampled = torch.tensor([3], dtype=torch.long)
+        if out is not None:
+            out.copy_(sampled)
+            return out
+        return sampled
+
+    monkeypatch.setattr(
+        "kestrel.scheduler.scheduler.sample_step_from_logits",
+        fake_sample_step_from_logits,
+    )
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = SimpleNamespace()
+    scheduler._sampling_rng = torch.Generator()
+    scheduler._sampling_temps_by_batch = torch.tensor([0.7], dtype=torch.float32)
+    scheduler._sampling_top_ps_by_batch = torch.tensor([1.0], dtype=torch.float32)
+    scheduler._sampling_temps = torch.empty((1,), dtype=torch.float32)
+    scheduler._sampling_top_ps = torch.empty((1,), dtype=torch.float32)
+    seqs = [
+        SimpleNamespace(
+            finalized=False,
+            skill_state=SimpleNamespace(
+                allowed_token_ids=lambda runtime: None,
+                suppressed_token_ids=lambda runtime: None,
+            ),
+            request=SimpleNamespace(temperature=0.7, return_logprobs=None),
+        )
+    ]
+
+    sampled, _, _, logprobs = GenerationScheduler._sample_batch(
+        scheduler,
+        torch.zeros((1, 8), dtype=torch.float32),
+        seqs,  # type: ignore[arg-type]
+        torch.empty((1,), dtype=torch.long),
+        batch_idx=torch.tensor([0], dtype=torch.long),
+        logprobs_out=torch.empty((1,), dtype=torch.float32),
+    )
+
+    assert sampled.tolist() == [3]
+    assert logprobs is None
+
+
+def test_spatial_logprobs_are_added_for_coord_and_size_tokens(monkeypatch) -> None:
+    batch = 3
+    coord_id = 90
+    size_id = 91
+    token_ids = torch.tensor([coord_id, size_id, 123], dtype=torch.long)
+    token_logprobs = torch.tensor([-1.0, -2.0, -3.0], dtype=torch.float32)
+    hidden_last = torch.zeros((batch, 2), dtype=torch.float32)
+    requests = [SimpleNamespace(temperature=0.7) for _ in range(batch)]
+    spatial_tables = SpatialDecodeTables(
+        coord_value_lut=torch.tensor([0.0, 0.5, 1.0], dtype=torch.float32),
+        size_value_lut=torch.tensor([0.25, 0.5, 1.0], dtype=torch.float32),
+        coord_logits_dim=3,
+    )
+
+    def fake_spatial_decode_logits(
+        hidden: torch.Tensor,
+        tables: SpatialDecodeTables,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return (
+            torch.zeros((batch, 3), dtype=torch.float32),
+            torch.zeros((batch, 3), dtype=torch.float32),
+            torch.zeros((batch, 3), dtype=torch.float32),
+        )
+
+    def fake_sample_step_from_logits(
+        logits: torch.Tensor,
+        temperatures: torch.Tensor,
+        top_p: torch.Tensor,
+        *,
+        generator: torch.Generator | None = None,
+        logprobs_out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if logits.shape[0] == batch:
+            if logprobs_out is not None:
+                logprobs_out.copy_(torch.tensor([-0.1, -0.2, -0.3]))
+            return torch.tensor([0, 1, 2], dtype=torch.long)
+        if logprobs_out is not None:
+            logprobs_out.copy_(
+                torch.tensor([-0.4, -0.5, -0.6, -0.7, -0.8, -0.9])
+            )
+        return torch.tensor([0, 1, 2, 1, 2, 0], dtype=torch.long)
+
+    monkeypatch.setattr(
+        "kestrel.scheduler.spatial.spatial_decode_logits",
+        fake_spatial_decode_logits,
+    )
+    monkeypatch.setattr(
+        "kestrel.scheduler.spatial.sample_step_from_logits",
+        fake_sample_step_from_logits,
+    )
+
+    compute_spatial_values(
+        token_ids,
+        hidden_last,
+        requests,  # type: ignore[arg-type]
+        spatial_tables,
+        temperatures=torch.full((batch,), 0.7),
+        top_ps=torch.ones((batch,), dtype=torch.float32),
+        token_logprobs=token_logprobs,
+        coord_id=coord_id,
+        size_id=size_id,
+        out_coord=torch.empty((batch, 1), dtype=torch.float32),
+        out_size=torch.empty((batch, 2), dtype=torch.float32),
+    )
+
+    torch.testing.assert_close(
+        token_logprobs,
+        torch.tensor([-1.1, -3.3, -3.0], dtype=torch.float32),
+    )
+
+
+def test_spatial_decode_omits_logprob_keyword_without_buffer(monkeypatch) -> None:
+    batch = 1
+    spatial_tables = SpatialDecodeTables(
+        coord_value_lut=torch.tensor([0.0, 1.0], dtype=torch.float32),
+        size_value_lut=torch.tensor([0.5, 1.0], dtype=torch.float32),
+        coord_logits_dim=2,
+    )
+
+    def fake_spatial_decode_logits(
+        hidden: torch.Tensor,
+        tables: SpatialDecodeTables,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return (
+            torch.zeros((batch, 2), dtype=torch.float32),
+            torch.zeros((batch, 2), dtype=torch.float32),
+            torch.zeros((batch, 2), dtype=torch.float32),
+        )
+
+    def fake_sample_step_from_logits(
+        logits: torch.Tensor,
+        temperatures: torch.Tensor,
+        top_p: torch.Tensor,
+        *,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        return torch.zeros((logits.shape[0],), dtype=torch.long)
+
+    monkeypatch.setattr(
+        "kestrel.scheduler.spatial.spatial_decode_logits",
+        fake_spatial_decode_logits,
+    )
+    monkeypatch.setattr(
+        "kestrel.scheduler.spatial.sample_step_from_logits",
+        fake_sample_step_from_logits,
+    )
+
+    coord, size = compute_spatial_values(
+        torch.tensor([123], dtype=torch.long),
+        torch.zeros((batch, 2), dtype=torch.float32),
+        [SimpleNamespace(temperature=0.7)],  # type: ignore[list-item]
+        spatial_tables,
+        temperatures=torch.full((batch,), 0.7),
+        top_ps=torch.ones((batch,), dtype=torch.float32),
+        out_coord=torch.empty((batch, 1), dtype=torch.float32),
+        out_size=torch.empty((batch, 2), dtype=torch.float32),
+    )
+
+    assert coord.tolist() == [[0.0]]
+    assert size.tolist() == [[0.5, 0.5]]

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -27,11 +27,17 @@ class _SkillStateStub(SkillState):
         self.append_token(step.token)
 
     def finalize(self, runtime: object, *, reason: str) -> SkillFinalizeResult:
-        return SkillFinalizeResult(
-            text="",
-            tokens=list(self.tokens),
-            output={},
-        )
+        return SkillFinalizeResult(text="", tokens=list(self.tokens), output={})
+
+
+class _FailingConsumeSkillState(_SkillStateStub):
+    def consume_step(self, runtime: object, step: DecodeStep) -> None:
+        raise RuntimeError("consume failed")
+
+
+class _FailingFinalizeSkillState(_SkillStateStub):
+    def finalize(self, runtime: object, *, reason: str) -> SkillFinalizeResult:
+        raise RuntimeError("finalize failed")
 
 
 def _make_lifecycle(*, return_logprobs: bool | None) -> RequestLifecycle:
@@ -50,13 +56,78 @@ def _make_lifecycle(*, return_logprobs: bool | None) -> RequestLifecycle:
     return lifecycle
 
 
+def _make_lifecycle_with_state(
+    state_cls: type[_SkillStateStub],
+    *,
+    return_logprobs: bool | None,
+) -> RequestLifecycle:
+    seq = _make_lifecycle(return_logprobs=return_logprobs)
+    state = state_cls(seq.request)
+    seq.skill_state = state
+    seq.request.skill_state = state
+    return seq
+
+
+def _scheduler(batch: int = 1) -> GenerationScheduler:
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = SimpleNamespace()
+    scheduler._sampling_rng = torch.Generator()
+    scheduler._sampling_temps = torch.empty((batch,), dtype=torch.float32)
+    scheduler._sampling_top_ps = torch.empty((batch,), dtype=torch.float32)
+    scheduler._sampling_temps_by_batch = torch.full(
+        (batch,), 0.7, dtype=torch.float32
+    )
+    scheduler._sampling_top_ps_by_batch = torch.ones((batch,), dtype=torch.float32)
+    return scheduler
+
+
+def _sequence(*, temperature: float, return_logprobs: bool | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        finalized=False,
+        skill_state=SimpleNamespace(
+            allowed_token_ids=lambda runtime: None,
+            suppressed_token_ids=lambda runtime: None,
+        ),
+        request=SimpleNamespace(
+            temperature=temperature,
+            return_logprobs=return_logprobs,
+        ),
+    )
+
+
+def _spatial_tables(dim: int) -> SpatialDecodeTables:
+    values = torch.arange(dim, dtype=torch.float32)
+    return SpatialDecodeTables(
+        coord_value_lut=values,
+        size_value_lut=values,
+        coord_logits_dim=dim,
+    )
+
+
+def _patch_spatial_logits(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    batch: int,
+    dim: int,
+) -> None:
+    def fake_spatial_decode_logits(
+        hidden: torch.Tensor,
+        tables: SpatialDecodeTables,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        shape = (batch, dim)
+        return torch.zeros(shape), torch.zeros(shape), torch.zeros(shape)
+
+    monkeypatch.setattr(
+        "kestrel.scheduler.spatial.spatial_decode_logits",
+        fake_spatial_decode_logits,
+    )
+
+
 def test_scheduler_result_omits_logprobs_by_default() -> None:
     seq = _make_lifecycle(return_logprobs=None)
     seq.stage_token(SimpleNamespace(), TextToken(10))
 
-    scheduler = object.__new__(GenerationScheduler)
-    scheduler.runtime = SimpleNamespace()
-    result = GenerationScheduler._build_result(scheduler, seq)
+    result = GenerationScheduler._build_result(_scheduler(), seq)
 
     assert result.tokens == [TextToken(10)]
     assert result.logprobs is None
@@ -67,9 +138,7 @@ def test_scheduler_result_returns_requested_token_logprobs() -> None:
     seq.stage_token(SimpleNamespace(), TextToken(10), logprob=-1.25)
     seq.stage_token(SimpleNamespace(), TextToken(11), logprob=-0.5)
 
-    scheduler = object.__new__(GenerationScheduler)
-    scheduler.runtime = SimpleNamespace()
-    result = GenerationScheduler._build_result(scheduler, seq)
+    result = GenerationScheduler._build_result(_scheduler(), seq)
 
     assert result.tokens == [TextToken(10), TextToken(11)]
     assert result.logprobs == [-1.25, -0.5]
@@ -80,9 +149,7 @@ def test_scheduler_result_rejects_misaligned_logprobs() -> None:
     seq.stage_token(SimpleNamespace(), TextToken(10), logprob=-1.25)
     seq.logprobs.append(-0.5)
 
-    scheduler = object.__new__(GenerationScheduler)
-    scheduler.runtime = SimpleNamespace()
-    result = GenerationScheduler._build_result(scheduler, seq)
+    result = GenerationScheduler._build_result(_scheduler(), seq)
 
     assert result.tokens == []
     assert result.logprobs is None
@@ -97,7 +164,35 @@ def test_requested_logprobs_require_sampling_result() -> None:
         seq.stage_token(SimpleNamespace(), TextToken(10))
 
 
-def test_sample_batch_omits_logprob_keyword_without_opt_in(monkeypatch) -> None:
+def test_logprob_is_not_appended_when_token_consume_fails() -> None:
+    seq = _make_lifecycle_with_state(
+        _FailingConsumeSkillState,
+        return_logprobs=True,
+    )
+
+    with pytest.raises(RuntimeError, match="consume failed"):
+        seq.stage_token(SimpleNamespace(), TextToken(10), logprob=-1.25)
+
+    assert seq.logprobs == []
+
+
+def test_logprob_alignment_check_preserves_finalize_error() -> None:
+    seq = _make_lifecycle_with_state(
+        _FailingFinalizeSkillState,
+        return_logprobs=True,
+    )
+    seq.stage_token(SimpleNamespace(), TextToken(10), logprob=-1.25)
+
+    result = GenerationScheduler._build_result(_scheduler(), seq)
+
+    assert result.finish_reason == "error"
+    assert result.output == {"error": "finalize failed"}
+    assert result.logprobs is None
+
+
+def test_sample_batch_omits_logprob_keyword_without_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def fake_sample_step_from_logits(
         logits: torch.Tensor,
         temperatures: torch.Tensor,
@@ -116,28 +211,11 @@ def test_sample_batch_omits_logprob_keyword_without_opt_in(monkeypatch) -> None:
         "kestrel.scheduler.scheduler.sample_step_from_logits",
         fake_sample_step_from_logits,
     )
-    scheduler = object.__new__(GenerationScheduler)
-    scheduler.runtime = SimpleNamespace()
-    scheduler._sampling_rng = torch.Generator()
-    scheduler._sampling_temps_by_batch = torch.tensor([0.7], dtype=torch.float32)
-    scheduler._sampling_top_ps_by_batch = torch.tensor([1.0], dtype=torch.float32)
-    scheduler._sampling_temps = torch.empty((1,), dtype=torch.float32)
-    scheduler._sampling_top_ps = torch.empty((1,), dtype=torch.float32)
-    seqs = [
-        SimpleNamespace(
-            finalized=False,
-            skill_state=SimpleNamespace(
-                allowed_token_ids=lambda runtime: None,
-                suppressed_token_ids=lambda runtime: None,
-            ),
-            request=SimpleNamespace(temperature=0.7, return_logprobs=None),
-        )
-    ]
 
     sampled, _, _, logprobs = GenerationScheduler._sample_batch(
-        scheduler,
+        _scheduler(),
         torch.zeros((1, 8), dtype=torch.float32),
-        seqs,  # type: ignore[arg-type]
+        [_sequence(temperature=0.7, return_logprobs=None)],  # type: ignore[list-item]
         torch.empty((1,), dtype=torch.long),
         batch_idx=torch.tensor([0], dtype=torch.long),
         logprobs_out=torch.empty((1,), dtype=torch.float32),
@@ -147,29 +225,65 @@ def test_sample_batch_omits_logprob_keyword_without_opt_in(monkeypatch) -> None:
     assert logprobs is None
 
 
-def test_spatial_logprobs_are_added_for_coord_and_size_tokens(monkeypatch) -> None:
-    batch = 3
-    coord_id = 90
-    size_id = 91
-    token_ids = torch.tensor([coord_id, size_id, 123], dtype=torch.long)
-    token_logprobs = torch.tensor([-1.0, -2.0, -3.0], dtype=torch.float32)
-    hidden_last = torch.zeros((batch, 2), dtype=torch.float32)
-    requests = [SimpleNamespace(temperature=0.7) for _ in range(batch)]
-    spatial_tables = SpatialDecodeTables(
-        coord_value_lut=torch.tensor([0.0, 0.5, 1.0], dtype=torch.float32),
-        size_value_lut=torch.tensor([0.25, 0.5, 1.0], dtype=torch.float32),
-        coord_logits_dim=3,
+def test_sample_batch_uses_sampler_for_greedy_logprobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[torch.Tensor, torch.Tensor, bool]] = []
+
+    def fake_sample_step_from_logits(
+        logits: torch.Tensor,
+        temperatures: torch.Tensor,
+        top_p: torch.Tensor,
+        *,
+        out: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+        logprobs_out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        calls.append((temperatures.clone(), top_p.clone(), logprobs_out is not None))
+        sampled = torch.tensor([4], dtype=torch.long)
+        if logprobs_out is not None:
+            logprobs_out.copy_(torch.tensor([-1.5], dtype=torch.float32))
+        if out is not None:
+            out.copy_(sampled)
+            return out
+        return sampled
+
+    monkeypatch.setattr(
+        "kestrel.scheduler.scheduler.sample_step_from_logits",
+        fake_sample_step_from_logits,
     )
 
-    def fake_spatial_decode_logits(
-        hidden: torch.Tensor,
-        tables: SpatialDecodeTables,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        return (
-            torch.zeros((batch, 3), dtype=torch.float32),
-            torch.zeros((batch, 3), dtype=torch.float32),
-            torch.zeros((batch, 3), dtype=torch.float32),
-        )
+    sampled, temps, top_ps, logprobs = GenerationScheduler._sample_batch(
+        _scheduler(),
+        torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0]], dtype=torch.float32),
+        [_sequence(temperature=0.0, return_logprobs=True)],  # type: ignore[list-item]
+        torch.empty((1,), dtype=torch.long),
+        logprobs_out=torch.empty((1,), dtype=torch.float32),
+    )
+
+    assert sampled.tolist() == [4]
+    assert logprobs is not None
+    torch.testing.assert_close(logprobs, torch.tensor([-1.5], dtype=torch.float32))
+    assert temps is not None and top_ps is not None
+    torch.testing.assert_close(temps, torch.zeros((1,), dtype=torch.float32))
+    torch.testing.assert_close(top_ps, torch.ones((1,), dtype=torch.float32))
+    assert len(calls) == 1
+    call_temps, call_top_ps, call_logprobs = calls[0]
+    torch.testing.assert_close(call_temps, torch.zeros((1,), dtype=torch.float32))
+    torch.testing.assert_close(call_top_ps, torch.ones((1,), dtype=torch.float32))
+    assert call_logprobs is True
+
+
+@pytest.mark.parametrize("temperature", [0.7, 0.0])
+def test_spatial_logprobs_are_added_for_coord_and_size_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+    temperature: float,
+) -> None:
+    batch = 3
+    dim = 3
+    coord_id = 90
+    size_id = 91
+    calls: list[tuple[torch.Tensor, torch.Tensor, bool]] = []
 
     def fake_sample_step_from_logits(
         logits: torch.Tensor,
@@ -179,6 +293,7 @@ def test_spatial_logprobs_are_added_for_coord_and_size_tokens(monkeypatch) -> No
         generator: torch.Generator | None = None,
         logprobs_out: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        calls.append((temperatures.clone(), top_p.clone(), logprobs_out is not None))
         if logits.shape[0] == batch:
             if logprobs_out is not None:
                 logprobs_out.copy_(torch.tensor([-0.1, -0.2, -0.3]))
@@ -189,22 +304,25 @@ def test_spatial_logprobs_are_added_for_coord_and_size_tokens(monkeypatch) -> No
             )
         return torch.tensor([0, 1, 2, 1, 2, 0], dtype=torch.long)
 
-    monkeypatch.setattr(
-        "kestrel.scheduler.spatial.spatial_decode_logits",
-        fake_spatial_decode_logits,
-    )
+    _patch_spatial_logits(monkeypatch, batch=batch, dim=dim)
     monkeypatch.setattr(
         "kestrel.scheduler.spatial.sample_step_from_logits",
         fake_sample_step_from_logits,
     )
 
+    sample_kwargs = {}
+    if temperature > 0.0:
+        sample_kwargs = {
+            "temperatures": torch.full((batch,), temperature),
+            "top_ps": torch.ones((batch,), dtype=torch.float32),
+        }
+    token_logprobs = torch.tensor([-1.0, -2.0, -3.0], dtype=torch.float32)
     compute_spatial_values(
-        token_ids,
-        hidden_last,
-        requests,  # type: ignore[arg-type]
-        spatial_tables,
-        temperatures=torch.full((batch,), 0.7),
-        top_ps=torch.ones((batch,), dtype=torch.float32),
+        torch.tensor([coord_id, size_id, 123], dtype=torch.long),
+        torch.zeros((batch, 2), dtype=torch.float32),
+        [SimpleNamespace(temperature=temperature) for _ in range(batch)],  # type: ignore[list-item]
+        _spatial_tables(dim),
+        **sample_kwargs,
         token_logprobs=token_logprobs,
         coord_id=coord_id,
         size_id=size_id,
@@ -216,25 +334,20 @@ def test_spatial_logprobs_are_added_for_coord_and_size_tokens(monkeypatch) -> No
         token_logprobs,
         torch.tensor([-1.1, -3.3, -3.0], dtype=torch.float32),
     )
+    assert [call[2] for call in calls] == [True, True]
+    expected_temp = torch.full((batch,), temperature, dtype=torch.float32)
+    torch.testing.assert_close(calls[0][0], expected_temp)
+    torch.testing.assert_close(calls[1][0], expected_temp.repeat(2))
+    torch.testing.assert_close(calls[0][1], torch.ones((batch,), dtype=torch.float32))
+    torch.testing.assert_close(calls[1][1], torch.ones((batch * 2,), dtype=torch.float32))
 
 
-def test_spatial_decode_omits_logprob_keyword_without_buffer(monkeypatch) -> None:
+def test_spatial_decode_omits_logprob_keyword_without_buffer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     batch = 1
-    spatial_tables = SpatialDecodeTables(
-        coord_value_lut=torch.tensor([0.0, 1.0], dtype=torch.float32),
-        size_value_lut=torch.tensor([0.5, 1.0], dtype=torch.float32),
-        coord_logits_dim=2,
-    )
-
-    def fake_spatial_decode_logits(
-        hidden: torch.Tensor,
-        tables: SpatialDecodeTables,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        return (
-            torch.zeros((batch, 2), dtype=torch.float32),
-            torch.zeros((batch, 2), dtype=torch.float32),
-            torch.zeros((batch, 2), dtype=torch.float32),
-        )
+    dim = 2
+    _patch_spatial_logits(monkeypatch, batch=batch, dim=dim)
 
     def fake_sample_step_from_logits(
         logits: torch.Tensor,
@@ -242,13 +355,11 @@ def test_spatial_decode_omits_logprob_keyword_without_buffer(monkeypatch) -> Non
         top_p: torch.Tensor,
         *,
         generator: torch.Generator | None = None,
+        **kwargs: object,
     ) -> torch.Tensor:
+        assert "logprobs_out" not in kwargs
         return torch.zeros((logits.shape[0],), dtype=torch.long)
 
-    monkeypatch.setattr(
-        "kestrel.scheduler.spatial.spatial_decode_logits",
-        fake_spatial_decode_logits,
-    )
     monkeypatch.setattr(
         "kestrel.scheduler.spatial.sample_step_from_logits",
         fake_sample_step_from_logits,
@@ -258,7 +369,7 @@ def test_spatial_decode_omits_logprob_keyword_without_buffer(monkeypatch) -> Non
         torch.tensor([123], dtype=torch.long),
         torch.zeros((batch, 2), dtype=torch.float32),
         [SimpleNamespace(temperature=0.7)],  # type: ignore[list-item]
-        spatial_tables,
+        _spatial_tables(dim),
         temperatures=torch.full((batch,), 0.7),
         top_ps=torch.ones((batch,), dtype=torch.float32),
         out_coord=torch.empty((batch, 1), dtype=torch.float32),
@@ -266,4 +377,4 @@ def test_spatial_decode_omits_logprob_keyword_without_buffer(monkeypatch) -> Non
     )
 
     assert coord.tolist() == [[0.0]]
-    assert size.tolist() == [[0.5, 0.5]]
+    assert size.tolist() == [[0.0, 0.0]]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8,7 +8,9 @@ from typing import Callable
 
 import numpy as np
 
-from kestrel.engine import _AdmissionCoordinator, _PendingRequest
+import pytest
+
+from kestrel.engine import InferenceEngine, _AdmissionCoordinator, _PendingRequest
 
 
 def _make_request(
@@ -172,3 +174,15 @@ def test_admission_coordinator_skips_failed_crop_and_keeps_promoting() -> None:
     assert len(failures) == 1
     assert failures[0][0] is failed_req
     assert str(failures[0][1]) == "crop failed"
+
+
+def test_extract_private_return_logprobs_setting() -> None:
+    engine = object.__new__(InferenceEngine)
+
+    assert engine._extract_return_logprobs(None) is None
+    assert engine._extract_return_logprobs({}) is None
+    assert engine._extract_return_logprobs({"_return_logprobs": None}) is None
+    assert engine._extract_return_logprobs({"_return_logprobs": True}) is True
+    assert engine._extract_return_logprobs({"_return_logprobs": False}) is False
+    with pytest.raises(TypeError, match="settings._return_logprobs"):
+        engine._extract_return_logprobs({"_return_logprobs": 1})

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -176,13 +176,13 @@ def test_admission_coordinator_skips_failed_crop_and_keeps_promoting() -> None:
     assert str(failures[0][1]) == "crop failed"
 
 
-def test_extract_private_return_logprobs_setting() -> None:
+def test_extract_private_logprobs_setting() -> None:
     engine = object.__new__(InferenceEngine)
 
-    assert engine._extract_return_logprobs(None) is None
-    assert engine._extract_return_logprobs({}) is None
-    assert engine._extract_return_logprobs({"_return_logprobs": None}) is None
-    assert engine._extract_return_logprobs({"_return_logprobs": True}) is True
-    assert engine._extract_return_logprobs({"_return_logprobs": False}) is False
-    with pytest.raises(TypeError, match="settings._return_logprobs"):
-        engine._extract_return_logprobs({"_return_logprobs": 1})
+    assert engine._extract_logprobs(None) is None
+    assert engine._extract_logprobs({}) is None
+    assert engine._extract_logprobs({"_logprobs": None}) is None
+    assert engine._extract_logprobs({"_logprobs": True}) is True
+    assert engine._extract_logprobs({"_logprobs": False}) is False
+    with pytest.raises(TypeError, match="settings._logprobs"):
+        engine._extract_logprobs({"_logprobs": 1})


### PR DESCRIPTION
## Summary
- Add private opt-in logprob support via `settings={"_logprobs": True}` and matching private submit APIs.
- Return `EngineResult.logprobs` / `SchedulerResult.logprobs` as `None` by default, or a generated-token-aligned `list[float]` when requested.
- Thread sampled-token logprobs through scheduler staging, D2H transfer, prefill/decode commits, and spatial coord/size decoding.
- Route all-greedy requests through the sampler when logprobs are requested, so greedy rows report model logprobs instead of `0.0`.
- Avoid passing `logprobs_out` unless requested so non-logprob traffic keeps the existing fast paths.

## Notes
- `_logprobs=True` requires a `kestrel-kernels` build containing the merged sampler logprob support from m87-labs/kestrel-proprietary#126.
- Coord/size token logprobs include the top-level coord/size token probability plus the selected spatial bin probability.
- Mixed scheduler batches may compute sampled logprobs for every row when any row opts in, but only opted-in requests expose values in results.

## Validation
- Local: `uv run pytest tests -q` -> `267 passed, 47 skipped`
- p2 focused kernel tests from m87-labs/kestrel-proprietary#126: `tests/test_sample_step_cuda.py` -> `20 passed, 1 warning`
- p2 sampler benchmarks showed no measurable regression for non-logprob calls because they continue using the non-logprob sampler entrypoint.