### PR TITLE
Split Runtime protocol by execution shape

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -56,7 +56,7 @@ import torch
 from kestrel_kernels import get_runtime
 from kestrel.config import RuntimeConfig
 from kestrel.device import set_device, synchronize
-from kestrel.runtime import Runtime
+from kestrel.runtime import AutoregressiveRuntime
 from kestrel.scheduler import (
     GeneratedPrefix,
     GenerationScheduler,
@@ -222,7 +222,7 @@ def _hash_image(image: np.ndarray | bytes) -> bytes:
 class _AdmissionCoordinator:
     def __init__(
         self,
-        runtime: Runtime,
+        runtime: AutoregressiveRuntime,
         wake_event: threading.Event,
         fail_request: Callable[[_PendingRequest, BaseException], None],
     ) -> None:
@@ -313,7 +313,7 @@ class InferenceEngine:
         self,
         runtime_cfg: RuntimeConfig,
         *,
-        runtime: Optional[Runtime] = None,
+        runtime: Optional[AutoregressiveRuntime] = None,
         skills: Optional[SkillRegistry] = None,
         adapter_provider: Optional[AdapterProvider] = None,
         api_key: Optional[str] = None,
@@ -336,7 +336,7 @@ class InferenceEngine:
         # on first ``create``. ``_owns_runtime`` lets shutdown skip the
         # preprocessor-shutdown call when the runtime came from the
         # caller (they own its lifecycle).
-        self._runtime: Optional[Runtime] = runtime
+        self._runtime: Optional[AutoregressiveRuntime] = runtime
         self._owns_runtime: bool = runtime is None
         # ``_initialized`` flips at the very end of ``_initialize`` so
         # any partial failure (warmup, photon validation) leaves the
@@ -375,7 +375,7 @@ class InferenceEngine:
         self._default_top_p = 0.9
 
     @property
-    def runtime(self) -> Runtime:
+    def runtime(self) -> AutoregressiveRuntime:
         if self._runtime is None:
             raise RuntimeError("InferenceEngine has not been started")
         return self._runtime
@@ -399,7 +399,7 @@ class InferenceEngine:
         cls,
         runtime_cfg: RuntimeConfig,
         *,
-        runtime: Optional[Runtime] = None,
+        runtime: Optional[AutoregressiveRuntime] = None,
         skills: Optional[SkillRegistry] = None,
         adapter_provider: Optional[AdapterProvider] = None,
         api_key: Optional[str] = None,
@@ -1643,7 +1643,7 @@ class InferenceEngine:
 
     def _build_generation_request(
         self,
-        runtime: Runtime,
+        runtime: AutoregressiveRuntime,
         req: _PendingRequest,
         image_crops: Any,
     ) -> tuple[GenerationRequest, SkillState]:
@@ -1702,7 +1702,7 @@ class InferenceEngine:
 
     def _validate_suppress_next_token_ids(
         self,
-        runtime: Runtime,
+        runtime: AutoregressiveRuntime,
         request: GenerationRequest,
         skill_state: SkillState,
     ) -> None:

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -32,6 +32,7 @@ from kestrel.prefix_cache import (
     TreeNode,
 )
 from kestrel.runtime import (
+    ExecutionShape,
     CoordToken,
     PrefillClassification,
     PreparedSequence,
@@ -237,6 +238,7 @@ class MoondreamRuntime:
     ) -> None:
         self._cfg = cfg
         self.device = cfg.resolved_device()
+        self.execution_shape = ExecutionShape.AUTOREGRESSIVE
         self.dtype = cfg.resolved_dtype()
         set_device(self.device)
         # Guards CUDA graph capture so other threads avoid device-wide sync during capture.

--- a/kestrel/runtime/__init__.py
+++ b/kestrel/runtime/__init__.py
@@ -7,7 +7,12 @@ scheduler↔runtime contract. Concrete runtimes (e.g.
 ``kestrel.models.moondream.runtime``) build on top of these.
 """
 
-from kestrel.runtime.protocol import Runtime
+from kestrel.runtime.protocol import (
+    AutoregressiveRuntime,
+    ExecutionShape,
+    Runtime,
+    SinglePassRuntime,
+)
 from kestrel.runtime.state import (
     PrefillClassification,
     PreparedSequence,
@@ -22,12 +27,15 @@ from kestrel.runtime.tokens import (
 )
 
 __all__ = [
+    "AutoregressiveRuntime",
     "CoordToken",
+    "ExecutionShape",
     "PrefillClassification",
     "PreparedSequence",
     "Runtime",
     "RuntimeDecodeResult",
     "SequenceState",
+    "SinglePassRuntime",
     "SizeToken",
     "TextToken",
     "Token",

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -1,11 +1,18 @@
-"""Protocol describing the runtime contract used by engine + scheduler.
+"""Protocols describing the runtime contract used by engine + scheduler.
 
-The :class:`~kestrel.engine.InferenceEngine` and
-:class:`~kestrel.scheduler.scheduler.GenerationScheduler` are generic
-over runtime implementations: they manage admission, queues, prefill
-batching, and decode pacing without knowing which model is actually
-running. Concrete runtimes (today: ``MoondreamRuntime``) implement the
-methods declared here.
+The runtime contract is a three-layer stack so the engine can host
+runtimes with different *execution shapes* behind one model-agnostic
+kernel:
+
+- :class:`Runtime` — the minimal surface every runtime exposes
+  (identity, device, and which execution shape it is). The engine uses
+  it to route work without caring how a model runs.
+- :class:`AutoregressiveRuntime` — runtimes that drive a prefill/decode
+  loop (KV cache, slots, prefix cache, per-token decode). This is the
+  surface the :class:`~kestrel.scheduler.scheduler.GenerationScheduler`
+  consumes; ``MoondreamRuntime`` implements it.
+- :class:`SinglePassRuntime` — runtimes that fulfill a request with one
+  forward (no decode loop).
 
 Some attributes are typed as ``Any`` because they expose model-specific
 state the engine + scheduler currently reach into directly (config,
@@ -17,6 +24,7 @@ record of the surface a runtime must satisfy today.
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Mapping, Protocol, Sequence
 
 from kestrel.runtime.state import (
@@ -33,13 +41,45 @@ if TYPE_CHECKING:
     from torch import Tensor
 
 
+class ExecutionShape(Enum):
+    """How a runtime turns a request into a result.
+
+    The engine owns one executor per shape and routes by this tag, so a
+    new shape is an additive change rather than an ``isinstance`` ladder.
+    """
+
+    AUTOREGRESSIVE = "autoregressive"
+    SINGLE_PASS = "single_pass"
+    # STREAMING = "streaming"  # video / memory-bank models, later
+
+
 class Runtime(Protocol):
-    """Surface that the engine and scheduler call on a runtime."""
+    """Minimal surface every runtime exposes, regardless of shape.
+
+    The engine uses this to route work and scope prefix-cache entries
+    without committing to a particular execution shape.
+    """
 
     # Identity. Stable across the runtime's lifetime; used to scope
-    # prefix-cache entries and (later) to route requests in a
-    # multi-runtime engine.
+    # prefix-cache entries and to route requests in a multi-runtime
+    # engine.
     model_name: str
+
+    # Device the runtime executes on.
+    device: torch.device
+
+    # Which executor drives this runtime.
+    execution_shape: ExecutionShape
+
+
+class AutoregressiveRuntime(Runtime, Protocol):
+    """Surface the scheduler calls on a prefill/decode runtime.
+
+    This is the full contract the
+    :class:`~kestrel.scheduler.scheduler.GenerationScheduler` consumes:
+    KV-cache capacity, prefill slots, prefix cache, and the
+    plan/prefill/decode/commit calls. ``MoondreamRuntime`` implements it.
+    """
 
     # Capacity / shape
     max_batch_size: int
@@ -47,8 +87,7 @@ class Runtime(Protocol):
     max_seq_length: int
     image_prefix_length: int
 
-    # Device + streams
-    device: torch.device
+    # Streams
     primary_stream: Any
     copy_stream: Any
 
@@ -147,3 +186,18 @@ class Runtime(Protocol):
     def release_sequence(self, state: SequenceState) -> None: ...
 
     def decode_with_slot(self, slot: Any, batch_size: int) -> None: ...
+
+
+class SinglePassRuntime(Runtime, Protocol):
+    """Runtime that fulfills a request with a single forward.
+
+    No KV cache, no decode loop. The engine's single-pass executor hands
+    it a task name + inputs and returns the result. ``run`` is the whole
+    contract beyond image preprocessing.
+    """
+
+    def preprocess_image_async(
+        self, image: np.ndarray | bytes
+    ) -> Future[Any]: ...
+
+    def run(self, task: str, inputs: Any) -> Any: ...

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -15,7 +15,7 @@ from kestrel.device import stream_context
 from kestrel.runtime import (
     PrefillClassification,
     PreparedSequence,
-    Runtime,
+    AutoregressiveRuntime,
     TextToken,
     Token,
 )
@@ -194,7 +194,7 @@ class GenerationScheduler:
 
     def __init__(
         self,
-        runtime: Runtime,
+        runtime: AutoregressiveRuntime,
         *,
         default_temperature: float = 0.2,
         default_top_p: float = 0.9,

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Callable, Dict, List, Optional, Sequence
 
 from kestrel.models.moondream.runtime import SequenceState, Token
-from kestrel.runtime import Runtime
+from kestrel.runtime import AutoregressiveRuntime
 from kestrel.models.moondream.image_crops import OverlapCropOutput
 from kestrel.skills import SkillSpec, SkillState, DecodeStep
 
@@ -113,7 +113,7 @@ class RequestLifecycle:
 
     def stage_token(
         self,
-        runtime: Runtime,
+        runtime: AutoregressiveRuntime,
         token: Token,
         *,
         logprob: float | None = None,

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -29,6 +29,7 @@ import torch
 
 from kestrel.device import NoopEvent
 from kestrel.runtime import (
+    ExecutionShape,
     PrefillClassification,
     PreparedSequence,
     SequenceState,
@@ -104,6 +105,7 @@ class FakeRuntime:
     ) -> None:
         # Identity
         self.model_name = model_name
+        self.execution_shape = ExecutionShape.AUTOREGRESSIVE
 
         # Capacity / shape
         self.max_batch_size = max_batch_size

--- a/tests/scheduler/test_runtime_conformance.py
+++ b/tests/scheduler/test_runtime_conformance.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import inspect
 
-from kestrel.runtime import Runtime
+from kestrel.runtime import AutoregressiveRuntime
 
 from tests.scheduler._fake_runtime import FakeRuntime
 
@@ -19,7 +19,9 @@ from tests.scheduler._fake_runtime import FakeRuntime
 def _protocol_members(protocol: type) -> set[str]:
     """Names declared on ``protocol`` — annotations + non-special methods."""
 
-    members = set(getattr(protocol, "__annotations__", {}))
+    members: set[str] = set()
+    for klass in getattr(protocol, "__mro__", [protocol]):
+        members.update(getattr(klass, "__annotations__", {}))
     for name in dir(protocol):
         if name.startswith("_"):
             continue
@@ -39,7 +41,7 @@ def _params_excluding_self(func: object) -> list[inspect.Parameter]:
 def test_fake_runtime_implements_every_protocol_member() -> None:
     fake = FakeRuntime()
     missing = sorted(
-        name for name in _protocol_members(Runtime) if not hasattr(fake, name)
+        name for name in _protocol_members(AutoregressiveRuntime) if not hasattr(fake, name)
     )
     assert missing == [], (
         f"FakeRuntime is missing Runtime members: {missing}. "
@@ -71,8 +73,8 @@ def test_fake_runtime_method_signatures_accept_protocol_calls() -> None:
     """
 
     mismatches: list[str] = []
-    for name in _protocol_members(Runtime):
-        proto_member = getattr(Runtime, name, None)
+    for name in _protocol_members(AutoregressiveRuntime):
+        proto_member = getattr(AutoregressiveRuntime, name, None)
         if not callable(proto_member):
             continue
         fake_member = getattr(FakeRuntime, name, None)


### PR DESCRIPTION
## Why

The engine is moving toward hosting multiple co-resident models in one process. Today's `Runtime` protocol is implicitly autoregressive — it bakes in prefill slots, a KV/prefix cache, and a per-token decode loop — even though its name is generic. To host models with a different execution shape (a single forward, no decode loop), the contract needs to separate "what every runtime is" from "what a prefill/decode runtime is."

## What

Introduce a three-layer protocol stack in `kestrel/runtime/protocol.py`:

- **`Runtime`** — the minimal base every runtime satisfies: `model_name`, `device`, and an `execution_shape` tag.
- **`AutoregressiveRuntime(Runtime)`** — the existing prefill/decode surface, moved verbatim under the base (KV cache, slots, prefix cache, `classify_prefill` / `prepare_sequence` / `launch_prepared_batch` / `decode_with_slot`, …). This is what `GenerationScheduler` consumes.
- **`SinglePassRuntime(Runtime)`** — runtimes that fulfill a request with one forward: `run(task, inputs)` plus image preprocessing.

A new `ExecutionShape` enum (`AUTOREGRESSIVE` / `SINGLE_PASS`) lets the engine route by shape via a lookup rather than `isinstance` checks.

The AR-specific `Runtime` type references in the engine, scheduler, and request types are renamed to `AutoregressiveRuntime`. `MoondreamRuntime` declares `execution_shape = AUTOREGRESSIVE`. The runtime-conformance check walks the protocol MRO so members inherited from the base stay covered.

No behavior change — protocol split plus mechanical rename. Existing scheduler and engine tests pass unchanged (`tests/scheduler/` — 93 passed).