### PR TITLE
Service single-pass jobs on the owner thread

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -56,7 +56,7 @@ import torch
 from kestrel_kernels import get_runtime
 from kestrel.config import RuntimeConfig
 from kestrel.device import set_device, synchronize
-from kestrel.runtime import AutoregressiveRuntime
+from kestrel.runtime import AutoregressiveRuntime, ExecutionShape
 from kestrel.scheduler import (
     GeneratedPrefix,
     GenerationScheduler,
@@ -213,6 +213,24 @@ class _ReadyAdmission:
     prefix_cache_hit: bool
 
 
+@dataclass(slots=True)
+class _SinglePassJob:
+    """A single-forward request serviced by the owner thread.
+
+    Single-pass runtimes (no decode loop) fulfill a request in one
+    forward. The owner thread runs that forward between autoregressive
+    decode steps — never overlapping an in-flight AR launch — so all
+    CUDA work stays on one thread (the single-owner invariant) without a
+    scheduler, KV cache, or slots.
+    """
+
+    model: str
+    task: str
+    inputs: object
+    future: asyncio.Future[object]
+    submitted_at: float
+
+
 def _hash_image(image: np.ndarray | bytes) -> bytes:
     """SHA-256 over the raw image input for prefix-cache keying."""
     raw = image.tobytes() if isinstance(image, np.ndarray) else image
@@ -365,6 +383,10 @@ class InferenceEngine:
         self._init_task: Optional[asyncio.Task[None]] = None
         self._queue: asyncio.Queue[Optional[_PendingRequest]] = asyncio.Queue()
         self._scheduler_queue: queue.Queue[_PendingRequest | None] = queue.Queue()
+        # Single-pass jobs (single-forward models) serviced by the owner
+        # thread between AR decode steps. Separate from the AR request
+        # queue: no admission, KV reservation, or prefill batching.
+        self._single_pass_queue: "queue.Queue[_SinglePassJob]" = queue.Queue()
         self._scheduler_event = threading.Event()
         self._run_gate = threading.Event()
         self._run_gate.set()  # set == running
@@ -1052,6 +1074,41 @@ class InferenceEngine:
         self._run_gate.set()
         self._scheduler_event.set()
 
+    async def _submit_single_pass(
+        self, model: str, task: str, inputs: object
+    ) -> object:
+        """Run a single-forward request and await its result.
+
+        The owner thread services the job between AR decode steps; this
+        is the internal seam the multi-model ``run`` surface will call.
+        """
+        if self._shutdown:
+            raise RuntimeError("InferenceEngine is shut down")
+        await self._ensure_started()
+
+        runtime = self._runtimes.get(model)
+        if runtime is None:
+            raise ValueError(f"Unknown model {model!r}")
+        if runtime.execution_shape is not ExecutionShape.SINGLE_PASS:
+            raise ValueError(
+                f"Model {model!r} is not a single-pass model "
+                f"(execution_shape={runtime.execution_shape.value})"
+            )
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[object] = loop.create_future()
+        self._single_pass_queue.put(
+            _SinglePassJob(
+                model=model,
+                task=task,
+                inputs=inputs,
+                future=future,
+                submitted_at=time.perf_counter(),
+            )
+        )
+        self._scheduler_event.set()
+        return await future
+
     async def _submit_request(
         self,
         *,
@@ -1585,12 +1642,49 @@ class InferenceEngine:
                     loop.call_soon_threadsafe(future.set_result, engine_result)
                 self._complete_stream(req, result=engine_result)
 
+        def deliver_single_pass(job: _SinglePassJob, result: object) -> None:
+            loop = self._loop
+            assert loop is not None
+            future = job.future
+            if not future.done():
+                loop.call_soon_threadsafe(future.set_result, result)
+
+        def fail_single_pass(job: _SinglePassJob, error: BaseException) -> None:
+            loop = self._loop
+            assert loop is not None
+            future = job.future
+            if not future.done():
+                loop.call_soon_threadsafe(future.set_exception, error)
+
+        def service_single_pass() -> bool:
+            """Run one queued single-pass job, if any.
+
+            Called only at a safe point — no AR launch in flight — so the
+            single forward never overlaps autoregressive GPU work. One job
+            per call keeps AR decode latency bounded.
+            """
+            try:
+                job = self._single_pass_queue.get_nowait()
+            except queue.Empty:
+                return False
+            runtime = self._runtimes.get(job.model)
+            try:
+                if runtime is None:
+                    raise ValueError(f"Unknown model {job.model!r}")
+                result = runtime.run(job.task, job.inputs)
+            except Exception as exc:
+                fail_single_pass(job, exc)
+            else:
+                deliver_single_pass(job, result)
+            return True
+
         def should_exit() -> bool:
             return (
                 shutdown_requested
                 and not scheduler.has_pending_work()
                 and not admission.has_pending()
                 and not active_requests
+                and self._single_pass_queue.empty()
             )
 
         try:
@@ -1646,6 +1740,13 @@ class InferenceEngine:
                         deliver_results(results)
                         progressed = True
 
+                    # Service one single-pass job at a safe point: only
+                    # when no AR forward is in flight, so the single
+                    # forward never overlaps autoregressive GPU work.
+                    if not scheduler._pipeline.has_launch_in_flight():
+                        if service_single_pass():
+                            progressed = True
+
                     if should_exit():
                         break
 
@@ -1657,6 +1758,12 @@ class InferenceEngine:
         finally:
             admission.fail_all()
             self._fail_all_pending(active_requests)
+            while True:
+                try:
+                    job = self._single_pass_queue.get_nowait()
+                except queue.Empty:
+                    break
+                fail_single_pass(job, RuntimeError("Engine shut down"))
 
     def _build_generation_request(
         self,

--- a/tests/test_single_pass.py
+++ b/tests/test_single_pass.py
@@ -1,0 +1,129 @@
+"""The owner thread services single-pass jobs alongside the AR loop.
+
+A single-pass runtime fulfils a request with one ``run(task, inputs)``
+call and no decode loop. These tests drive the real ``_scheduler_loop``
+on CPU with a ``FakeRuntime`` as the autoregressive default plus a stub
+single-pass runtime registered alongside it, and check that a job
+submitted through ``_submit_single_pass`` round-trips through the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import pytest
+
+from kestrel.engine import InferenceEngine
+from kestrel.runtime import ExecutionShape
+
+from tests.scheduler._fake_runtime import FakeRuntime
+
+
+class _StubSinglePass:
+    """Minimal single-pass runtime: echoes the task + inputs back."""
+
+    def __init__(self, *, model_name: str = "stub-sp") -> None:
+        self.model_name = model_name
+        self.device = "cpu"
+        self.execution_shape = ExecutionShape.SINGLE_PASS
+        self.calls: list[tuple[str, Any]] = []
+
+    def run(self, task: str, inputs: Any) -> Any:
+        self.calls.append((task, inputs))
+        if task == "boom":
+            raise ValueError("task failed")
+        return {"task": task, "inputs": inputs}
+
+
+def _engine_with(default_ar: FakeRuntime, single_pass: _StubSinglePass) -> InferenceEngine:
+    """Build an engine wired for the scheduler loop without ``create``.
+
+    Bypasses Moondream construction / warmup / photon: registers the
+    runtimes directly and lets the test start the loop thread itself.
+    """
+    engine = object.__new__(InferenceEngine)
+    engine._default_model = default_ar.model_name
+    engine._runtimes = {
+        default_ar.model_name: default_ar,
+        single_pass.model_name: single_pass,
+    }
+    # Loop plumbing normally set up in __init__ / _initialize.
+    import queue as _queue
+
+    engine._scheduler_queue = _queue.Queue()
+    engine._single_pass_queue = _queue.Queue()
+    engine._scheduler_event = threading.Event()
+    engine._run_gate = threading.Event()
+    engine._run_gate.set()
+    engine._paused_flag = threading.Event()
+    engine._paused_event = threading.Event()
+    engine._shutdown = False
+    engine._photon_reporter = None
+    engine._adapter_provider = None
+    engine._default_temperature = 0.2
+    engine._default_top_p = 0.9
+    engine._skills = None  # scheduler defaults to a QuerySkill registry
+    return engine
+
+
+async def _run_case(task: str, inputs: Any) -> Any:
+    ar = FakeRuntime(model_name="ar-default", device="cpu")
+    sp = _StubSinglePass()
+    engine = _engine_with(ar, sp)
+    engine._loop = asyncio.get_running_loop()
+    # The loop is started by hand below, so skip _ensure_started's
+    # Moondream build path.
+    engine._initialized = True
+    engine._init_task = None
+
+    thread = threading.Thread(target=engine._scheduler_loop, name="t", daemon=True)
+    thread.start()
+    try:
+        return await asyncio.wait_for(
+            engine._submit_single_pass(sp.model_name, task, inputs), timeout=5.0
+        )
+    finally:
+        # Signal shutdown so the loop's should_exit() trips and the
+        # thread joins.
+        engine._shutdown = True
+        engine._scheduler_queue.put(None)
+        engine._scheduler_event.set()
+        thread.join(timeout=5.0)
+
+
+def test_single_pass_job_round_trips_through_loop() -> None:
+    result = asyncio.run(_run_case("segment", {"points": [[1, 2]]}))
+    assert result == {"task": "segment", "inputs": {"points": [[1, 2]]}}
+
+
+def test_single_pass_job_error_propagates() -> None:
+    with pytest.raises(ValueError, match="task failed"):
+        asyncio.run(_run_case("boom", {}))
+
+
+def test_submit_rejects_unknown_model() -> None:
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        sp = _StubSinglePass()
+        engine = _engine_with(ar, sp)
+        engine._loop = asyncio.get_running_loop()
+        engine._initialized = True  # skip _ensure_started's build path
+        with pytest.raises(ValueError, match="Unknown model"):
+            await engine._submit_single_pass("nope", "segment", {})
+
+    asyncio.run(go())
+
+
+def test_submit_rejects_autoregressive_model() -> None:
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        sp = _StubSinglePass()
+        engine = _engine_with(ar, sp)
+        engine._loop = asyncio.get_running_loop()
+        engine._initialized = True
+        with pytest.raises(ValueError, match="not a single-pass model"):
+            await engine._submit_single_pass("ar-default", "segment", {})
+
+    asyncio.run(go())


### PR DESCRIPTION
## Why

The engine drives one model family today: autoregressive prefill/decode. The next execution shape — single-pass models that fulfill a request with one forward and no decode loop — needs to run on the **same owner thread** that owns all CUDA state, without a second scheduler and without overlapping autoregressive GPU work. This PR adds that path. It's the only PR in the series that touches the scheduler loop, kept isolated for that reason.

## What

- **`_SinglePassJob`** + a thread-safe **`_single_pass_queue`** on the engine — separate from the AR request queue (no admission, KV reservation, or prefill batching).
- **`_submit_single_pass(model, task, inputs)`** — validates the model is registered and single-pass (`execution_shape`), enqueues a job, wakes the loop, and awaits its future. This is the internal seam the multi-model surface will call; there is no public API yet.
- **`_scheduler_loop`** services **one** single-pass job per iteration at a safe point — only when no AR forward is in flight (`pipeline.has_launch_in_flight()` is false) — so the single forward never overlaps autoregressive GPU work and all CUDA stays on one thread (the single-owner invariant). `should_exit` waits for the queue to drain; the `finally` fails any leftover jobs on shutdown.

## Tests

CPU end-to-end tests drive the **real** `_scheduler_loop` with a `FakeRuntime` as the autoregressive default plus a stub single-pass runtime registered alongside it: a job round-trips through the loop, a failing job propagates its exception, and submission rejects unknown / wrong-shape models. Full engine + scheduler suite green (119 passed).