### PR TITLE
Use kernels MoE handle cache

### DIFF
--- a/kestrel/moondream/moe.py
+++ b/kestrel/moondream/moe.py
@@ -8,8 +8,6 @@ from torch.compiler import disable as torch_compiler_disable
 from .lora_workspace import MoELoRALayerWorkspace
 from kestrel_kernels import get_runtime, moe as _MOE_API
 
-_SHARED_MOE_HANDLES: dict[tuple, _MOE_API.MoeHandle] = {}
-
 
 class ExpertWeights(nn.Module):
     """Container for per-expert weight tensors."""
@@ -106,31 +104,11 @@ class MoEModule(nn.Module):
             max_lora_rank=max_lora_rank,
             mode=mode,
         )
-        key = (
-            str(hidden_states.device),
-            hidden_states.dtype,
-            weight_format,
-            capacity.max_tokens,
-            capacity.max_loras,
-            capacity.max_lora_rank,
-            capacity.mode,
-            self.num_experts,
-            self.top_k,
-            self.input_size,
-            self.hidden_size,
-            self.config.allow_tf32,
-            self.config.backend,
-            self.config.auto_backend_token_threshold,
+        return self._moe_runtime.prepare(
+            spec,
+            capacity,
+            device=hidden_states.device,
         )
-        handle = _SHARED_MOE_HANDLES.get(key)
-        if handle is None:
-            handle = self._moe_runtime.prepare(
-                spec,
-                capacity,
-                device=hidden_states.device,
-            )
-            _SHARED_MOE_HANDLES[key] = handle
-        return handle
 
     @torch_compiler_disable()
     def forward(

--- a/tests/moondream/test_moe.py
+++ b/tests/moondream/test_moe.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import torch
 
-from kestrel.moondream.moe import MoEConfig, MoEModule, _SHARED_MOE_HANDLES
+from kestrel.moondream.moe import MoEConfig, MoEModule
 from kestrel.moondream import runtime as runtime_mod
 from kestrel.utils import CpuGpuBuffer
 
@@ -12,15 +12,22 @@ from kestrel.utils import CpuGpuBuffer
 class _FakeMoeRuntime:
     def __init__(self) -> None:
         self.capacities = []
+        self.handles = {}
 
     def prepare(self, spec, capacity, *, device):
+        key = (spec, capacity, torch.device(device))
+        handle = self.handles.get(key)
+        if handle is not None:
+            return handle
         self.capacities.append(capacity)
-        return SimpleNamespace(
+        handle = SimpleNamespace(
             spec=spec,
             capacity=capacity,
             device=torch.device(device),
             impl=None,
         )
+        self.handles[key] = handle
+        return handle
 
 
 def _make_module(runtime: _FakeMoeRuntime) -> MoEModule:
@@ -35,80 +42,68 @@ def _make_module(runtime: _FakeMoeRuntime) -> MoEModule:
 
 
 def test_prefill_moe_handles_reuse_power_of_two_capacity_bucket() -> None:
-    _SHARED_MOE_HANDLES.clear()
-    try:
-        runtime = _FakeMoeRuntime()
-        module = _make_module(runtime)
+    runtime = _FakeMoeRuntime()
+    module = _make_module(runtime)
 
-        first = module._get_moe_handle(
-            hidden_states=torch.empty((129, 2048), dtype=torch.bfloat16),
-            weight_format="bf16",
-            max_loras=0,
-            mode="prefill",
-        )
-        second = module._get_moe_handle(
-            hidden_states=torch.empty((200, 2048), dtype=torch.bfloat16),
-            weight_format="bf16",
-            max_loras=0,
-            mode="prefill",
-        )
+    first = module._get_moe_handle(
+        hidden_states=torch.empty((129, 2048), dtype=torch.bfloat16),
+        weight_format="bf16",
+        max_loras=0,
+        mode="prefill",
+    )
+    second = module._get_moe_handle(
+        hidden_states=torch.empty((200, 2048), dtype=torch.bfloat16),
+        weight_format="bf16",
+        max_loras=0,
+        mode="prefill",
+    )
 
-        assert first is second
-        assert [capacity.max_tokens for capacity in runtime.capacities] == [256]
-    finally:
-        _SHARED_MOE_HANDLES.clear()
+    assert first is second
+    assert [capacity.max_tokens for capacity in runtime.capacities] == [256]
 
 
 def test_decode_moe_handles_remain_exact_capacity_for_cuda_graph_buckets() -> None:
-    _SHARED_MOE_HANDLES.clear()
-    try:
-        runtime = _FakeMoeRuntime()
-        module = _make_module(runtime)
+    runtime = _FakeMoeRuntime()
+    module = _make_module(runtime)
 
-        first = module._get_moe_handle(
-            hidden_states=torch.empty((8, 2048), dtype=torch.bfloat16),
-            weight_format="bf16",
-            max_loras=0,
-            mode="decode",
-        )
-        second = module._get_moe_handle(
-            hidden_states=torch.empty((16, 2048), dtype=torch.bfloat16),
-            weight_format="bf16",
-            max_loras=0,
-            mode="decode",
-        )
+    first = module._get_moe_handle(
+        hidden_states=torch.empty((8, 2048), dtype=torch.bfloat16),
+        weight_format="bf16",
+        max_loras=0,
+        mode="decode",
+    )
+    second = module._get_moe_handle(
+        hidden_states=torch.empty((16, 2048), dtype=torch.bfloat16),
+        weight_format="bf16",
+        max_loras=0,
+        mode="decode",
+    )
 
-        assert first is not second
-        assert [capacity.max_tokens for capacity in runtime.capacities] == [8, 16]
-    finally:
-        _SHARED_MOE_HANDLES.clear()
+    assert first is not second
+    assert [capacity.max_tokens for capacity in runtime.capacities] == [8, 16]
 
 
 def test_lora_rank_is_part_of_moe_handle_capacity() -> None:
-    _SHARED_MOE_HANDLES.clear()
-    try:
-        runtime = _FakeMoeRuntime()
-        module = _make_module(runtime)
+    runtime = _FakeMoeRuntime()
+    module = _make_module(runtime)
 
-        first = module._get_moe_handle(
-            hidden_states=torch.empty((8, 2048), dtype=torch.bfloat16),
-            weight_format="bf16",
-            max_loras=1,
-            max_lora_rank=4,
-            mode="decode",
-        )
-        second = module._get_moe_handle(
-            hidden_states=torch.empty((8, 2048), dtype=torch.bfloat16),
-            weight_format="bf16",
-            max_loras=1,
-            max_lora_rank=8,
-            mode="decode",
-        )
+    first = module._get_moe_handle(
+        hidden_states=torch.empty((8, 2048), dtype=torch.bfloat16),
+        weight_format="bf16",
+        max_loras=1,
+        max_lora_rank=4,
+        mode="decode",
+    )
+    second = module._get_moe_handle(
+        hidden_states=torch.empty((8, 2048), dtype=torch.bfloat16),
+        weight_format="bf16",
+        max_loras=1,
+        max_lora_rank=8,
+        mode="decode",
+    )
 
-        assert first is not second
-        assert [capacity.max_lora_rank for capacity in runtime.capacities] == [4, 8]
-    finally:
-        _SHARED_MOE_HANDLES.clear()
+    assert first is not second
+    assert [capacity.max_lora_rank for capacity in runtime.capacities] == [4, 8]
 
 
 class _FakeLoraWorkspace:


### PR DESCRIPTION
## Summary

- remove Kestrel's local `_SHARED_MOE_HANDLES` cache
- keep capacity bucketing in `MoEModule`, then delegate handle reuse to `kestrel-kernels.moe.prepare()`
- update MoE tests to model the cached runtime behavior

## Dependency

This should merge after `m87-labs/kestrel-proprietary` has the cached `kestrel-kernels.moe.prepare()` change available, or after a release that includes it.

## Validation

- `uv run pytest tests/moondream/test_moe.py -k "moe_handles or lora_rank"`
- `git diff --check`