### PR TITLE
Add private generated prefix support

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -34,7 +34,7 @@ import threading
 import time
 from concurrent.futures import Future
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import (
     AsyncIterator,
     Callable,
@@ -57,6 +57,7 @@ from kestrel.device import set_device, synchronize
 from kestrel.moondream.runtime import MoondreamRuntime
 from kestrel.runtime import Runtime
 from kestrel.scheduler import (
+    GeneratedPrefix,
     GenerationScheduler,
     GenerationRequest,
     RequestLifecycle,
@@ -70,6 +71,7 @@ from kestrel.moondream.vision import compute_overlap_crops
 from kestrel.skills import (
     CaptionSkill,
     DetectSkill,
+    DecodeStep,
     PointSkill,
     QuerySkill,
     SegmentSkill,
@@ -77,7 +79,7 @@ from kestrel.skills import (
     SkillSpec,
     SkillState,
 )
-from kestrel.moondream.runtime import Token
+from kestrel.moondream.runtime import CoordToken, SizeToken, TextToken, Token
 from kestrel.skills.caption import CaptionRequest, CaptionSettings
 from kestrel.skills.detect import DetectRequest, DetectSettings
 from kestrel.skills.point import PointRequest, PointSettings
@@ -201,6 +203,7 @@ class _PendingRequest:
     adapter: Optional[str] = None
     lora_slot: int = 0  # Always 0 here; scheduler assigns actual slot at admission
     return_logprobs: Optional[bool] = None
+    generated_prefix: GeneratedPrefix = field(default_factory=GeneratedPrefix)
 
 
 @dataclass(slots=True)
@@ -236,8 +239,9 @@ class _AdmissionCoordinator:
 
         if self._runtime.prefix_cache is not None:
             req.image_hash = self._compute_image_hash(req.image)
+            prefill_tokens = list(req.prompt_tokens) + list(req.generated_prefix.tokens)
             if self._runtime.check_prefix_cache(
-                list(req.prompt_tokens), req.image_hash, req.adapter
+                prefill_tokens, req.image_hash, req.adapter
             ):
                 return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=True)
 
@@ -541,7 +545,12 @@ class InferenceEngine:
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         _logprobs: Optional[bool] = None,
+        _generated_prefix: Optional[object] = None,
     ) -> EngineResult:
+        generated_prefix = self._normalize_generated_prefix(
+            _generated_prefix,
+            "_generated_prefix",
+        )
         future, _ = await self._submit_request(
             max_new_tokens=max_new_tokens,
             request_context=request_context,
@@ -550,6 +559,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             return_logprobs=_logprobs,
+            generated_prefix=generated_prefix,
             stream_queue=None,
             skill=skill,
         )
@@ -610,6 +620,7 @@ class InferenceEngine:
         max_tokens = self._default_max_new_tokens
         adapter: Optional[str] = None
         return_logprobs = self._extract_logprobs(settings)
+        generated_prefix = self._extract_generated_prefix(settings)
         if settings is not None:
             if "temperature" in settings:
                 temperature = float(settings["temperature"])
@@ -655,6 +666,7 @@ class InferenceEngine:
                 temperature=temperature,
                 top_p=top_p,
                 _logprobs=return_logprobs,
+                _generated_prefix=generated_prefix,
                 skill="query",
             )
         return await self.submit(
@@ -665,6 +677,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             _logprobs=return_logprobs,
+            _generated_prefix=generated_prefix,
             skill="query",
         )
 
@@ -680,6 +693,7 @@ class InferenceEngine:
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)
+        generated_prefix = self._extract_generated_prefix(settings)
         max_tokens = self._default_max_new_tokens
         max_objects = None
         temperature = 0.0
@@ -714,6 +728,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             _logprobs=return_logprobs,
+            _generated_prefix=generated_prefix,
             skill="point",
         )
 
@@ -764,6 +779,7 @@ class InferenceEngine:
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)
+        generated_prefix = self._extract_generated_prefix(settings)
         temperature = self._default_temperature
         top_p = self._default_top_p
         max_tokens = self._default_max_new_tokens
@@ -797,6 +813,7 @@ class InferenceEngine:
                 temperature=temperature,
                 top_p=top_p,
                 _logprobs=return_logprobs,
+                _generated_prefix=generated_prefix,
                 skill="caption",
             )
         return await self.submit(
@@ -807,6 +824,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             _logprobs=return_logprobs,
+            _generated_prefix=generated_prefix,
             skill="caption",
         )
 
@@ -822,6 +840,7 @@ class InferenceEngine:
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)
+        generated_prefix = self._extract_generated_prefix(settings)
         max_objects = 50
         temperature = 0.0
         top_p = 1.0
@@ -851,6 +870,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             _logprobs=return_logprobs,
+            _generated_prefix=generated_prefix,
             skill="detect",
         )
 
@@ -868,6 +888,7 @@ class InferenceEngine:
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)
+        generated_prefix = self._extract_generated_prefix(settings)
         temperature = 0.0
         top_p = 1.0
         max_tokens = self._default_max_new_tokens
@@ -908,6 +929,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             _logprobs=return_logprobs,
+            _generated_prefix=generated_prefix,
             skill="segment",
         )
 
@@ -922,8 +944,13 @@ class InferenceEngine:
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         _logprobs: Optional[bool] = None,
+        _generated_prefix: Optional[object] = None,
     ) -> EngineStream:
         queue: _StreamQueue = asyncio.Queue()
+        generated_prefix = self._normalize_generated_prefix(
+            _generated_prefix,
+            "_generated_prefix",
+        )
         future, request_id = await self._submit_request(
             max_new_tokens=max_new_tokens,
             request_context=request_context,
@@ -932,6 +959,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             return_logprobs=_logprobs,
+            generated_prefix=generated_prefix,
             stream_queue=queue,
             skill=skill,
         )
@@ -978,6 +1006,7 @@ class InferenceEngine:
         temperature: Optional[float],
         top_p: Optional[float],
         return_logprobs: Optional[bool],
+        generated_prefix: GeneratedPrefix,
         stream_queue: Optional[_StreamQueue],
         skill: str,
     ) -> Tuple[asyncio.Future[EngineResult], int]:
@@ -1009,6 +1038,12 @@ class InferenceEngine:
         norm_temperature = self._normalize_temperature(temperature)
         norm_top_p = self._normalize_top_p(top_p)
         self._warn_if_outside_mps_sampler_envelope(norm_temperature, norm_top_p)
+        self._validate_generated_prefix_for_request(
+            generated_prefix,
+            max_new_tokens=max_new_tokens,
+            return_logprobs=return_logprobs,
+            streaming=stream_queue is not None,
+        )
         payload = _PendingRequest(
             request_id=req_id,
             prompt=prompt_str,
@@ -1025,6 +1060,7 @@ class InferenceEngine:
             request_context=request_context,
             adapter=adapter_id,
             return_logprobs=return_logprobs,
+            generated_prefix=generated_prefix,
         )
         await self._queue.put(payload)
         return future, req_id
@@ -1160,6 +1196,118 @@ class InferenceEngine:
         if not isinstance(raw, bool):
             raise TypeError("settings._logprobs must be a bool or None")
         return raw
+
+    def _extract_generated_prefix(
+        self, settings: Optional[Mapping[str, object]]
+    ) -> GeneratedPrefix:
+        if settings is None or "_generated_prefix" not in settings:
+            return GeneratedPrefix()
+        return self._normalize_generated_prefix(
+            settings["_generated_prefix"],
+            "settings._generated_prefix",
+        )
+
+    def _normalize_generated_prefix(
+        self,
+        raw: Optional[object],
+        field_name: str,
+    ) -> GeneratedPrefix:
+        if raw is None:
+            return GeneratedPrefix()
+        if isinstance(raw, GeneratedPrefix):
+            raw_tokens = raw.tokens
+            raw_logprobs = raw.logprobs
+        else:
+            if not isinstance(raw, Mapping):
+                raise TypeError(f"{field_name} must be a mapping or None")
+
+            allowed_keys = {"tokens", "logprobs"}
+            extra_keys = set(raw) - allowed_keys
+            if extra_keys:
+                names = ", ".join(sorted(str(key) for key in extra_keys))
+                raise TypeError(f"{field_name} has unsupported key(s): {names}")
+
+            if "tokens" not in raw:
+                raise ValueError(f"{field_name}.tokens is required")
+            raw_tokens = raw["tokens"]
+            raw_logprobs = raw.get("logprobs")
+
+        tokens = self._normalize_generated_prefix_tokens(
+            raw_tokens,
+            f"{field_name}.tokens",
+        )
+        logprobs = self._normalize_generated_prefix_logprobs(
+            raw_logprobs,
+            f"{field_name}.logprobs",
+            expected_length=len(tokens),
+        )
+        return GeneratedPrefix(tokens=tokens, logprobs=logprobs)
+
+    def _normalize_generated_prefix_tokens(
+        self,
+        raw: object,
+        field_name: str,
+    ) -> tuple[Token, ...]:
+        if raw is None:
+            return ()
+        if isinstance(raw, (str, bytes, bytearray)) or not isinstance(raw, Sequence):
+            raise TypeError(
+                f"{field_name} must be a sequence of generated Token objects"
+            )
+        tokens = tuple(raw)
+        for token in tokens:
+            if not isinstance(token, (TextToken, CoordToken, SizeToken)):
+                raise TypeError(
+                    f"{field_name} must contain only generated Token objects"
+                )
+        return tokens
+
+    def _normalize_generated_prefix_logprobs(
+        self,
+        raw: object,
+        field_name: str,
+        *,
+        expected_length: int,
+    ) -> Optional[tuple[float, ...]]:
+        if raw is None:
+            return None
+        if isinstance(raw, (str, bytes, bytearray)) or not isinstance(raw, Sequence):
+            raise TypeError(f"{field_name} must be a sequence of floats or None")
+        logprobs = tuple(float(value) for value in raw)
+        if len(logprobs) != expected_length:
+            raise ValueError(
+                f"{field_name} must have the same length as generated prefix tokens"
+            )
+        return logprobs
+
+    def _validate_generated_prefix_for_request(
+        self,
+        generated_prefix: GeneratedPrefix,
+        *,
+        max_new_tokens: int,
+        return_logprobs: Optional[bool],
+        streaming: bool,
+    ) -> None:
+        if not generated_prefix.tokens:
+            return
+        if streaming:
+            raise ValueError("settings._generated_prefix is not supported with streaming")
+        if len(generated_prefix.tokens) >= max_new_tokens:
+            raise ValueError(
+                "settings._generated_prefix.tokens must be shorter than max_tokens"
+            )
+        if return_logprobs is True and generated_prefix.logprobs is None:
+            raise ValueError(
+                "settings._generated_prefix.logprobs is required when "
+                "settings._logprobs is true"
+            )
+
+        eos_id = self.runtime.config.tokenizer.eos_id
+        for token in generated_prefix.tokens:
+            if isinstance(token, TextToken) and token.token_id == eos_id:
+                raise ValueError(
+                    "settings._generated_prefix.tokens must not contain EOS"
+                )
 
     def _build_stream_callback(
         self, req: _PendingRequest
@@ -1448,6 +1596,7 @@ class InferenceEngine:
             adapter=adapter,
             lora_slot=req.lora_slot,
             return_logprobs=req.return_logprobs,
+            generated_prefix=req.generated_prefix,
         )
         limit = runtime.max_seq_length
         target_total = request_obj.target_length
@@ -1461,6 +1610,11 @@ class InferenceEngine:
             request_obj,
             request_context=request_obj.request_context,
         )
+        for token in request_obj.generated_prefix.tokens:
+            skill_state.consume_step(
+                runtime,
+                DecodeStep(token=token, position=skill_state.token_count),
+            )
         return request_obj, skill_state
 
     def _to_engine_result(self, result: SchedulerResult) -> EngineResult:

--- a/kestrel/scheduler/__init__.py
+++ b/kestrel/scheduler/__init__.py
@@ -2,6 +2,7 @@
 
 from .scheduler import GenerationScheduler
 from .types import (
+    GeneratedPrefix,
     GenerationRequest,
     RequestLifecycle,
     RequestPhase,
@@ -11,6 +12,7 @@ from .types import (
 
 __all__ = [
     "GenerationScheduler",
+    "GeneratedPrefix",
     "GenerationRequest",
     "RequestLifecycle",
     "RequestPhase",

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -493,7 +493,7 @@ class GenerationScheduler:
 
         lifecycle = request.lifecycle
         classification = self.runtime.classify_prefill(
-            request.prompt_tokens,
+            request.prefill_tokens,
             has_image=lifecycle.has_image,
             image_hash=request.image_hash,
             adapter_id=request.adapter,
@@ -715,10 +715,10 @@ class GenerationScheduler:
                 lifecycle.prefill_started_at = prefill_start
                 lifecycle.transition(RequestPhase.PREFILLING)
                 prepared = self.runtime.prepare_sequence(
-                    prompt_tokens=request.prompt_tokens,
+                    prompt_tokens=request.prefill_tokens,
                     image=request.image,
                     image_crops=request.image_crops,
-                    max_new_tokens=request.max_new_tokens,
+                    max_new_tokens=request.remaining_new_tokens,
                     lora_slot=request.lora_slot,
                     image_hash=request.image_hash,
                     adapter_id=request.adapter,
@@ -1232,9 +1232,14 @@ class GenerationScheduler:
         """
         if seq.state.batch_idx in self.runtime.active_sequences:
             try:
+                # The generated prefix was part of prefill, so only tokens
+                # decoded after prefill should be retained as generated suffix.
+                generated_tokens = seq.skill_state.tokens[
+                    seq.request.generated_prefix_length:
+                ]
                 self.runtime.retain_sequence_prefix(
                     seq.state,
-                    seq.skill_state.tokens,
+                    generated_tokens,
                     adapter_id=seq.request.adapter,
                     image_hash=seq.request.image_hash,
                 )
@@ -1453,7 +1458,10 @@ class GenerationScheduler:
                 }
                 logprobs = None
 
-        decode_tokens = len(tokens) if tokens else len(seq.skill_state.tokens)
+        decode_tokens = max(
+            0,
+            seq.skill_state.token_count - seq.request.generated_prefix_length,
+        )
         metrics = seq.build_metrics(decode_tokens=decode_tokens)
         return SchedulerResult(
             request_id=seq.request.request_id,

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -12,6 +12,14 @@ from kestrel.moondream.image_crops import OverlapCropOutput
 from kestrel.skills import SkillSpec, SkillState, DecodeStep
 
 
+@dataclass(frozen=True, slots=True)
+class GeneratedPrefix:
+    """Generated tokens that should be treated as already decoded."""
+
+    tokens: tuple[Token, ...] = ()
+    logprobs: Optional[tuple[float, ...]] = None
+
+
 class RequestPhase(str, Enum):
     NEW = "new"
     WAITING_RESOURCES = "waiting_resources"
@@ -55,6 +63,11 @@ class RequestLifecycle:
     finish_reason: Optional[str] = None
     error: Optional[BaseException] = None
     logprobs: List[float] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        prefix_logprobs = self.request.generated_prefix.logprobs
+        if self.request.return_logprobs is True and prefix_logprobs is not None:
+            self.logprobs.extend(float(value) for value in prefix_logprobs)
 
     def transition(self, phase: RequestPhase) -> None:
         """Update phase with minimal bookkeeping."""
@@ -177,12 +190,32 @@ class GenerationRequest:
     adapter: Optional[str] = None
     lora_slot: int = 0  # Slot in workspace; 0 = no LoRA
     return_logprobs: Optional[bool] = None
+    generated_prefix: GeneratedPrefix = field(default_factory=GeneratedPrefix)
 
     prompt_length: int = field(init=False)
 
     def __post_init__(self) -> None:
         tokens = list(self.prompt_tokens)
         self.prompt_tokens = tokens
+        prefix_tokens = self.generated_prefix.tokens
+        prefix_logprobs = self.generated_prefix.logprobs
+        if prefix_logprobs is not None and len(prefix_logprobs) != len(prefix_tokens):
+            raise ValueError(
+                "generated_prefix.logprobs must have the same length as "
+                "generated_prefix.tokens"
+            )
+        if prefix_tokens and len(prefix_tokens) >= self.max_new_tokens:
+            raise ValueError(
+                "generated_prefix.tokens must be shorter than max_new_tokens"
+            )
+        if (
+            prefix_tokens
+            and self.return_logprobs is True
+            and prefix_logprobs is None
+        ):
+            raise ValueError(
+                "generated_prefix.logprobs is required when return_logprobs is true"
+            )
         # Prompt tokens are already materialized (including BOS if required by
         # the template), so prompt_length is the list length.
         self.prompt_length = len(tokens)
@@ -196,6 +229,18 @@ class GenerationRequest:
     @property
     def target_length(self) -> int:
         return self.prompt_length + self.image_length + self.max_new_tokens
+
+    @property
+    def generated_prefix_length(self) -> int:
+        return len(self.generated_prefix.tokens)
+
+    @property
+    def remaining_new_tokens(self) -> int:
+        return self.max_new_tokens - self.generated_prefix_length
+
+    @property
+    def prefill_tokens(self) -> List[Token]:
+        return list(self.prompt_tokens) + list(self.generated_prefix.tokens)
 
 
 @dataclass

--- a/tests/scheduler/test_launch_prefill_step.py
+++ b/tests/scheduler/test_launch_prefill_step.py
@@ -9,7 +9,12 @@ from kestrel.moondream.runtime import PrefillClassification, TextToken
 from kestrel.scheduler.pipeline import PipelineState
 from kestrel.scheduler.queues import RequestQueue, RunningQueue
 from kestrel.scheduler.scheduler import GenerationScheduler, _PrefillCandidate
-from kestrel.scheduler.types import GenerationRequest, RequestLifecycle, RequestPhase
+from kestrel.scheduler.types import (
+    GeneratedPrefix,
+    GenerationRequest,
+    RequestLifecycle,
+    RequestPhase,
+)
 
 from tests.scheduler._fake_runtime import FakeRuntime
 
@@ -24,7 +29,12 @@ class _SkillStateStub:
             self.tokens = []
 
 
-def _make_request(*, request_id: int = 1, max_new_tokens: int = 8) -> GenerationRequest:
+def _make_request(
+    *,
+    request_id: int = 1,
+    max_new_tokens: int = 8,
+    generated_prefix_tokens: list[TextToken] | None = None,
+) -> GenerationRequest:
     request = GenerationRequest(
         request_id=request_id,
         prompt="prompt",
@@ -32,6 +42,7 @@ def _make_request(*, request_id: int = 1, max_new_tokens: int = 8) -> Generation
         max_new_tokens=max_new_tokens,
         skill=object(),
         request_context=object(),
+        generated_prefix=GeneratedPrefix(tokens=tuple(generated_prefix_tokens or [])),
     )
     lifecycle = RequestLifecycle(
         request=request,
@@ -73,6 +84,41 @@ def _make_scheduler(
     scheduler._completed = deque()
     scheduler._select_prefill_batch = lambda capacity_remaining: [_make_candidate(request)]
     return scheduler
+
+
+def test_make_prefill_candidate_classifies_prompt_and_generated_prefix() -> None:
+    request = _make_request(generated_prefix_tokens=[TextToken(10), TextToken(11)])
+    runtime = FakeRuntime()
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = runtime
+
+    candidate = GenerationScheduler._make_prefill_candidate(scheduler, request)
+
+    assert candidate is not None
+    assert runtime.classify_calls == [[TextToken(1), TextToken(10), TextToken(11)]]
+    assert candidate.reserve_length == request.target_length
+
+
+def test_launch_prefill_step_prefills_generated_prefix_then_remaining_tokens() -> None:
+    request = _make_request(
+        max_new_tokens=5,
+        generated_prefix_tokens=[TextToken(10), TextToken(11)],
+    )
+    request.lifecycle.lora_slot_ready = True
+    runtime = FakeRuntime(prepare_exc=RuntimeError("prepare failed"))
+    scheduler = _make_scheduler(request, runtime)
+    scheduler._acquire_adapter_slot = lambda adapter_id: 0
+    pipeline = PipelineState()
+
+    GenerationScheduler._launch_prefill_step(scheduler, pipeline)
+
+    assert len(runtime.prepare_calls) == 1
+    assert runtime.prepare_calls[0]["prompt_tokens"] == [
+        TextToken(1),
+        TextToken(10),
+        TextToken(11),
+    ]
+    assert runtime.prepare_calls[0]["max_new_tokens"] == 3
 
 
 @pytest.mark.parametrize("failure_stage", ["adapter", "prepare"])

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -10,7 +10,7 @@ from kestrel.moondream.region import SpatialDecodeTables
 from kestrel.moondream.runtime import TextToken
 from kestrel.scheduler.scheduler import GenerationScheduler
 from kestrel.scheduler.spatial import compute_spatial_values
-from kestrel.scheduler.types import GenerationRequest, RequestLifecycle
+from kestrel.scheduler.types import GeneratedPrefix, GenerationRequest, RequestLifecycle
 from kestrel.skills import DecodeStep, SkillFinalizeResult, SkillState
 
 
@@ -142,6 +142,86 @@ def test_scheduler_result_returns_requested_token_logprobs() -> None:
 
     assert result.tokens == [TextToken(10), TextToken(11)]
     assert result.logprobs == [-1.25, -0.5]
+
+
+def test_scheduler_result_keeps_generated_prefix_logprobs_aligned() -> None:
+    request = GenerationRequest(
+        request_id=7,
+        prompt="prompt",
+        prompt_tokens=[TextToken(1)],
+        max_new_tokens=4,
+        skill=_SkillSpecStub(),  # type: ignore[arg-type]
+        request_context=object(),
+        return_logprobs=True,
+        generated_prefix=GeneratedPrefix(
+            tokens=(TextToken(10), TextToken(11)),
+            logprobs=(-0.1, -0.2),
+        ),
+    )
+    state = _SkillStateStub(request)
+    state.consume_step(SimpleNamespace(), DecodeStep(TextToken(10), 0))
+    state.consume_step(SimpleNamespace(), DecodeStep(TextToken(11), 1))
+    lifecycle = RequestLifecycle(request=request, skill_state=state)
+    request.lifecycle = lifecycle
+
+    lifecycle.stage_token(SimpleNamespace(), TextToken(12), logprob=-0.3)
+    result = GenerationScheduler._build_result(_scheduler(), lifecycle)
+
+    assert result.tokens == [TextToken(10), TextToken(11), TextToken(12)]
+    assert result.logprobs == [-0.1, -0.2, -0.3]
+    assert result.metrics.decode_tokens == 1
+
+
+def test_generation_request_tracks_generated_prefix_prefill_shape() -> None:
+    request = GenerationRequest(
+        request_id=7,
+        prompt="prompt",
+        prompt_tokens=[TextToken(1)],
+        max_new_tokens=4,
+        skill=_SkillSpecStub(),  # type: ignore[arg-type]
+        request_context=object(),
+        generated_prefix=GeneratedPrefix(tokens=(TextToken(10), TextToken(11))),
+    )
+
+    assert request.prompt_length == 1
+    assert request.generated_prefix_length == 2
+    assert request.remaining_new_tokens == 2
+    assert request.prefill_tokens == [TextToken(1), TextToken(10), TextToken(11)]
+    assert request.target_length == 5
+
+
+def test_generation_request_validates_generated_prefix() -> None:
+    with pytest.raises(ValueError, match="shorter"):
+        GenerationRequest(
+            request_id=7,
+            prompt="prompt",
+            prompt_tokens=[TextToken(1)],
+            max_new_tokens=2,
+            skill=_SkillSpecStub(),  # type: ignore[arg-type]
+            request_context=object(),
+            generated_prefix=GeneratedPrefix(tokens=(TextToken(10), TextToken(11))),
+        )
+    with pytest.raises(ValueError, match="same length"):
+        GenerationRequest(
+            request_id=7,
+            prompt="prompt",
+            prompt_tokens=[TextToken(1)],
+            max_new_tokens=4,
+            skill=_SkillSpecStub(),  # type: ignore[arg-type]
+            request_context=object(),
+            generated_prefix=GeneratedPrefix(tokens=(TextToken(10),), logprobs=()),
+        )
+    with pytest.raises(ValueError, match="return_logprobs"):
+        GenerationRequest(
+            request_id=7,
+            prompt="prompt",
+            prompt_tokens=[TextToken(1)],
+            max_new_tokens=4,
+            skill=_SkillSpecStub(),  # type: ignore[arg-type]
+            request_context=object(),
+            return_logprobs=True,
+            generated_prefix=GeneratedPrefix(tokens=(TextToken(10),)),
+        )
 
 
 def test_scheduler_result_rejects_misaligned_logprobs() -> None:

--- a/tests/scheduler/test_release_sequence.py
+++ b/tests/scheduler/test_release_sequence.py
@@ -8,7 +8,7 @@ import pytest
 
 from kestrel.runtime import SequenceState, TextToken, Token
 from kestrel.scheduler.scheduler import GenerationScheduler
-from kestrel.scheduler.types import GenerationRequest, RequestLifecycle
+from kestrel.scheduler.types import GeneratedPrefix, GenerationRequest, RequestLifecycle
 
 from tests.scheduler._fake_runtime import FakeRuntime
 
@@ -85,6 +85,25 @@ def test_finalize_sequence_retains_prefix_before_release() -> None:
     assert retain_call["adapter_id"] == "adapter-a"
     assert retain_call["image_hash"] == b"0123456789abcdef"
     assert runtime.released_sequences == [state]
+
+
+def test_release_sequence_retains_only_decoded_suffix_after_generated_prefix() -> None:
+    runtime = FakeRuntime()
+    lifecycle = _make_lifecycle(runtime)
+    lifecycle.state.length = 4
+    lifecycle.state.prompt_length = 2
+    lifecycle.request.generated_prefix = GeneratedPrefix(tokens=(TextToken(10),))
+    lifecycle.skill_state.tokens = [TextToken(10), TextToken(11), TextToken(12)]
+
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = runtime
+
+    GenerationScheduler._release_sequence(scheduler, lifecycle)
+
+    assert len(runtime.retained_prefixes) == 1
+    retain_call = runtime.retained_prefixes[0]
+    assert retain_call["generated_tokens"] == [TextToken(11), TextToken(12)]
+    assert runtime.released_sequences == [lifecycle.state]
 
 
 def test_release_sequence_releases_and_propagates_when_retention_fails() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -10,7 +10,14 @@ import numpy as np
 
 import pytest
 
-from kestrel.engine import InferenceEngine, _AdmissionCoordinator, _PendingRequest
+from kestrel.engine import (
+    InferenceEngine,
+    _AdmissionCoordinator,
+    _PendingRequest,
+)
+from kestrel.moondream.runtime import TextToken
+from kestrel.scheduler import GeneratedPrefix
+from kestrel.skills import DecodeStep, SkillFinalizeResult, SkillSpec, SkillState
 
 
 def _make_request(
@@ -32,6 +39,37 @@ def _make_request(
         request_context=object(),
         adapter=None,
     )
+
+
+class _PrefixSkillState(SkillState):
+    def __init__(self, spec: SkillSpec, request: object) -> None:
+        super().__init__(spec, request)
+        self.positions: list[int] = []
+
+    def consume_step(self, runtime: object, step: DecodeStep) -> None:
+        self.positions.append(step.position)
+        self.append_token(step.token)
+
+    def finalize(self, runtime: object, *, reason: str) -> SkillFinalizeResult:
+        return SkillFinalizeResult(text="", tokens=list(self.tokens), output={})
+
+
+class _PrefixSkill(SkillSpec):
+    def __init__(self) -> None:
+        super().__init__(name="prefix")
+
+    def build_prompt_tokens(
+        self, runtime: object, request_context: object
+    ) -> list[object]:
+        return []
+
+    def create_state(
+        self,
+        runtime: object,
+        request: object,
+        request_context: object,
+    ) -> _PrefixSkillState:
+        return _PrefixSkillState(self, request)
 
 
 class _FakeRuntime:
@@ -114,6 +152,30 @@ def test_admission_coordinator_skips_crop_work_on_prefix_hit() -> None:
     assert failures == []
 
 
+def test_admission_coordinator_checks_prefix_cache_with_generated_prefix() -> None:
+    image = np.arange(12, dtype=np.uint8).reshape(3, 4)
+    runtime = _FakeRuntime(prefix_cache=object(), prefix_hit=True)
+    preprocessor = _FakeImagePreprocessor()
+    failures: list[tuple[_PendingRequest, BaseException]] = []
+    coordinator = _AdmissionCoordinator(
+        runtime=runtime,
+        image_preprocessor=preprocessor,
+        wake_event=threading.Event(),
+        fail_request=_record_failure(failures),
+    )
+    req = _make_request(image=image)
+    req.prompt_tokens = [TextToken(1)]
+    req.generated_prefix = GeneratedPrefix(tokens=(TextToken(10), TextToken(11)))
+
+    ready = coordinator.submit(req)
+
+    assert ready is not None
+    assert len(runtime.cache_checks) == 1
+    assert runtime.cache_checks[0][0] == [TextToken(1), TextToken(10), TextToken(11)]
+    assert preprocessor.submissions == []
+    assert failures == []
+
+
 def test_admission_coordinator_promotes_completed_crops() -> None:
     image = np.zeros((4, 4, 3), dtype=np.uint8)
     crop_future: Future[object] = Future()
@@ -186,3 +248,108 @@ def test_extract_private_logprobs_setting() -> None:
     assert engine._extract_logprobs({"_logprobs": False}) is False
     with pytest.raises(TypeError, match="settings._logprobs"):
         engine._extract_logprobs({"_logprobs": 1})
+
+
+def test_extract_private_generated_prefix_setting() -> None:
+    engine = object.__new__(InferenceEngine)
+
+    assert engine._extract_generated_prefix(None) == GeneratedPrefix()
+    assert engine._extract_generated_prefix({}) == GeneratedPrefix()
+
+    prefix = engine._extract_generated_prefix(
+        {
+            "_generated_prefix": {
+                "tokens": [TextToken(10), TextToken(11)],
+                "logprobs": [-1, -2.5],
+            }
+        }
+    )
+
+    assert prefix.tokens == (TextToken(10), TextToken(11))
+    assert prefix.logprobs == (-1.0, -2.5)
+
+    prefix = engine._normalize_generated_prefix(
+        GeneratedPrefix(tokens=(TextToken(10),), logprobs=("-1",)),
+        "_generated_prefix",
+    )
+    assert prefix.tokens == (TextToken(10),)
+    assert prefix.logprobs == (-1.0,)
+
+    with pytest.raises(TypeError, match="settings._generated_prefix"):
+        engine._extract_generated_prefix({"_generated_prefix": []})
+    with pytest.raises(TypeError, match="unsupported key"):
+        engine._extract_generated_prefix(
+            {"_generated_prefix": {"tokens": [], "text": "answer"}}
+        )
+    with pytest.raises(ValueError, match="tokens is required"):
+        engine._extract_generated_prefix({"_generated_prefix": {}})
+    with pytest.raises(TypeError, match="generated Token"):
+        engine._extract_generated_prefix({"_generated_prefix": {"tokens": [10]}})
+    with pytest.raises(TypeError, match="generated Token"):
+        engine._normalize_generated_prefix(
+            GeneratedPrefix(tokens=(10,)),
+            "_generated_prefix",
+        )
+    with pytest.raises(ValueError, match="same length"):
+        engine._extract_generated_prefix(
+            {"_generated_prefix": {"tokens": [TextToken(10)], "logprobs": []}}
+        )
+
+
+def test_validate_generated_prefix_rejects_unsupported_requests() -> None:
+    engine = object.__new__(InferenceEngine)
+    engine._runtime = SimpleNamespace(
+        config=SimpleNamespace(tokenizer=SimpleNamespace(eos_id=2))
+    )
+
+    prefix = GeneratedPrefix(tokens=(TextToken(10),))
+
+    with pytest.raises(ValueError, match="streaming"):
+        engine._validate_generated_prefix_for_request(
+            prefix,
+            max_new_tokens=4,
+            return_logprobs=None,
+            streaming=True,
+        )
+    with pytest.raises(ValueError, match="shorter"):
+        engine._validate_generated_prefix_for_request(
+            prefix,
+            max_new_tokens=1,
+            return_logprobs=None,
+            streaming=False,
+        )
+    with pytest.raises(ValueError, match="logprobs is required"):
+        engine._validate_generated_prefix_for_request(
+            prefix,
+            max_new_tokens=4,
+            return_logprobs=True,
+            streaming=False,
+        )
+    with pytest.raises(ValueError, match="must not contain EOS"):
+        engine._validate_generated_prefix_for_request(
+            GeneratedPrefix(tokens=(TextToken(2),), logprobs=(-0.1,)),
+            max_new_tokens=4,
+            return_logprobs=True,
+            streaming=False,
+        )
+
+
+def test_build_generation_request_consumes_generated_prefix() -> None:
+    engine = object.__new__(InferenceEngine)
+    req = _make_request()
+    req.prompt_tokens = [TextToken(1)]
+    req.max_new_tokens = 4
+    req.skill = _PrefixSkill()
+    req.generated_prefix = GeneratedPrefix(
+        tokens=(TextToken(10), TextToken(11)),
+        logprobs=(-0.1, -0.2),
+    )
+    runtime = SimpleNamespace(max_seq_length=32, image_prefix_length=0)
+
+    generation_req, skill_state = engine._build_generation_request(runtime, req, None)
+
+    assert generation_req.prompt_tokens == [TextToken(1)]
+    assert generation_req.prefill_tokens == [TextToken(1), TextToken(10), TextToken(11)]
+    assert generation_req.remaining_new_tokens == 2
+    assert list(skill_state.tokens) == [TextToken(10), TextToken(11)]
+    assert skill_state.positions == [0, 1]


### PR DESCRIPTION
## Summary
- Add a private `_generated_prefix` request setting that accepts opaque generated tokens plus optional aligned logprobs.
- Feed `prompt_tokens + generated_prefix_tokens` through prefix-cache admission and prefill, while limiting runtime generation to the remaining token budget.
- Seed skill state and requested result logprobs from the prefix so final `EngineResult.tokens` and `EngineResult.logprobs` remain aligned as `prefix + continuation`.

## Validation
- `uv run pytest -q`

## Notes
- `_generated_prefix` is rejected for streaming in this first version.
- If `_logprobs` is true, prefix logprobs are required so Kestrel does not silently return misaligned arrays.