### PR TITLE
Add point spatial references

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ print(result.output["points"])
 ```
 
 Coordinates are normalized to [0, 1] where (0, 0) is top-left.
+Point prompts can also include normalized spatial references:
+
+```python
+result = await engine.point(
+    image,
+    "gaze",
+    spatial_refs=[[0.42, 0.18]],  # e.g. the subject's head or eye location
+)
+```
 
 ### Detect
 

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -695,10 +695,14 @@ class InferenceEngine:
         image: Optional[np.ndarray | bytes],
         object: str,
         settings: Optional[Mapping[str, object]] = None,
+        *,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = None,
     ) -> EngineResult:
         normalized_object = object.strip()
         if not normalized_object:
             raise ValueError("object must be a non-empty string")
+        if spatial_refs and image is None:
+            raise ValueError("spatial_refs can only be used with an image")
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)
@@ -724,11 +728,13 @@ class InferenceEngine:
         if max_tokens <= 0:
             raise ValueError("max_tokens must be positive")
 
+        normalized_refs = normalize_spatial_refs(spatial_refs)
         request = PointRequest(
             object=normalized_object,
             image=image,
             stream=False,
             settings=PointSettings(temperature=temperature, top_p=top_p),
+            spatial_refs=normalized_refs,
         )
         return await self.submit(
             request,

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -618,7 +618,7 @@ class InferenceEngine:
         normalized_question = question.strip()
         if not normalized_question:
             raise ValueError("question must be a non-empty string")
-        if spatial_refs and image is None:
+        if spatial_refs is not None and image is None:
             raise ValueError("spatial_refs can only be used with an image")
 
         temperature = self._default_temperature
@@ -701,8 +701,8 @@ class InferenceEngine:
         normalized_object = object.strip()
         if not normalized_object:
             raise ValueError("object must be a non-empty string")
-        if spatial_refs and image is None:
-            raise ValueError("spatial_refs can only be used with an image")
+        if image is None:
+            raise ValueError("image must be provided for pointing")
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)
@@ -907,6 +907,8 @@ class InferenceEngine:
         normalized_object = object.strip()
         if not normalized_object:
             raise ValueError("object must be a non-empty string")
+        if image is None:
+            raise ValueError("image must be provided for segmentation")
 
         adapter = self._extract_adapter_id(settings)
         return_logprobs = self._extract_logprobs(settings)

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -618,7 +618,8 @@ class InferenceEngine:
         normalized_question = question.strip()
         if not normalized_question:
             raise ValueError("question must be a non-empty string")
-        if spatial_refs is not None and image is None:
+        normalized_refs = normalize_spatial_refs(spatial_refs)
+        if normalized_refs is not None and image is None:
             raise ValueError("spatial_refs can only be used with an image")
 
         temperature = self._default_temperature
@@ -651,7 +652,6 @@ class InferenceEngine:
         if max_tokens <= 0:
             raise ValueError("max_tokens must be positive")
 
-        normalized_refs = normalize_spatial_refs(spatial_refs)
         request = QueryRequest(
             question=normalized_question,
             image=image,

--- a/kestrel/skills/point.py
+++ b/kestrel/skills/point.py
@@ -2,11 +2,12 @@
 
 
 from dataclasses import dataclass
-from typing import Dict, Optional, Sequence
+from typing import Dict, List, Optional, Sequence
 
 import numpy as np
 
 from kestrel.moondream.runtime import CoordToken, SizeToken, TextToken, Token
+from kestrel.utils.spatial_refs import build_spatial_tokens
 
 from .base import DecodeStep, SkillFinalizeResult, SkillSpec, SkillState
 
@@ -31,6 +32,7 @@ class PointRequest:
     image: Optional[np.ndarray | bytes]
     stream: bool
     settings: PointSettings
+    spatial_refs: Optional[Sequence[Sequence[float]]] = None
 
 
 class PointSkill(SkillSpec):
@@ -53,9 +55,11 @@ class PointSkill(SkillSpec):
         suffix: Sequence[int] = template["suffix"]
         prompt = request_context.object
         object_tokens = runtime.tokenizer.encode(" " + prompt).ids if prompt else []
-        ids = [*prefix, *object_tokens, *suffix]
-        tokens = [TextToken(token_id=int(runtime.config.tokenizer.bos_id))]
-        tokens.extend(TextToken(token_id=int(tid)) for tid in ids)
+        tokens: List[Token] = [TextToken(token_id=int(runtime.config.tokenizer.bos_id))]
+        tokens.extend(TextToken(token_id=int(tid)) for tid in prefix)
+        tokens.extend(build_spatial_tokens(request_context.spatial_refs))
+        tokens.extend(TextToken(token_id=int(tid)) for tid in object_tokens)
+        tokens.extend(TextToken(token_id=int(tid)) for tid in suffix)
         return tokens
 
     def create_state(

--- a/tests/test_point_spatial_refs.py
+++ b/tests/test_point_spatial_refs.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from kestrel.engine import InferenceEngine
+from kestrel.moondream.runtime import CoordToken, SizeToken, TextToken
+from kestrel.skills.point import PointRequest, PointSettings, PointSkill
+
+
+class _FakeTokenizer:
+    def encode(self, text: str) -> SimpleNamespace:
+        assert text == " gaze"
+        return SimpleNamespace(ids=[42])
+
+
+def _fake_runtime() -> SimpleNamespace:
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            tokenizer=SimpleNamespace(
+                bos_id=1,
+                templates={"point": {"prefix": [10, 11], "suffix": [12]}},
+            )
+        ),
+        tokenizer=_FakeTokenizer(),
+    )
+
+
+def test_point_prompt_tokens_include_spatial_refs_before_object_text() -> None:
+    request = PointRequest(
+        object="gaze",
+        image=None,
+        stream=False,
+        settings=PointSettings(temperature=0.0, top_p=1.0),
+        spatial_refs=((0.2, 0.3), (0.1, 0.2, 0.5, 0.6)),
+    )
+
+    tokens = PointSkill().build_prompt_tokens(_fake_runtime(), request)
+
+    assert tokens[:3] == [TextToken(1), TextToken(10), TextToken(11)]
+    assert tokens[3] == CoordToken(pos=pytest.approx(0.2))
+    assert tokens[4] == CoordToken(pos=pytest.approx(0.3))
+    assert tokens[5] == CoordToken(pos=pytest.approx(0.3))
+    assert tokens[6] == CoordToken(pos=pytest.approx(0.4))
+    assert tokens[7] == SizeToken(width=pytest.approx(0.4), height=pytest.approx(0.4))
+    assert tokens[8:] == [TextToken(42), TextToken(12)]
+
+
+def test_engine_point_normalizes_spatial_refs_for_request() -> None:
+    engine = object.__new__(InferenceEngine)
+    engine._default_max_new_tokens = 128
+    captured: dict[str, object] = {}
+
+    async def fake_submit(request_context: object, **kwargs: object) -> SimpleNamespace:
+        captured["request_context"] = request_context
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(output={})
+
+    engine.submit = fake_submit  # type: ignore[method-assign]
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+
+    asyncio.run(
+        engine.point(
+            image,
+            " gaze ",
+            settings={"max_tokens": 32},
+            spatial_refs=[[0.2, 0.3], [0.1, 0.2, 0.5, 0.6]],
+        )
+    )
+
+    request = captured["request_context"]
+    assert isinstance(request, PointRequest)
+    assert request.object == "gaze"
+    assert request.spatial_refs == ((0.2, 0.3), (0.1, 0.2, 0.5, 0.6))
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["skill"] == "point"
+    assert kwargs["max_new_tokens"] == 32
+
+
+def test_engine_point_keeps_positional_settings_compatibility() -> None:
+    engine = object.__new__(InferenceEngine)
+    engine._default_max_new_tokens = 128
+    captured: dict[str, object] = {}
+
+    async def fake_submit(request_context: object, **kwargs: object) -> SimpleNamespace:
+        captured["request_context"] = request_context
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(output={})
+
+    engine.submit = fake_submit  # type: ignore[method-assign]
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+
+    asyncio.run(engine.point(image, "person", {"max_tokens": 12}))
+
+    request = captured["request_context"]
+    assert isinstance(request, PointRequest)
+    assert request.spatial_refs is None
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["max_new_tokens"] == 12
+
+
+def test_engine_point_rejects_spatial_refs_without_image() -> None:
+    engine = object.__new__(InferenceEngine)
+
+    with pytest.raises(ValueError, match="spatial_refs can only be used with an image"):
+        asyncio.run(engine.point(None, "gaze", spatial_refs=[[0.2, 0.3]]))

--- a/tests/test_point_spatial_refs.py
+++ b/tests/test_point_spatial_refs.py
@@ -9,6 +9,7 @@ import pytest
 from kestrel.engine import InferenceEngine
 from kestrel.moondream.runtime import CoordToken, SizeToken, TextToken
 from kestrel.skills.point import PointRequest, PointSettings, PointSkill
+from kestrel.skills.query import QueryRequest
 
 
 class _FakeTokenizer:
@@ -121,6 +122,28 @@ def test_engine_query_rejects_array_spatial_refs_without_image() -> None:
     refs = np.array([[0.2, 0.3]], dtype=np.float32)
     with pytest.raises(ValueError, match="spatial_refs can only be used with an image"):
         asyncio.run(engine.query(question="Where?", spatial_refs=refs))
+
+
+def test_engine_query_treats_empty_spatial_refs_as_unset_without_image() -> None:
+    engine = object.__new__(InferenceEngine)
+    engine._default_temperature = 0.0
+    engine._default_top_p = 1.0
+    engine._default_max_new_tokens = 128
+    captured: dict[str, object] = {}
+
+    async def fake_submit(request_context: object, **kwargs: object) -> SimpleNamespace:
+        captured["request_context"] = request_context
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(output={})
+
+    engine.submit = fake_submit  # type: ignore[method-assign]
+
+    asyncio.run(engine.query(question="Where?", spatial_refs=[]))
+
+    request = captured["request_context"]
+    assert isinstance(request, QueryRequest)
+    assert request.image is None
+    assert request.spatial_refs is None
 
 
 def test_engine_segment_requires_image_before_spatial_ref_validation() -> None:

--- a/tests/test_point_spatial_refs.py
+++ b/tests/test_point_spatial_refs.py
@@ -104,8 +104,28 @@ def test_engine_point_keeps_positional_settings_compatibility() -> None:
     assert kwargs["max_new_tokens"] == 12
 
 
-def test_engine_point_rejects_spatial_refs_without_image() -> None:
+def test_engine_point_requires_image_before_spatial_ref_validation() -> None:
     engine = object.__new__(InferenceEngine)
 
-    with pytest.raises(ValueError, match="spatial_refs can only be used with an image"):
+    with pytest.raises(ValueError, match="image must be provided for pointing"):
         asyncio.run(engine.point(None, "gaze", spatial_refs=[[0.2, 0.3]]))
+
+    refs = np.array([[0.2, 0.3]], dtype=np.float32)
+    with pytest.raises(ValueError, match="image must be provided for pointing"):
+        asyncio.run(engine.point(None, "gaze", spatial_refs=refs))
+
+
+def test_engine_query_rejects_array_spatial_refs_without_image() -> None:
+    engine = object.__new__(InferenceEngine)
+
+    refs = np.array([[0.2, 0.3]], dtype=np.float32)
+    with pytest.raises(ValueError, match="spatial_refs can only be used with an image"):
+        asyncio.run(engine.query(question="Where?", spatial_refs=refs))
+
+
+def test_engine_segment_requires_image_before_spatial_ref_validation() -> None:
+    engine = object.__new__(InferenceEngine)
+
+    refs = np.array([[0.2, 0.3]], dtype=np.float32)
+    with pytest.raises(ValueError, match="image must be provided for segmentation"):
+        asyncio.run(engine.segment(None, "person", spatial_refs=refs))


### PR DESCRIPTION
## Summary

- Adds optional `spatial_refs` support to `InferenceEngine.point`.
- Materializes point spatial references as typed coord/size prompt tokens before the point object text.
- Keeps existing positional `settings` calls working by making `spatial_refs` keyword-only.
- Documents the point-localization call shape in the README.

## Why

Gaze-style point prompts need to identify the subject whose gaze should be followed, such as a head or eye location. Query and segment already support spatial references; this brings point prompts in line with that behavior.

## Validation

- `uv run pytest tests/test_point_spatial_refs.py tests/test_engine.py tests/scheduler/test_tokens.py`
- `uv run python -m py_compile kestrel/engine.py kestrel/skills/point.py tests/test_point_spatial_refs.py`
- `git diff --check`