### PR TITLE
Image preprocessing moves into the Runtime protocol

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -26,7 +26,6 @@ Callers provide raw questions/objects; the engine derives skill-specific context
 
 
 import asyncio
-import hashlib
 import itertools
 import logging
 import queue
@@ -36,6 +35,7 @@ from concurrent.futures import Future
 import os
 from dataclasses import dataclass, field
 from typing import (
+    Any,
     AsyncIterator,
     Callable,
     Dict,
@@ -65,8 +65,6 @@ from kestrel.scheduler import (
     SchedulerResult,
     StreamUpdate,
 )
-from kestrel.models.moondream.image_crops import OverlapCropOutput
-from kestrel.models.moondream.image_preprocessor import ImagePreprocessor
 from kestrel.models.moondream.vision import compute_overlap_crops
 from kestrel.skills import (
     CaptionSkill,
@@ -210,7 +208,7 @@ class _PendingRequest:
 @dataclass(slots=True)
 class _ReadyAdmission:
     req: _PendingRequest
-    crops: Optional[OverlapCropOutput]
+    crops: Any
     prefix_cache_hit: bool
 
 
@@ -218,16 +216,18 @@ class _AdmissionCoordinator:
     def __init__(
         self,
         runtime: Runtime,
-        image_preprocessor: ImagePreprocessor,
         wake_event: threading.Event,
         fail_request: Callable[[_PendingRequest, BaseException], None],
     ) -> None:
         self._runtime = runtime
-        self._image_preprocessor = image_preprocessor
         self._wake_event = wake_event
         self._fail_request = fail_request
+        # Image preprocessing payloads are opaque — the runtime decides
+        # what they contain (Moondream's ``OverlapCropOutput``,
+        # Gemma 4's pixel_values bundle, etc.) and threads them back
+        # into ``launch_prepared_batch``.
         self._pending_crops: Dict[
-            int, tuple[_PendingRequest, Future[OverlapCropOutput]]
+            int, tuple[_PendingRequest, "Future[Any]"]
         ] = {}
         self._ready_crops: queue.Queue[int] = queue.Queue()
 
@@ -239,7 +239,7 @@ class _AdmissionCoordinator:
             return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=False)
 
         if self._runtime.prefix_cache is not None:
-            req.image_hash = self._compute_image_hash(req.image)
+            req.image_hash = self._runtime.image_hash(req.image)
             prefill_tokens = list(req.prompt_tokens) + list(req.generated_prefix.tokens)
             if self._runtime.check_prefix_cache(
                 prefill_tokens, req.image_hash, req.adapter
@@ -247,9 +247,7 @@ class _AdmissionCoordinator:
                 return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=True)
 
         try:
-            future = self._image_preprocessor.submit(
-                req.image, self._runtime.config.vision
-            )
+            future = self._runtime.preprocess_image_async(req.image)
         except Exception as exc:
             self._fail_request(req, exc)
             return None
@@ -288,10 +286,6 @@ class _AdmissionCoordinator:
             self._fail_request(req, exc)
         self._pending_crops.clear()
         self._drain_ready_notifications()
-
-    def _compute_image_hash(self, image: np.ndarray | bytes) -> bytes:
-        raw_bytes = image.tobytes() if isinstance(image, np.ndarray) else image
-        return hashlib.sha256(raw_bytes).digest()
 
     def _on_crops_ready(self, request_id: int) -> None:
         self._ready_crops.put(request_id)
@@ -357,7 +351,6 @@ class InferenceEngine:
         self._request_ids = itertools.count()
         self._shutdown = False
         self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._image_preprocessor = ImagePreprocessor()
         self._skills = skills or SkillRegistry(
             [
                 QuerySkill(),
@@ -535,7 +528,8 @@ class InferenceEngine:
                 _LOGGER.exception("Failed to stop Photon reporter")
             finally:
                 self._photon_reporter = None
-        self._image_preprocessor.shutdown(wait=True)
+        if self._runtime is not None:
+            self._runtime.shutdown_image_preprocessor()
 
     async def submit(
         self,
@@ -1474,14 +1468,13 @@ class InferenceEngine:
         paused_event = self._paused_event
         admission = _AdmissionCoordinator(
             runtime=runtime,
-            image_preprocessor=self._image_preprocessor,
             wake_event=wake_event,
             fail_request=self._fail_request,
         )
 
         def admit_request(
             req: _PendingRequest,
-            crops: Optional[OverlapCropOutput],
+            crops: Any,
             *,
             prefix_cache_hit: bool = False,
         ) -> None:
@@ -1642,7 +1635,7 @@ class InferenceEngine:
         self,
         runtime: Runtime,
         req: _PendingRequest,
-        image_crops: Optional[OverlapCropOutput],
+        image_crops: Any,
     ) -> tuple[GenerationRequest, SkillState]:
         prompt_tokens = req.prompt_tokens
         stream_cb = self._build_stream_callback(req)

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -26,6 +26,7 @@ Callers provide raw questions/objects; the engine derives skill-specific context
 
 
 import asyncio
+import hashlib
 import itertools
 import logging
 import queue
@@ -212,6 +213,12 @@ class _ReadyAdmission:
     prefix_cache_hit: bool
 
 
+def _hash_image(image: np.ndarray | bytes) -> bytes:
+    """SHA-256 over the raw image input for prefix-cache keying."""
+    raw = image.tobytes() if isinstance(image, np.ndarray) else image
+    return hashlib.sha256(raw).digest()
+
+
 class _AdmissionCoordinator:
     def __init__(
         self,
@@ -239,7 +246,7 @@ class _AdmissionCoordinator:
             return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=False)
 
         if self._runtime.prefix_cache is not None:
-            req.image_hash = self._runtime.image_hash(req.image)
+            req.image_hash = _hash_image(req.image)
             prefill_tokens = list(req.prompt_tokens) + list(req.generated_prefix.tokens)
             if self._runtime.check_prefix_cache(
                 prefill_tokens, req.image_hash, req.adapter

--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -333,8 +333,11 @@ class InferenceEngine:
 
         # An externally-built runtime is held from construction; otherwise
         # ``_initialize`` builds one via the spec's ``runtime`` factory
-        # on first ``create``.
+        # on first ``create``. ``_owns_runtime`` lets shutdown skip the
+        # preprocessor-shutdown call when the runtime came from the
+        # caller (they own its lifecycle).
         self._runtime: Optional[Runtime] = runtime
+        self._owns_runtime: bool = runtime is None
         # ``_initialized`` flips at the very end of ``_initialize`` so
         # any partial failure (warmup, photon validation) leaves the
         # engine retry-able. ``_init_task`` is the asyncio task that's
@@ -535,7 +538,7 @@ class InferenceEngine:
                 _LOGGER.exception("Failed to stop Photon reporter")
             finally:
                 self._photon_reporter = None
-        if self._runtime is not None:
+        if self._runtime is not None and self._owns_runtime:
             self._runtime.shutdown_image_preprocessor()
 
     async def submit(

--- a/kestrel/models/moondream/config.py
+++ b/kestrel/models/moondream/config.py
@@ -87,11 +87,19 @@ class TokenizerConfig:
         template = self.templates.get("query")
         if template is None:
             return None
+        # ``prefix_when_reasoning`` is optional; configs that don't set
+        # it (Moondream today) fall through to ``prefix`` for both modes.
+        prefix_when_reasoning = template.get("prefix_when_reasoning")
         return QueryTemplate(
             prefix=list(template["prefix"]),
             answer_prefix=list(template["answer_prefix"]),
             reasoning_prefix=list(template["reasoning_prefix"]),
             post_reasoning_prefix=list(template["post_reasoning_prefix"]),
+            prefix_when_reasoning=(
+                list(prefix_when_reasoning)
+                if prefix_when_reasoning is not None
+                else None
+            ),
         )
 
     def detect(self) -> Optional[PrefixSuffix]:

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -437,6 +437,11 @@ class MoondreamRuntime:
         # (Primary stream was created earlier for PageTable H2D sync.)
         self._copy_stream = make_stream(self.device)
 
+        # Image preprocessing pool — owned here so other runtimes can
+        # plug in their own preprocessing without the engine knowing.
+        from kestrel.models.moondream.image_preprocessor import ImagePreprocessor
+        self._image_preprocessor = ImagePreprocessor()
+
         # Spatial decode RNG. Pre-refactor the scheduler's sampling RNG
         # was reused; now that spatial decode is runtime-owned we keep
         # our own generator so stochastic point/detect requests don't
@@ -752,6 +757,20 @@ class MoondreamRuntime:
             materialize_tokens=materialize_tokens,
             prepare_decode_inputs=prepare_decode_inputs,
         )
+
+    # --- Image preprocessing (Runtime protocol) ----------------------
+    def preprocess_image_async(self, image):
+        """Return a Future for Moondream's overlap-crop preprocessing."""
+        return self._image_preprocessor.submit(image, self.config.vision)
+
+    def shutdown_image_preprocessor(self) -> None:
+        self._image_preprocessor.shutdown(wait=True)
+
+    def image_hash(self, image) -> bytes:
+        import hashlib
+        import numpy as _np
+        raw = image.tobytes() if isinstance(image, _np.ndarray) else image
+        return hashlib.sha256(raw).digest()
 
     def acquire_prefill_slot(self, slot_id: int | None = None) -> PrefillSlot:
         if slot_id is None:

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import functools
+import hashlib
 import json
 from copy import deepcopy
 from dataclasses import dataclass
@@ -53,6 +54,7 @@ from kestrel.scheduler.spatial import compute_spatial_values
 from kestrel.models.registry import get_spec
 
 from .config import MoondreamConfig
+from .image_preprocessor import ImagePreprocessor
 from .model import MoondreamModel
 from .weights import load_moondream_weights
 from .text import (
@@ -439,7 +441,6 @@ class MoondreamRuntime:
 
         # Image preprocessing pool — owned here so other runtimes can
         # plug in their own preprocessing without the engine knowing.
-        from kestrel.models.moondream.image_preprocessor import ImagePreprocessor
         self._image_preprocessor = ImagePreprocessor()
 
         # Spatial decode RNG. Pre-refactor the scheduler's sampling RNG
@@ -767,9 +768,7 @@ class MoondreamRuntime:
         self._image_preprocessor.shutdown(wait=True)
 
     def image_hash(self, image) -> bytes:
-        import hashlib
-        import numpy as _np
-        raw = image.tobytes() if isinstance(image, _np.ndarray) else image
+        raw = image.tobytes() if isinstance(image, np.ndarray) else image
         return hashlib.sha256(raw).digest()
 
     def acquire_prefill_slot(self, slot_id: int | None = None) -> PrefillSlot:

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -3,7 +3,6 @@
 
 import contextlib
 import functools
-import hashlib
 import json
 from copy import deepcopy
 from dataclasses import dataclass
@@ -766,10 +765,6 @@ class MoondreamRuntime:
 
     def shutdown_image_preprocessor(self) -> None:
         self._image_preprocessor.shutdown(wait=True)
-
-    def image_hash(self, image) -> bytes:
-        raw = image.tobytes() if isinstance(image, np.ndarray) else image
-        return hashlib.sha256(raw).digest()
 
     def acquire_prefill_slot(self, slot_id: int | None = None) -> PrefillSlot:
         if slot_id is None:

--- a/kestrel/models/protocols.py
+++ b/kestrel/models/protocols.py
@@ -24,6 +24,12 @@ class QueryTemplate:
     answer_prefix: List[int]
     reasoning_prefix: List[int]
     post_reasoning_prefix: List[int]
+    # Optional override for ``prefix`` when ``reasoning=True``. Set this
+    # for models whose CoT mode needs a different *pre-question* structure
+    # (e.g. Gemma 4 emits an extra ``<|turn>system\n<|think|>`` block to
+    # activate thinking). ``None`` (default) keeps ``prefix`` for both
+    # modes — Moondream's pre-question layout is reasoning-independent.
+    prefix_reasoning: Optional[List[int]] = None
 
 
 @dataclass(frozen=True)

--- a/kestrel/models/protocols.py
+++ b/kestrel/models/protocols.py
@@ -29,7 +29,7 @@ class QueryTemplate:
     # (e.g. Gemma 4 emits an extra ``<|turn>system\n<|think|>`` block to
     # activate thinking). ``None`` (default) keeps ``prefix`` for both
     # modes — Moondream's pre-question layout is reasoning-independent.
-    prefix_reasoning: Optional[List[int]] = None
+    prefix_when_reasoning: Optional[List[int]] = None
 
 
 @dataclass(frozen=True)

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -17,7 +17,6 @@ record of the surface a runtime must satisfy today.
 
 from __future__ import annotations
 
-from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any, Mapping, Protocol, Sequence
 
 from kestrel.runtime.state import (
@@ -28,6 +27,7 @@ from kestrel.runtime.state import (
 from kestrel.runtime.tokens import Token
 
 if TYPE_CHECKING:
+    from concurrent.futures import Future
     import numpy as np
     import torch
     from torch import Tensor
@@ -88,11 +88,6 @@ class Runtime(Protocol):
     # Called once when the engine is shutting down so the runtime can
     # tear down its preprocessing thread pool (if any).
     def shutdown_image_preprocessor(self) -> None: ...
-
-    # Hash an image into the bytes used as the prefix-cache key. Lets
-    # runtimes pick a hashing scheme that matches how their preprocessor
-    # canonicalises the input.
-    def image_hash(self, image: np.ndarray | bytes) -> bytes: ...
 
     # Slot lifecycle
     def acquire_prefill_slot(self, slot_id: int | None = ...) -> Any: ...

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -17,6 +17,7 @@ record of the surface a runtime must satisfy today.
 
 from __future__ import annotations
 
+from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any, Mapping, Protocol, Sequence
 
 from kestrel.runtime.state import (
@@ -71,6 +72,27 @@ class Runtime(Protocol):
     def can_reserve(self, total_length: int) -> bool: ...
 
     def prefill_budget(self) -> tuple[int, int]: ...
+
+    # Image preprocessing. The engine receives raw images (np.ndarray
+    # or bytes) and needs them converted to whatever opaque payload the
+    # runtime threads through ``GenerationRequest.image_crops`` and
+    # back into ``launch_prepared_batch``. Different runtimes need
+    # different preprocessing (Moondream's overlap-crop pipeline vs.
+    # Gemma's resize+normalize), so the dispatch lives here. Async so
+    # the engine can hide preprocessing latency behind admission /
+    # other work.
+    def preprocess_image_async(
+        self, image: np.ndarray | bytes
+    ) -> Future[Any]: ...
+
+    # Called once when the engine is shutting down so the runtime can
+    # tear down its preprocessing thread pool (if any).
+    def shutdown_image_preprocessor(self) -> None: ...
+
+    # Hash an image into the bytes used as the prefix-cache key. Lets
+    # runtimes pick a hashing scheme that matches how their preprocessor
+    # canonicalises the input.
+    def image_hash(self, image: np.ndarray | bytes) -> bytes: ...
 
     # Slot lifecycle
     def acquire_prefill_slot(self, slot_id: int | None = ...) -> Any: ...

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -800,12 +800,13 @@ class GenerationScheduler:
             seq = lifecycle
             prepared_seq = prepared_sequences[0]
             try:
-                self.runtime.launch_prepared_batch(
-                    [prepared_seq],
-                    prefill_slot,
-                    images=[request.image],
-                    image_crops_list=[request.image_crops],
-                )
+                with torch.inference_mode():
+                    self.runtime.launch_prepared_batch(
+                        [prepared_seq],
+                        prefill_slot,
+                        images=[request.image],
+                        image_crops_list=[request.image_crops],
+                    )
                 lifecycle.prefill_completed_at = time.perf_counter()
                 # Ensure prefill forward completes before cache finalize + release.
                 with stream_context(self.runtime.primary_stream):
@@ -834,12 +835,13 @@ class GenerationScheduler:
             raise
 
         try:
-            logits = self.runtime.launch_prepared_batch(
-                prepared_sequences,
-                prefill_slot,
-                images=[request.image for request in requests],
-                image_crops_list=[request.image_crops for request in requests],
-            )
+            with torch.inference_mode():
+                logits = self.runtime.launch_prepared_batch(
+                    prepared_sequences,
+                    prefill_slot,
+                    images=[request.image for request in requests],
+                    image_crops_list=[request.image_crops for request in requests],
+                )
             prefill_completed = time.perf_counter()
             for lifecycle in lifecycles:
                 lifecycle.prefill_completed_at = prefill_completed
@@ -1016,8 +1018,12 @@ class GenerationScheduler:
             batch_indices_list = [seq.state.batch_idx for seq in sequences]
             self.runtime.page_table.commit_block_table(batch_indices_list)
 
-            # Run forward pass - writes to slot.logits and slot.hidden_last
-            self.runtime.decode_with_slot(slot, batch_size)
+            # Run forward pass - writes to slot.logits and slot.hidden_last.
+            # ``inference_mode`` is applied centrally here (not left to each
+            # runtime) so eager model paths can't accidentally retain
+            # autograd graphs in their KV caches across decode steps.
+            with torch.inference_mode():
+                self.runtime.decode_with_slot(slot, batch_size)
         except Exception:
             # Rollback inflight_refs on failure
             for seq in sequences:

--- a/kestrel/skills/query.py
+++ b/kestrel/skills/query.py
@@ -64,12 +64,12 @@ class QuerySkill(SkillSpec):
             if request_context.reasoning
             else template.answer_prefix
         )
-        # ``prefix_reasoning`` lets a model swap in a different pre-question
+        # ``prefix_when_reasoning`` lets a model swap in a different pre-question
         # structure for CoT (Gemma 4: extra ``<|turn>system\n<|think|>`` block
         # to activate thinking). When None, the same ``prefix`` covers both.
         pre_question: Sequence[int] = (
-            template.prefix_reasoning
-            if request_context.reasoning and template.prefix_reasoning is not None
+            template.prefix_when_reasoning
+            if request_context.reasoning and template.prefix_when_reasoning is not None
             else template.prefix
         )
         encoded = runtime.tokenizer.encode(prompt).ids if prompt else []

--- a/kestrel/skills/query.py
+++ b/kestrel/skills/query.py
@@ -64,11 +64,19 @@ class QuerySkill(SkillSpec):
             if request_context.reasoning
             else template.answer_prefix
         )
+        # ``prefix_reasoning`` lets a model swap in a different pre-question
+        # structure for CoT (Gemma 4: extra ``<|turn>system\n<|think|>`` block
+        # to activate thinking). When None, the same ``prefix`` covers both.
+        pre_question: Sequence[int] = (
+            template.prefix_reasoning
+            if request_context.reasoning and template.prefix_reasoning is not None
+            else template.prefix
+        )
         encoded = runtime.tokenizer.encode(prompt).ids if prompt else []
         # The runtime's _prepare_full_prefill_inputs places the first prompt token
         # before image tokens, so prepend BOS explicitly.
         tokens: List[Token] = [TextToken(token_id=int(pt.bos_id))]
-        tokens.extend(TextToken(token_id=int(tid)) for tid in template.prefix)
+        tokens.extend(TextToken(token_id=int(tid)) for tid in pre_question)
         tokens.extend(build_spatial_tokens(request_context.spatial_refs))
         tokens.extend(TextToken(token_id=int(tid)) for tid in encoded)
         tokens.extend(TextToken(token_id=int(tid)) for tid in opener)

--- a/scripts/chartqa_eval.py
+++ b/scripts/chartqa_eval.py
@@ -50,7 +50,7 @@ PREFIX = (
     "and provide a precise answer without any additional explanation or formatting. "
 )
 POT_PREFIX = "Write a Python program to answer the following question: "
-COT_MAX_TOKENS = 512
+COT_MAX_TOKENS = 1536  # bumped for Gemma 4's verbose CoT channel
 DEFAULT_MAX_TOKENS = 10
 POT_MAX_TOKENS = 200
 

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -174,6 +174,21 @@ class FakeRuntime:
     def prefill_budget(self) -> tuple[int, int]:
         return (self.max_seq_length, self.max_batch_slots)
 
+    # Image preprocessing ----------------------------------------------
+    def preprocess_image_async(self, image: Any) -> Any:
+        from concurrent.futures import Future
+        fut: Future = Future()
+        fut.set_result(image)
+        return fut
+
+    def shutdown_image_preprocessor(self) -> None:
+        pass
+
+    def image_hash(self, image: Any) -> bytes:
+        import hashlib
+        raw = image.tobytes() if hasattr(image, "tobytes") else bytes(image)
+        return hashlib.sha256(raw).digest()
+
     # Slot lifecycle ---------------------------------------------------
     def acquire_prefill_slot(self, slot_id: int | None = None) -> Any:
         self.acquired_prefill_slots.append(slot_id)

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -22,6 +22,8 @@ Behaviour:
 from __future__ import annotations
 
 import contextlib
+import hashlib
+from concurrent.futures import Future
 from typing import Any, Mapping, Sequence
 
 import torch
@@ -175,8 +177,7 @@ class FakeRuntime:
         return (self.max_seq_length, self.max_batch_slots)
 
     # Image preprocessing ----------------------------------------------
-    def preprocess_image_async(self, image: Any) -> Any:
-        from concurrent.futures import Future
+    def preprocess_image_async(self, image: Any) -> Future:
         fut: Future = Future()
         fut.set_result(image)
         return fut
@@ -185,7 +186,6 @@ class FakeRuntime:
         pass
 
     def image_hash(self, image: Any) -> bytes:
-        import hashlib
         raw = image.tobytes() if hasattr(image, "tobytes") else bytes(image)
         return hashlib.sha256(raw).digest()
 

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -22,7 +22,6 @@ Behaviour:
 from __future__ import annotations
 
 import contextlib
-import hashlib
 from concurrent.futures import Future
 from typing import Any, Mapping, Sequence
 
@@ -184,10 +183,6 @@ class FakeRuntime:
 
     def shutdown_image_preprocessor(self) -> None:
         pass
-
-    def image_hash(self, image: Any) -> bytes:
-        raw = image.tobytes() if hasattr(image, "tobytes") else bytes(image)
-        return hashlib.sha256(raw).digest()
 
     # Slot lifecycle ---------------------------------------------------
     def acquire_prefill_slot(self, slot_id: int | None = None) -> Any:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -115,10 +115,6 @@ class _FakeRuntime:
     def shutdown_image_preprocessor(self) -> None:  # pragma: no cover
         pass
 
-    def image_hash(self, image: np.ndarray | bytes) -> bytes:
-        raw = image.tobytes() if isinstance(image, np.ndarray) else image
-        return hashlib.sha256(raw).digest()
-
 
 def _record_failure(
     failures: list[tuple[_PendingRequest, BaseException]]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -72,12 +72,36 @@ class _PrefixSkill(SkillSpec):
         return _PrefixSkillState(self, request)
 
 
+class _FakeImagePreprocessor:
+    """Stand-in for a runtime's image-preprocessing executor.
+
+    The engine now dispatches image preprocessing through
+    ``runtime.preprocess_image_async``; tests attach one of these to a
+    ``_FakeRuntime`` to control the future returned per call.
+    """
+
+    def __init__(self, futures: list[Future[object]] | None = None) -> None:
+        self.futures = futures or [Future()]
+        self.submissions: list[np.ndarray | bytes] = []
+
+    def submit(self, image: np.ndarray | bytes) -> Future[object]:
+        self.submissions.append(image)
+        return self.futures.pop(0)
+
+
 class _FakeRuntime:
-    def __init__(self, *, prefix_cache: object | None, prefix_hit: bool) -> None:
+    def __init__(
+        self,
+        *,
+        prefix_cache: object | None,
+        prefix_hit: bool,
+        image_preprocessor: _FakeImagePreprocessor | None = None,
+    ) -> None:
         self.prefix_cache = prefix_cache
         self.config = SimpleNamespace(vision=object())
         self._prefix_hit = prefix_hit
         self.cache_checks: list[tuple[list[object], bytes | None, str | None]] = []
+        self._image_preprocessor = image_preprocessor or _FakeImagePreprocessor()
 
     def check_prefix_cache(
         self, tokens_list: list[object], image_hash: bytes | None, adapter: str | None
@@ -85,17 +109,15 @@ class _FakeRuntime:
         self.cache_checks.append((tokens_list, image_hash, adapter))
         return self._prefix_hit
 
+    def preprocess_image_async(self, image: np.ndarray | bytes) -> Future[object]:
+        return self._image_preprocessor.submit(image)
 
-class _FakeImagePreprocessor:
-    def __init__(self, futures: list[Future[object]] | None = None) -> None:
-        self.futures = futures or [Future()]
-        self.submissions: list[tuple[np.ndarray | bytes, object]] = []
+    def shutdown_image_preprocessor(self) -> None:  # pragma: no cover
+        pass
 
-    def submit(
-        self, image: np.ndarray | bytes, vision_config: object
-    ) -> Future[object]:
-        self.submissions.append((image, vision_config))
-        return self.futures.pop(0)
+    def image_hash(self, image: np.ndarray | bytes) -> bytes:
+        raw = image.tobytes() if isinstance(image, np.ndarray) else image
+        return hashlib.sha256(raw).digest()
 
 
 def _record_failure(
@@ -108,12 +130,13 @@ def _record_failure(
 
 
 def test_admission_coordinator_immediately_admits_text_only_request() -> None:
-    runtime = _FakeRuntime(prefix_cache=None, prefix_hit=False)
     preprocessor = _FakeImagePreprocessor()
+    runtime = _FakeRuntime(
+        prefix_cache=None, prefix_hit=False, image_preprocessor=preprocessor,
+    )
     failures: list[tuple[_PendingRequest, BaseException]] = []
     coordinator = _AdmissionCoordinator(
         runtime=runtime,
-        image_preprocessor=preprocessor,
         wake_event=threading.Event(),
         fail_request=_record_failure(failures),
     )
@@ -130,12 +153,13 @@ def test_admission_coordinator_immediately_admits_text_only_request() -> None:
 
 def test_admission_coordinator_skips_crop_work_on_prefix_hit() -> None:
     image = np.arange(12, dtype=np.uint8).reshape(3, 4)
-    runtime = _FakeRuntime(prefix_cache=object(), prefix_hit=True)
     preprocessor = _FakeImagePreprocessor()
+    runtime = _FakeRuntime(
+        prefix_cache=object(), prefix_hit=True, image_preprocessor=preprocessor,
+    )
     failures: list[tuple[_PendingRequest, BaseException]] = []
     coordinator = _AdmissionCoordinator(
         runtime=runtime,
-        image_preprocessor=preprocessor,
         wake_event=threading.Event(),
         fail_request=_record_failure(failures),
     )
@@ -154,12 +178,13 @@ def test_admission_coordinator_skips_crop_work_on_prefix_hit() -> None:
 
 def test_admission_coordinator_checks_prefix_cache_with_generated_prefix() -> None:
     image = np.arange(12, dtype=np.uint8).reshape(3, 4)
-    runtime = _FakeRuntime(prefix_cache=object(), prefix_hit=True)
     preprocessor = _FakeImagePreprocessor()
+    runtime = _FakeRuntime(
+        prefix_cache=object(), prefix_hit=True, image_preprocessor=preprocessor,
+    )
     failures: list[tuple[_PendingRequest, BaseException]] = []
     coordinator = _AdmissionCoordinator(
         runtime=runtime,
-        image_preprocessor=preprocessor,
         wake_event=threading.Event(),
         fail_request=_record_failure(failures),
     )
@@ -183,8 +208,10 @@ def test_admission_coordinator_promotes_completed_crops() -> None:
     wake_event = threading.Event()
     failures: list[tuple[_PendingRequest, BaseException]] = []
     coordinator = _AdmissionCoordinator(
-        runtime=_FakeRuntime(prefix_cache=object(), prefix_hit=False),
-        image_preprocessor=preprocessor,
+        runtime=_FakeRuntime(
+            prefix_cache=object(), prefix_hit=False,
+            image_preprocessor=preprocessor,
+        ),
         wake_event=wake_event,
         fail_request=_record_failure(failures),
     )
@@ -215,8 +242,10 @@ def test_admission_coordinator_skips_failed_crop_and_keeps_promoting() -> None:
     preprocessor = _FakeImagePreprocessor([failed_future, ready_future])
     failures: list[tuple[_PendingRequest, BaseException]] = []
     coordinator = _AdmissionCoordinator(
-        runtime=_FakeRuntime(prefix_cache=None, prefix_hit=False),
-        image_preprocessor=preprocessor,
+        runtime=_FakeRuntime(
+            prefix_cache=None, prefix_hit=False,
+            image_preprocessor=preprocessor,
+        ),
         wake_event=threading.Event(),
         fail_request=_record_failure(failures),
     )

--- a/tests/test_query_skill.py
+++ b/tests/test_query_skill.py
@@ -1,0 +1,86 @@
+"""QuerySkill.build_prompt_tokens behaviour around the new
+``QueryTemplate.prefix_when_reasoning`` field."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import List, Optional
+
+from kestrel.models.moondream.runtime import TextToken
+from kestrel.models.protocols import QueryTemplate
+from kestrel.skills.query import QueryRequest, QuerySkill
+
+
+@dataclass
+class _PromptTemplate:
+    bos_id: int = 2
+    eos_id: int = 99
+    answer_id: int = 0
+    thinking_id: int = 0
+    coord_id: int = 0
+    size_id: int = 0
+    start_ground_points_id: int = 0
+    end_ground_id: int = 0
+    _query_template: Optional[QueryTemplate] = None
+
+    def query(self) -> Optional[QueryTemplate]:
+        return self._query_template
+
+
+class _Tokenizer:
+    """``runtime.tokenizer.encode(prompt).ids`` — minimal shape."""
+
+    def encode(self, text: str) -> SimpleNamespace:
+        return SimpleNamespace(ids=[42])
+
+
+class _Runtime:
+    def __init__(self, *, prefix_when_reasoning: Optional[List[int]] = None) -> None:
+        self.prompt_template = _PromptTemplate(
+            _query_template=QueryTemplate(
+                prefix=[10, 11],
+                answer_prefix=[20],
+                reasoning_prefix=[21],
+                post_reasoning_prefix=[],
+                prefix_when_reasoning=prefix_when_reasoning,
+            )
+        )
+        self.tokenizer = _Tokenizer()
+
+
+def _ids(tokens) -> List[int]:
+    return [t.token_id for t in tokens]
+
+
+def test_query_skill_uses_prefix_when_reasoning_override() -> None:
+    runtime = _Runtime(prefix_when_reasoning=[30, 31, 32])
+    req = QueryRequest(
+        question="hi", image=None, reasoning=True, stream=False, settings=None,
+    )
+    skill = QuerySkill()
+    tokens = skill.build_prompt_tokens(runtime, req)
+    # bos + prefix_when_reasoning + encoded question + reasoning_prefix
+    assert _ids(tokens) == [2, 30, 31, 32, 42, 21]
+
+
+def test_query_skill_falls_back_to_prefix_when_override_unset() -> None:
+    runtime = _Runtime(prefix_when_reasoning=None)
+    req = QueryRequest(
+        question="hi", image=None, reasoning=True, stream=False, settings=None,
+    )
+    skill = QuerySkill()
+    tokens = skill.build_prompt_tokens(runtime, req)
+    # bos + prefix + encoded question + reasoning_prefix
+    assert _ids(tokens) == [2, 10, 11, 42, 21]
+
+
+def test_query_skill_non_reasoning_ignores_override() -> None:
+    runtime = _Runtime(prefix_when_reasoning=[30, 31, 32])
+    req = QueryRequest(
+        question="hi", image=None, reasoning=False, stream=False, settings=None,
+    )
+    skill = QuerySkill()
+    tokens = skill.build_prompt_tokens(runtime, req)
+    # bos + prefix + encoded question + answer_prefix  (override is reasoning-only)
+    assert _ids(tokens) == [2, 10, 11, 42, 20]


### PR DESCRIPTION
## Summary
The engine used to construct Moondream's `ImagePreprocessor` directly and dispatch through it for every non-None image, baking Moondream's overlap-crop pipeline into the engine. Non-Moondream runtimes whose preprocessing returns something other than `OverlapCropOutput` couldn't plug in without engine changes.

This PR moves that responsibility into the runtime via two new `Runtime` protocol methods. It's one step on the broader path of decoupling the engine from Moondream specifics; the engine still imports plenty of Moondream things (token classes, image crop helpers via skills, etc.).

| method | purpose |
|---|---|
| `preprocess_image_async(image) -> Future[Any]` | runtime owns the executor; returns an opaque payload the engine threads through `GenerationRequest.image_crops` and back into `launch_prepared_batch` without inspection |
| `shutdown_image_preprocessor()` | engine calls this once on shutdown so the runtime can tear down its pool |

Engine-side: `_AdmissionCoordinator` calls the runtime hook instead of holding an `ImagePreprocessor` reference; the engine drops its imports of `ImagePreprocessor` and `OverlapCropOutput`; `request.image_crops` is now `Any`. Prefix-cache image hashing stays in the engine as a module-private `_hash_image` helper — duplicating SHA-256 over raw bytes across every runtime was paying abstraction tax for an unbought contingency.

Moondream implements both methods by delegating to its existing `ImagePreprocessor` — behaviour unchanged.

Test fakes (`tests/scheduler/_fake_runtime.py`, `tests/test_engine.py`) grow the two methods; the admission-coordinator test cases stop passing `image_preprocessor=` explicitly and attach a fake preprocessor to the fake runtime instead.

## Companion: `QueryTemplate.prefix_when_reasoning`
A second commit adds an optional `prefix_when_reasoning: Optional[List[int]]` field to `QueryTemplate` so models can swap a different pre-question structure when `reasoning=True`. Gemma 4 prepends a `<|turn>system\n<|think|>\n<turn|>\n` activation block before the user turn so the model emits its CoT in a dedicated `<|channel>...<channel|>` block; Moondream's layout is reasoning-independent so the default (`None`) keeps the existing behaviour. `QuerySkill.build_prompt_tokens` picks `prefix_when_reasoning` over `prefix` when both `request.reasoning` and the override are set. `chartqa_eval.py` bumps `COT_MAX_TOKENS` to 1536 — Gemma 4's CoT channel is verbose enough that 512 cuts off most reasoning blocks before the model reaches `<channel|>`.

## Validation
319 / 319 tests pass on evee2 (316 existing + 3 new `tests/test_query_skill.py` for the `prefix_when_reasoning` branches).

Moondream2 ChartQA on belka (full 2500-question eval, RTX 3090, `max_batch_size=4`):

| metric | pre-refactor (main + PR #70 baseline) | this PR | Δ |
|---|---:|---:|---:|
| Total Accuracy   | 77.80%  | 77.80%   | identical |
| Human Accuracy   | 61.76%  | 61.76%   | identical |
| Prefill tok/s    | 8295.90 | 8310.39  | +0.17% |
| Decode tok/s     | 35.81   | 35.87    | +0.17% |
| Req/s            | 10.79   | 10.81    | +0.18% |
| P50 ms           | 424.79  | 423.92   | −0.20% |
| P99 ms           | 1031.56 | 1009.78  | −2.11% |
| Prefix hit       | 39.0%   | 39.2%    | +0.2pp |

All deltas inside main's own run-to-run noise — no regression.
