### PR TITLE
Add private next-token suppression setting

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -201,6 +201,7 @@ class _PendingRequest:
     adapter: Optional[str] = None
     lora_slot: int = 0  # Always 0 here; scheduler assigns actual slot at admission
     return_logprobs: Optional[bool] = None
+    suppress_next_token_ids: Optional[tuple[int, ...]] = None
 
 
 @dataclass(slots=True)
@@ -541,6 +542,7 @@ class InferenceEngine:
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         _logprobs: Optional[bool] = None,
+        _suppress_next_token_ids: Optional[Sequence[int]] = None,
     ) -> EngineResult:
         future, _ = await self._submit_request(
             max_new_tokens=max_new_tokens,
@@ -550,6 +552,10 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             return_logprobs=_logprobs,
+            suppress_next_token_ids=self._normalize_suppress_next_token_ids(
+                _suppress_next_token_ids,
+                field_name="_suppress_next_token_ids",
+            ),
             stream_queue=None,
             skill=skill,
         )
@@ -610,6 +616,7 @@ class InferenceEngine:
         max_tokens = self._default_max_new_tokens
         adapter: Optional[str] = None
         return_logprobs = self._extract_logprobs(settings)
+        suppress_next_token_ids = self._extract_suppress_next_token_ids(settings)
         if settings is not None:
             if "temperature" in settings:
                 temperature = float(settings["temperature"])
@@ -655,6 +662,7 @@ class InferenceEngine:
                 temperature=temperature,
                 top_p=top_p,
                 _logprobs=return_logprobs,
+                _suppress_next_token_ids=suppress_next_token_ids,
                 skill="query",
             )
         return await self.submit(
@@ -665,6 +673,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             _logprobs=return_logprobs,
+            _suppress_next_token_ids=suppress_next_token_ids,
             skill="query",
         )
 
@@ -680,6 +689,7 @@ class InferenceEngine:
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)
+        suppress_next_token_ids = self._extract_suppress_next_token_ids(settings)
         max_tokens = self._default_max_new_tokens
         max_objects = None
         temperature = 0.0
@@ -714,6 +724,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             _logprobs=return_logprobs,
+            _suppress_next_token_ids=suppress_next_token_ids,
             skill="point",
         )
 
@@ -764,6 +775,7 @@ class InferenceEngine:
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)
+        suppress_next_token_ids = self._extract_suppress_next_token_ids(settings)
         temperature = self._default_temperature
         top_p = self._default_top_p
         max_tokens = self._default_max_new_tokens
@@ -797,6 +809,7 @@ class InferenceEngine:
                 temperature=temperature,
                 top_p=top_p,
                 _logprobs=return_logprobs,
+                _suppress_next_token_ids=suppress_next_token_ids,
                 skill="caption",
             )
         return await self.submit(
@@ -807,6 +820,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             _logprobs=return_logprobs,
+            _suppress_next_token_ids=suppress_next_token_ids,
             skill="caption",
         )
 
@@ -822,6 +836,7 @@ class InferenceEngine:
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)
+        suppress_next_token_ids = self._extract_suppress_next_token_ids(settings)
         max_objects = 50
         temperature = 0.0
         top_p = 1.0
@@ -851,6 +866,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             _logprobs=return_logprobs,
+            _suppress_next_token_ids=suppress_next_token_ids,
             skill="detect",
         )
 
@@ -868,6 +884,7 @@ class InferenceEngine:
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)
+        suppress_next_token_ids = self._extract_suppress_next_token_ids(settings)
         temperature = 0.0
         top_p = 1.0
         max_tokens = self._default_max_new_tokens
@@ -908,6 +925,7 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             _logprobs=return_logprobs,
+            _suppress_next_token_ids=suppress_next_token_ids,
             skill="segment",
         )
 
@@ -922,6 +940,7 @@ class InferenceEngine:
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         _logprobs: Optional[bool] = None,
+        _suppress_next_token_ids: Optional[Sequence[int]] = None,
     ) -> EngineStream:
         queue: _StreamQueue = asyncio.Queue()
         future, request_id = await self._submit_request(
@@ -932,6 +951,10 @@ class InferenceEngine:
             temperature=temperature,
             top_p=top_p,
             return_logprobs=_logprobs,
+            suppress_next_token_ids=self._normalize_suppress_next_token_ids(
+                _suppress_next_token_ids,
+                field_name="_suppress_next_token_ids",
+            ),
             stream_queue=queue,
             skill=skill,
         )
@@ -978,6 +1001,7 @@ class InferenceEngine:
         temperature: Optional[float],
         top_p: Optional[float],
         return_logprobs: Optional[bool],
+        suppress_next_token_ids: Optional[tuple[int, ...]],
         stream_queue: Optional[_StreamQueue],
         skill: str,
     ) -> Tuple[asyncio.Future[EngineResult], int]:
@@ -1025,6 +1049,7 @@ class InferenceEngine:
             request_context=request_context,
             adapter=adapter_id,
             return_logprobs=return_logprobs,
+            suppress_next_token_ids=suppress_next_token_ids,
         )
         await self._queue.put(payload)
         return future, req_id
@@ -1160,6 +1185,43 @@ class InferenceEngine:
         if not isinstance(raw, bool):
             raise TypeError("settings._logprobs must be a bool or None")
         return raw
+
+    def _extract_suppress_next_token_ids(
+        self, settings: Optional[Mapping[str, object]]
+    ) -> Optional[tuple[int, ...]]:
+        if settings is None or "_suppress_next_token_ids" not in settings:
+            return None
+        return self._normalize_suppress_next_token_ids(
+            settings["_suppress_next_token_ids"],
+            field_name="settings._suppress_next_token_ids",
+        )
+
+    def _normalize_suppress_next_token_ids(
+        self,
+        raw: object,
+        *,
+        field_name: str,
+    ) -> Optional[tuple[int, ...]]:
+        if raw is None:
+            return None
+        if isinstance(raw, (str, bytes)) or not isinstance(raw, Sequence):
+            raise TypeError(
+                f"{field_name} must be a sequence of non-negative token ids or None"
+            )
+
+        seen: set[int] = set()
+        token_ids: list[int] = []
+        for idx, value in enumerate(raw):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{field_name}[{idx}] must be an int token id")
+            if value < 0:
+                raise ValueError(f"{field_name}[{idx}] must be non-negative")
+            if value not in seen:
+                seen.add(value)
+                token_ids.append(value)
+        if not token_ids:
+            return None
+        return tuple(token_ids)
 
     def _build_stream_callback(
         self, req: _PendingRequest
@@ -1448,6 +1510,7 @@ class InferenceEngine:
             adapter=adapter,
             lora_slot=req.lora_slot,
             return_logprobs=req.return_logprobs,
+            suppress_next_token_ids=req.suppress_next_token_ids,
         )
         limit = runtime.max_seq_length
         target_total = request_obj.target_length
@@ -1461,7 +1524,48 @@ class InferenceEngine:
             request_obj,
             request_context=request_obj.request_context,
         )
+        self._validate_suppress_next_token_ids(
+            runtime,
+            request_obj,
+            skill_state,
+        )
         return request_obj, skill_state
+
+    def _validate_suppress_next_token_ids(
+        self,
+        runtime: Runtime,
+        request: GenerationRequest,
+        skill_state: SkillState,
+    ) -> None:
+        suppress = request.suppress_next_token_ids
+        if not suppress:
+            return
+
+        vocab_size = int(runtime.config.text.vocab_size)
+        for token_id in suppress:
+            if token_id >= vocab_size:
+                raise ValueError(
+                    "_suppress_next_token_ids contains token id "
+                    f"{token_id}, but vocab size is {vocab_size}"
+                )
+
+        allowed = skill_state.allowed_token_ids(runtime)
+        skill_suppressed = skill_state.suppressed_token_ids(runtime) or ()
+        if allowed:
+            remaining = (
+                set(int(token_id) for token_id in allowed)
+                - set(int(token_id) for token_id in skill_suppressed)
+                - set(suppress)
+            )
+            if not remaining:
+                raise ValueError(
+                    "_suppress_next_token_ids removed every allowed next token"
+                )
+        else:
+            banned = set(int(token_id) for token_id in skill_suppressed)
+            banned.update(suppress)
+            if len(banned) >= vocab_size:
+                raise ValueError("_suppress_next_token_ids removed every next token")
 
     def _to_engine_result(self, result: SchedulerResult) -> EngineResult:
         sched_metrics = result.metrics

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -52,6 +52,7 @@ from .spatial import compute_spatial_values
 _LOGGER = logging.getLogger(__name__)
 # Greedily build a prefill batch until aggregate query tokens reaches this floor.
 _MIN_PREFILL_LAUNCH_TOKENS = 2048
+_SAMPLING_EPS = 1e-6
 # Prefer seeding miss-frontier work only when launch capacity is large enough to
 # absorb the short-term hit latency tradeoff.
 _MISS_FRONTIER_MIN_CAPACITY = 32
@@ -1262,6 +1263,7 @@ class GenerationScheduler:
             return out[:0], None, None, None
 
         allowed_tokens: list[Optional[Sequence[int]]] = []
+        suppressed_tokens: list[Optional[Sequence[int]]] = []
         restrict = False
         for seq in sequences:
             # Skip constraint queries for finalized sequences (zombies).
@@ -1269,11 +1271,13 @@ class GenerationScheduler:
             # use-after-finalization bugs.
             if seq.finalized:
                 allowed_tokens.append(None)
+                suppressed_tokens.append(None)
                 continue
             allowed = seq.skill_state.allowed_token_ids(self.runtime)
             allowed_tokens.append(allowed)
             if allowed:
                 restrict = True
+            suppressed_tokens.append(seq.skill_state.suppressed_token_ids(self.runtime))
 
         if restrict:
             for i, allowed in enumerate(allowed_tokens):
@@ -1286,10 +1290,7 @@ class GenerationScheduler:
                 logits[i] = pruned
 
         # Apply per-skill token suppression (blacklist).
-        for i, seq in enumerate(sequences):
-            if seq.finalized:
-                continue
-            suppressed = seq.skill_state.suppressed_token_ids(self.runtime)
+        for i, suppressed in enumerate(suppressed_tokens):
             if suppressed:
                 idx = torch.tensor(suppressed, device=logits.device, dtype=torch.long)
                 logits[i, idx] = float("-inf")
@@ -1300,6 +1301,35 @@ class GenerationScheduler:
         )
         logprobs = logprobs_out[:batch] if want_logprobs else None
         out_view = out[:batch]
+
+        suppress_rows: list[tuple[int, tuple[int, ...]]] = []
+        for i, seq in enumerate(sequences):
+            suppress = seq.request.suppress_next_token_ids
+            if (
+                seq.finalized
+                or not suppress
+                or seq.skill_state.token_count != 0
+            ):
+                continue
+            suppress_rows.append((i, suppress))
+
+        baseline_row_idx: Tensor | None = None
+        baseline_logits: Tensor | None = None
+        if logprobs is not None and suppress_rows:
+            rows = [
+                i
+                for i, _ in suppress_rows
+                if sequences[i].request.return_logprobs is True
+            ]
+            if rows:
+                baseline_row_idx = torch.tensor(
+                    rows, device=logits.device, dtype=torch.long
+                )
+                baseline_logits = logits.index_select(0, baseline_row_idx)
+
+        for i, suppress in suppress_rows:
+            idx = torch.tensor(suppress, device=logits.device, dtype=torch.long)
+            logits[i, idx] = float("-inf")
 
         all_greedy = all(seq.request.temperature <= 0.0 for seq in sequences)
         if all_greedy:
@@ -1333,7 +1363,32 @@ class GenerationScheduler:
         )
         if sampled_raw is not out_view:
             out_view.copy_(sampled_raw)
+        if baseline_logits is not None and baseline_row_idx is not None:
+            if temps is None:
+                raise AssertionError("sampling temperatures are required for logprobs")
+            base_logprobs = self._selected_logprobs_from_logits(
+                baseline_logits,
+                out_view.index_select(0, baseline_row_idx),
+                temps.index_select(0, baseline_row_idx),
+            )
+            logprobs.index_copy_(0, baseline_row_idx, base_logprobs)
         return out_view, temps, top_ps, logprobs
+
+    @staticmethod
+    def _selected_logprobs_from_logits(
+        logits: Tensor,
+        sampled_ids: Tensor,
+        temperatures: Tensor,
+    ) -> Tensor:
+        temps = torch.clamp(temperatures, min=0.0)
+        effective_temp = torch.where(
+            temps > _SAMPLING_EPS,
+            temps,
+            torch.ones_like(temps),
+        ).unsqueeze(-1)
+        scaled = logits.to(dtype=torch.float32) / effective_temp
+        selected = scaled.gather(1, sampled_ids.unsqueeze(1)).squeeze(1)
+        return selected - torch.logsumexp(scaled, dim=-1)
 
     def _logprobs_for_sequences(
         self,

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -177,6 +177,7 @@ class GenerationRequest:
     adapter: Optional[str] = None
     lora_slot: int = 0  # Slot in workspace; 0 = no LoRA
     return_logprobs: Optional[bool] = None
+    suppress_next_token_ids: Optional[tuple[int, ...]] = None
 
     prompt_length: int = field(init=False)
 

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -81,16 +81,26 @@ def _scheduler(batch: int = 1) -> GenerationScheduler:
     return scheduler
 
 
-def _sequence(*, temperature: float, return_logprobs: bool | None) -> SimpleNamespace:
+def _sequence(
+    *,
+    temperature: float,
+    return_logprobs: bool | None,
+    suppress_next_token_ids: tuple[int, ...] | None = None,
+    token_count: int = 0,
+    allowed_token_ids: list[int] | None = None,
+    suppressed_token_ids: list[int] | None = None,
+) -> SimpleNamespace:
     return SimpleNamespace(
         finalized=False,
         skill_state=SimpleNamespace(
-            allowed_token_ids=lambda runtime: None,
-            suppressed_token_ids=lambda runtime: None,
+            token_count=token_count,
+            allowed_token_ids=lambda runtime: allowed_token_ids,
+            suppressed_token_ids=lambda runtime: suppressed_token_ids,
         ),
         request=SimpleNamespace(
             temperature=temperature,
             return_logprobs=return_logprobs,
+            suppress_next_token_ids=suppress_next_token_ids,
         ),
     )
 
@@ -272,6 +282,173 @@ def test_sample_batch_uses_sampler_for_greedy_logprobs(
     torch.testing.assert_close(call_temps, torch.zeros((1,), dtype=torch.float32))
     torch.testing.assert_close(call_top_ps, torch.ones((1,), dtype=torch.float32))
     assert call_logprobs is True
+
+
+def test_sample_batch_suppresses_next_token_only() -> None:
+    logits = torch.tensor([[5.0, 4.0, 0.0]], dtype=torch.float32)
+
+    sampled, _, _, _ = GenerationScheduler._sample_batch(
+        _scheduler(),
+        logits.clone(),
+        [
+            _sequence(
+                temperature=0.0,
+                return_logprobs=None,
+                suppress_next_token_ids=(0,),
+                token_count=0,
+            )
+        ],  # type: ignore[list-item]
+        torch.empty((1,), dtype=torch.long),
+    )
+    assert sampled.tolist() == [1]
+
+    sampled, _, _, _ = GenerationScheduler._sample_batch(
+        _scheduler(),
+        logits.clone(),
+        [
+            _sequence(
+                temperature=0.0,
+                return_logprobs=None,
+                suppress_next_token_ids=(0,),
+                token_count=1,
+            )
+        ],  # type: ignore[list-item]
+        torch.empty((1,), dtype=torch.long),
+    )
+    assert sampled.tolist() == [0]
+
+
+def test_sample_batch_suppression_preserves_baseline_logprob(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_sample_step_from_logits(
+        logits: torch.Tensor,
+        temperatures: torch.Tensor,
+        top_p: torch.Tensor,
+        *,
+        out: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+        logprobs_out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert torch.isneginf(logits[0, 0])
+        sampled = torch.tensor([1], dtype=torch.long)
+        if logprobs_out is not None:
+            logprobs_out.copy_(torch.tensor([-999.0], dtype=torch.float32))
+        if out is not None:
+            out.copy_(sampled)
+            return out
+        return sampled
+
+    monkeypatch.setattr(
+        "kestrel.scheduler.scheduler.sample_step_from_logits",
+        fake_sample_step_from_logits,
+    )
+
+    scheduler = _scheduler()
+    scheduler._sampling_temps_by_batch.fill_(1.0)
+    logits = torch.tensor([[10.0, 0.0, -10.0]], dtype=torch.float32)
+    sampled, _, _, logprobs = GenerationScheduler._sample_batch(
+        scheduler,
+        logits,
+        [
+            _sequence(
+                temperature=1.0,
+                return_logprobs=True,
+                suppress_next_token_ids=(0,),
+            )
+        ],  # type: ignore[list-item]
+        torch.empty((1,), dtype=torch.long),
+        batch_idx=torch.tensor([0], dtype=torch.long),
+        logprobs_out=torch.empty((1,), dtype=torch.float32),
+    )
+
+    expected = torch.log_softmax(
+        torch.tensor([[10.0, 0.0, -10.0]], dtype=torch.float32), dim=-1
+    )[0, 1]
+    assert sampled.tolist() == [1]
+    assert logprobs is not None
+    torch.testing.assert_close(logprobs, expected.view(1))
+
+
+def test_sample_batch_suppression_logprob_overwrite_is_row_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_sample_step_from_logits(
+        logits: torch.Tensor,
+        temperatures: torch.Tensor,
+        top_p: torch.Tensor,
+        *,
+        out: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+        logprobs_out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert torch.isneginf(logits[0, 0])
+        assert logits[1, 0] == 1.0
+        sampled = torch.tensor([1, 2], dtype=torch.long)
+        if logprobs_out is not None:
+            logprobs_out.copy_(torch.tensor([-999.0, -2.0], dtype=torch.float32))
+        if out is not None:
+            out.copy_(sampled)
+            return out
+        return sampled
+
+    monkeypatch.setattr(
+        "kestrel.scheduler.scheduler.sample_step_from_logits",
+        fake_sample_step_from_logits,
+    )
+
+    scheduler = _scheduler(batch=2)
+    scheduler._sampling_temps_by_batch.fill_(1.0)
+    logits = torch.tensor(
+        [
+            [10.0, 0.0, -10.0],
+            [1.0, 2.0, 3.0],
+        ],
+        dtype=torch.float32,
+    )
+    sampled, _, _, logprobs = GenerationScheduler._sample_batch(
+        scheduler,
+        logits,
+        [
+            _sequence(
+                temperature=1.0,
+                return_logprobs=True,
+                suppress_next_token_ids=(0,),
+            ),
+            _sequence(temperature=1.0, return_logprobs=True),
+        ],  # type: ignore[list-item]
+        torch.empty((2,), dtype=torch.long),
+        batch_idx=torch.tensor([0, 1], dtype=torch.long),
+        logprobs_out=torch.empty((2,), dtype=torch.float32),
+    )
+
+    expected_row0 = torch.log_softmax(
+        torch.tensor([[10.0, 0.0, -10.0]], dtype=torch.float32), dim=-1
+    )[0, 1]
+    assert sampled.tolist() == [1, 2]
+    assert logprobs is not None
+    torch.testing.assert_close(
+        logprobs,
+        torch.tensor([float(expected_row0), -2.0], dtype=torch.float32),
+    )
+
+
+def test_sample_batch_suppression_composes_with_allowed_tokens() -> None:
+    sampled, _, _, _ = GenerationScheduler._sample_batch(
+        _scheduler(),
+        torch.tensor([[5.0, 4.0, 3.0]], dtype=torch.float32),
+        [
+            _sequence(
+                temperature=0.0,
+                return_logprobs=None,
+                suppress_next_token_ids=(0,),
+                allowed_token_ids=[0, 1],
+            )
+        ],  # type: ignore[list-item]
+        torch.empty((1,), dtype=torch.long),
+    )
+
+    assert sampled.tolist() == [1]
 
 
 @pytest.mark.parametrize("temperature", [0.7, 0.0])

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -186,3 +186,67 @@ def test_extract_private_logprobs_setting() -> None:
     assert engine._extract_logprobs({"_logprobs": False}) is False
     with pytest.raises(TypeError, match="settings._logprobs"):
         engine._extract_logprobs({"_logprobs": 1})
+
+
+def test_extract_private_suppress_next_token_ids_setting() -> None:
+    engine = object.__new__(InferenceEngine)
+
+    assert engine._extract_suppress_next_token_ids(None) is None
+    assert engine._extract_suppress_next_token_ids({}) is None
+    assert engine._extract_suppress_next_token_ids({"_suppress_next_token_ids": None}) is None
+    assert engine._extract_suppress_next_token_ids({"_suppress_next_token_ids": []}) is None
+    assert engine._extract_suppress_next_token_ids({"_suppress_next_token_ids": [3, 5, 3]}) == (3, 5)
+
+    with pytest.raises(TypeError, match="settings._suppress_next_token_ids"):
+        engine._extract_suppress_next_token_ids({"_suppress_next_token_ids": 3})
+    with pytest.raises(TypeError, match="settings._suppress_next_token_ids"):
+        engine._extract_suppress_next_token_ids({"_suppress_next_token_ids": ["3"]})
+    with pytest.raises(TypeError, match="settings._suppress_next_token_ids"):
+        engine._extract_suppress_next_token_ids({"_suppress_next_token_ids": [True]})
+    with pytest.raises(ValueError, match="settings._suppress_next_token_ids"):
+        engine._extract_suppress_next_token_ids({"_suppress_next_token_ids": [-1]})
+
+
+def test_validate_suppress_next_token_ids_rejects_bad_request_scope() -> None:
+    engine = object.__new__(InferenceEngine)
+    runtime = SimpleNamespace(
+        config=SimpleNamespace(text=SimpleNamespace(vocab_size=4))
+    )
+
+    def skill_state(
+        *,
+        allowed: list[int] | None = None,
+        suppressed: list[int] | None = None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            allowed_token_ids=lambda runtime: allowed,
+            suppressed_token_ids=lambda runtime: suppressed,
+        )
+
+    valid_request = SimpleNamespace(suppress_next_token_ids=(1,))
+    engine._validate_suppress_next_token_ids(
+        runtime,
+        valid_request,
+        skill_state(allowed=[0, 1], suppressed=None),
+    )
+
+    with pytest.raises(ValueError, match="vocab size"):
+        engine._validate_suppress_next_token_ids(
+            runtime,
+            SimpleNamespace(suppress_next_token_ids=(4,)),
+            skill_state(),
+        )
+
+    with pytest.raises(ValueError, match="removed every allowed next token"):
+        engine._validate_suppress_next_token_ids(
+            runtime,
+            SimpleNamespace(suppress_next_token_ids=(0, 1)),
+            skill_state(allowed=[0, 1]),
+        )
+
+    with pytest.raises(ValueError, match="removed every next token"):
+        engine._validate_suppress_next_token_ids(
+            runtime,
+            SimpleNamespace(suppress_next_token_ids=(0, 1)),
+            skill_state(suppressed=[2, 3]),
+        )


### PR DESCRIPTION
## Summary
- Add private `_suppress_next_token_ids` request plumbing through the engine and scheduler.
- Apply the setting only to the first generated token, after existing skill constraints.
- Preserve baseline sampled-token logprobs by overwriting affected first-token logprobs from pre-private-suppression logits.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/home/vikhyat/code/scratch/worktrees/kestrel-suppress-next-token:/home/vikhyat/code/kestrel-proprietary/kestrel-kernels/python /home/vikhyat/code/kestrel/.venv/bin/pytest -p no:cacheprovider tests/test_engine.py tests/scheduler/test_logprobs.py`