### PR TITLE
Introduce the Executor protocol; wrap AR scheduling as a kernel lane

### DIFF
--- a/kestrel/engine.py
+++ b/kestrel/engine.py
@@ -43,6 +43,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Protocol,
     Sequence,
     Tuple,
     Union,
@@ -304,6 +305,244 @@ class _AdmissionCoordinator:
                 self._ready_crops.get_nowait()
             except queue.Empty:
                 break
+
+
+@dataclass(slots=True)
+class Completion:
+    """A terminal result from an executor, for the kernel to deliver.
+
+    Executors emit these as plain values and never touch the event loop
+    or telemetry; the kernel maps each ``Completion`` to its effects
+    (resolve the request future, record usage, finish the stream). This
+    keeps executors pure-compute and directly testable.
+
+    Exactly one of ``result`` / ``error`` is set.
+    """
+
+    request: "_PendingRequest"
+    result: Optional[EngineResult] = None
+    error: Optional[BaseException] = None
+
+
+@dataclass(frozen=True, slots=True)
+class TickResult:
+    """Immutable summary of one executor ``advance`` step."""
+
+    progressed: bool = False
+    completed: tuple[Completion, ...] = ()
+    in_flight: bool = False  # GPU work outstanding (gates pause drain)
+    has_work: bool = False   # queued or in flight (gates shutdown exit)
+
+
+class Executor(Protocol):
+    """A kernel-side lane wrapping one driver behind a uniform face.
+
+    The kernel loop folds ``advance`` over its executors without knowing
+    the execution shape. ``submit`` runs on the event-loop thread
+    (thread-safe ingress); ``advance`` / ``shutdown`` run on the kernel
+    thread. ``advance`` returns an immutable :class:`TickResult`; the
+    kernel performs the effects for any ``completed`` entries.
+    """
+
+    def submit(self, request: "_PendingRequest") -> None: ...
+
+    def advance(self) -> TickResult: ...
+
+    def shutdown(self, error: Optional[BaseException] = ...) -> None: ...
+
+
+class AutoregressiveExecutor:
+    """Executor lane wrapping the autoregressive prefill/decode scheduler.
+
+    Owns the :class:`GenerationScheduler`, the image-crop admission
+    coordinator, and the in-flight request map. The pipelined-decode
+    internals (``PipelineState``, ``launch_forward_async``,
+    ``commit_step``, ping-pong slots) are untouched — this is a
+    lift-and-wrap of the engine's former scheduler loop into the uniform
+    :class:`Executor` face, with delivery turned into :class:`Completion`
+    values the kernel acts on.
+    """
+
+    def __init__(
+        self,
+        runtime: AutoregressiveRuntime,
+        *,
+        skills: "SkillRegistry",
+        adapter_provider: Optional[AdapterProvider],
+        default_temperature: float,
+        default_top_p: float,
+        build_generation_request: Callable[
+            [AutoregressiveRuntime, "_PendingRequest", Any],
+            "tuple[GenerationRequest, SkillState]",
+        ],
+        to_engine_result: Callable[[SchedulerResult], EngineResult],
+        wake_event: threading.Event,
+    ) -> None:
+        self._runtime = runtime
+        self._build_generation_request = build_generation_request
+        self._to_engine_result = to_engine_result
+        self._scheduler = GenerationScheduler(
+            runtime,
+            default_temperature=default_temperature,
+            default_top_p=default_top_p,
+            skill_registry=skills,
+            adapter_provider=adapter_provider,
+        )
+        # Admission wakes the kernel loop when async crop work completes.
+        self._admission = _AdmissionCoordinator(
+            runtime=runtime,
+            wake_event=wake_event,
+            fail_request=self._fail_via_admission,
+        )
+        self._active: Dict[int, _PendingRequest] = {}
+        # Admission-time failures surface as completions the kernel delivers.
+        self._admission_failures: List[Completion] = []
+
+    # -- ingress (event-loop thread) ----------------------------------
+
+    def submit(self, request: _PendingRequest) -> None:
+        ready = self._admission.submit(request)
+        if ready is not None:
+            self._admit_ready(ready)
+
+    # -- step (kernel thread) -----------------------------------------
+
+    @property
+    def has_work(self) -> bool:
+        """Queued, admitting, or in-flight work remains (read-only)."""
+        return (
+            self._scheduler.has_pending_work()
+            or self._admission.has_pending()
+            or bool(self._active)
+            or bool(self._admission_failures)
+        )
+
+    def advance(self) -> TickResult:
+        scheduler = self._scheduler
+        progressed = False
+        completed: List[Completion] = []
+
+        if self._admission_failures:
+            completed.extend(self._admission_failures)
+            self._admission_failures = []
+            progressed = True
+
+        progressed = self._promote_ready() or progressed
+
+        if scheduler.has_pending_work():
+            progressed = scheduler.advance() or progressed
+
+        for result in scheduler.pop_completed():
+            completion = self._completion_for(result)
+            if completion is not None:
+                completed.append(completion)
+            progressed = True
+
+        return TickResult(
+            progressed=progressed,
+            completed=tuple(completed),
+            in_flight=scheduler.has_pending_work(),
+            has_work=(
+                scheduler.has_pending_work()
+                or self._admission.has_pending()
+                or bool(self._active)
+            ),
+        )
+
+    def drain(self) -> tuple[Completion, ...]:
+        """Complete in-flight pipeline work (used before a pause)."""
+        self._scheduler._drain_pipeline()
+        completed: List[Completion] = []
+        for result in self._scheduler.pop_completed():
+            completion = self._completion_for(result)
+            if completion is not None:
+                completed.append(completion)
+        return tuple(completed)
+
+    def shutdown(self, error: Optional[BaseException] = None) -> tuple[Completion, ...]:
+        exc = error or RuntimeError("Engine shut down")
+        completions = [c for c in self._admission_failures]
+        self._admission_failures = []
+        self._admission.fail_all(exc)
+        for req in self._active.values():
+            completions.append(Completion(request=req, error=exc))
+        self._active.clear()
+        self._release_active_sequences()
+        return tuple(completions)
+
+    # -- internals ----------------------------------------------------
+
+    def _fail_via_admission(
+        self, req: _PendingRequest, error: BaseException
+    ) -> None:
+        self._admission_failures.append(Completion(request=req, error=error))
+
+    def _admit_ready(self, ready: _ReadyAdmission) -> None:
+        req = ready.req
+        try:
+            generation_req, skill_state = self._build_generation_request(
+                self._runtime, req, ready.crops
+            )
+        except Exception as exc:
+            self._admission_failures.append(Completion(request=req, error=exc))
+            return
+        crops_ready = (
+            req.image is None or ready.prefix_cache_hit or (ready.crops is not None)
+        )
+        lora_slot_ready = req.adapter is None
+        phase = (
+            RequestPhase.READY_FOR_PREFILL
+            if (crops_ready and lora_slot_ready)
+            else RequestPhase.WAITING_RESOURCES
+        )
+        lifecycle = RequestLifecycle(
+            request=generation_req,
+            skill_state=skill_state,
+            phase=phase,
+            has_image=req.image is not None,
+            crops_ready=crops_ready,
+            lora_slot_ready=lora_slot_ready,
+            prefix_cache_hit=ready.prefix_cache_hit,
+            submitted_at=req.submitted_at,
+        )
+        generation_req.lifecycle = lifecycle
+        self._scheduler.enqueue_request(generation_req, skill_state)
+        self._active[req.request_id] = req
+
+    def _promote_ready(self) -> bool:
+        promoted = False
+        cap = self._runtime.max_batch_size * 4
+        while len(self._scheduler.waiting) < cap:
+            ready = self._admission.take_ready()
+            if ready is None:
+                break
+            self._admit_ready(ready)
+            promoted = True
+        return promoted
+
+    def _completion_for(self, result: SchedulerResult) -> Optional[Completion]:
+        req = self._active.pop(result.request_id, None)
+        if req is None:
+            _LOGGER.error(
+                "Scheduler produced unknown request_id %s", result.request_id
+            )
+            return None
+        if result.finish_reason == "error" and "error" in result.output:
+            return Completion(
+                request=req, error=RuntimeError(result.output["error"])
+            )
+        return Completion(request=req, result=self._to_engine_result(result))
+
+    def _release_active_sequences(self) -> None:
+        try:
+            runtime_sequences = list(self._runtime.active_sequences.values())
+        except Exception:  # pragma: no cover - defensive cleanup
+            return
+        for state in runtime_sequences:
+            try:
+                self._runtime.release_sequence(state)
+            except Exception:
+                pass
 
 
 class InferenceEngine:
@@ -1448,17 +1687,6 @@ class InferenceEngine:
             except Exception:
                 _LOGGER.exception("Failed to record Photon error telemetry")
 
-    def _release_active_sequences(self) -> None:
-        try:
-            runtime_sequences = list(self.runtime.active_sequences.values())
-        except Exception:  # pragma: no cover - defensive cleanup
-            return
-        for state in runtime_sequences:
-            try:
-                self.runtime.release_sequence(state)
-            except Exception:
-                pass
-
     def _extract_prompt_text(self, skill: SkillSpec, request_context: object) -> str:
         if isinstance(request_context, QueryRequest):
             return request_context.question
@@ -1478,99 +1706,33 @@ class InferenceEngine:
             return
         set_device(runtime.device)
 
-        adapter_provider = self._adapter_provider
-        scheduler = GenerationScheduler(
+        executor = AutoregressiveExecutor(
             runtime,
+            skills=self._skills,
+            adapter_provider=self._adapter_provider,
             default_temperature=self._default_temperature,
             default_top_p=self._default_top_p,
-            skill_registry=self._skills,
-            adapter_provider=adapter_provider,
+            build_generation_request=self._build_generation_request,
+            to_engine_result=self._to_engine_result,
+            wake_event=self._scheduler_event,
         )
 
-        active_requests: Dict[int, _PendingRequest] = {}
         shutdown_requested = False
         wake_event = self._scheduler_event
         run_gate = self._run_gate
         paused_flag = self._paused_flag
         paused_event = self._paused_event
-        admission = _AdmissionCoordinator(
-            runtime=runtime,
-            wake_event=wake_event,
-            fail_request=self._fail_request,
-        )
 
-        def admit_request(
-            req: _PendingRequest,
-            crops: Any,
-            *,
-            prefix_cache_hit: bool = False,
-        ) -> None:
-            try:
-                generation_req, skill_state = self._build_generation_request(
-                    runtime, req, crops
-                )
-            except Exception as exc:
-                self._fail_request(req, exc)
-                return
-            crops_ready = (
-                req.image is None or prefix_cache_hit or (crops is not None)
-            )
-            lora_slot_ready = req.adapter is None
-            phase = (
-                RequestPhase.READY_FOR_PREFILL
-                if (crops_ready and lora_slot_ready)
-                else RequestPhase.WAITING_RESOURCES
-            )
-            lifecycle = RequestLifecycle(
-                request=generation_req,
-                skill_state=skill_state,
-                phase=phase,
-                has_image=req.image is not None,
-                crops_ready=crops_ready,
-                lora_slot_ready=lora_slot_ready,
-                prefix_cache_hit=prefix_cache_hit,
-                submitted_at=req.submitted_at,
-            )
-            generation_req.lifecycle = lifecycle
-            scheduler.enqueue_request(generation_req, skill_state)
-            active_requests[req.request_id] = req
-
-        def admit_ready(ready: _ReadyAdmission) -> None:
-            admit_request(
-                ready.req,
-                ready.crops,
-                prefix_cache_hit=ready.prefix_cache_hit,
-            )
-
-        def promote_ready_requests() -> bool:
-            promoted = False
-            while len(scheduler.waiting) < runtime.max_batch_size * 4:
-                ready = admission.take_ready()
-                if ready is None:
-                    break
-                admit_ready(ready)
-                promoted = True
-            return promoted
-
-        def deliver_results(results: List[SchedulerResult]) -> None:
-            if not results:
-                return
+        def deliver(completions: tuple[Completion, ...]) -> None:
             loop = self._loop
             assert loop is not None
-            for result in results:
-                req = active_requests.pop(result.request_id, None)
-                if req is None:
-                    _LOGGER.error(
-                        "Scheduler produced unknown request_id %s",
-                        result.request_id,
-                    )
+            for c in completions:
+                req = c.request
+                if c.error is not None:
+                    self._fail_request(req, c.error)
                     continue
-                if result.finish_reason == "error" and "error" in result.output:
-                    # Fail only the offending request while keeping the engine running.
-                    self._fail_request(req, RuntimeError(result.output["error"]))
-                    continue
-
-                engine_result = self._to_engine_result(result)
+                engine_result = c.result
+                assert engine_result is not None
                 if self._photon_reporter is not None:
                     try:
                         self._photon_reporter.record_success(
@@ -1585,31 +1747,19 @@ class InferenceEngine:
                     loop.call_soon_threadsafe(future.set_result, engine_result)
                 self._complete_stream(req, result=engine_result)
 
-        def should_exit() -> bool:
-            return (
-                shutdown_requested
-                and not scheduler.has_pending_work()
-                and not admission.has_pending()
-                and not active_requests
-            )
-
         try:
             with torch.inference_mode():
                 while True:
                     # If paused, wait until resumed or shutdown completes.
                     if paused_flag.is_set():
-                        # Drain pipeline before pause - complete all in-flight work.
-                        # Required per design doc §4.5a: callers may mutate runtime
-                        # state while paused (e.g. rebuild CUDA graphs).
-                        scheduler._drain_pipeline()
-                        # Deliver any results from drained steps before pausing.
-                        drained_results = scheduler.pop_completed()
-                        if drained_results:
-                            deliver_results(drained_results)
+                        # Drain in-flight work before pause — callers may
+                        # mutate runtime state while paused (e.g. rebuild
+                        # CUDA graphs).
+                        deliver(executor.drain())
                         with runtime.graph_capture_lock:
                             synchronize(runtime.device)
                         paused_event.set()
-                        if should_exit():
+                        if shutdown_requested and not executor.has_work:
                             break
                         run_gate.wait(timeout=0.1)
                         continue
@@ -1623,30 +1773,22 @@ class InferenceEngine:
                         if item is None:
                             shutdown_requested = True
                             continue
-                        ready = admission.submit(item)
-                        if ready is not None:
-                            admit_ready(ready)
-                        progressed = True
-
-                    if promote_ready_requests():
+                        executor.submit(item)
                         progressed = True
 
                     try:
-                        if scheduler.has_pending_work():
-                            progressed = scheduler.advance() or progressed
+                        tick = executor.advance()
                     except Exception as exc:
-                        _LOGGER.exception("Scheduler advance failed", exc_info=exc)
-                        admission.fail_all(exc)
-                        self._fail_all_pending(active_requests, exc)
-                        self._release_active_sequences()
+                        _LOGGER.exception("Executor advance failed", exc_info=exc)
+                        deliver(executor.shutdown(exc))
+                        self._fail_all_pending(exc)
                         return
 
-                    results = scheduler.pop_completed()
-                    if results:
-                        deliver_results(results)
-                        progressed = True
+                    if tick.completed:
+                        deliver(tick.completed)
+                    progressed = tick.progressed or progressed
 
-                    if should_exit():
+                    if shutdown_requested and not tick.has_work:
                         break
 
                     if not progressed:
@@ -1655,8 +1797,8 @@ class InferenceEngine:
                         wake_event.wait()
                         wake_event.clear()
         finally:
-            admission.fail_all()
-            self._fail_all_pending(active_requests)
+            deliver(executor.shutdown())
+            self._fail_all_pending()
 
     def _build_generation_request(
         self,
@@ -1777,14 +1919,15 @@ class InferenceEngine:
 
     def _fail_all_pending(
         self,
-        active_requests: Dict[int, _PendingRequest],
         error: Optional[BaseException] = None,
     ) -> None:
+        """Fail any requests still sitting in the ingress queue.
+
+        In-flight requests are owned by the executor (failed via its
+        ``shutdown``); this drains only what the kernel hasn't handed off
+        yet.
+        """
         exc = error or RuntimeError("Engine shut down")
-        if active_requests:
-            for req in list(active_requests.values()):
-                self._fail_request(req, exc)
-            active_requests.clear()
         while True:
             try:
                 pending = self._scheduler_queue.get_nowait()
@@ -1795,4 +1938,13 @@ class InferenceEngine:
             self._fail_request(pending, exc)
 
 
-__all__ = ["InferenceEngine", "EngineResult", "EngineMetrics", "EngineStream"]
+__all__ = [
+    "InferenceEngine",
+    "EngineResult",
+    "EngineMetrics",
+    "EngineStream",
+    "Executor",
+    "AutoregressiveExecutor",
+    "Completion",
+    "TickResult",
+]

--- a/kestrel/engine/__init__.py
+++ b/kestrel/engine/__init__.py
@@ -1,0 +1,31 @@
+"""Engine package: the inference kernel and its executor lanes.
+
+Re-exports the public surface so ``from kestrel.engine import ...``
+keeps working after the split from a single module into a package.
+"""
+
+from kestrel.engine._types import (
+    Completion,
+    EngineMetrics,
+    EngineResult,
+    EngineStream,
+    TickResult,
+)
+from kestrel.engine.executor import (
+    AutoregressiveExecutor,
+    Executor,
+    _AdmissionCoordinator,
+)
+from kestrel.engine._types import _PendingRequest
+from kestrel.engine.core import InferenceEngine
+
+__all__ = [
+    "InferenceEngine",
+    "EngineResult",
+    "EngineMetrics",
+    "EngineStream",
+    "Executor",
+    "AutoregressiveExecutor",
+    "Completion",
+    "TickResult",
+]

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -1,0 +1,168 @@
+"""Value types exchanged across the engine package.
+
+Plain data — request/result containers, the streaming iterator, and the
+executor handoff values (:class:`Completion`, :class:`TickResult`). Kept
+in their own module so the executor and the kernel core can share them
+without an import cycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Dict, List, Optional, Sequence, Union
+
+import numpy as np
+
+from kestrel.scheduler import GeneratedPrefix, StreamUpdate
+from kestrel.models.moondream.runtime import Token
+from kestrel.skills import SkillSpec, SkillState
+
+@dataclass(slots=True)
+class EngineMetrics:
+    """Token counts and timing for a single request."""
+
+    input_tokens: int
+    output_tokens: int
+    prefill_time_ms: float
+    decode_time_ms: float
+    ttft_ms: float
+    cached_tokens: int = 0  # KV positions reused from prefix cache
+
+
+@dataclass(slots=True)
+class EngineResult:
+    """Inference output returned to callers."""
+
+    request_id: int
+    tokens: List[Token]
+    finish_reason: str
+    metrics: EngineMetrics
+    output: Dict[str, object]
+    logprobs: Optional[List[float]] = None
+
+
+@dataclass(slots=True)
+class _StreamCompletion:
+    result: Optional[EngineResult] = None
+    error: Optional[BaseException] = None
+
+
+_StreamQueueItem = Union[StreamUpdate, _StreamCompletion]
+_StreamQueue = asyncio.Queue[_StreamQueueItem]
+
+
+class EngineStream(AsyncIterator[StreamUpdate]):
+    """Asynchronous iterator that yields incremental generation updates."""
+
+    __slots__ = (
+        "request_id",
+        "_queue",
+        "_result_future",
+        "_final_result",
+        "_error",
+    )
+
+    def __init__(
+        self,
+        request_id: int,
+        queue: _StreamQueue,
+        result_future: asyncio.Future[EngineResult],
+    ) -> None:
+        self.request_id = request_id
+        self._queue = queue
+        self._result_future = result_future
+        self._final_result: Optional[EngineResult] = None
+        self._error: Optional[BaseException] = None
+
+    def __aiter__(self) -> "EngineStream":
+        return self
+
+    async def __anext__(self) -> StreamUpdate:
+        while True:
+            item = await self._queue.get()
+            if isinstance(item, _StreamCompletion):
+                if item.error is not None:
+                    self._error = item.error
+                    raise item.error
+                if item.result is not None:
+                    self._final_result = item.result
+                raise StopAsyncIteration
+            return item
+
+    async def result(self) -> EngineResult:
+        if self._final_result is not None:
+            return self._final_result
+        if self._error is not None:
+            raise self._error
+        result = await self._result_future
+        self._final_result = result
+        return result
+
+
+@dataclass(slots=True)
+class _PendingRequest:
+    request_id: int
+    prompt: str
+    prompt_tokens: Sequence[Token]
+    image: Optional[np.ndarray | bytes]
+    image_hash: Optional[bytes]  # SHA256 hash for prefix caching
+    max_new_tokens: int
+    temperature: float
+    top_p: float
+    submitted_at: float
+    future: asyncio.Future[EngineResult]
+    stream_queue: Optional["_StreamQueue"]
+    skill: SkillSpec
+    request_context: object
+    adapter: Optional[str] = None
+    lora_slot: int = 0  # Always 0 here; scheduler assigns actual slot at admission
+    return_logprobs: Optional[bool] = None
+    generated_prefix: GeneratedPrefix = field(default_factory=GeneratedPrefix)
+    suppress_next_token_ids: Optional[tuple[int, ...]] = None
+
+
+@dataclass(slots=True)
+class _ReadyAdmission:
+    req: _PendingRequest
+    crops: Any
+    prefix_cache_hit: bool
+
+
+def _hash_image(image: np.ndarray | bytes) -> bytes:
+    """SHA-256 over the raw image input for prefix-cache keying."""
+    raw = image.tobytes() if isinstance(image, np.ndarray) else image
+    return hashlib.sha256(raw).digest()
+
+
+
+
+@dataclass(slots=True)
+class Completion:
+    """A terminal result from an executor, for the kernel to deliver.
+
+    Executors emit these as plain values and never touch the event loop
+    or telemetry; the kernel maps each ``Completion`` to its effects
+    (resolve the request future, record usage, finish the stream). This
+    keeps executors pure-compute and directly testable.
+
+    Exactly one of ``result`` / ``error`` is set.
+    """
+
+    request: "_PendingRequest"
+    result: Optional[EngineResult] = None
+    error: Optional[BaseException] = None
+
+
+@dataclass(frozen=True, slots=True)
+class TickResult:
+    """Immutable summary of one executor ``advance`` step."""
+
+    progressed: bool = False
+    completed: tuple[Completion, ...] = ()
+    in_flight: bool = False  # GPU work outstanding (gates pause drain)
+    has_work: bool = False   # queued or in flight (gates shutdown exit)
+
+

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -137,8 +137,6 @@ def _hash_image(image: np.ndarray | bytes) -> bytes:
     return hashlib.sha256(raw).digest()
 
 
-
-
 @dataclass(slots=True)
 class Completion:
     """A terminal result from an executor, for the kernel to deliver.
@@ -162,7 +160,6 @@ class TickResult:
 
     progressed: bool = False
     completed: tuple[Completion, ...] = ()
-    in_flight: bool = False  # GPU work outstanding (gates pause drain)
-    has_work: bool = False   # queued or in flight (gates shutdown exit)
+    has_work: bool = False  # queued or in flight (gates shutdown exit)
 
 

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -26,24 +26,19 @@ Callers provide raw questions/objects; the engine derives skill-specific context
 
 
 import asyncio
-import hashlib
 import itertools
 import logging
 import queue
 import threading
 import time
-from concurrent.futures import Future
 import os
-from dataclasses import dataclass, field
 from typing import (
     Any,
-    AsyncIterator,
     Callable,
     Dict,
     List,
     Mapping,
     Optional,
-    Protocol,
     Sequence,
     Tuple,
     Union,
@@ -60,14 +55,10 @@ from kestrel.device import set_device, synchronize
 from kestrel.runtime import AutoregressiveRuntime
 from kestrel.scheduler import (
     GeneratedPrefix,
-    GenerationScheduler,
     GenerationRequest,
-    RequestLifecycle,
-    RequestPhase,
     SchedulerResult,
     StreamUpdate,
 )
-from kestrel.models.moondream.vision import compute_overlap_crops
 from kestrel.skills import (
     CaptionSkill,
     DetectSkill,
@@ -89,6 +80,19 @@ from kestrel.models.moondream.lora import AdapterProvider
 from kestrel.photon import PhotonReporter
 from kestrel.utils.spatial_refs import normalize_spatial_refs
 
+from kestrel.engine._types import (
+    Completion,
+    EngineMetrics,
+    EngineResult,
+    EngineStream,
+    TickResult,
+    _PendingRequest,
+    _StreamCompletion,
+    _StreamQueue,
+    _StreamQueueItem,
+)
+from kestrel.engine.executor import AutoregressiveExecutor
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,448 +105,6 @@ _ALLOWED_API_BASE_URLS = (
     "https://api-staging.moondream.ai",
     _DEFAULT_API_BASE_URL,
 )
-
-
-@dataclass(slots=True)
-class EngineMetrics:
-    """Token counts and timing for a single request."""
-
-    input_tokens: int
-    output_tokens: int
-    prefill_time_ms: float
-    decode_time_ms: float
-    ttft_ms: float
-    cached_tokens: int = 0  # KV positions reused from prefix cache
-
-
-@dataclass(slots=True)
-class EngineResult:
-    """Inference output returned to callers."""
-
-    request_id: int
-    tokens: List[Token]
-    finish_reason: str
-    metrics: EngineMetrics
-    output: Dict[str, object]
-    logprobs: Optional[List[float]] = None
-
-
-@dataclass(slots=True)
-class _StreamCompletion:
-    result: Optional[EngineResult] = None
-    error: Optional[BaseException] = None
-
-
-_StreamQueueItem = Union[StreamUpdate, _StreamCompletion]
-_StreamQueue = asyncio.Queue[_StreamQueueItem]
-
-
-class EngineStream(AsyncIterator[StreamUpdate]):
-    """Asynchronous iterator that yields incremental generation updates."""
-
-    __slots__ = (
-        "request_id",
-        "_queue",
-        "_result_future",
-        "_final_result",
-        "_error",
-    )
-
-    def __init__(
-        self,
-        request_id: int,
-        queue: _StreamQueue,
-        result_future: asyncio.Future[EngineResult],
-    ) -> None:
-        self.request_id = request_id
-        self._queue = queue
-        self._result_future = result_future
-        self._final_result: Optional[EngineResult] = None
-        self._error: Optional[BaseException] = None
-
-    def __aiter__(self) -> "EngineStream":
-        return self
-
-    async def __anext__(self) -> StreamUpdate:
-        while True:
-            item = await self._queue.get()
-            if isinstance(item, _StreamCompletion):
-                if item.error is not None:
-                    self._error = item.error
-                    raise item.error
-                if item.result is not None:
-                    self._final_result = item.result
-                raise StopAsyncIteration
-            return item
-
-    async def result(self) -> EngineResult:
-        if self._final_result is not None:
-            return self._final_result
-        if self._error is not None:
-            raise self._error
-        result = await self._result_future
-        self._final_result = result
-        return result
-
-
-@dataclass(slots=True)
-class _PendingRequest:
-    request_id: int
-    prompt: str
-    prompt_tokens: Sequence[Token]
-    image: Optional[np.ndarray | bytes]
-    image_hash: Optional[bytes]  # SHA256 hash for prefix caching
-    max_new_tokens: int
-    temperature: float
-    top_p: float
-    submitted_at: float
-    future: asyncio.Future[EngineResult]
-    stream_queue: Optional["_StreamQueue"]
-    skill: SkillSpec
-    request_context: object
-    adapter: Optional[str] = None
-    lora_slot: int = 0  # Always 0 here; scheduler assigns actual slot at admission
-    return_logprobs: Optional[bool] = None
-    generated_prefix: GeneratedPrefix = field(default_factory=GeneratedPrefix)
-    suppress_next_token_ids: Optional[tuple[int, ...]] = None
-
-
-@dataclass(slots=True)
-class _ReadyAdmission:
-    req: _PendingRequest
-    crops: Any
-    prefix_cache_hit: bool
-
-
-def _hash_image(image: np.ndarray | bytes) -> bytes:
-    """SHA-256 over the raw image input for prefix-cache keying."""
-    raw = image.tobytes() if isinstance(image, np.ndarray) else image
-    return hashlib.sha256(raw).digest()
-
-
-class _AdmissionCoordinator:
-    def __init__(
-        self,
-        runtime: AutoregressiveRuntime,
-        wake_event: threading.Event,
-        fail_request: Callable[[_PendingRequest, BaseException], None],
-    ) -> None:
-        self._runtime = runtime
-        self._wake_event = wake_event
-        self._fail_request = fail_request
-        # Image preprocessing payloads are opaque — the runtime decides
-        # what they contain (Moondream's ``OverlapCropOutput``,
-        # Gemma 4's pixel_values bundle, etc.) and threads them back
-        # into ``launch_prepared_batch``.
-        self._pending_crops: Dict[
-            int, tuple[_PendingRequest, "Future[Any]"]
-        ] = {}
-        self._ready_crops: queue.Queue[int] = queue.Queue()
-
-    def has_pending(self) -> bool:
-        return bool(self._pending_crops)
-
-    def submit(self, req: _PendingRequest) -> Optional[_ReadyAdmission]:
-        if req.image is None:
-            return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=False)
-
-        if self._runtime.prefix_cache is not None:
-            req.image_hash = _hash_image(req.image)
-            prefill_tokens = list(req.prompt_tokens) + list(req.generated_prefix.tokens)
-            if self._runtime.check_prefix_cache(
-                prefill_tokens, req.image_hash, req.adapter
-            ):
-                return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=True)
-
-        try:
-            future = self._runtime.preprocess_image_async(req.image)
-        except Exception as exc:
-            self._fail_request(req, exc)
-            return None
-
-        req_id = req.request_id
-        self._pending_crops[req_id] = (req, future)
-        future.add_done_callback(
-            lambda _future, rid=req_id: self._on_crops_ready(rid)
-        )
-        return None
-
-    def take_ready(self) -> Optional[_ReadyAdmission]:
-        while True:
-            try:
-                req_id = self._ready_crops.get_nowait()
-            except queue.Empty:
-                return None
-
-            pending = self._pending_crops.pop(req_id, None)
-            if pending is None:
-                continue
-
-            req, future = pending
-            try:
-                crops = future.result()
-            except Exception as exc:
-                self._fail_request(req, exc)
-                continue
-            return _ReadyAdmission(req=req, crops=crops, prefix_cache_hit=False)
-
-    def fail_all(self, error: Optional[BaseException] = None) -> None:
-        exc = error or RuntimeError("Engine shut down")
-        for req, future in list(self._pending_crops.values()):
-            if future and not future.done():
-                future.cancel()
-            self._fail_request(req, exc)
-        self._pending_crops.clear()
-        self._drain_ready_notifications()
-
-    def _on_crops_ready(self, request_id: int) -> None:
-        self._ready_crops.put(request_id)
-        self._wake_event.set()
-
-    def _drain_ready_notifications(self) -> None:
-        while True:
-            try:
-                self._ready_crops.get_nowait()
-            except queue.Empty:
-                break
-
-
-@dataclass(slots=True)
-class Completion:
-    """A terminal result from an executor, for the kernel to deliver.
-
-    Executors emit these as plain values and never touch the event loop
-    or telemetry; the kernel maps each ``Completion`` to its effects
-    (resolve the request future, record usage, finish the stream). This
-    keeps executors pure-compute and directly testable.
-
-    Exactly one of ``result`` / ``error`` is set.
-    """
-
-    request: "_PendingRequest"
-    result: Optional[EngineResult] = None
-    error: Optional[BaseException] = None
-
-
-@dataclass(frozen=True, slots=True)
-class TickResult:
-    """Immutable summary of one executor ``advance`` step."""
-
-    progressed: bool = False
-    completed: tuple[Completion, ...] = ()
-    in_flight: bool = False  # GPU work outstanding (gates pause drain)
-    has_work: bool = False   # queued or in flight (gates shutdown exit)
-
-
-class Executor(Protocol):
-    """A kernel-side lane wrapping one driver behind a uniform face.
-
-    The kernel loop folds ``advance`` over its executors without knowing
-    the execution shape. ``submit`` runs on the event-loop thread
-    (thread-safe ingress); ``advance`` / ``shutdown`` run on the kernel
-    thread. ``advance`` returns an immutable :class:`TickResult`; the
-    kernel performs the effects for any ``completed`` entries.
-    """
-
-    def submit(self, request: "_PendingRequest") -> None: ...
-
-    def advance(self) -> TickResult: ...
-
-    def shutdown(self, error: Optional[BaseException] = ...) -> None: ...
-
-
-class AutoregressiveExecutor:
-    """Executor lane wrapping the autoregressive prefill/decode scheduler.
-
-    Owns the :class:`GenerationScheduler`, the image-crop admission
-    coordinator, and the in-flight request map. The pipelined-decode
-    internals (``PipelineState``, ``launch_forward_async``,
-    ``commit_step``, ping-pong slots) are untouched — this is a
-    lift-and-wrap of the engine's former scheduler loop into the uniform
-    :class:`Executor` face, with delivery turned into :class:`Completion`
-    values the kernel acts on.
-    """
-
-    def __init__(
-        self,
-        runtime: AutoregressiveRuntime,
-        *,
-        skills: "SkillRegistry",
-        adapter_provider: Optional[AdapterProvider],
-        default_temperature: float,
-        default_top_p: float,
-        build_generation_request: Callable[
-            [AutoregressiveRuntime, "_PendingRequest", Any],
-            "tuple[GenerationRequest, SkillState]",
-        ],
-        to_engine_result: Callable[[SchedulerResult], EngineResult],
-        wake_event: threading.Event,
-    ) -> None:
-        self._runtime = runtime
-        self._build_generation_request = build_generation_request
-        self._to_engine_result = to_engine_result
-        self._scheduler = GenerationScheduler(
-            runtime,
-            default_temperature=default_temperature,
-            default_top_p=default_top_p,
-            skill_registry=skills,
-            adapter_provider=adapter_provider,
-        )
-        # Admission wakes the kernel loop when async crop work completes.
-        self._admission = _AdmissionCoordinator(
-            runtime=runtime,
-            wake_event=wake_event,
-            fail_request=self._fail_via_admission,
-        )
-        self._active: Dict[int, _PendingRequest] = {}
-        # Admission-time failures surface as completions the kernel delivers.
-        self._admission_failures: List[Completion] = []
-
-    # -- ingress (event-loop thread) ----------------------------------
-
-    def submit(self, request: _PendingRequest) -> None:
-        ready = self._admission.submit(request)
-        if ready is not None:
-            self._admit_ready(ready)
-
-    # -- step (kernel thread) -----------------------------------------
-
-    @property
-    def has_work(self) -> bool:
-        """Queued, admitting, or in-flight work remains (read-only)."""
-        return (
-            self._scheduler.has_pending_work()
-            or self._admission.has_pending()
-            or bool(self._active)
-            or bool(self._admission_failures)
-        )
-
-    def advance(self) -> TickResult:
-        scheduler = self._scheduler
-        progressed = False
-        completed: List[Completion] = []
-
-        if self._admission_failures:
-            completed.extend(self._admission_failures)
-            self._admission_failures = []
-            progressed = True
-
-        progressed = self._promote_ready() or progressed
-
-        if scheduler.has_pending_work():
-            progressed = scheduler.advance() or progressed
-
-        for result in scheduler.pop_completed():
-            completion = self._completion_for(result)
-            if completion is not None:
-                completed.append(completion)
-            progressed = True
-
-        return TickResult(
-            progressed=progressed,
-            completed=tuple(completed),
-            in_flight=scheduler.has_pending_work(),
-            has_work=(
-                scheduler.has_pending_work()
-                or self._admission.has_pending()
-                or bool(self._active)
-            ),
-        )
-
-    def drain(self) -> tuple[Completion, ...]:
-        """Complete in-flight pipeline work (used before a pause)."""
-        self._scheduler._drain_pipeline()
-        completed: List[Completion] = []
-        for result in self._scheduler.pop_completed():
-            completion = self._completion_for(result)
-            if completion is not None:
-                completed.append(completion)
-        return tuple(completed)
-
-    def shutdown(self, error: Optional[BaseException] = None) -> tuple[Completion, ...]:
-        exc = error or RuntimeError("Engine shut down")
-        completions = [c for c in self._admission_failures]
-        self._admission_failures = []
-        self._admission.fail_all(exc)
-        for req in self._active.values():
-            completions.append(Completion(request=req, error=exc))
-        self._active.clear()
-        self._release_active_sequences()
-        return tuple(completions)
-
-    # -- internals ----------------------------------------------------
-
-    def _fail_via_admission(
-        self, req: _PendingRequest, error: BaseException
-    ) -> None:
-        self._admission_failures.append(Completion(request=req, error=error))
-
-    def _admit_ready(self, ready: _ReadyAdmission) -> None:
-        req = ready.req
-        try:
-            generation_req, skill_state = self._build_generation_request(
-                self._runtime, req, ready.crops
-            )
-        except Exception as exc:
-            self._admission_failures.append(Completion(request=req, error=exc))
-            return
-        crops_ready = (
-            req.image is None or ready.prefix_cache_hit or (ready.crops is not None)
-        )
-        lora_slot_ready = req.adapter is None
-        phase = (
-            RequestPhase.READY_FOR_PREFILL
-            if (crops_ready and lora_slot_ready)
-            else RequestPhase.WAITING_RESOURCES
-        )
-        lifecycle = RequestLifecycle(
-            request=generation_req,
-            skill_state=skill_state,
-            phase=phase,
-            has_image=req.image is not None,
-            crops_ready=crops_ready,
-            lora_slot_ready=lora_slot_ready,
-            prefix_cache_hit=ready.prefix_cache_hit,
-            submitted_at=req.submitted_at,
-        )
-        generation_req.lifecycle = lifecycle
-        self._scheduler.enqueue_request(generation_req, skill_state)
-        self._active[req.request_id] = req
-
-    def _promote_ready(self) -> bool:
-        promoted = False
-        cap = self._runtime.max_batch_size * 4
-        while len(self._scheduler.waiting) < cap:
-            ready = self._admission.take_ready()
-            if ready is None:
-                break
-            self._admit_ready(ready)
-            promoted = True
-        return promoted
-
-    def _completion_for(self, result: SchedulerResult) -> Optional[Completion]:
-        req = self._active.pop(result.request_id, None)
-        if req is None:
-            _LOGGER.error(
-                "Scheduler produced unknown request_id %s", result.request_id
-            )
-            return None
-        if result.finish_reason == "error" and "error" in result.output:
-            return Completion(
-                request=req, error=RuntimeError(result.output["error"])
-            )
-        return Completion(request=req, result=self._to_engine_result(result))
-
-    def _release_active_sequences(self) -> None:
-        try:
-            runtime_sequences = list(self._runtime.active_sequences.values())
-        except Exception:  # pragma: no cover - defensive cleanup
-            return
-        for state in runtime_sequences:
-            try:
-                self._runtime.release_sequence(state)
-            except Exception:
-                pass
 
 
 class InferenceEngine:
@@ -1938,13 +1500,3 @@ class InferenceEngine:
             self._fail_request(pending, exc)
 
 
-__all__ = [
-    "InferenceEngine",
-    "EngineResult",
-    "EngineMetrics",
-    "EngineStream",
-    "Executor",
-    "AutoregressiveExecutor",
-    "Completion",
-    "TickResult",
-]

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -85,7 +85,6 @@ from kestrel.engine._types import (
     EngineMetrics,
     EngineResult,
     EngineStream,
-    TickResult,
     _PendingRequest,
     _StreamCompletion,
     _StreamQueue,

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -1,0 +1,341 @@
+"""Execution lanes: the Executor protocol and the autoregressive lane.
+
+An executor is a kernel-side component wrapping one driver behind a
+uniform face (``submit`` / ``advance`` -> :class:`TickResult` /
+``shutdown``). The kernel loop folds ``advance`` over its executors and
+performs the delivery effects for the :class:`Completion` values they
+emit; executors themselves never touch the event loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from concurrent.futures import Future
+from typing import Any, Callable, Dict, List, Optional, Protocol
+
+import numpy as np
+
+from kestrel.runtime import AutoregressiveRuntime
+from kestrel.scheduler import (
+    GenerationScheduler,
+    GenerationRequest,
+    RequestLifecycle,
+    RequestPhase,
+    SchedulerResult,
+)
+from kestrel.skills import SkillRegistry, SkillState
+from kestrel.models.moondream.lora import AdapterProvider
+
+from kestrel.engine._types import (
+    Completion,
+    EngineResult,
+    TickResult,
+    _PendingRequest,
+    _ReadyAdmission,
+    _hash_image,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+class _AdmissionCoordinator:
+    def __init__(
+        self,
+        runtime: AutoregressiveRuntime,
+        wake_event: threading.Event,
+        fail_request: Callable[[_PendingRequest, BaseException], None],
+    ) -> None:
+        self._runtime = runtime
+        self._wake_event = wake_event
+        self._fail_request = fail_request
+        # Image preprocessing payloads are opaque — the runtime decides
+        # what they contain (Moondream's ``OverlapCropOutput``,
+        # Gemma 4's pixel_values bundle, etc.) and threads them back
+        # into ``launch_prepared_batch``.
+        self._pending_crops: Dict[
+            int, tuple[_PendingRequest, "Future[Any]"]
+        ] = {}
+        self._ready_crops: queue.Queue[int] = queue.Queue()
+
+    def has_pending(self) -> bool:
+        return bool(self._pending_crops)
+
+    def submit(self, req: _PendingRequest) -> Optional[_ReadyAdmission]:
+        if req.image is None:
+            return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=False)
+
+        if self._runtime.prefix_cache is not None:
+            req.image_hash = _hash_image(req.image)
+            prefill_tokens = list(req.prompt_tokens) + list(req.generated_prefix.tokens)
+            if self._runtime.check_prefix_cache(
+                prefill_tokens, req.image_hash, req.adapter
+            ):
+                return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=True)
+
+        try:
+            future = self._runtime.preprocess_image_async(req.image)
+        except Exception as exc:
+            self._fail_request(req, exc)
+            return None
+
+        req_id = req.request_id
+        self._pending_crops[req_id] = (req, future)
+        future.add_done_callback(
+            lambda _future, rid=req_id: self._on_crops_ready(rid)
+        )
+        return None
+
+    def take_ready(self) -> Optional[_ReadyAdmission]:
+        while True:
+            try:
+                req_id = self._ready_crops.get_nowait()
+            except queue.Empty:
+                return None
+
+            pending = self._pending_crops.pop(req_id, None)
+            if pending is None:
+                continue
+
+            req, future = pending
+            try:
+                crops = future.result()
+            except Exception as exc:
+                self._fail_request(req, exc)
+                continue
+            return _ReadyAdmission(req=req, crops=crops, prefix_cache_hit=False)
+
+    def fail_all(self, error: Optional[BaseException] = None) -> None:
+        exc = error or RuntimeError("Engine shut down")
+        for req, future in list(self._pending_crops.values()):
+            if future and not future.done():
+                future.cancel()
+            self._fail_request(req, exc)
+        self._pending_crops.clear()
+        self._drain_ready_notifications()
+
+    def _on_crops_ready(self, request_id: int) -> None:
+        self._ready_crops.put(request_id)
+        self._wake_event.set()
+
+    def _drain_ready_notifications(self) -> None:
+        while True:
+            try:
+                self._ready_crops.get_nowait()
+            except queue.Empty:
+                break
+
+
+
+
+class Executor(Protocol):
+    """A kernel-side lane wrapping one driver behind a uniform face.
+
+    The kernel loop folds ``advance`` over its executors without knowing
+    the execution shape. ``submit`` runs on the event-loop thread
+    (thread-safe ingress); ``advance`` / ``shutdown`` run on the kernel
+    thread. ``advance`` returns an immutable :class:`TickResult`; the
+    kernel performs the effects for any ``completed`` entries.
+    """
+
+    def submit(self, request: "_PendingRequest") -> None: ...
+
+    def advance(self) -> TickResult: ...
+
+    def shutdown(self, error: Optional[BaseException] = ...) -> None: ...
+
+
+class AutoregressiveExecutor:
+    """Executor lane wrapping the autoregressive prefill/decode scheduler.
+
+    Owns the :class:`GenerationScheduler`, the image-crop admission
+    coordinator, and the in-flight request map. The pipelined-decode
+    internals (``PipelineState``, ``launch_forward_async``,
+    ``commit_step``, ping-pong slots) are untouched — this is a
+    lift-and-wrap of the engine's former scheduler loop into the uniform
+    :class:`Executor` face, with delivery turned into :class:`Completion`
+    values the kernel acts on.
+    """
+
+    def __init__(
+        self,
+        runtime: AutoregressiveRuntime,
+        *,
+        skills: "SkillRegistry",
+        adapter_provider: Optional[AdapterProvider],
+        default_temperature: float,
+        default_top_p: float,
+        build_generation_request: Callable[
+            [AutoregressiveRuntime, "_PendingRequest", Any],
+            "tuple[GenerationRequest, SkillState]",
+        ],
+        to_engine_result: Callable[[SchedulerResult], EngineResult],
+        wake_event: threading.Event,
+    ) -> None:
+        self._runtime = runtime
+        self._build_generation_request = build_generation_request
+        self._to_engine_result = to_engine_result
+        self._scheduler = GenerationScheduler(
+            runtime,
+            default_temperature=default_temperature,
+            default_top_p=default_top_p,
+            skill_registry=skills,
+            adapter_provider=adapter_provider,
+        )
+        # Admission wakes the kernel loop when async crop work completes.
+        self._admission = _AdmissionCoordinator(
+            runtime=runtime,
+            wake_event=wake_event,
+            fail_request=self._fail_via_admission,
+        )
+        self._active: Dict[int, _PendingRequest] = {}
+        # Admission-time failures surface as completions the kernel delivers.
+        self._admission_failures: List[Completion] = []
+
+    # -- ingress (event-loop thread) ----------------------------------
+
+    def submit(self, request: _PendingRequest) -> None:
+        ready = self._admission.submit(request)
+        if ready is not None:
+            self._admit_ready(ready)
+
+    # -- step (kernel thread) -----------------------------------------
+
+    @property
+    def has_work(self) -> bool:
+        """Queued, admitting, or in-flight work remains (read-only)."""
+        return (
+            self._scheduler.has_pending_work()
+            or self._admission.has_pending()
+            or bool(self._active)
+            or bool(self._admission_failures)
+        )
+
+    def advance(self) -> TickResult:
+        scheduler = self._scheduler
+        progressed = False
+        completed: List[Completion] = []
+
+        if self._admission_failures:
+            completed.extend(self._admission_failures)
+            self._admission_failures = []
+            progressed = True
+
+        progressed = self._promote_ready() or progressed
+
+        if scheduler.has_pending_work():
+            progressed = scheduler.advance() or progressed
+
+        for result in scheduler.pop_completed():
+            completion = self._completion_for(result)
+            if completion is not None:
+                completed.append(completion)
+            progressed = True
+
+        return TickResult(
+            progressed=progressed,
+            completed=tuple(completed),
+            in_flight=scheduler.has_pending_work(),
+            has_work=(
+                scheduler.has_pending_work()
+                or self._admission.has_pending()
+                or bool(self._active)
+            ),
+        )
+
+    def drain(self) -> tuple[Completion, ...]:
+        """Complete in-flight pipeline work (used before a pause)."""
+        self._scheduler._drain_pipeline()
+        completed: List[Completion] = []
+        for result in self._scheduler.pop_completed():
+            completion = self._completion_for(result)
+            if completion is not None:
+                completed.append(completion)
+        return tuple(completed)
+
+    def shutdown(self, error: Optional[BaseException] = None) -> tuple[Completion, ...]:
+        exc = error or RuntimeError("Engine shut down")
+        completions = [c for c in self._admission_failures]
+        self._admission_failures = []
+        self._admission.fail_all(exc)
+        for req in self._active.values():
+            completions.append(Completion(request=req, error=exc))
+        self._active.clear()
+        self._release_active_sequences()
+        return tuple(completions)
+
+    # -- internals ----------------------------------------------------
+
+    def _fail_via_admission(
+        self, req: _PendingRequest, error: BaseException
+    ) -> None:
+        self._admission_failures.append(Completion(request=req, error=error))
+
+    def _admit_ready(self, ready: _ReadyAdmission) -> None:
+        req = ready.req
+        try:
+            generation_req, skill_state = self._build_generation_request(
+                self._runtime, req, ready.crops
+            )
+        except Exception as exc:
+            self._admission_failures.append(Completion(request=req, error=exc))
+            return
+        crops_ready = (
+            req.image is None or ready.prefix_cache_hit or (ready.crops is not None)
+        )
+        lora_slot_ready = req.adapter is None
+        phase = (
+            RequestPhase.READY_FOR_PREFILL
+            if (crops_ready and lora_slot_ready)
+            else RequestPhase.WAITING_RESOURCES
+        )
+        lifecycle = RequestLifecycle(
+            request=generation_req,
+            skill_state=skill_state,
+            phase=phase,
+            has_image=req.image is not None,
+            crops_ready=crops_ready,
+            lora_slot_ready=lora_slot_ready,
+            prefix_cache_hit=ready.prefix_cache_hit,
+            submitted_at=req.submitted_at,
+        )
+        generation_req.lifecycle = lifecycle
+        self._scheduler.enqueue_request(generation_req, skill_state)
+        self._active[req.request_id] = req
+
+    def _promote_ready(self) -> bool:
+        promoted = False
+        cap = self._runtime.max_batch_size * 4
+        while len(self._scheduler.waiting) < cap:
+            ready = self._admission.take_ready()
+            if ready is None:
+                break
+            self._admit_ready(ready)
+            promoted = True
+        return promoted
+
+    def _completion_for(self, result: SchedulerResult) -> Optional[Completion]:
+        req = self._active.pop(result.request_id, None)
+        if req is None:
+            _LOGGER.error(
+                "Scheduler produced unknown request_id %s", result.request_id
+            )
+            return None
+        if result.finish_reason == "error" and "error" in result.output:
+            return Completion(
+                request=req, error=RuntimeError(result.output["error"])
+            )
+        return Completion(request=req, result=self._to_engine_result(result))
+
+    def _release_active_sequences(self) -> None:
+        try:
+            runtime_sequences = list(self._runtime.active_sequences.values())
+        except Exception:  # pragma: no cover - defensive cleanup
+            return
+        for state in runtime_sequences:
+            try:
+                self._runtime.release_sequence(state)
+            except Exception:
+                pass
+
+

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -238,12 +238,17 @@ class AutoregressiveExecutor:
 
     def shutdown(self, error: Optional[BaseException] = None) -> tuple[Completion, ...]:
         exc = error or RuntimeError("Engine shut down")
-        completions = [c for c in self._admission_failures]
-        self._admission_failures = []
+        # Fail in-flight admission first: fail_all() synchronously routes
+        # any request still in async preprocessing through
+        # _fail_via_admission, which appends to _admission_failures — so
+        # collect that list *after*, or those requests' futures never get
+        # resolved and callers hang.
         self._admission.fail_all(exc)
         for req in self._active.values():
-            completions.append(Completion(request=req, error=exc))
+            self._admission_failures.append(Completion(request=req, error=exc))
         self._active.clear()
+        completions = self._admission_failures
+        self._admission_failures = []
         self._release_active_sequences()
         return tuple(completions)
 

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -39,6 +39,7 @@ from kestrel.engine._types import (
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class _AdmissionCoordinator:
     def __init__(
         self,
@@ -126,8 +127,6 @@ class _AdmissionCoordinator:
                 break
 
 
-
-
 class Executor(Protocol):
     """A kernel-side lane wrapping one driver behind a uniform face.
 
@@ -213,45 +212,29 @@ class AutoregressiveExecutor:
 
     def advance(self) -> TickResult:
         scheduler = self._scheduler
-        progressed = False
-        completed: List[Completion] = []
-
-        if self._admission_failures:
-            completed.extend(self._admission_failures)
-            self._admission_failures = []
-            progressed = True
+        completed = self._admission_failures
+        self._admission_failures = []
+        progressed = bool(completed)
 
         progressed = self._promote_ready() or progressed
 
         if scheduler.has_pending_work():
             progressed = scheduler.advance() or progressed
 
-        for result in scheduler.pop_completed():
-            completion = self._completion_for(result)
-            if completion is not None:
-                completed.append(completion)
-            progressed = True
+        new_completions = self._collect()
+        completed.extend(new_completions)
+        progressed = progressed or bool(new_completions)
 
         return TickResult(
             progressed=progressed,
             completed=tuple(completed),
-            in_flight=scheduler.has_pending_work(),
-            has_work=(
-                scheduler.has_pending_work()
-                or self._admission.has_pending()
-                or bool(self._active)
-            ),
+            has_work=self.has_work,
         )
 
     def drain(self) -> tuple[Completion, ...]:
         """Complete in-flight pipeline work (used before a pause)."""
         self._scheduler._drain_pipeline()
-        completed: List[Completion] = []
-        for result in self._scheduler.pop_completed():
-            completion = self._completion_for(result)
-            if completion is not None:
-                completed.append(completion)
-        return tuple(completed)
+        return tuple(self._collect())
 
     def shutdown(self, error: Optional[BaseException] = None) -> tuple[Completion, ...]:
         exc = error or RuntimeError("Engine shut down")
@@ -313,6 +296,15 @@ class AutoregressiveExecutor:
             self._admit_ready(ready)
             promoted = True
         return promoted
+
+    def _collect(self) -> List[Completion]:
+        """Drain finished scheduler results into Completion values."""
+        completions: List[Completion] = []
+        for result in self._scheduler.pop_completed():
+            completion = self._completion_for(result)
+            if completion is not None:
+                completions.append(completion)
+        return completions
 
     def _completion_for(self, result: SchedulerResult) -> Optional[Completion]:
         req = self._active.pop(result.request_id, None)

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -212,18 +212,22 @@ class AutoregressiveExecutor:
 
     def advance(self) -> TickResult:
         scheduler = self._scheduler
-        completed = self._admission_failures
-        self._admission_failures = []
-        progressed = bool(completed)
-
-        progressed = self._promote_ready() or progressed
+        progressed = self._promote_ready()
 
         if scheduler.has_pending_work():
             progressed = scheduler.advance() or progressed
 
-        new_completions = self._collect()
-        completed.extend(new_completions)
-        progressed = progressed or bool(new_completions)
+        new = self._collect()
+
+        # Drain the admission-failure buffer LAST. _admission_failures is
+        # the durable home for not-yet-delivered failures; clearing it
+        # only here (after the work above that can raise) means that if
+        # scheduler.advance() raises, the buffer stays intact and the
+        # kernel's shutdown(exc) path still delivers those callers'
+        # completions instead of leaving their futures unresolved.
+        completed = self._admission_failures + new
+        self._admission_failures = []
+        progressed = progressed or bool(completed)
 
         return TickResult(
             progressed=progressed,

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -185,3 +185,25 @@ def test_admission_failure_surfaces_as_completion() -> None:
     assert len(tick.completed) == 1
     assert isinstance(tick.completed[0].error, ValueError)
     assert ex.has_work is False
+
+
+def test_shutdown_returns_requests_failed_during_fail_all() -> None:
+    """Regression: a request still in async preprocessing at shutdown.
+
+    The real admission coordinator's fail_all() synchronously routes
+    in-flight preprocessing requests through _fail_via_admission, which
+    appends to _admission_failures. shutdown() must collect that list
+    *after* fail_all() runs, or those requests' completions are dropped
+    and their callers hang forever.
+    """
+    ex = _executor()
+    stuck = _pending(5)
+    # Mimic the real coordinator: fail_all routes the stuck request back
+    # through the executor's admission-failure path.
+    ex._admission.fail_all = lambda exc: ex._fail_via_admission(stuck, exc)
+
+    completions = ex.shutdown(RuntimeError("stop"))
+
+    assert [c.request for c in completions] == [stuck]
+    assert isinstance(completions[0].error, RuntimeError)
+    assert ex._admission_failures == []

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -187,6 +187,37 @@ def test_admission_failure_surfaces_as_completion() -> None:
     assert ex.has_work is False
 
 
+def test_advance_raising_preserves_queued_admission_failures() -> None:
+    """Regression: a buffered admission failure must survive advance() raising.
+
+    advance() must not move _admission_failures into a local that's lost
+    if scheduler.advance() raises mid-tick. The kernel responds to the
+    exception by calling shutdown(exc); that must still see the buffered
+    failure and return it, or the failed-admission caller hangs.
+    """
+    ex = _executor()
+    failed = _pending(6)
+    ex._fail_via_admission(failed, ValueError("bad image"))
+
+    def boom() -> bool:
+        raise RuntimeError("advance blew up")
+
+    ex._scheduler.has_pending_work = lambda: True
+    ex._scheduler.advance = boom
+
+    # Mirror the kernel loop: advance() raises, then shutdown(exc) runs.
+    import pytest
+
+    with pytest.raises(RuntimeError, match="advance blew up"):
+        ex.advance()
+
+    completions = ex.shutdown(RuntimeError("stop"))
+    assert failed in [c.request for c in completions]
+    assert isinstance(
+        next(c for c in completions if c.request is failed).error, ValueError
+    )
+
+
 def test_shutdown_returns_requests_failed_during_fail_all() -> None:
     """Regression: a request still in async preprocessing at shutdown.
 

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -1,0 +1,187 @@
+"""The AR executor maps scheduler output to Completion values.
+
+`AutoregressiveExecutor` wraps the generation scheduler + admission and
+presents the uniform `Executor` face (submit / advance -> TickResult /
+shutdown). These tests pin the new mapping logic — scheduler results and
+in-flight requests becoming `Completion`s the kernel delivers — without a
+GPU: the scheduler and admission are stubbed, since their internals are
+covered by tests/scheduler/.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from typing import Any
+
+from kestrel.engine import (
+    AutoregressiveExecutor,
+    Completion,
+    EngineResult,
+    EngineMetrics,
+    _PendingRequest,
+)
+from kestrel.scheduler import SchedulerResult
+from kestrel.scheduler.types import RequestMetrics
+
+
+def _pending(request_id: int) -> _PendingRequest:
+    loop = asyncio.new_event_loop()
+    try:
+        fut: asyncio.Future = loop.create_future()
+    finally:
+        loop.close()
+    return _PendingRequest(
+        request_id=request_id,
+        prompt="p",
+        prompt_tokens=[],
+        image=None,
+        image_hash=None,
+        max_new_tokens=4,
+        temperature=0.0,
+        top_p=1.0,
+        submitted_at=0.0,
+        future=fut,
+        stream_queue=None,
+        skill=SimpleNamespace(name="stub"),
+        request_context=object(),
+    )
+
+
+def _executor() -> AutoregressiveExecutor:
+    """An executor with the scheduler + admission replaced by stubs."""
+    ex = object.__new__(AutoregressiveExecutor)
+    ex._runtime = SimpleNamespace(
+        max_batch_size=1,
+        active_sequences={},
+        release_sequence=lambda state: None,
+    )
+    ex._to_engine_result = _fake_to_engine_result
+    ex._active = {}
+    ex._admission_failures = []
+    ex._scheduler = SimpleNamespace(
+        _completed=[],
+        waiting=[],
+        has_pending_work=lambda: bool(ex._scheduler._completed),
+        advance=lambda: False,
+        pop_completed=lambda: [
+            ex._scheduler._completed.pop(0) for _ in list(ex._scheduler._completed)
+        ],
+        enqueue_request=lambda req, state: None,
+    )
+    ex._admission = SimpleNamespace(
+        has_pending=lambda: False,
+        take_ready=lambda: None,
+        fail_all=lambda exc: None,
+    )
+    return ex
+
+
+def _fake_to_engine_result(result: SchedulerResult) -> EngineResult:
+    return EngineResult(
+        request_id=result.request_id,
+        tokens=result.tokens,
+        finish_reason=result.finish_reason,
+        metrics=EngineMetrics(
+            input_tokens=0,
+            output_tokens=0,
+            prefill_time_ms=0.0,
+            decode_time_ms=0.0,
+            ttft_ms=0.0,
+        ),
+        output=result.output,
+    )
+
+
+def _sched_result(request_id: int, *, error: str | None = None) -> SchedulerResult:
+    return SchedulerResult(
+        request_id=request_id,
+        tokens=[],
+        finish_reason="error" if error else "stop",
+        metrics=RequestMetrics(
+            prompt_tokens=0,
+            decode_tokens=0,
+            prefill_time_ms=0.0,
+            ttft_ms=0.0,
+            decode_time_ms=0.0,
+        ),
+        output={"error": error} if error else {"answer": "hi"},
+    )
+
+
+def test_completed_result_becomes_success_completion() -> None:
+    ex = _executor()
+    req = _pending(1)
+    ex._active[1] = req
+    ex._scheduler._completed.append(_sched_result(1))
+
+    tick = ex.advance()
+
+    assert tick.progressed is True
+    assert len(tick.completed) == 1
+    completion = tick.completed[0]
+    assert completion.request is req
+    assert completion.error is None
+    assert completion.result is not None and completion.result.request_id == 1
+    # The request left the in-flight map.
+    assert 1 not in ex._active
+
+
+def test_error_result_becomes_error_completion() -> None:
+    ex = _executor()
+    req = _pending(2)
+    ex._active[2] = req
+    ex._scheduler._completed.append(_sched_result(2, error="boom"))
+
+    tick = ex.advance()
+
+    assert len(tick.completed) == 1
+    completion = tick.completed[0]
+    assert completion.result is None
+    assert isinstance(completion.error, RuntimeError)
+    assert "boom" in str(completion.error)
+
+
+def test_unknown_request_id_is_dropped() -> None:
+    ex = _executor()
+    ex._scheduler._completed.append(_sched_result(999))
+
+    tick = ex.advance()
+
+    assert tick.completed == ()
+
+
+def test_idle_executor_reports_no_work() -> None:
+    ex = _executor()
+    tick = ex.advance()
+    assert tick.completed == ()
+    assert tick.has_work is False
+    assert ex.has_work is False
+
+
+def test_shutdown_fails_in_flight_requests() -> None:
+    ex = _executor()
+    req = _pending(3)
+    ex._active[3] = req
+
+    completions = ex.shutdown(RuntimeError("stop"))
+
+    assert len(completions) == 1
+    assert completions[0].request is req
+    assert isinstance(completions[0].error, RuntimeError)
+    assert not ex._active
+
+
+def test_admission_failure_surfaces_as_completion() -> None:
+    ex = _executor()
+    req = _pending(4)
+    # Simulate admission deciding the request can't proceed.
+    ex._fail_via_admission(req, ValueError("bad image"))
+    assert ex.has_work is True  # a pending failure counts as work
+
+    tick = ex.advance()
+
+    assert len(tick.completed) == 1
+    assert isinstance(tick.completed[0].error, ValueError)
+    assert ex.has_work is False


### PR DESCRIPTION
## Why

The engine drives one execution shape today — autoregressive prefill/decode — with the scheduler loop written as a pile of inline closures. To host additional execution shapes behind one process without rewriting that loop each time, the owner thread becomes a **kernel** that folds a uniform **executor** protocol over its lanes. This PR establishes the paradigm and moves AR onto it, with no behavior change. (Design: kestrel-proprietary#177.)

## What

**`Executor` protocol** — three methods, two threads:
- `submit(request)` — event-loop thread, thread-safe ingress.
- `advance() -> TickResult` — kernel thread, one non-blocking step. Returns an immutable `TickResult` (`progressed`, `completed`, `in_flight`, `has_work`).
- `shutdown(error)` — fail queued + in-flight.

Executors emit `Completion` **values** and never touch asyncio; the **kernel** performs the effects for each completion (resolve the request future, record telemetry, finish the stream). Decisions stay on the executor, effects at the edge — which also makes the executor directly unit-testable without a GPU.

**`AutoregressiveExecutor`** wraps `GenerationScheduler` + the image-crop admission coordinator and presents that face. The pipelined-decode internals — `PipelineState`, `launch_forward_async`, `commit_step`, ping-pong slots — are **untouched**; the former inline loop closures (admit / promote / deliver) move onto the executor, with scheduler results mapped to `Completion`s.

**`_scheduler_loop` becomes the kernel loop:** drain ingress → fold `advance()` over executors → deliver completions, preserving the pause/drain/sync and shutdown-drain semantics exactly. The fold is trivial with one lane today; it's the seam additional shapes attach to.

## Tests

- New `tests/test_autoregressive_executor.py` pins the new mapping logic (success/error completions, unknown-id drop, idle, shutdown-fails-in-flight, admission-failure-as-completion) with the scheduler stubbed — its internals are covered by `tests/scheduler/`.
- Full engine + scheduler suites pass (**123** after review fixes).

No behavior change for autoregressive inference. Validated on B200 end-to-end (single + 3 concurrent queries decode correctly through the executor kernel loop) plus the full CPU engine + scheduler suites. The current count is **123 passed** after addressing review (the two shutdown/admission-failure fixes below).