### PR TITLE
Retain decoded prefixes in prefix cache

### DIFF
--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -1424,6 +1424,11 @@ class MoondreamRuntime:
             namespace=namespace,
         )
         if insert_result.inserted_pages == 0:
+            # Normal non-retainable case: the token path may already exist with
+            # different physical pages. This happens after append-prefill
+            # recomputes the last prompt token, or when another branch cached a
+            # shared generated prefix first. Keep this sequence's private pages
+            # private so release_sequence() frees them normally.
             return
 
         old_lock_node = state.cache_lock_node

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -1424,10 +1424,7 @@ class MoondreamRuntime:
             namespace=namespace,
         )
         if insert_result.inserted_pages == 0:
-            match = self.prefix_cache.match_prefix(cache_tokens, namespace=namespace)
-            if match.matched_kv_length >= target_len:
-                return
-            raise RuntimeError("Failed to retain decoded prefix in prefix cache")
+            return
 
         old_lock_node = state.cache_lock_node
         if insert_result.node is not old_lock_node:

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -1414,24 +1414,20 @@ class MoondreamRuntime:
             return
 
         prompt_len = state.prompt_length or state.length
-        available_generated_kv = max(0, state.length - prompt_len)
-        if available_generated_kv <= 0:
+        processed_generated = min(
+            len(generated_tokens),
+            max(0, state.length - prompt_len),
+        )
+        if processed_generated <= 0:
             return
 
-        retained_generated: list[CacheToken] = []
-        retained_kv = 0
-        for token in generated_tokens:
-            token_kv = token.kv_length()
-            if retained_kv + token_kv > available_generated_kv:
-                break
-            retained_generated.append(token)
-            retained_kv += token_kv
-
-        target_len = prompt_len + retained_kv
-        if retained_kv <= 0 or target_len <= state.cache_owned_page_count:
+        target_len = prompt_len + processed_generated
+        if target_len <= state.cache_owned_page_count:
             return
 
-        cache_tokens = list(state.cache_tokens) + retained_generated
+        cache_tokens: list[CacheToken] = (
+            list(state.cache_tokens) + list(generated_tokens[:processed_generated])
+        )
         pages = self.page_table.get_pages(state.batch_idx, 0, target_len)
         namespace = CacheNamespace(
             runtime_id=self.model_name,
@@ -1445,21 +1441,14 @@ class MoondreamRuntime:
             pages,
             namespace=namespace,
         )
-
-        new_lock_node = insert_result.node
         if insert_result.inserted_pages == 0:
-            match = self.prefix_cache.match_prefix(cache_tokens, namespace=namespace)
-            if match.matched_kv_length < target_len:
-                return
-            if match.matched_pages[:target_len] != pages:
-                return
-            new_lock_node = match.last_node
+            return
 
         old_lock_node = state.cache_lock_node
-        if new_lock_node is not old_lock_node:
-            self.prefix_cache.lock(new_lock_node)
+        if insert_result.node is not old_lock_node:
+            self.prefix_cache.lock(insert_result.node)
             self.prefix_cache.unlock(old_lock_node)
-            state.cache_lock_node = new_lock_node
+            state.cache_lock_node = insert_result.node
         state.cache_owned_page_count = target_len
 
     def release_sequence(self, state: SequenceState) -> None:

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -1442,7 +1442,10 @@ class MoondreamRuntime:
             namespace=namespace,
         )
         if insert_result.inserted_pages == 0:
-            return
+            match = self.prefix_cache.match_prefix(cache_tokens, namespace=namespace)
+            if match.matched_kv_length >= target_len:
+                return
+            raise RuntimeError("Failed to retain decoded prefix in prefix cache")
 
         old_lock_node = state.cache_lock_node
         if insert_result.node is not old_lock_node:

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -783,14 +783,7 @@ class MoondreamRuntime:
         image_kv_length = self.image_prefix_length
         cache_tokens = self._build_cache_tokens(tokens_list, image_hash, image_kv_length)
 
-        # Build namespace
-        image_hash_int = int.from_bytes(image_hash[:16], "big")
-        namespace = CacheNamespace(
-            runtime_id=self.model_name,
-            lora_id=adapter_id,
-            image_hash=image_hash_int,
-        )
-
+        namespace = self._cache_namespace(adapter_id, image_hash)
         match = self.prefix_cache.match_prefix(cache_tokens, namespace=namespace)
 
         # Cache hit must cover at least BOS + full image prefix
@@ -819,13 +812,7 @@ class MoondreamRuntime:
                     "image_hash must be provided when prefix cache is enabled for image prompts"
                 )
             cache_tokens = self._build_cache_tokens(tokens_list, image_hash, image_kv_length)
-            namespace = CacheNamespace(
-                runtime_id=self.model_name,
-                lora_id=adapter_id,
-                image_hash=(
-                    int.from_bytes(image_hash[:16], "big") if image_hash is not None else None
-                ),
-            )
+            namespace = self._cache_namespace(adapter_id, image_hash)
             match = self.prefix_cache.match_prefix(cache_tokens, namespace=namespace)
             can_reuse = match.matched_kv_length > 0
             if image_kv_length > 0 and can_reuse:
@@ -864,6 +851,21 @@ class MoondreamRuntime:
             cache_tokens.extend(tokens_list[1:])
         return cache_tokens
 
+    def _cache_namespace(
+        self,
+        adapter_id: str | None,
+        image_hash: bytes | None,
+    ) -> CacheNamespace:
+        return CacheNamespace(
+            runtime_id=self.model_name,
+            lora_id=adapter_id,
+            image_hash=(
+                int.from_bytes(image_hash[:16], "big")
+                if image_hash is not None
+                else None
+            ),
+        )
+
     def _lookup_prefix_cache(
         self,
         cache_tokens: list[CacheToken],
@@ -883,15 +885,7 @@ class MoondreamRuntime:
                 namespace=None,
             )
 
-        # Build namespace from adapter identity and image hash
-        image_hash_int = (
-            int.from_bytes(image_hash[:16], "big") if image_hash else None
-        )
-        namespace = CacheNamespace(
-            runtime_id=self.model_name,
-            lora_id=adapter_id,
-            image_hash=image_hash_int,
-        )
+        namespace = self._cache_namespace(adapter_id, image_hash)
         match = self.prefix_cache.match_prefix(cache_tokens, namespace=namespace)
         can_reuse = match.matched_kv_length > 0
 
@@ -1034,13 +1028,7 @@ class MoondreamRuntime:
 
         # Insert prompt into cache
         prompt_pages = self.page_table.get_pages(batch_idx, 0, prompt_len)
-        namespace = CacheNamespace(
-            runtime_id=self.model_name,
-            lora_id=adapter_id,
-            image_hash=(
-                int.from_bytes(image_hash[:16], "big") if image_hash else None
-            ),
-        )
+        namespace = self._cache_namespace(adapter_id, image_hash)
         insert_result = self.prefix_cache.insert(
             cache_tokens,
             prompt_pages,
@@ -1429,13 +1417,7 @@ class MoondreamRuntime:
             list(state.cache_tokens) + list(generated_tokens[:processed_generated])
         )
         pages = self.page_table.get_pages(state.batch_idx, 0, target_len)
-        namespace = CacheNamespace(
-            runtime_id=self.model_name,
-            lora_id=adapter_id,
-            image_hash=(
-                int.from_bytes(image_hash[:16], "big") if image_hash else None
-            ),
-        )
+        namespace = self._cache_namespace(adapter_id, image_hash)
         insert_result = self.prefix_cache.insert(
             cache_tokens,
             pages,

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -1401,6 +1401,67 @@ class MoondreamRuntime:
         # Release batch slot; do NOT free cache-owned mapped prefix pages.
         self.page_table.erase(batch_idx, prepared.cache_result.skip_positions)
 
+    def retain_sequence_prefix(
+        self,
+        state: SequenceState,
+        generated_tokens: Sequence[Token],
+        *,
+        adapter_id: str | None,
+        image_hash: bytes | None,
+    ) -> None:
+        """Make decoded generated KV pages eligible for prefix-cache reuse."""
+        if self.prefix_cache is None or not state.cache_tokens:
+            return
+
+        prompt_len = state.prompt_length or state.length
+        available_generated_kv = max(0, state.length - prompt_len)
+        if available_generated_kv <= 0:
+            return
+
+        retained_generated: list[CacheToken] = []
+        retained_kv = 0
+        for token in generated_tokens:
+            token_kv = token.kv_length()
+            if retained_kv + token_kv > available_generated_kv:
+                break
+            retained_generated.append(token)
+            retained_kv += token_kv
+
+        target_len = prompt_len + retained_kv
+        if retained_kv <= 0 or target_len <= state.cache_owned_page_count:
+            return
+
+        cache_tokens = list(state.cache_tokens) + retained_generated
+        pages = self.page_table.get_pages(state.batch_idx, 0, target_len)
+        namespace = CacheNamespace(
+            runtime_id=self.model_name,
+            lora_id=adapter_id,
+            image_hash=(
+                int.from_bytes(image_hash[:16], "big") if image_hash else None
+            ),
+        )
+        insert_result = self.prefix_cache.insert(
+            cache_tokens,
+            pages,
+            namespace=namespace,
+        )
+
+        new_lock_node = insert_result.node
+        if insert_result.inserted_pages == 0:
+            match = self.prefix_cache.match_prefix(cache_tokens, namespace=namespace)
+            if match.matched_kv_length < target_len:
+                return
+            if match.matched_pages[:target_len] != pages:
+                return
+            new_lock_node = match.last_node
+
+        old_lock_node = state.cache_lock_node
+        if new_lock_node is not old_lock_node:
+            self.prefix_cache.lock(new_lock_node)
+            self.prefix_cache.unlock(old_lock_node)
+            state.cache_lock_node = new_lock_node
+        state.cache_owned_page_count = target_len
+
     def release_sequence(self, state: SequenceState) -> None:
         self.active_sequences.pop(state.batch_idx, None)
 

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -118,6 +118,15 @@ class Runtime(Protocol):
 
     def abort_prepared_sequence(self, prepared: PreparedSequence) -> None: ...
 
+    def retain_sequence_prefix(
+        self,
+        state: SequenceState,
+        generated_tokens: Sequence[Token],
+        *,
+        adapter_id: str | None,
+        image_hash: bytes | None,
+    ) -> None: ...
+
     def release_sequence(self, state: SequenceState) -> None: ...
 
     def decode_with_slot(self, slot: Any, batch_size: int) -> None: ...

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1231,15 +1231,13 @@ class GenerationScheduler:
         but resource release was deferred because inflight_refs > 0.
         """
         if seq.state.batch_idx in self.runtime.active_sequences:
-            try:
-                self.runtime.retain_sequence_prefix(
-                    seq.state,
-                    seq.skill_state.tokens,
-                    adapter_id=seq.request.adapter,
-                    image_hash=seq.request.image_hash,
-                )
-            finally:
-                self.runtime.release_sequence(seq.state)
+            self.runtime.retain_sequence_prefix(
+                seq.state,
+                seq.skill_state.tokens,
+                adapter_id=seq.request.adapter,
+                image_hash=seq.request.image_hash,
+            )
+            self.runtime.release_sequence(seq.state)
 
     def _sample_batch(
         self,

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1231,7 +1231,15 @@ class GenerationScheduler:
         but resource release was deferred because inflight_refs > 0.
         """
         if seq.state.batch_idx in self.runtime.active_sequences:
-            self.runtime.release_sequence(seq.state)
+            try:
+                self.runtime.retain_sequence_prefix(
+                    seq.state,
+                    seq.skill_state.tokens,
+                    adapter_id=seq.request.adapter,
+                    image_hash=seq.request.image_hash,
+                )
+            finally:
+                self.runtime.release_sequence(seq.state)
 
     def _sample_batch(
         self,
@@ -1387,8 +1395,7 @@ class GenerationScheduler:
         # Otherwise, release is deferred to commit_step() when inflight_refs hits 0.
         if seq.inflight_refs == 0:
             seq.transition(RequestPhase.COMPLETED)
-            if seq.state.batch_idx in self.runtime.active_sequences:
-                self.runtime.release_sequence(seq.state)
+            self._release_sequence(seq)
         else:
             seq.transition(RequestPhase.FINALIZING)
 

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1231,13 +1231,19 @@ class GenerationScheduler:
         but resource release was deferred because inflight_refs > 0.
         """
         if seq.state.batch_idx in self.runtime.active_sequences:
-            self.runtime.retain_sequence_prefix(
-                seq.state,
-                seq.skill_state.tokens,
-                adapter_id=seq.request.adapter,
-                image_hash=seq.request.image_hash,
-            )
-            self.runtime.release_sequence(seq.state)
+            try:
+                self.runtime.retain_sequence_prefix(
+                    seq.state,
+                    seq.skill_state.tokens,
+                    adapter_id=seq.request.adapter,
+                    image_hash=seq.request.image_hash,
+                )
+            finally:
+                # Retention is part of the cache path, but release is resource
+                # ownership. If retention hits an invariant bug, still release
+                # the batch slot/pages/adapter, then let the original exception
+                # propagate through the scheduler-fatal path.
+                self.runtime.release_sequence(seq.state)
 
     def _sample_batch(
         self,

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -163,6 +163,7 @@ class FakeRuntime:
         self.launch_calls: list[Sequence[PreparedSequence]] = []
         self.finalized_prepared: list[PreparedSequence] = []
         self.aborted_prepared: list[PreparedSequence] = []
+        self.retained_prefixes: list[dict[str, Any]] = []
         self.released_sequences: list[SequenceState] = []
         self.decode_calls: list[tuple[Any, int]] = []
 
@@ -259,6 +260,23 @@ class FakeRuntime:
 
     def abort_prepared_sequence(self, prepared: PreparedSequence) -> None:
         self.aborted_prepared.append(prepared)
+
+    def retain_sequence_prefix(
+        self,
+        state: SequenceState,
+        generated_tokens: Sequence[Token],
+        *,
+        adapter_id: str | None,
+        image_hash: bytes | None,
+    ) -> None:
+        self.retained_prefixes.append(
+            {
+                "state": state,
+                "generated_tokens": list(generated_tokens),
+                "adapter_id": adapter_id,
+                "image_hash": image_hash,
+            }
+        )
 
     def release_sequence(self, state: SequenceState) -> None:
         self.released_sequences.append(state)

--- a/tests/scheduler/test_release_sequence.py
+++ b/tests/scheduler/test_release_sequence.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass, field
+from typing import Sequence
 
-from kestrel.runtime import SequenceState, TextToken
+import pytest
+
+from kestrel.runtime import SequenceState, TextToken, Token
 from kestrel.scheduler.scheduler import GenerationScheduler
 from kestrel.scheduler.types import GenerationRequest, RequestLifecycle
 
@@ -19,8 +22,23 @@ class _SkillStateStub:
         return len(self.tokens)
 
 
-def test_finalize_sequence_retains_prefix_before_release() -> None:
-    runtime = FakeRuntime()
+class _FailingRetainRuntime(FakeRuntime):
+    def retain_sequence_prefix(
+        self,
+        state: SequenceState,
+        generated_tokens: Sequence[Token],
+        *,
+        adapter_id: str | None,
+        image_hash: bytes | None,
+    ) -> None:
+        raise RuntimeError("retain failed")
+
+
+def _make_lifecycle(
+    runtime: FakeRuntime,
+    *,
+    request_id: int = 7,
+) -> RequestLifecycle:
     state = SequenceState(
         batch_idx=0,
         length=2,
@@ -30,7 +48,7 @@ def test_finalize_sequence_retains_prefix_before_release() -> None:
     runtime.active_sequences[state.batch_idx] = state
 
     request = GenerationRequest(
-        request_id=7,
+        request_id=request_id,
         prompt="prompt",
         prompt_tokens=[TextToken(1)],
         max_new_tokens=4,
@@ -45,6 +63,13 @@ def test_finalize_sequence_retains_prefix_before_release() -> None:
         sequence_state=state,
     )
     request.lifecycle = lifecycle
+    return lifecycle
+
+
+def test_finalize_sequence_retains_prefix_before_release() -> None:
+    runtime = FakeRuntime()
+    lifecycle = _make_lifecycle(runtime)
+    state = lifecycle.state
 
     scheduler = object.__new__(GenerationScheduler)
     scheduler.runtime = runtime
@@ -60,3 +85,17 @@ def test_finalize_sequence_retains_prefix_before_release() -> None:
     assert retain_call["adapter_id"] == "adapter-a"
     assert retain_call["image_hash"] == b"0123456789abcdef"
     assert runtime.released_sequences == [state]
+
+
+def test_release_sequence_does_not_release_when_retention_fails() -> None:
+    runtime = _FailingRetainRuntime()
+    lifecycle = _make_lifecycle(runtime)
+
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = runtime
+
+    with pytest.raises(RuntimeError, match="retain failed"):
+        GenerationScheduler._release_sequence(scheduler, lifecycle)
+
+    assert runtime.released_sequences == []
+    assert lifecycle.state.batch_idx in runtime.active_sequences

--- a/tests/scheduler/test_release_sequence.py
+++ b/tests/scheduler/test_release_sequence.py
@@ -87,7 +87,7 @@ def test_finalize_sequence_retains_prefix_before_release() -> None:
     assert runtime.released_sequences == [state]
 
 
-def test_release_sequence_does_not_release_when_retention_fails() -> None:
+def test_release_sequence_releases_and_propagates_when_retention_fails() -> None:
     runtime = _FailingRetainRuntime()
     lifecycle = _make_lifecycle(runtime)
 
@@ -97,5 +97,5 @@ def test_release_sequence_does_not_release_when_retention_fails() -> None:
     with pytest.raises(RuntimeError, match="retain failed"):
         GenerationScheduler._release_sequence(scheduler, lifecycle)
 
-    assert runtime.released_sequences == []
-    assert lifecycle.state.batch_idx in runtime.active_sequences
+    assert runtime.released_sequences == [lifecycle.state]
+    assert lifecycle.state.batch_idx not in runtime.active_sequences

--- a/tests/scheduler/test_release_sequence.py
+++ b/tests/scheduler/test_release_sequence.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+
+from kestrel.runtime import SequenceState, TextToken
+from kestrel.scheduler.scheduler import GenerationScheduler
+from kestrel.scheduler.types import GenerationRequest, RequestLifecycle
+
+from tests.scheduler._fake_runtime import FakeRuntime
+
+
+@dataclass
+class _SkillStateStub:
+    tokens: list[object] = field(default_factory=list)
+
+    @property
+    def token_count(self) -> int:
+        return len(self.tokens)
+
+
+def test_finalize_sequence_retains_prefix_before_release() -> None:
+    runtime = FakeRuntime()
+    state = SequenceState(
+        batch_idx=0,
+        length=2,
+        max_length=4,
+        prompt_length=1,
+    )
+    runtime.active_sequences[state.batch_idx] = state
+
+    request = GenerationRequest(
+        request_id=7,
+        prompt="prompt",
+        prompt_tokens=[TextToken(1)],
+        max_new_tokens=4,
+        skill=object(),
+        request_context=object(),
+        image_hash=b"0123456789abcdef",
+        adapter="adapter-a",
+    )
+    lifecycle = RequestLifecycle(
+        request=request,
+        skill_state=_SkillStateStub(tokens=[TextToken(10), TextToken(11)]),
+        sequence_state=state,
+    )
+    request.lifecycle = lifecycle
+
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = runtime
+    scheduler._completed = deque()
+    scheduler._build_result = lambda seq: object()
+
+    GenerationScheduler._finalize_sequence(scheduler, lifecycle, "stop")
+
+    assert len(runtime.retained_prefixes) == 1
+    retain_call = runtime.retained_prefixes[0]
+    assert retain_call["state"] is state
+    assert retain_call["generated_tokens"] == [TextToken(10), TextToken(11)]
+    assert retain_call["adapter_id"] == "adapter-a"
+    assert retain_call["image_hash"] == b"0123456789abcdef"
+    assert runtime.released_sequences == [state]

--- a/tests/test_page_table.py
+++ b/tests/test_page_table.py
@@ -1047,6 +1047,141 @@ class TestDuplicatePrefill:
 
 
 # =============================================================================
+# Decoded Prefix Retention Tests
+# =============================================================================
+
+
+class TestDecodedPrefixRetention:
+    """Tests for retaining decoded generated KV in prefix cache."""
+
+    def test_retain_sequence_prefix_extends_cache_to_processed_generated_tokens(
+        self,
+    ) -> None:
+        """Only generated tokens with KV pages are retained."""
+        cache = RadixPrefixCache()
+        page_table = PageTable(
+            n_pages=50, page_size=1, max_batch_size=5, device="cpu",
+            prefix_cache=cache,
+        )
+        runtime = _make_runtime_for_cache(cache, page_table)
+
+        prompt_tokens = [MockToken(1), MockToken(2)]
+        generated = [MockToken(10), MockToken(11), MockToken(12), MockToken(13)]
+        prompt_len = len(prompt_tokens)
+        batch = page_table.allocate()
+        page_table.reserve(batch, prompt_len + len(generated))
+
+        cache_result = runtime_mod._CacheLookupResult(
+            match=None,
+            skip_positions=0,
+            temp_lock_node=None,
+            can_reuse=False,
+            namespace=None,
+        )
+        cache_lock_node, cache_owned_page_count = runtime._finalize_cache_after_prefill(
+            cache_tokens=prompt_tokens,
+            cache_result=cache_result,
+            prompt_len=prompt_len,
+            batch_idx=batch,
+            adapter_id=None,
+            image_hash=None,
+        )
+        state = runtime_mod.SequenceState(
+            batch_idx=batch,
+            length=prompt_len + 3,
+            max_length=prompt_len + len(generated),
+            prompt_length=prompt_len,
+            cache_tokens=prompt_tokens,
+            cache_lock_node=cache_lock_node,
+            cache_owned_page_count=cache_owned_page_count,
+        )
+        runtime.active_sequences = {batch: state}
+        retained_pages = page_table.get_pages(batch, 0, prompt_len + 3)
+        final_private_page = page_table.get_pages(
+            batch, prompt_len + 3, prompt_len + 4
+        )[0]
+
+        runtime.retain_sequence_prefix(
+            state,
+            generated,
+            adapter_id=None,
+            image_hash=None,
+        )
+
+        namespace = CacheNamespace(runtime_id="test-model")
+        match = cache.match_prefix(prompt_tokens + generated, namespace=namespace)
+        assert match.matched_kv_length == prompt_len + 3
+        assert state.cache_owned_page_count == prompt_len + 3
+        assert state.cache_lock_node is match.last_node
+
+        runtime.release_sequence(state)
+        for page in retained_pages:
+            assert page not in page_table.free_pages
+        assert final_private_page in page_table.free_pages
+
+    def test_retain_sequence_prefix_does_not_claim_duplicate_private_pages(
+        self,
+    ) -> None:
+        """Duplicate generated prefixes keep private pages private."""
+        cache = RadixPrefixCache()
+        page_table = PageTable(
+            n_pages=80, page_size=1, max_batch_size=6, device="cpu",
+            prefix_cache=cache,
+        )
+        runtime = _make_runtime_for_cache(cache, page_table)
+
+        prompt_tokens = [MockToken(1), MockToken(2)]
+        generated = [MockToken(10), MockToken(11)]
+        full_tokens = prompt_tokens + generated
+        namespace = CacheNamespace(runtime_id="test-model")
+
+        batch_a = page_table.allocate()
+        pages_a = page_table.allocate_pages(len(full_tokens))
+        page_table.map_pages(batch_a, 0, pages_a)
+        insert_a = cache.insert(full_tokens, pages_a, namespace=namespace)
+        cache.lock(insert_a.node)
+        cache.unlock(insert_a.node)
+        page_table.erase(batch_a, cached_page_count=len(full_tokens))
+
+        match_prompt = cache.match_prefix(prompt_tokens, namespace=namespace)
+        assert match_prompt.matched_kv_length == len(prompt_tokens)
+        cache.lock(match_prompt.last_node)
+
+        batch_b = page_table.allocate()
+        page_table.map_pages(batch_b, 0, match_prompt.matched_pages)
+        private_generated_pages = page_table.allocate_pages(len(generated))
+        page_table.map_pages(
+            batch_b,
+            len(prompt_tokens),
+            private_generated_pages,
+        )
+        state = runtime_mod.SequenceState(
+            batch_idx=batch_b,
+            length=len(full_tokens),
+            max_length=len(full_tokens),
+            prompt_length=len(prompt_tokens),
+            cache_tokens=prompt_tokens,
+            cache_lock_node=match_prompt.last_node,
+            cache_owned_page_count=len(prompt_tokens),
+        )
+        runtime.active_sequences = {batch_b: state}
+
+        runtime.retain_sequence_prefix(
+            state,
+            generated,
+            adapter_id=None,
+            image_hash=None,
+        )
+
+        assert state.cache_owned_page_count == len(prompt_tokens)
+        assert state.cache_lock_node is match_prompt.last_node
+
+        runtime.release_sequence(state)
+        for page in private_generated_pages:
+            assert page in page_table.free_pages
+
+
+# =============================================================================
 # Backward Compatibility Tests
 # =============================================================================
 

--- a/tests/test_page_table.py
+++ b/tests/test_page_table.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 import torch
 
@@ -1182,61 +1180,65 @@ class TestDecodedPrefixRetention:
         for page in private_generated_pages:
             assert page in page_table.free_pages
 
-    def test_retain_sequence_prefix_raises_when_insert_is_refused(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """A refused insert must not silently drop generated-prefix reuse."""
+    def test_retain_sequence_prefix_skips_divergent_cached_prefix(self) -> None:
+        """Divergent generated prefixes release private pages normally."""
         cache = RadixPrefixCache()
         page_table = PageTable(
-            n_pages=50, page_size=1, max_batch_size=5, device="cpu",
+            n_pages=80, page_size=1, max_batch_size=6, device="cpu",
             prefix_cache=cache,
         )
         runtime = _make_runtime_for_cache(cache, page_table)
 
         prompt_tokens = [MockToken(1), MockToken(2)]
-        generated = [MockToken(10), MockToken(11)]
-        prompt_len = len(prompt_tokens)
-        batch = page_table.allocate()
-        page_table.reserve(batch, prompt_len + len(generated))
+        cached_prefix = prompt_tokens + [MockToken(10)]
+        generated = [MockToken(10), MockToken(12)]
+        full_tokens = prompt_tokens + generated
+        namespace = CacheNamespace(runtime_id="test-model")
 
-        cache_result = runtime_mod._CacheLookupResult(
-            match=None,
-            skip_positions=0,
-            temp_lock_node=None,
-            can_reuse=False,
-            namespace=None,
+        batch_a = page_table.allocate()
+        pages_a = page_table.allocate_pages(len(cached_prefix))
+        page_table.map_pages(batch_a, 0, pages_a)
+        insert_a = cache.insert(cached_prefix, pages_a, namespace=namespace)
+        cache.lock(insert_a.node)
+        cache.unlock(insert_a.node)
+        page_table.erase(batch_a, cached_page_count=len(cached_prefix))
+
+        match_prompt = cache.match_prefix(prompt_tokens, namespace=namespace)
+        assert match_prompt.matched_kv_length == len(prompt_tokens)
+        cache.lock(match_prompt.last_node)
+
+        batch_b = page_table.allocate()
+        page_table.map_pages(batch_b, 0, match_prompt.matched_pages)
+        private_generated_pages = page_table.allocate_pages(len(generated))
+        page_table.map_pages(
+            batch_b,
+            len(prompt_tokens),
+            private_generated_pages,
         )
-        cache_lock_node, cache_owned_page_count = runtime._finalize_cache_after_prefill(
+        state = runtime_mod.SequenceState(
+            batch_idx=batch_b,
+            length=len(full_tokens),
+            max_length=len(full_tokens),
+            prompt_length=len(prompt_tokens),
             cache_tokens=prompt_tokens,
-            cache_result=cache_result,
-            prompt_len=prompt_len,
-            batch_idx=batch,
+            cache_lock_node=match_prompt.last_node,
+            cache_owned_page_count=len(prompt_tokens),
+        )
+        runtime.active_sequences = {batch_b: state}
+
+        runtime.retain_sequence_prefix(
+            state,
+            generated,
             adapter_id=None,
             image_hash=None,
         )
-        state = runtime_mod.SequenceState(
-            batch_idx=batch,
-            length=prompt_len + len(generated),
-            max_length=prompt_len + len(generated),
-            prompt_length=prompt_len,
-            cache_tokens=prompt_tokens,
-            cache_lock_node=cache_lock_node,
-            cache_owned_page_count=cache_owned_page_count,
-        )
-        monkeypatch.setattr(
-            cache,
-            "insert",
-            lambda *args, **kwargs: SimpleNamespace(inserted_pages=0),
-        )
 
-        with pytest.raises(RuntimeError, match="Failed to retain decoded prefix"):
-            runtime.retain_sequence_prefix(
-                state,
-                generated,
-                adapter_id=None,
-                image_hash=None,
-            )
+        assert state.cache_owned_page_count == len(prompt_tokens)
+        assert state.cache_lock_node is match_prompt.last_node
+
+        runtime.release_sequence(state)
+        for page in private_generated_pages:
+            assert page in page_table.free_pages
 
 
 # =============================================================================

--- a/tests/test_page_table.py
+++ b/tests/test_page_table.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -1179,6 +1181,62 @@ class TestDecodedPrefixRetention:
         runtime.release_sequence(state)
         for page in private_generated_pages:
             assert page in page_table.free_pages
+
+    def test_retain_sequence_prefix_raises_when_insert_is_refused(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A refused insert must not silently drop generated-prefix reuse."""
+        cache = RadixPrefixCache()
+        page_table = PageTable(
+            n_pages=50, page_size=1, max_batch_size=5, device="cpu",
+            prefix_cache=cache,
+        )
+        runtime = _make_runtime_for_cache(cache, page_table)
+
+        prompt_tokens = [MockToken(1), MockToken(2)]
+        generated = [MockToken(10), MockToken(11)]
+        prompt_len = len(prompt_tokens)
+        batch = page_table.allocate()
+        page_table.reserve(batch, prompt_len + len(generated))
+
+        cache_result = runtime_mod._CacheLookupResult(
+            match=None,
+            skip_positions=0,
+            temp_lock_node=None,
+            can_reuse=False,
+            namespace=None,
+        )
+        cache_lock_node, cache_owned_page_count = runtime._finalize_cache_after_prefill(
+            cache_tokens=prompt_tokens,
+            cache_result=cache_result,
+            prompt_len=prompt_len,
+            batch_idx=batch,
+            adapter_id=None,
+            image_hash=None,
+        )
+        state = runtime_mod.SequenceState(
+            batch_idx=batch,
+            length=prompt_len + len(generated),
+            max_length=prompt_len + len(generated),
+            prompt_length=prompt_len,
+            cache_tokens=prompt_tokens,
+            cache_lock_node=cache_lock_node,
+            cache_owned_page_count=cache_owned_page_count,
+        )
+        monkeypatch.setattr(
+            cache,
+            "insert",
+            lambda *args, **kwargs: SimpleNamespace(inserted_pages=0),
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to retain decoded prefix"):
+            runtime.retain_sequence_prefix(
+                state,
+                generated,
+                adapter_id=None,
+                image_hash=None,
+            )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- retain generated-token KV pages in the prefix cache before releasing completed scheduler sequences
- only mark pages as cache-owned when they correspond to processed KV positions and match the cache tree's physical pages
- add runtime, duplicate-prefix ownership, scheduler release-order, and protocol fake coverage

## Validation
- `uv run pytest`
- `git diff --check`

## Notes
This keeps the behavior tied to the existing prefix-cache lifecycle: retained pages remain reclaimable after release and are returned through normal prefix-cache eviction.