### PR TITLE
Drop dead reserve_lora_scratch call in moondream runtime

### DIFF
--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -528,14 +528,6 @@ class MoondreamRuntime:
                 device=self.device,
                 dtype=self.dtype,
             )
-            if self.config.text.moe is not None:
-                get_runtime().moe.reserve_lora_scratch(
-                    max_tokens=self.max_seq_length - 1,
-                    top_k=self.config.text.moe.experts_per_token,
-                    max_lora_rank=self._lora_workspace.max_rank_per_expert,
-                    device=self.device,
-                    dtype=self.dtype,
-                )
 
         # Create two ping-pong decode slots for pipelined decoding.
         # Each slot has its own staging buffers, FA3 paged-KV metadata buffers,


### PR DESCRIPTION
Pairs with m87-labs/kestrel-proprietary#170 (Mac MoE-LoRA), which drops the matching no-op stub from \`MoeRuntime\` in kestrel-kernels.

\`get_runtime().moe.reserve_lora_scratch(...)\` is a validation-only stub on both backends (CUDA \`_cuda_moe_reserve_lora_scratch\` returns after a device-type check; MPS just had \`lambda: None\`). The real LoRA workspace is reserved inside \`prepare_compact_mps\` / the CUDA compact prepare path from the prepared \`MoeCapacity\`. The call here did nothing.

Removing the dead call so the kestrel-kernels side can drop the field without breaking this caller.

## Test plan
- [x] Code change is a pure deletion of a no-op call.
- [ ] After kestrel-kernels#170 lands and the bumped \`kestrel_kernels\` is picked up here, run the moondream MoE LoRA flow (the previously-reached call did nothing, so behavior is unchanged).