### PR TITLE
Pass token-major MoE LoRA metadata

### DIFF
--- a/kestrel/moondream/decode_slot.py
+++ b/kestrel/moondream/decode_slot.py
@@ -45,9 +45,16 @@ class DecodeMetaBuffers:
     batch_idx: CpuGpuBuffer  # int64 [max_batch] - sequence batch indices
     input_pos: CpuGpuBuffer  # int32 [max_batch] - token positions
     lora_slot_ids: CpuGpuBuffer  # int32 [max_batch] - LoRA slot assignments
-    lora_route_ids: CpuGpuBuffer  # int32 [max_batch] - compact MoE LoRA route ids
+    active_token_ids: CpuGpuBuffer  # int32 [max_batch] - token-major MoE LoRA ids
     active_lora_ids: CpuGpuBuffer  # int32 [max_batch] - active MoE LoRA ids
-    active_lora_meta: CpuGpuBuffer  # int32 [2] - active count and max rank
+    # int32 [max_loras + 4]. Layout:
+    #   [0] active LoRA count
+    #   [1] active max rank
+    #   [2] active token count
+    #   [3:] per-active-LoRA token-start offsets, plus one sentinel end offset
+    # The sentinel lets kernels read each range as meta[3 + i]..meta[4 + i]
+    # without a last-route special case.
+    active_lora_meta: CpuGpuBuffer
     moe_lora_metadata: Any | None = None
 
 
@@ -188,7 +195,7 @@ def create_decode_slot(
             device=device,
             pin_memory=True,
         ),
-        lora_route_ids=CpuGpuBuffer(
+        active_token_ids=CpuGpuBuffer(
             max_batch_slots,
             dtype=torch.int32,
             device=device,
@@ -201,7 +208,9 @@ def create_decode_slot(
             pin_memory=True,
         ),
         active_lora_meta=CpuGpuBuffer(
-            2,
+            # max_loras == max_batch_slots - 1 because LoRA slot 0 means no LoRA.
+            # The +4 layout above therefore becomes max_batch_slots + 3 here.
+            max_batch_slots + 3,
             dtype=torch.int32,
             device=device,
             pin_memory=True,

--- a/kestrel/moondream/layers.py
+++ b/kestrel/moondream/layers.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from ..dense_lora import (
@@ -156,7 +156,6 @@ def moe_mlp(
     *,
     mode: Literal["prefill", "decode"] = "decode",
     lora_workspace: MoELoRALayerWorkspace | None = None,
-    lora_slot_ids: torch.Tensor | None = None,
     moe_lora_metadata: Any | None = None,
 ) -> torch.Tensor:
     B, T, C = x.shape
@@ -172,24 +171,12 @@ def moe_mlp(
         softmax=True,
     )
 
-    # Expand slot IDs for all tokens if we have a sequence length > 1
-    expanded_slot_ids = None
-    expanded_metadata = moe_lora_metadata
-    if lora_workspace is not None and lora_slot_ids is not None:
-        expanded_slot_ids = lora_slot_ids.repeat_interleave(T)
-        if moe_lora_metadata is not None and moe_lora_metadata.lora_route_ids is not None:
-            expanded_metadata = replace(
-                moe_lora_metadata,
-                lora_route_ids=moe_lora_metadata.lora_route_ids.repeat_interleave(T),
-            )
-
     mlp_out = fused_mlp(
         x_flat,
         topk_weights,
         topk_idxs,
         lora_workspace,
-        expanded_slot_ids,
-        expanded_metadata,
+        moe_lora_metadata,
         mode=mode,
     ).view(B, T, C)
     return mlp_out

--- a/kestrel/moondream/moe.py
+++ b/kestrel/moondream/moe.py
@@ -139,7 +139,6 @@ class MoEModule(nn.Module):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         lora_workspace: MoELoRALayerWorkspace | None = None,
-        lora_slot_ids: torch.Tensor | None = None,
         moe_lora_metadata: _MOE_API.MoeLoraMetadata | None = None,
         mode: Literal["prefill", "decode"] = "decode",
     ) -> torch.Tensor:
@@ -183,15 +182,16 @@ class MoEModule(nn.Module):
         )
 
         lora_state = None
-        if lora_workspace is not None and lora_slot_ids is not None:
+        if lora_workspace is not None:
+            if moe_lora_metadata is None:
+                raise RuntimeError("MoE LoRA requires prepared token-major metadata")
             lora_state = _MOE_API.MoeLoraState(
-                lora_slot_ids=lora_slot_ids,
                 up_a=lora_workspace.up_a,
                 up_b=lora_workspace.up_b,
                 down_a=lora_workspace.down_a,
                 down_b=lora_workspace.down_b,
-                lora_ranks=lora_workspace.lora_ranks,
                 metadata=moe_lora_metadata,
+                lora_ranks=lora_workspace.lora_ranks,
             )
 
         return self._moe_runtime.forward(

--- a/kestrel/moondream/runtime.py
+++ b/kestrel/moondream/runtime.py
@@ -1511,26 +1511,30 @@ class MoondreamRuntime:
             )
             lora_slot_ids_cpu = torch.tensor([lora_slot], dtype=torch.int32)
             lora_slot_ids = lora_slot_ids_cpu.to(self.device)
+            token_lora_slot_ids_cpu = torch.full(
+                (int(M),), int(lora_slot), dtype=torch.int32
+            )
             moe_lora_metadata = moe_runtime.prepare_lora_metadata(
-                lora_slot_ids_cpu=lora_slot_ids_cpu,
-                lora_route_ids_cpu=torch.empty((1,), dtype=torch.int32),
-                lora_route_ids_gpu=torch.empty(
-                    (1,), dtype=torch.int32, device=self.device
+                lora_slot_ids_cpu=token_lora_slot_ids_cpu,
+                active_token_ids_cpu=torch.empty((int(M),), dtype=torch.int32),
+                active_token_ids_gpu=torch.empty(
+                    (int(M),), dtype=torch.int32, device=self.device
                 ),
-                active_lora_ids_cpu=torch.empty((1,), dtype=torch.int32),
+                active_lora_ids_cpu=torch.empty((max_loras,), dtype=torch.int32),
                 active_lora_ids_gpu=torch.empty(
-                    (1,), dtype=torch.int32, device=self.device
+                    (max_loras,), dtype=torch.int32, device=self.device
                 ),
-                active_lora_meta_cpu=torch.empty((2,), dtype=torch.int32),
+                # 3 header ints + one start offset per active LoRA + one sentinel
+                # end offset, so kernels can read route i as meta[3+i]..meta[4+i].
+                active_lora_meta_cpu=torch.empty((max_loras + 4,), dtype=torch.int32),
                 active_lora_meta_gpu=torch.empty(
-                    (2,), dtype=torch.int32, device=self.device
+                    (max_loras + 4,), dtype=torch.int32, device=self.device
                 ),
-                batch_size=1,
+                batch_size=int(M),
                 max_loras=max_loras,
                 lora_ranks_host=[
                     lora_workspace.moe_lora_rank_for_id(i) for i in range(max_loras)
                 ] if lora_workspace else None,
-                active_lora_token_counts=(int(M),),
                 active_lora_max_rank=active_lora_max_rank,
             )
 
@@ -1660,9 +1664,11 @@ class MoondreamRuntime:
     ) -> None:
         workspace = self._lora_workspace
         if workspace is None:
-            slot.meta.lora_route_ids.np[:batch_size] = -1
+            slot.meta.active_token_ids.np[:batch_size] = 0
+            slot.meta.active_lora_ids.np[:batch_size] = 0
             slot.meta.active_lora_meta.np[:] = 0
-            slot.meta.lora_route_ids.copy_to_gpu(batch_size)
+            slot.meta.active_token_ids.copy_to_gpu(batch_size)
+            slot.meta.active_lora_ids.copy_to_gpu(batch_size)
             slot.meta.active_lora_meta.copy_to_gpu()
             slot.meta.moe_lora_metadata = None
             return
@@ -1670,8 +1676,8 @@ class MoondreamRuntime:
         max_loras = max(0, workspace.max_slots - 1)
         slot.meta.moe_lora_metadata = get_runtime().moe.prepare_lora_metadata(
             lora_slot_ids_cpu=slot.meta.lora_slot_ids.cpu,
-            lora_route_ids_cpu=slot.meta.lora_route_ids.cpu,
-            lora_route_ids_gpu=slot.meta.lora_route_ids.gpu,
+            active_token_ids_cpu=slot.meta.active_token_ids.cpu,
+            active_token_ids_gpu=slot.meta.active_token_ids.gpu,
             active_lora_ids_cpu=slot.meta.active_lora_ids.cpu,
             active_lora_ids_gpu=slot.meta.active_lora_ids.gpu,
             active_lora_meta_cpu=slot.meta.active_lora_meta.cpu,
@@ -1924,8 +1930,8 @@ class MoondreamRuntime:
                 slot.meta.input_pos.gpu.zero_()
                 slot.meta.input_pos.cpu.zero_()
                 slot.meta.lora_slot_ids.gpu.zero_()
-                slot.meta.lora_route_ids.gpu.fill_(-1)
-                slot.meta.lora_route_ids.cpu.fill_(-1)
+                slot.meta.active_token_ids.gpu.zero_()
+                slot.meta.active_token_ids.cpu.zero_()
                 slot.meta.active_lora_ids.gpu.zero_()
                 slot.meta.active_lora_ids.cpu.zero_()
                 slot.meta.active_lora_meta.gpu.zero_()
@@ -1966,7 +1972,7 @@ class MoondreamRuntime:
                     slot.meta.batch_idx.gpu.zero_()
                     slot.meta.input_pos.gpu.zero_()
                     slot.meta.lora_slot_ids.gpu.zero_()
-                    slot.meta.lora_route_ids.gpu.fill_(-1)
+                    slot.meta.active_token_ids.gpu.zero_()
                     slot.meta.active_lora_ids.gpu.zero_()
                     slot.meta.active_lora_meta.gpu.zero_()
                     slot.fa3_page_table.zero_()

--- a/kestrel/moondream/text.py
+++ b/kestrel/moondream/text.py
@@ -241,7 +241,6 @@ def text_decoder(
                 config.moe.experts_per_token,
                 mode=mode,
                 lora_workspace=moe_workspace,
-                lora_slot_ids=lora_slot_ids,
                 moe_lora_metadata=moe_lora_metadata,
             )
         else:

--- a/tests/moondream/test_moe.py
+++ b/tests/moondream/test_moe.py
@@ -127,14 +127,14 @@ def _make_decode_meta(max_batch: int) -> SimpleNamespace:
         lora_slot_ids=CpuGpuBuffer(
             max_batch, dtype=torch.int32, device=device, pin_memory=False
         ),
-        lora_route_ids=CpuGpuBuffer(
+        active_token_ids=CpuGpuBuffer(
             max_batch, dtype=torch.int32, device=device, pin_memory=False
         ),
         active_lora_ids=CpuGpuBuffer(
             max_batch, dtype=torch.int32, device=device, pin_memory=False
         ),
         active_lora_meta=CpuGpuBuffer(
-            2, dtype=torch.int32, device=device, pin_memory=False
+            max_batch + 3, dtype=torch.int32, device=device, pin_memory=False
         ),
     )
 
@@ -149,23 +149,25 @@ def test_decode_lora_metadata_uses_compact_graph_stable_buffers() -> None:
     runtime._prepare_decode_lora_metadata(slot, 6)
 
     torch.testing.assert_close(
-        slot.meta.active_lora_meta.gpu,
-        torch.tensor([3, 7], dtype=torch.int32),
+        slot.meta.active_lora_meta.gpu[:7],
+        torch.tensor([3, 7, 4, 0, 2, 3, 4], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        slot.meta.active_token_ids.gpu[:4],
+        torch.tensor([1, 3, 2, 4], dtype=torch.int32),
     )
     torch.testing.assert_close(
         slot.meta.active_lora_ids.gpu[:3],
         torch.tensor([2, 0, 1], dtype=torch.int32),
     )
-    torch.testing.assert_close(
-        slot.meta.lora_route_ids.gpu[:6],
-        torch.tensor([-1, 0, 1, 0, 2, -1], dtype=torch.int32),
-    )
+    assert slot.meta.moe_lora_metadata.active_token_ids.numel() == 6
+    assert slot.meta.moe_lora_metadata.active_lora_ids.numel() == 3
+    assert slot.meta.moe_lora_metadata.active_lora_meta.numel() == 7
 
     slot.meta.lora_slot_ids.np[:6] = 0
     runtime._prepare_decode_lora_metadata(slot, 6)
 
     torch.testing.assert_close(
-        slot.meta.lora_route_ids.gpu[:6],
-        torch.full((6,), -1, dtype=torch.int32),
+        slot.meta.active_lora_meta.gpu[:7],
+        torch.zeros((7,), dtype=torch.int32),
     )
-    torch.testing.assert_close(slot.meta.active_lora_meta.gpu, torch.zeros((2,), dtype=torch.int32))

--- a/tests/test_moe_lora.py
+++ b/tests/test_moe_lora.py
@@ -8,61 +8,6 @@ import torch.nn.functional as F
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 
 
-def _round_up(x: int, multiple: int) -> int:
-    return ((x + multiple - 1) // multiple) * multiple
-
-
-def _max_tokens_padded(topk_ids: torch.Tensor, block_size: int, num_experts: int) -> int:
-    padded = int(topk_ids.numel()) + int(num_experts) * (int(block_size) - 1)
-    if topk_ids.numel() < num_experts:
-        padded = min(int(topk_ids.numel()) * int(block_size), padded)
-    return padded
-
-
-def _alloc_lora_route(
-    topk_ids: torch.Tensor,
-    *,
-    block_size: int,
-    num_experts: int,
-    max_loras: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    max_tokens = _max_tokens_padded(topk_ids, block_size, num_experts)
-    max_blocks = _round_up(max_tokens, block_size) // block_size
-    return (
-        torch.empty((max_loras, max_tokens), dtype=torch.int32, device=topk_ids.device),
-        torch.empty((max_loras, max_blocks), dtype=torch.int32, device=topk_ids.device),
-        torch.empty((max_loras,), dtype=torch.int32, device=topk_ids.device),
-    )
-
-
-def _lora_route(
-    topk_ids: torch.Tensor,
-    token_lora_mapping: torch.Tensor,
-    *,
-    block_size: int,
-    num_experts: int,
-    max_loras: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    from kestrel_kernels.moe_align import moe_lora_align_block_size
-
-    sorted_ids, expert_ids, post = _alloc_lora_route(
-        topk_ids,
-        block_size=block_size,
-        num_experts=num_experts,
-        max_loras=max_loras,
-    )
-    moe_lora_align_block_size(
-        topk_ids,
-        token_lora_mapping,
-        num_experts,
-        block_size,
-        sorted_ids,
-        expert_ids,
-        post,
-    )
-    return sorted_ids, expert_ids, post
-
-
 def _reference_moe_lora(
     *,
     x: torch.Tensor,
@@ -96,6 +41,42 @@ def _reference_moe_lora(
     return out
 
 
+def _prepare_metadata(
+    lora_slot_ids: torch.Tensor,
+    *,
+    max_loras: int,
+    active_lora_max_rank: int = 8,
+    fixed_capacity: bool = False,
+):
+    from kestrel_kernels import get_runtime
+
+    lora_slot_ids_cpu = lora_slot_ids.detach().cpu().to(torch.int32)
+    num_tokens = int(lora_slot_ids_cpu.numel())
+    active_token_ids_cpu = torch.empty((num_tokens,), dtype=torch.int32)
+    active_lora_ids_cpu = torch.empty((max_loras,), dtype=torch.int32)
+    active_lora_meta_cpu = torch.empty((max_loras + 4,), dtype=torch.int32)
+    device = lora_slot_ids.device
+    return get_runtime().moe.prepare_lora_metadata(
+        lora_slot_ids_cpu=lora_slot_ids_cpu,
+        active_token_ids_cpu=active_token_ids_cpu,
+        active_token_ids_gpu=torch.empty(
+            (num_tokens,), dtype=torch.int32, device=device
+        ),
+        active_lora_ids_cpu=active_lora_ids_cpu,
+        active_lora_ids_gpu=torch.empty(
+            (max_loras,), dtype=torch.int32, device=device
+        ),
+        active_lora_meta_cpu=active_lora_meta_cpu,
+        active_lora_meta_gpu=torch.empty(
+            (max_loras + 4,), dtype=torch.int32, device=device
+        ),
+        batch_size=num_tokens,
+        max_loras=max_loras,
+        active_lora_max_rank=active_lora_max_rank,
+        fixed_capacity=fixed_capacity,
+    )
+
+
 def _apply_moe_lora(
     *,
     x: torch.Tensor,
@@ -104,25 +85,16 @@ def _apply_moe_lora(
     lora_a: torch.Tensor,
     lora_b: torch.Tensor,
     lora_slot_ids: torch.Tensor,
-    block_size: int,
     num_experts: int,
     max_loras: int,
     mul_routed_weight: bool = False,
-    active_lora_ids: torch.Tensor | None = None,
 ) -> torch.Tensor:
     from kestrel_kernels.moe.lora import apply_moe_lora_batched
 
-    token_lora_mapping = torch.where(
-        lora_slot_ids > 0,
-        lora_slot_ids - 1,
-        torch.tensor(-1, device=x.device, dtype=torch.int32),
-    ).to(torch.int32)
-    sorted_ids, expert_ids, post = _lora_route(
-        topk_ids,
-        token_lora_mapping,
-        block_size=block_size,
-        num_experts=num_experts,
+    metadata = _prepare_metadata(
+        lora_slot_ids,
         max_loras=max_loras,
+        active_lora_max_rank=int(lora_a.shape[1]),
     )
     output = torch.zeros(
         (topk_ids.shape[0], topk_ids.shape[1], lora_b.shape[1]),
@@ -136,19 +108,19 @@ def _apply_moe_lora(
     )
     apply_moe_lora_batched(
         x=x,
+        topk_ids=topk_ids,
         topk_weights=topk_weights,
         output=output,
         lora_a=lora_a,
         lora_b=lora_b,
-        sorted_token_ids=sorted_ids,
-        expert_ids=expert_ids,
-        num_tokens_post_padded=post,
+        active_token_ids=metadata.active_token_ids,
+        active_lora_ids=metadata.active_lora_ids,
+        active_lora_meta=metadata.active_lora_meta,
         top_k=topk_ids.shape[1],
         num_experts=num_experts,
-        block_size_m=block_size,
         scratch=scratch,
         mul_routed_weight=mul_routed_weight,
-        active_lora_ids=active_lora_ids,
+        active_lora_max_rank=metadata.active_lora_max_rank,
     )
     return output
 
@@ -166,9 +138,8 @@ def test_moe_lora_application_matches_reference(device: torch.device) -> None:
     num_experts = 64
     max_loras = 3
     rank = 8
-    hidden_dim = 32
-    out_dim = 48
-    block_size = 16
+    hidden_dim = 2048
+    out_dim = 2048
 
     x = (torch.randn((num_tokens, hidden_dim), device=device) * 0.25).to(dtype)
     topk_ids = torch.stack(
@@ -189,7 +160,6 @@ def test_moe_lora_application_matches_reference(device: torch.device) -> None:
         lora_a=lora_a,
         lora_b=lora_b,
         lora_slot_ids=lora_slot_ids,
-        block_size=block_size,
         num_experts=num_experts,
         max_loras=max_loras,
         mul_routed_weight=True,
@@ -222,11 +192,9 @@ def test_moe_lora_no_active_adapters_is_noop(device: torch.device) -> None:
         topk_weights=topk_weights,
         lora_a=lora_a,
         lora_b=lora_b,
-        lora_slot_ids=lora_slot_ids,
-        block_size=16,
+        lora_slot_ids=torch.zeros_like(lora_slot_ids),
         num_experts=64,
         max_loras=1,
-        active_lora_ids=torch.empty((0,), dtype=torch.int32, device=device),
     )
 
     torch.testing.assert_close(output, torch.zeros_like(output), rtol=0, atol=0)
@@ -234,7 +202,6 @@ def test_moe_lora_no_active_adapters_is_noop(device: torch.device) -> None:
 
 def test_moe_lora_cudagraph_replay_is_stable(device: torch.device) -> None:
     from kestrel_kernels.moe.lora import apply_moe_lora_batched
-    from kestrel_kernels.moe_align import moe_lora_align_block_size
 
     torch.manual_seed(1)
     dtype = torch.bfloat16
@@ -242,26 +209,25 @@ def test_moe_lora_cudagraph_replay_is_stable(device: torch.device) -> None:
     top_k = 8
     num_experts = 64
     rank = 8
-    block_size = 16
 
-    x = torch.randn((num_tokens, 16), dtype=dtype, device=device)
-    topk_ids = torch.randint(0, num_experts, (num_tokens, top_k), dtype=torch.int32, device=device)
+    hidden_dim = 2048
+    out_dim = 2048
+
+    x = torch.randn((num_tokens, hidden_dim), dtype=dtype, device=device)
+    topk_ids = torch.randint(
+        0, num_experts, (num_tokens, top_k), dtype=torch.int32, device=device
+    )
     topk_weights = torch.ones((num_tokens, top_k), dtype=dtype, device=device)
     lora_slot_ids = torch.tensor([1, 2, 0, 1], dtype=torch.int32, device=device)
-    lora_a = torch.randn((2 * num_experts, rank, 16), dtype=dtype, device=device)
-    lora_b = torch.randn((2 * num_experts, 24, rank), dtype=dtype, device=device)
-    token_lora_mapping = torch.where(
-        lora_slot_ids > 0,
-        lora_slot_ids - 1,
-        torch.tensor(-1, device=device, dtype=torch.int32),
-    ).to(torch.int32)
-    sorted_ids, expert_ids, post = _alloc_lora_route(
-        topk_ids,
-        block_size=block_size,
-        num_experts=num_experts,
+    lora_a = torch.randn((2 * num_experts, rank, hidden_dim), dtype=dtype, device=device)
+    lora_b = torch.randn((2 * num_experts, out_dim, rank), dtype=dtype, device=device)
+    metadata = _prepare_metadata(
+        lora_slot_ids,
         max_loras=2,
+        active_lora_max_rank=rank,
+        fixed_capacity=True,
     )
-    output = torch.empty((num_tokens, top_k, 24), dtype=dtype, device=device)
+    output = torch.empty((num_tokens, top_k, out_dim), dtype=dtype, device=device)
     scratch = torch.empty((num_tokens * top_k, rank), dtype=dtype, device=device)
 
     expected = _reference_moe_lora(
@@ -277,28 +243,20 @@ def test_moe_lora_cudagraph_replay_is_stable(device: torch.device) -> None:
 
     def run() -> None:
         output.zero_()
-        moe_lora_align_block_size(
-            topk_ids,
-            token_lora_mapping,
-            num_experts,
-            block_size,
-            sorted_ids,
-            expert_ids,
-            post,
-        )
         apply_moe_lora_batched(
             x=x,
+            topk_ids=topk_ids,
             topk_weights=topk_weights,
             output=output,
             lora_a=lora_a,
             lora_b=lora_b,
-            sorted_token_ids=sorted_ids,
-            expert_ids=expert_ids,
-            num_tokens_post_padded=post,
+            active_token_ids=metadata.active_token_ids,
+            active_lora_ids=metadata.active_lora_ids,
+            active_lora_meta=metadata.active_lora_meta,
             top_k=top_k,
             num_experts=num_experts,
-            block_size_m=block_size,
             scratch=scratch,
+            active_lora_max_rank=metadata.active_lora_max_rank,
         )
 
     for _ in range(3):
@@ -311,4 +269,4 @@ def test_moe_lora_cudagraph_replay_is_stable(device: torch.device) -> None:
     graph.replay()
     torch.cuda.synchronize()
 
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=2e-2, atol=2e-2)


### PR DESCRIPTION
## Summary
- switch MoE LoRA decode metadata from route IDs to token-major active-token IDs and offsets
- build token-major metadata for prefill and graph-stable decode
- stop passing LoRA slot IDs into the MoE kernel state; `MoeLoraState` now requires prepared metadata
- update Kestrel MoE LoRA tests to use the public metadata API instead of the deleted padded align helper

## Validation
- Local: `python -m py_compile kestrel/moondream/decode_slot.py kestrel/moondream/layers.py kestrel/moondream/runtime.py tests/moondream/test_moe.py tests/test_moe_lora.py`
- Local: `PYTHONPATH=/tmp/kestrel-kernels-moe-lora-token-major/kestrel-kernels/python /home/vikhyat/code/kestrel/.venv/bin/python -m pytest tests/moondream/test_moe.py -q` -> 4 passed
- evee2/B200: `tests/moondream/test_moe.py tests/test_moe_lora.py -q` against kernels PR source -> 7 passed
- belka/RTX 3090: `tests/moondream/test_moe.py tests/test_moe_lora.py -q` against kernels PR source -> 7 passed
- evee2/B200: active zero-adapter E2E ChartQA smoke over 5 rows; no-adapter and zero-adapter answers matched for every row, provider loaded the adapter 5 times