### PR TITLE
Dispatch runtime construction through ModelSpec.runtime

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -55,7 +55,6 @@ import torch
 from kestrel_kernels import get_runtime
 from kestrel.config import RuntimeConfig
 from kestrel.device import set_device, synchronize
-from kestrel.models.moondream.runtime import MoondreamRuntime
 from kestrel.runtime import Runtime
 from kestrel.scheduler import (
     GeneratedPrefix,
@@ -332,7 +331,8 @@ class InferenceEngine:
         self._api_base_url = api_base_url
 
         # An externally-built runtime is held from construction; otherwise
-        # ``_initialize`` builds a MoondreamRuntime on first ``create``.
+        # ``_initialize`` builds one via the spec's ``runtime`` factory
+        # on first ``create``.
         self._runtime: Optional[Runtime] = runtime
         # ``_initialized`` flips at the very end of ``_initialize`` so
         # any partial failure (warmup, photon validation) leaves the
@@ -452,8 +452,11 @@ class InferenceEngine:
                         "if LoRA support is needed on your platform."
                     )
                     max_lora_rank = None
+            from kestrel.models import get_spec
+
+            runtime_cls = get_spec(self._runtime_cfg.model).runtime
             self._runtime = await loop.run_in_executor(
-                None, lambda: MoondreamRuntime(self._runtime_cfg, max_lora_rank=max_lora_rank)
+                None, lambda: runtime_cls(self._runtime_cfg, max_lora_rank=max_lora_rank)
             )
         if self._scheduler_thread is None or not self._scheduler_thread.is_alive():
             self._scheduler_thread = threading.Thread(

--- a/kestrel/models/moondream/__init__.py
+++ b/kestrel/models/moondream/__init__.py
@@ -26,6 +26,7 @@ register(
         checkpoint_format="md2",
         default_config=DEFAULT_MOONDREAM2_CONFIG,
         tokenizer_id="moondream/starmie-v1",
+        runtime=MoondreamRuntime,
     )
 )
 register(
@@ -36,6 +37,7 @@ register(
         checkpoint_format="md3",
         default_config=DEFAULT_MOONDREAM3_CONFIG,
         tokenizer_id="moondream/starmie-v1",
+        runtime=MoondreamRuntime,
     )
 )
 

--- a/kestrel/models/registry.py
+++ b/kestrel/models/registry.py
@@ -3,14 +3,18 @@
 A ``ModelSpec`` carries the small handful of facts the engine needs to
 bootstrap a model: the HuggingFace download coordinates, the default
 config dict, the checkpoint format tag (consumed by the weight loader),
-and the HF tokenizer hub id.
+the HF tokenizer hub id, and the runtime constructor.
 
 New model families register themselves at import time from their
 package's ``__init__.py`` (see ``kestrel/models/moondream/__init__.py``).
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Callable, Dict, List
+
+if TYPE_CHECKING:
+    from kestrel.config import RuntimeConfig
+    from kestrel.runtime import Runtime
 
 
 @dataclass(frozen=True)
@@ -23,6 +27,11 @@ class ModelSpec:
     checkpoint_format: str
     default_config: Dict[str, Any]
     tokenizer_id: str
+    # Constructor invoked as ``runtime(cfg, **kwargs)`` by the engine to
+    # produce a concrete :class:`~kestrel.runtime.Runtime` for this
+    # model. Kwargs (e.g. ``max_lora_rank``) are forwarded from the
+    # engine's runtime-construction path.
+    runtime: Callable[..., "Runtime"]
 
 
 _REGISTRY: Dict[str, ModelSpec] = {}


### PR DESCRIPTION
## Summary

- Adds a ``runtime`` field to ``ModelSpec`` holding the constructor the engine invokes as ``runtime(cfg, **kwargs)`` to produce a concrete ``Runtime`` for the given model. Both Moondream specs set it to ``MoondreamRuntime``.
- Replaces the hardcoded ``MoondreamRuntime(self._runtime_cfg, max_lora_rank=...)`` in ``InferenceEngine._initialize`` with ``get_spec(cfg.model).runtime(cfg, max_lora_rank=...)``, and drops the now-unused top-level ``MoondreamRuntime`` import from ``engine.py``.
- Lets external model packages plug in by registering a spec whose ``runtime`` points at their own class — no engine changes required to add a new model family.

The engine still imports other Moondream-specific helpers (image preprocessing, token types, LoRA adapter); decoupling those is a separate, larger follow-up.

## Verification

- ``pytest tests/`` on evee2 (B200): 316 passed, 4 skipped. The pre-existing ``tests/test_moe_lora.py`` kernel-skew failure is unchanged.
- Confirmed ``get_spec("moondream2").runtime`` and ``get_spec("moondream3-preview").runtime`` both resolve to ``MoondreamRuntime``.