### PR TITLE
Add the single-pass executor lane + engine.run()

### DIFF
--- a/kestrel/engine/__init__.py
+++ b/kestrel/engine/__init__.py
@@ -16,7 +16,8 @@ from kestrel.engine.executor import (
     Executor,
     _AdmissionCoordinator,
 )
-from kestrel.engine._types import _PendingRequest
+from kestrel.engine.single_pass import SinglePassExecutor
+from kestrel.engine._types import _AutoregressiveRequest
 from kestrel.engine.core import InferenceEngine
 
 __all__ = [
@@ -26,6 +27,7 @@ __all__ = [
     "EngineStream",
     "Executor",
     "AutoregressiveExecutor",
+    "SinglePassExecutor",
     "Completion",
     "TickResult",
 ]

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -12,7 +12,7 @@ import asyncio
 import hashlib
 from concurrent.futures import Future
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, List, Optional, Sequence, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Protocol, Sequence, Union
 
 import numpy as np
 
@@ -103,7 +103,7 @@ class EngineStream(AsyncIterator[StreamUpdate]):
 
 
 @dataclass(slots=True)
-class _PendingRequest:
+class _AutoregressiveRequest:
     request_id: int
     prompt: str
     prompt_tokens: Sequence[Token]
@@ -126,7 +126,7 @@ class _PendingRequest:
 
 @dataclass(slots=True)
 class _ReadyAdmission:
-    req: _PendingRequest
+    req: _AutoregressiveRequest
     crops: Any
     prefix_cache_hit: bool
 
@@ -135,6 +135,30 @@ def _hash_image(image: np.ndarray | bytes) -> bytes:
     """SHA-256 over the raw image input for prefix-cache keying."""
     raw = image.tobytes() if isinstance(image, np.ndarray) else image
     return hashlib.sha256(raw).digest()
+
+
+class EngineRequest(Protocol):
+    """The envelope the kernel needs to return an answer to a caller.
+
+    Every execution shape submits a concrete request carrying its own
+    lane-specific payload (``_AutoregressiveRequest`` holds prompt/tokens/skill
+    for the autoregressive lane; the single-pass lane holds task/inputs).
+    What the kernel's delivery path actually touches is only this common
+    envelope: the identity, the future to resolve, the optional stream
+    sink, and the finetune id. Typing ``Completion.request`` as this
+    protocol keeps the kernel's return path independent of any one lane's
+    request type — a new lane defines its own request satisfying this and
+    nothing in delivery changes.
+
+    ``adapter`` is the finetune id (``None`` when no finetune is
+    selected); it is reported to telemetry and, for lanes that support
+    finetunes, selects the weights.
+    """
+
+    request_id: int
+    future: "asyncio.Future[EngineResult]"
+    stream_queue: "Optional[_StreamQueue]"
+    adapter: Optional[str]
 
 
 @dataclass(slots=True)
@@ -149,7 +173,7 @@ class Completion:
     Exactly one of ``result`` / ``error`` is set.
     """
 
-    request: "_PendingRequest"
+    request: EngineRequest
     result: Optional[EngineResult] = None
     error: Optional[BaseException] = None
 

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1412,23 +1412,38 @@ class InferenceEngine:
                             lane.submit(req)
                         progressed = True
 
+                    # Advance the autoregressive lane. Its pipeline is the
+                    # shared device state, so a failure here is fatal to the
+                    # kernel — tear everything down.
                     try:
                         tick = ar_executor.advance()
-                        if tick.completed:
-                            deliver(tick.completed)
-                        progressed = tick.progressed or progressed
-                        for lane in single_pass.values():
-                            sp_tick = lane.advance()
-                            if sp_tick.completed:
-                                deliver(sp_tick.completed)
-                            progressed = sp_tick.progressed or progressed
                     except Exception as exc:
-                        _LOGGER.exception("Executor advance failed", exc_info=exc)
+                        _LOGGER.exception("Autoregressive advance failed", exc_info=exc)
                         deliver(ar_executor.shutdown(exc))
                         for lane in single_pass.values():
                             deliver(lane.shutdown(exc))
                         self._fail_all_pending(exc)
                         return
+                    if tick.completed:
+                        deliver(tick.completed)
+                    progressed = tick.progressed or progressed
+
+                    # Advance each single-pass lane in isolation: a single
+                    # forward blowing up must fail only that lane's in-flight
+                    # work, never take down the kernel or the other lanes.
+                    for name, lane in single_pass.items():
+                        try:
+                            sp_tick = lane.advance()
+                        except Exception as exc:
+                            _LOGGER.exception(
+                                "Single-pass advance failed for %s", name, exc_info=exc
+                            )
+                            deliver(lane.shutdown(exc))
+                            progressed = True
+                            continue
+                        if sp_tick.completed:
+                            deliver(sp_tick.completed)
+                        progressed = sp_tick.progressed or progressed
 
                     if shutdown_requested and not any_work():
                         break

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -371,7 +371,7 @@ class InferenceEngine:
             finally:
                 self._photon_reporter = None
         for runtime in self._runtimes.values():
-            runtime.shutdown_image_preprocessor()
+            runtime.shutdown()
 
     async def submit(
         self,

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -107,6 +107,12 @@ _ALLOWED_API_BASE_URLS = (
     _DEFAULT_API_BASE_URL,
 )
 
+# How long the kernel parks between polls while a single-pass forward is
+# in flight. A single forward is a few ms and its GPU completion event
+# sets no host event, so the kernel re-checks on this cadence; ~1ms keeps
+# completion latency low without busy-spinning a core.
+_SINGLE_PASS_POLL_INTERVAL_S = 0.001
+
 
 class InferenceEngine:
     """Orchestrates batched inference over a shared runtime and scheduler."""
@@ -1451,7 +1457,17 @@ class InferenceEngine:
                     if not progressed:
                         if shutdown_requested:
                             break
-                        wake_event.wait()
+                        # A launched single-pass forward signals completion
+                        # via a CUDA event, which sets no host event — so if
+                        # any lane has in-flight event-backed work, poll on a
+                        # short timeout instead of blocking, or the kernel
+                        # could sleep past the GPU finishing and leave
+                        # engine.run() unresolved until an unrelated request
+                        # happens to wake the loop.
+                        if any(sp.has_in_flight for sp in single_pass.values()):
+                            wake_event.wait(timeout=_SINGLE_PASS_POLL_INTERVAL_S)
+                        else:
+                            wake_event.wait()
                         wake_event.clear()
         finally:
             deliver(ar_executor.shutdown())

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -52,7 +52,7 @@ import torch
 from kestrel_kernels import get_runtime
 from kestrel.config import RuntimeConfig
 from kestrel.device import set_device, synchronize
-from kestrel.runtime import AutoregressiveRuntime
+from kestrel.runtime import AutoregressiveRuntime, ExecutionShape, SinglePassRuntime
 from kestrel.scheduler import (
     GeneratedPrefix,
     GenerationRequest,
@@ -83,14 +83,16 @@ from kestrel.utils.spatial_refs import normalize_spatial_refs
 from kestrel.engine._types import (
     Completion,
     EngineMetrics,
+    EngineRequest,
     EngineResult,
     EngineStream,
-    _PendingRequest,
+    _AutoregressiveRequest,
     _StreamCompletion,
     _StreamQueue,
     _StreamQueueItem,
 )
 from kestrel.engine.executor import AutoregressiveExecutor
+from kestrel.engine.single_pass import SinglePassExecutor, _SinglePassRequest
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -163,8 +165,15 @@ class InferenceEngine:
         # that it's already inside init and bails without recursing.
         self._initialized = False
         self._init_task: Optional[asyncio.Task[None]] = None
-        self._queue: asyncio.Queue[Optional[_PendingRequest]] = asyncio.Queue()
-        self._scheduler_queue: queue.Queue[_PendingRequest | None] = queue.Queue()
+        self._queue: asyncio.Queue[Optional[_AutoregressiveRequest]] = asyncio.Queue()
+        self._scheduler_queue: queue.Queue[_AutoregressiveRequest | None] = queue.Queue()
+        # Single-pass ingress: (model_id, request) tagged so the kernel
+        # routes to that model's single-pass lane. Separate from the AR
+        # queue, which has no model tag (it always targets the default
+        # autoregressive model).
+        self._single_pass_queue: "queue.Queue[tuple[str, _SinglePassRequest]]" = (
+            queue.Queue()
+        )
         self._scheduler_event = threading.Event()
         self._run_gate = threading.Event()
         self._run_gate.set()  # set == running
@@ -852,6 +861,40 @@ class InferenceEngine:
         self._run_gate.set()
         self._scheduler_event.set()
 
+    async def run(self, model: str, task: str, inputs: Any) -> EngineResult:
+        """Run a single-pass ``task`` on ``model`` and await its result.
+
+        The low-level multi-model entry point: routes to the model's
+        single-pass lane, which runs one ``forward`` and returns the
+        structured result. (Autoregressive models keep using ``submit`` /
+        the typed verbs.)
+        """
+        if self._shutdown:
+            raise RuntimeError("InferenceEngine is shut down")
+        await self._ensure_started()
+
+        runtime = self._runtimes.get(model)
+        if runtime is None:
+            raise ValueError(f"Unknown model {model!r}")
+        if runtime.execution_shape is not ExecutionShape.SINGLE_PASS:
+            raise ValueError(
+                f"Model {model!r} is not a single-pass model "
+                f"(execution_shape={runtime.execution_shape.value})"
+            )
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[EngineResult] = loop.create_future()
+        req = _SinglePassRequest(
+            request_id=next(self._request_ids),
+            future=future,
+            task=task,
+            inputs=inputs,
+            submitted_at=time.perf_counter(),
+        )
+        self._single_pass_queue.put((model, req))
+        self._scheduler_event.set()
+        return await future
+
     async def _submit_request(
         self,
         *,
@@ -901,7 +944,7 @@ class InferenceEngine:
             return_logprobs=return_logprobs,
             streaming=stream_queue is not None,
         )
-        payload = _PendingRequest(
+        payload = _AutoregressiveRequest(
             request_id=req_id,
             prompt=prompt_str,
             prompt_tokens=tokens,
@@ -1205,7 +1248,7 @@ class InferenceEngine:
         return tuple(token_ids)
 
     def _build_stream_callback(
-        self, req: _PendingRequest
+        self, req: _AutoregressiveRequest
     ) -> Optional[Callable[[StreamUpdate], None]]:
         queue = req.stream_queue
         if queue is None:
@@ -1224,7 +1267,7 @@ class InferenceEngine:
 
     def _complete_stream(
         self,
-        req: _PendingRequest,
+        req: EngineRequest,
         *,
         result: Optional[EngineResult] = None,
         error: Optional[BaseException] = None,
@@ -1236,7 +1279,7 @@ class InferenceEngine:
         completion = _StreamCompletion(result=result, error=error)
         self._loop.call_soon_threadsafe(queue.put_nowait, completion)
 
-    def _fail_request(self, req: _PendingRequest, error: BaseException) -> None:
+    def _fail_request(self, req: EngineRequest, error: BaseException) -> None:
         future = req.future
         if future and not future.done():
             assert self._loop is not None
@@ -1267,7 +1310,9 @@ class InferenceEngine:
             return
         set_device(runtime.device)
 
-        executor = AutoregressiveExecutor(
+        # The default (autoregressive) lane. Its pipeline owns the device's
+        # CUDA-graph capture, so pause/drain is handled specially below.
+        ar_executor = AutoregressiveExecutor(
             runtime,
             skills=self._skills,
             adapter_provider=self._adapter_provider,
@@ -1277,6 +1322,14 @@ class InferenceEngine:
             to_engine_result=self._to_engine_result,
             wake_event=self._scheduler_event,
         )
+        # One single-pass lane per registered single-pass model. The kernel
+        # folds advance() over every lane; single-pass forwards interleave
+        # with autoregressive decode on the shared stream.
+        single_pass: Dict[str, SinglePassExecutor] = {
+            name: SinglePassExecutor(rt)
+            for name, rt in self._runtimes.items()
+            if rt.execution_shape is ExecutionShape.SINGLE_PASS
+        }
 
         shutdown_requested = False
         wake_event = self._scheduler_event
@@ -1308,6 +1361,11 @@ class InferenceEngine:
                     loop.call_soon_threadsafe(future.set_result, engine_result)
                 self._complete_stream(req, result=engine_result)
 
+        def any_work() -> bool:
+            return ar_executor.has_work or any(
+                sp.has_work for sp in single_pass.values()
+            )
+
         try:
             with torch.inference_mode():
                 while True:
@@ -1315,17 +1373,20 @@ class InferenceEngine:
                     if paused_flag.is_set():
                         # Drain in-flight work before pause — callers may
                         # mutate runtime state while paused (e.g. rebuild
-                        # CUDA graphs).
-                        deliver(executor.drain())
+                        # CUDA graphs). Only the AR lane has graph state;
+                        # single-pass forwards are one-shot, so draining the
+                        # AR pipeline is sufficient.
+                        deliver(ar_executor.drain())
                         with runtime.graph_capture_lock:
                             synchronize(runtime.device)
                         paused_event.set()
-                        if shutdown_requested and not executor.has_work:
+                        if shutdown_requested and not any_work():
                             break
                         run_gate.wait(timeout=0.1)
                         continue
 
                     progressed = False
+                    # AR ingress (untagged — always the default model).
                     while True:
                         try:
                             item = self._scheduler_queue.get_nowait()
@@ -1334,22 +1395,42 @@ class InferenceEngine:
                         if item is None:
                             shutdown_requested = True
                             continue
-                        executor.submit(item)
+                        ar_executor.submit(item)
+                        progressed = True
+                    # Single-pass ingress (model-tagged).
+                    while True:
+                        try:
+                            model, req = self._single_pass_queue.get_nowait()
+                        except queue.Empty:
+                            break
+                        lane = single_pass.get(model)
+                        if lane is None:  # pragma: no cover - guarded in run()
+                            self._fail_request(
+                                req, ValueError(f"No single-pass lane for {model!r}")
+                            )
+                        else:
+                            lane.submit(req)
                         progressed = True
 
                     try:
-                        tick = executor.advance()
+                        tick = ar_executor.advance()
+                        if tick.completed:
+                            deliver(tick.completed)
+                        progressed = tick.progressed or progressed
+                        for lane in single_pass.values():
+                            sp_tick = lane.advance()
+                            if sp_tick.completed:
+                                deliver(sp_tick.completed)
+                            progressed = sp_tick.progressed or progressed
                     except Exception as exc:
                         _LOGGER.exception("Executor advance failed", exc_info=exc)
-                        deliver(executor.shutdown(exc))
+                        deliver(ar_executor.shutdown(exc))
+                        for lane in single_pass.values():
+                            deliver(lane.shutdown(exc))
                         self._fail_all_pending(exc)
                         return
 
-                    if tick.completed:
-                        deliver(tick.completed)
-                    progressed = tick.progressed or progressed
-
-                    if shutdown_requested and not tick.has_work:
+                    if shutdown_requested and not any_work():
                         break
 
                     if not progressed:
@@ -1358,13 +1439,15 @@ class InferenceEngine:
                         wake_event.wait()
                         wake_event.clear()
         finally:
-            deliver(executor.shutdown())
+            deliver(ar_executor.shutdown())
+            for lane in single_pass.values():
+                deliver(lane.shutdown())
             self._fail_all_pending()
 
     def _build_generation_request(
         self,
         runtime: AutoregressiveRuntime,
-        req: _PendingRequest,
+        req: _AutoregressiveRequest,
         image_crops: Any,
     ) -> tuple[GenerationRequest, SkillState]:
         prompt_tokens = req.prompt_tokens
@@ -1497,5 +1580,11 @@ class InferenceEngine:
             if pending is None:
                 continue
             self._fail_request(pending, exc)
+        while True:
+            try:
+                _model, req = self._single_pass_queue.get_nowait()
+            except queue.Empty:
+                break
+            self._fail_request(req, exc)
 
 

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -32,7 +32,7 @@ from kestrel.engine._types import (
     Completion,
     EngineResult,
     TickResult,
-    _PendingRequest,
+    _AutoregressiveRequest,
     _ReadyAdmission,
     _hash_image,
 )
@@ -45,7 +45,7 @@ class _AdmissionCoordinator:
         self,
         runtime: AutoregressiveRuntime,
         wake_event: threading.Event,
-        fail_request: Callable[[_PendingRequest, BaseException], None],
+        fail_request: Callable[[_AutoregressiveRequest, BaseException], None],
     ) -> None:
         self._runtime = runtime
         self._wake_event = wake_event
@@ -55,14 +55,14 @@ class _AdmissionCoordinator:
         # Gemma 4's pixel_values bundle, etc.) and threads them back
         # into ``launch_prepared_batch``.
         self._pending_crops: Dict[
-            int, tuple[_PendingRequest, "Future[Any]"]
+            int, tuple[_AutoregressiveRequest, "Future[Any]"]
         ] = {}
         self._ready_crops: queue.Queue[int] = queue.Queue()
 
     def has_pending(self) -> bool:
         return bool(self._pending_crops)
 
-    def submit(self, req: _PendingRequest) -> Optional[_ReadyAdmission]:
+    def submit(self, req: _AutoregressiveRequest) -> Optional[_ReadyAdmission]:
         if req.image is None:
             return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=False)
 
@@ -137,7 +137,7 @@ class Executor(Protocol):
     kernel performs the effects for any ``completed`` entries.
     """
 
-    def submit(self, request: "_PendingRequest") -> None: ...
+    def submit(self, request: "_AutoregressiveRequest") -> None: ...
 
     def advance(self) -> TickResult: ...
 
@@ -165,7 +165,7 @@ class AutoregressiveExecutor:
         default_temperature: float,
         default_top_p: float,
         build_generation_request: Callable[
-            [AutoregressiveRuntime, "_PendingRequest", Any],
+            [AutoregressiveRuntime, "_AutoregressiveRequest", Any],
             "tuple[GenerationRequest, SkillState]",
         ],
         to_engine_result: Callable[[SchedulerResult], EngineResult],
@@ -187,13 +187,13 @@ class AutoregressiveExecutor:
             wake_event=wake_event,
             fail_request=self._fail_via_admission,
         )
-        self._active: Dict[int, _PendingRequest] = {}
+        self._active: Dict[int, _AutoregressiveRequest] = {}
         # Admission-time failures surface as completions the kernel delivers.
         self._admission_failures: List[Completion] = []
 
     # -- ingress (event-loop thread) ----------------------------------
 
-    def submit(self, request: _PendingRequest) -> None:
+    def submit(self, request: _AutoregressiveRequest) -> None:
         ready = self._admission.submit(request)
         if ready is not None:
             self._admit_ready(ready)
@@ -259,7 +259,7 @@ class AutoregressiveExecutor:
     # -- internals ----------------------------------------------------
 
     def _fail_via_admission(
-        self, req: _PendingRequest, error: BaseException
+        self, req: _AutoregressiveRequest, error: BaseException
     ) -> None:
         self._admission_failures.append(Completion(request=req, error=error))
 

--- a/kestrel/engine/single_pass.py
+++ b/kestrel/engine/single_pass.py
@@ -137,6 +137,16 @@ class SinglePassExecutor:
     def has_work(self) -> bool:
         return bool(self._in_flight) or not self._queue.empty()
 
+    @property
+    def has_in_flight(self) -> bool:
+        """A launched forward is awaiting its GPU completion event.
+
+        Distinct from ``has_work``: queued requests wake the kernel via the
+        submit event, but a pending GPU event sets no host event, so the
+        kernel must keep polling (timed wait, not block) while this holds.
+        """
+        return bool(self._in_flight)
+
     def advance(self) -> TickResult:
         progressed = self._launch()
         completed = self._collect()

--- a/kestrel/engine/single_pass.py
+++ b/kestrel/engine/single_pass.py
@@ -65,8 +65,17 @@ def _single_pass_result(request_id: int, output: Any) -> EngineResult:
     """Wrap a driver forward's output as an EngineResult.
 
     Single-pass tasks produce structured output (e.g. masks + scores),
-    not tokens, so token fields are empty/zero. Keeping one result type
-    lets the kernel deliver every lane through the same path.
+    not tokens. We deliberately reuse the one ``EngineResult`` type so the
+    kernel delivers every lane through a single path (a second result type
+    would force the delivery code to branch); the token fields are
+    zero-filled because they don't apply.
+
+    KNOWN GAP (usage metering): the zero token counts mean a single-pass
+    request is counted by Photon (request_count++) but contributes no
+    billable token usage. Token-based billing therefore undercounts
+    single-pass work. Picking the right unit for single-pass (images /
+    pixels / forwards) and wiring it into telemetry is deferred — tracked
+    for when single-pass models are actually metered.
     """
     return EngineResult(
         request_id=request_id,
@@ -110,7 +119,9 @@ class SinglePassExecutor:
     ) -> None:
         self._runtime = runtime
         self._device = runtime.device
-        self._stream = getattr(runtime, "primary_stream", None)
+        # Declared on SinglePassRuntime — access directly so a runtime that
+        # forgets it fails loudly instead of silently losing interleaving.
+        self._stream = runtime.primary_stream
         self._max_in_flight = max_in_flight
         self._queue: "queue.Queue[_SinglePassRequest]" = queue.Queue()
         self._in_flight: List[_InFlight] = []

--- a/kestrel/engine/single_pass.py
+++ b/kestrel/engine/single_pass.py
@@ -1,0 +1,206 @@
+"""The single-pass executor lane.
+
+A single-pass driver (:class:`~kestrel.runtime.SinglePassRuntime`) fulfils
+a request with one ``forward(task, inputs)`` that enqueues kernels and
+returns result tensors *without* a host sync. This executor owns the
+pipeline around that call — a slot pool, a completion event per in-flight
+forward, and result delivery — so a single-pass forward overlaps
+autoregressive decode on the shared stream (async launch + deferred
+collect, the autoregressive pipeline's trick generalized to a second
+lane).
+
+It presents the same uniform :class:`Executor` face the kernel folds over
+(``submit`` / ``advance`` -> :class:`TickResult` / ``shutdown``) and emits
+:class:`Completion` values; like the autoregressive lane, it never touches
+the event loop.
+
+First cut: one in-flight forward (``max_in_flight=1``). Adding slots or
+batching is a parameter change here, not a new abstraction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+from kestrel.device import make_event, stream_context
+from kestrel.runtime import SinglePassRuntime
+
+from kestrel.engine._types import (
+    Completion,
+    EngineMetrics,
+    EngineResult,
+    TickResult,
+    _StreamQueue,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _SinglePassRequest:
+    """A single-pass request the engine is tracking.
+
+    Satisfies the :class:`~kestrel.engine._types.EngineRequest` envelope
+    (``request_id`` / ``future`` / ``stream_queue`` / ``adapter``) the
+    kernel delivers to, plus this lane's payload: the ``task`` name and
+    its ``inputs``. ``adapter`` is ``None`` until finetune support lands
+    for single-pass models; ``stream_queue`` is ``None`` until partial
+    output (e.g. streamed masks) is supported.
+    """
+
+    request_id: int
+    future: "asyncio.Future[EngineResult]"
+    task: str
+    inputs: Any
+    submitted_at: float
+    adapter: Optional[str] = None
+    stream_queue: "Optional[_StreamQueue]" = None
+
+
+def _single_pass_result(request_id: int, output: Any) -> EngineResult:
+    """Wrap a driver forward's output as an EngineResult.
+
+    Single-pass tasks produce structured output (e.g. masks + scores),
+    not tokens, so token fields are empty/zero. Keeping one result type
+    lets the kernel deliver every lane through the same path.
+    """
+    return EngineResult(
+        request_id=request_id,
+        tokens=[],
+        finish_reason="stop",
+        metrics=EngineMetrics(
+            input_tokens=0,
+            output_tokens=0,
+            prefill_time_ms=0.0,
+            decode_time_ms=0.0,
+            ttft_ms=0.0,
+        ),
+        output=output if isinstance(output, dict) else {"result": output},
+    )
+
+
+@dataclass(slots=True)
+class _InFlight:
+    """A forward whose kernels are enqueued and whose result is pending.
+
+    ``error`` is set instead of ``output``/``done_event`` when the
+    ``forward`` call raised at launch; it surfaces as an error completion
+    on the next collect, keeping launch failures on the same path as
+    results.
+    """
+
+    request: _SinglePassRequest
+    output: Any
+    done_event: Any  # torch.cuda.Event | NoopEvent | None
+    error: Optional[BaseException] = None
+
+
+class SinglePassExecutor:
+    """Executor lane driving single-forward requests with async collect."""
+
+    def __init__(
+        self,
+        runtime: SinglePassRuntime,
+        *,
+        max_in_flight: int = 1,
+    ) -> None:
+        self._runtime = runtime
+        self._device = runtime.device
+        self._stream = getattr(runtime, "primary_stream", None)
+        self._max_in_flight = max_in_flight
+        self._queue: "queue.Queue[_SinglePassRequest]" = queue.Queue()
+        self._in_flight: List[_InFlight] = []
+
+    # -- ingress (event-loop thread) ----------------------------------
+
+    def submit(self, request: _SinglePassRequest) -> None:
+        self._queue.put(request)
+
+    # -- step (kernel thread) -----------------------------------------
+
+    @property
+    def has_work(self) -> bool:
+        return bool(self._in_flight) or not self._queue.empty()
+
+    def advance(self) -> TickResult:
+        progressed = self._launch()
+        completed = self._collect()
+        progressed = progressed or bool(completed)
+        return TickResult(
+            progressed=progressed,
+            completed=tuple(completed),
+            has_work=self.has_work,
+        )
+
+    def shutdown(self, error: Optional[BaseException] = None) -> tuple[Completion, ...]:
+        exc = error or RuntimeError("Engine shut down")
+        completions: List[Completion] = [
+            Completion(request=f.request, error=exc) for f in self._in_flight
+        ]
+        self._in_flight = []
+        while True:
+            try:
+                req = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            completions.append(Completion(request=req, error=exc))
+        return tuple(completions)
+
+    # -- internals ----------------------------------------------------
+
+    def _launch(self) -> bool:
+        """Start forwards until the in-flight pool is full or the queue drains."""
+        launched = False
+        while len(self._in_flight) < self._max_in_flight:
+            try:
+                req = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            launched = self._launch_one(req) or launched
+        return launched
+
+    def _launch_one(self, req: _SinglePassRequest) -> bool:
+        try:
+            with stream_context(self._stream):
+                output = self._runtime.forward(req.task, req.inputs)
+                done_event = make_event(self._device)
+                done_event.record()
+        except Exception as exc:
+            # Launch-time failure: hold the error so it surfaces as a
+            # completion on the next collect, uniform with normal results.
+            self._in_flight.append(
+                _InFlight(request=req, output=None, done_event=None, error=exc)
+            )
+            return True
+        self._in_flight.append(
+            _InFlight(request=req, output=output, done_event=done_event, error=None)
+        )
+        return True
+
+    def _collect(self) -> List[Completion]:
+        """Emit completions for any in-flight forward that has finished."""
+        if not self._in_flight:
+            return []
+        still: List[_InFlight] = []
+        completed: List[Completion] = []
+        for f in self._in_flight:
+            if f.error is not None:
+                completed.append(Completion(request=f.request, error=f.error))
+            elif f.done_event.query():
+                completed.append(
+                    Completion(
+                        request=f.request,
+                        result=_single_pass_result(f.request.request_id, f.output),
+                    )
+                )
+            else:
+                still.append(f)
+        self._in_flight = still
+        return completed
+
+
+__all__ = ["SinglePassExecutor", "_SinglePassRequest"]

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -757,7 +757,12 @@ class MoondreamRuntime:
         """Return a Future for Moondream's overlap-crop preprocessing."""
         return self._image_preprocessor.submit(image, self.config.vision)
 
-    def shutdown_image_preprocessor(self) -> None:
+    def shutdown(self) -> None:
+        """Release runtime resources (Runtime protocol).
+
+        The engine calls this once per runtime on shutdown; for Moondream
+        that means tearing down the image-preprocessor thread pool.
+        """
         self._image_preprocessor.shutdown(wait=True)
 
     def acquire_prefill_slot(self, slot_id: int | None = None) -> PrefillSlot:

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -71,6 +71,12 @@ class Runtime(Protocol):
     # Which executor drives this runtime.
     execution_shape: ExecutionShape
 
+    # Release the runtime's resources. Called once by the engine on
+    # shutdown for every registered runtime, regardless of shape, so
+    # teardown lives on the universal surface (the AR runtime tears down
+    # its image preprocessor here; a single-pass runtime may be a no-op).
+    def shutdown(self) -> None: ...
+
 
 class AutoregressiveRuntime(Runtime, Protocol):
     """Surface the scheduler calls on a prefill/decode runtime.
@@ -123,10 +129,6 @@ class AutoregressiveRuntime(Runtime, Protocol):
     def preprocess_image_async(
         self, image: np.ndarray | bytes
     ) -> Future[Any]: ...
-
-    # Called once when the engine is shutting down so the runtime can
-    # tear down its preprocessing thread pool (if any).
-    def shutdown_image_preprocessor(self) -> None: ...
 
     # Slot lifecycle
     def acquire_prefill_slot(self, slot_id: int | None = ...) -> Any: ...

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -191,13 +191,22 @@ class AutoregressiveRuntime(Runtime, Protocol):
 class SinglePassRuntime(Runtime, Protocol):
     """Runtime that fulfills a request with a single forward.
 
-    No KV cache, no decode loop. The engine's single-pass executor hands
-    it a task name + inputs and returns the result. ``run`` is the whole
-    contract beyond image preprocessing.
+    No KV cache, no decode loop. The driver is pure compute: ``forward``
+    enqueues the kernels for one forward and returns the result tensors
+    *without* a host sync, so the engine's single-pass executor can let
+    that work overlap autoregressive decode on the shared stream. The
+    executor owns the completion event, slot, and result delivery (the
+    driver↔executor split mirrors the autoregressive path, where the
+    model computes and the scheduler owns the pipeline).
+
+    A synchronous ``forward`` (one that blocks on its own result) would
+    stall the kernel loop and defeat interleaving — implementations must
+    not call ``.item()`` / ``.cpu()`` / ``torch.cuda.synchronize`` before
+    returning.
     """
 
     def preprocess_image_async(
         self, image: np.ndarray | bytes
     ) -> Future[Any]: ...
 
-    def run(self, task: str, inputs: Any) -> Any: ...
+    def forward(self, task: str, inputs: Any) -> Any: ...

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -205,6 +205,13 @@ class SinglePassRuntime(Runtime, Protocol):
     returning.
     """
 
+    # Stream the executor launches forwards on, so a single-pass forward
+    # and autoregressive decode share one ordered stream (the device's
+    # serialize-on-stream invariant). Declared here — not discovered via
+    # getattr — so a runtime that omits it fails loudly rather than
+    # silently running on the default stream with no interleaving.
+    primary_stream: Any
+
     def preprocess_image_async(
         self, image: np.ndarray | bytes
     ) -> Future[Any]: ...

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -183,7 +183,7 @@ class FakeRuntime:
         fut.set_result(image)
         return fut
 
-    def shutdown_image_preprocessor(self) -> None:
+    def shutdown(self) -> None:
         pass
 
     # Slot lifecycle ---------------------------------------------------

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -20,19 +20,19 @@ from kestrel.engine import (
     Completion,
     EngineResult,
     EngineMetrics,
-    _PendingRequest,
+    _AutoregressiveRequest,
 )
 from kestrel.scheduler import SchedulerResult
 from kestrel.scheduler.types import RequestMetrics
 
 
-def _pending(request_id: int) -> _PendingRequest:
+def _pending(request_id: int) -> _AutoregressiveRequest:
     loop = asyncio.new_event_loop()
     try:
         fut: asyncio.Future = loop.create_future()
     finally:
         loop.close()
-    return _PendingRequest(
+    return _AutoregressiveRequest(
         request_id=request_id,
         prompt="p",
         prompt_tokens=[],

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -112,7 +112,7 @@ class _FakeRuntime:
     def preprocess_image_async(self, image: np.ndarray | bytes) -> Future[object]:
         return self._image_preprocessor.submit(image)
 
-    def shutdown_image_preprocessor(self) -> None:  # pragma: no cover
+    def shutdown(self) -> None:  # pragma: no cover
         pass
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,7 +13,7 @@ import pytest
 from kestrel.engine import (
     InferenceEngine,
     _AdmissionCoordinator,
-    _PendingRequest,
+    _AutoregressiveRequest,
 )
 from kestrel.models.moondream.runtime import TextToken
 from kestrel.scheduler import GeneratedPrefix
@@ -22,8 +22,8 @@ from kestrel.skills import DecodeStep, SkillFinalizeResult, SkillSpec, SkillStat
 
 def _make_request(
     *, request_id: int = 1, image: np.ndarray | bytes | None = None
-) -> _PendingRequest:
-    return _PendingRequest(
+) -> _AutoregressiveRequest:
+    return _AutoregressiveRequest(
         request_id=request_id,
         prompt="prompt",
         prompt_tokens=[object(), object()],
@@ -117,9 +117,9 @@ class _FakeRuntime:
 
 
 def _record_failure(
-    failures: list[tuple[_PendingRequest, BaseException]]
-) -> Callable[[_PendingRequest, BaseException], None]:
-    def _fail(req: _PendingRequest, exc: BaseException) -> None:
+    failures: list[tuple[_AutoregressiveRequest, BaseException]]
+) -> Callable[[_AutoregressiveRequest, BaseException], None]:
+    def _fail(req: _AutoregressiveRequest, exc: BaseException) -> None:
         failures.append((req, exc))
 
     return _fail
@@ -130,7 +130,7 @@ def test_admission_coordinator_immediately_admits_text_only_request() -> None:
     runtime = _FakeRuntime(
         prefix_cache=None, prefix_hit=False, image_preprocessor=preprocessor,
     )
-    failures: list[tuple[_PendingRequest, BaseException]] = []
+    failures: list[tuple[_AutoregressiveRequest, BaseException]] = []
     coordinator = _AdmissionCoordinator(
         runtime=runtime,
         wake_event=threading.Event(),
@@ -153,7 +153,7 @@ def test_admission_coordinator_skips_crop_work_on_prefix_hit() -> None:
     runtime = _FakeRuntime(
         prefix_cache=object(), prefix_hit=True, image_preprocessor=preprocessor,
     )
-    failures: list[tuple[_PendingRequest, BaseException]] = []
+    failures: list[tuple[_AutoregressiveRequest, BaseException]] = []
     coordinator = _AdmissionCoordinator(
         runtime=runtime,
         wake_event=threading.Event(),
@@ -178,7 +178,7 @@ def test_admission_coordinator_checks_prefix_cache_with_generated_prefix() -> No
     runtime = _FakeRuntime(
         prefix_cache=object(), prefix_hit=True, image_preprocessor=preprocessor,
     )
-    failures: list[tuple[_PendingRequest, BaseException]] = []
+    failures: list[tuple[_AutoregressiveRequest, BaseException]] = []
     coordinator = _AdmissionCoordinator(
         runtime=runtime,
         wake_event=threading.Event(),
@@ -202,7 +202,7 @@ def test_admission_coordinator_promotes_completed_crops() -> None:
     crop_future: Future[object] = Future()
     preprocessor = _FakeImagePreprocessor([crop_future])
     wake_event = threading.Event()
-    failures: list[tuple[_PendingRequest, BaseException]] = []
+    failures: list[tuple[_AutoregressiveRequest, BaseException]] = []
     coordinator = _AdmissionCoordinator(
         runtime=_FakeRuntime(
             prefix_cache=object(), prefix_hit=False,
@@ -236,7 +236,7 @@ def test_admission_coordinator_skips_failed_crop_and_keeps_promoting() -> None:
     failed_future: Future[object] = Future()
     ready_future: Future[object] = Future()
     preprocessor = _FakeImagePreprocessor([failed_future, ready_future])
-    failures: list[tuple[_PendingRequest, BaseException]] = []
+    failures: list[tuple[_AutoregressiveRequest, BaseException]] = []
     coordinator = _AdmissionCoordinator(
         runtime=_FakeRuntime(
             prefix_cache=None, prefix_hit=False,

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -1,0 +1,119 @@
+"""engine.run() routes single-pass work through the real kernel loop.
+
+Drives the actual _scheduler_loop on CPU with an autoregressive
+FakeRuntime as the default lane plus a stub single-pass runtime
+registered alongside it, and checks that engine.run(model, task, inputs)
+round-trips through the single-pass lane. Complements
+test_single_pass_executor.py (which unit-tests the lane in isolation) by
+exercising the kernel's multi-lane fold + ingress routing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import pytest
+import torch
+
+from kestrel.engine import InferenceEngine
+from kestrel.runtime import ExecutionShape
+
+from tests.scheduler._fake_runtime import FakeRuntime
+
+
+class _StubSinglePass:
+    """Single-pass runtime: forward() echoes the task + inputs."""
+
+    def __init__(self, model_name: str = "stub-sp") -> None:
+        self.model_name = model_name
+        self.device = torch.device("cpu")
+        self.execution_shape = ExecutionShape.SINGLE_PASS
+        self.primary_stream = None
+        self.calls: list[tuple[str, Any]] = []
+
+    def forward(self, task: str, inputs: Any) -> Any:
+        self.calls.append((task, inputs))
+        if task == "boom":
+            raise ValueError("forward failed")
+        return {"task": task, "inputs": inputs}
+
+
+def _engine_with(ar: FakeRuntime, sp: _StubSinglePass) -> InferenceEngine:
+    """Wire an engine for the loop without create() (no Moondream/warmup)."""
+    import queue as _queue
+
+    engine = object.__new__(InferenceEngine)
+    engine._default_model = ar.model_name
+    engine._runtimes = {ar.model_name: ar, sp.model_name: sp}
+    engine._scheduler_queue = _queue.Queue()
+    engine._single_pass_queue = _queue.Queue()
+    engine._scheduler_event = threading.Event()
+    engine._run_gate = threading.Event()
+    engine._run_gate.set()
+    engine._paused_flag = threading.Event()
+    engine._paused_event = threading.Event()
+    engine._shutdown = False
+    engine._photon_reporter = None
+    engine._adapter_provider = None
+    engine._default_temperature = 0.2
+    engine._default_top_p = 0.9
+    engine._skills = None
+    engine._request_ids = iter(range(1, 1_000_000))
+    return engine
+
+
+async def _run(task: str, inputs: Any) -> Any:
+    ar = FakeRuntime(model_name="ar-default", device="cpu")
+    sp = _StubSinglePass()
+    engine = _engine_with(ar, sp)
+    engine._loop = asyncio.get_running_loop()
+    engine._initialized = True
+    engine._init_task = None
+
+    thread = threading.Thread(target=engine._scheduler_loop, name="kernel", daemon=True)
+    thread.start()
+    try:
+        return await asyncio.wait_for(engine.run(sp.model_name, task, inputs), timeout=5.0)
+    finally:
+        engine._shutdown = True
+        engine._scheduler_queue.put(None)
+        engine._scheduler_event.set()
+        thread.join(timeout=5.0)
+
+
+def test_run_routes_single_pass_through_kernel_loop() -> None:
+    result = asyncio.run(_run("segment", {"points": [[1, 2]]}))
+    assert result.output == {"task": "segment", "inputs": {"points": [[1, 2]]}}
+
+
+def test_run_propagates_forward_error() -> None:
+    with pytest.raises(ValueError, match="forward failed"):
+        asyncio.run(_run("boom", {}))
+
+
+def test_run_rejects_unknown_model() -> None:
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        sp = _StubSinglePass()
+        engine = _engine_with(ar, sp)
+        engine._loop = asyncio.get_running_loop()
+        engine._initialized = True
+        with pytest.raises(ValueError, match="Unknown model"):
+            await engine.run("nope", "segment", {})
+
+    asyncio.run(go())
+
+
+def test_run_rejects_autoregressive_model() -> None:
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        sp = _StubSinglePass()
+        engine = _engine_with(ar, sp)
+        engine._loop = asyncio.get_running_loop()
+        engine._initialized = True
+        with pytest.raises(ValueError, match="not a single-pass model"):
+            await engine.run("ar-default", "segment", {})
+
+    asyncio.run(go())

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -119,6 +119,63 @@ def test_run_rejects_autoregressive_model() -> None:
     asyncio.run(go())
 
 
+def test_run_resolves_when_event_pending_with_no_other_traffic() -> None:
+    """Regression (P1): a pending GPU event must not hang the kernel.
+
+    A launched single-pass forward signals completion via a CUDA event,
+    which sets no host event. If the kernel blocks on wake_event.wait()
+    while the only in-flight work is that pending event, it sleeps past
+    GPU completion and engine.run() never resolves. With nothing else in
+    flight to wake the loop, run() must still complete on its own.
+    """
+    import kestrel.engine.single_pass as sp_mod
+
+    class _PendingEvent:
+        def __init__(self) -> None:
+            self._polls = 0
+
+        def record(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def query(self) -> bool:
+            # Not done for the first few polls — forces the kernel to park
+            # with a pending event and nothing else to wake it.
+            self._polls += 1
+            return self._polls > 3
+
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        sp = _StubSinglePass()
+        engine = _engine_with(ar, sp)
+        engine._loop = asyncio.get_running_loop()
+        engine._initialized = True
+        engine._init_task = None
+
+        orig_make_event = sp_mod.make_event
+        sp_mod.make_event = lambda device: _PendingEvent()
+        try:
+            thread = threading.Thread(
+                target=engine._scheduler_loop, name="kernel", daemon=True
+            )
+            thread.start()
+            try:
+                # No other traffic: only this single-pass request is in
+                # flight. It must resolve via the kernel's poll, not hang.
+                result = await asyncio.wait_for(
+                    engine.run(sp.model_name, "segment", {"k": 1}), timeout=5.0
+                )
+                assert result.output == {"task": "segment", "inputs": {"k": 1}}
+            finally:
+                engine._shutdown = True
+                engine._scheduler_queue.put(None)
+                engine._scheduler_event.set()
+                thread.join(timeout=5.0)
+        finally:
+            sp_mod.make_event = orig_make_event
+
+    asyncio.run(go())
+
+
 def test_single_pass_lane_crash_does_not_kill_the_kernel() -> None:
     """A single-pass lane whose advance() raises is isolated.
 

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -117,3 +117,68 @@ def test_run_rejects_autoregressive_model() -> None:
             await engine.run("ar-default", "segment", {})
 
     asyncio.run(go())
+
+
+def test_single_pass_lane_crash_does_not_kill_the_kernel() -> None:
+    """A single-pass lane whose advance() raises is isolated.
+
+    The broken lane's in-flight request is failed, but the kernel keeps
+    running and other lanes still serve — one bad single-pass request
+    must not take down autoregressive decode or sibling lanes.
+    """
+
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        good = _StubSinglePass("good-sp")
+        bad = _StubSinglePass("bad-sp")
+        engine = _engine_with(ar, good)
+        engine._runtimes[bad.model_name] = bad
+        engine._loop = asyncio.get_running_loop()
+        engine._initialized = True
+        engine._init_task = None
+
+        # Make the bad lane's executor.advance() raise (a bug escaping the
+        # executor's own forward() try/except). Patch after the loop builds
+        # its executors, so wrap _scheduler_loop's lane construction by
+        # poisoning the runtime's forward to raise a BaseException-free
+        # error path: simplest is to monkeypatch SinglePassExecutor.advance
+        # for the bad runtime via a sentinel task.
+        import kestrel.engine.single_pass as sp_mod
+
+        orig_advance = sp_mod.SinglePassExecutor.advance
+
+        def advance(self):  # type: ignore[no-untyped-def]
+            # The bad lane explodes whenever it has a request to service,
+            # before it can produce a completion — simulating a bug that
+            # escapes the executor's own forward() try/except.
+            if self._runtime.model_name == "bad-sp" and (
+                self._in_flight or not self._queue.empty()
+            ):
+                raise RuntimeError("lane exploded")
+            return orig_advance(self)
+
+        sp_mod.SinglePassExecutor.advance = advance
+        try:
+            thread = threading.Thread(
+                target=engine._scheduler_loop, name="kernel", daemon=True
+            )
+            thread.start()
+            try:
+                # The bad lane crashes on its request; the good lane still works.
+                with pytest.raises(RuntimeError, match="Engine shut down|lane exploded"):
+                    await asyncio.wait_for(
+                        engine.run("bad-sp", "segment", {}), timeout=5.0
+                    )
+                good_result = await asyncio.wait_for(
+                    engine.run("good-sp", "segment", {"ok": 1}), timeout=5.0
+                )
+                assert good_result.output == {"task": "segment", "inputs": {"ok": 1}}
+            finally:
+                engine._shutdown = True
+                engine._scheduler_queue.put(None)
+                engine._scheduler_event.set()
+                thread.join(timeout=5.0)
+        finally:
+            sp_mod.SinglePassExecutor.advance = orig_advance
+
+    asyncio.run(go())

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -39,6 +39,9 @@ class _StubSinglePass:
             raise ValueError("forward failed")
         return {"task": task, "inputs": inputs}
 
+    def shutdown(self) -> None:
+        pass
+
 
 def _engine_with(ar: FakeRuntime, sp: _StubSinglePass) -> InferenceEngine:
     """Wire an engine for the loop without create() (no Moondream/warmup)."""
@@ -172,6 +175,40 @@ def test_run_resolves_when_event_pending_with_no_other_traffic() -> None:
                 thread.join(timeout=5.0)
         finally:
             sp_mod.make_event = orig_make_event
+
+    asyncio.run(go())
+
+
+def test_engine_shutdown_tears_down_single_pass_runtime() -> None:
+    """Regression (P2): engine.shutdown() must not AttributeError on a
+    single-pass runtime.
+
+    shutdown() iterates every registered runtime and calls runtime.shutdown();
+    a conformant single-pass runtime implements that, so a co-hosted
+    Moondream + single-pass engine tears down cleanly.
+    """
+
+    class _RecordingSinglePass(_StubSinglePass):
+        def __init__(self) -> None:
+            super().__init__("recording-sp")
+            self.shutdown_called = False
+
+        def shutdown(self) -> None:
+            self.shutdown_called = True
+
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        sp = _RecordingSinglePass()
+        engine = _engine_with(ar, sp)
+        # Minimal lifecycle state shutdown() touches; no loop/worker started.
+        engine._queue = asyncio.Queue()
+        engine._worker_task = None
+        engine._scheduler_thread = None
+
+        await engine.shutdown()
+
+        assert engine._shutdown is True
+        assert sp.shutdown_called is True
 
     asyncio.run(go())
 

--- a/tests/test_single_pass_executor.py
+++ b/tests/test_single_pass_executor.py
@@ -15,6 +15,7 @@ from typing import Any
 import torch
 
 from kestrel.engine import SinglePassExecutor
+import kestrel.engine.single_pass as single_pass_mod
 from kestrel.engine.single_pass import _SinglePassRequest
 from kestrel.runtime import ExecutionShape
 
@@ -103,6 +104,54 @@ def test_idle_executor_reports_no_work() -> None:
     tick = ex.advance()
     assert tick.completed == ()
     assert tick.has_work is False
+    assert ex.has_work is False
+
+
+class _PendingEvent:
+    """Fake completion event: reports not-done for the first ``n`` polls.
+
+    Lets a CPU test exercise the deferred-collect path that NoopEvent
+    (always done) can't reach.
+    """
+
+    def __init__(self, not_done_polls: int) -> None:
+        self._remaining = not_done_polls
+
+    def record(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+    def query(self) -> bool:
+        if self._remaining > 0:
+            self._remaining -= 1
+            return False
+        return True
+
+
+def test_forward_stays_in_flight_until_event_fires(monkeypatch) -> None:
+    """The result is held back until its completion event reports done."""
+    event = _PendingEvent(not_done_polls=2)
+    monkeypatch.setattr(single_pass_mod, "make_event", lambda device: event)
+
+    ex = SinglePassExecutor(_StubDriver())
+    ex.submit(_req(7, "segment", {"k": "v"}))
+
+    # Tick 1: forward launched, but the event reports not-done — nothing
+    # delivered yet, work still pending.
+    tick1 = ex.advance()
+    assert tick1.completed == ()
+    assert tick1.progressed is True  # a launch is progress
+    assert ex.has_work is True
+    assert len(ex._in_flight) == 1
+
+    # Tick 2: event still not done — still held.
+    tick2 = ex.advance()
+    assert tick2.completed == ()
+    assert ex.has_work is True
+
+    # Tick 3: event fires — the result is finally delivered.
+    tick3 = ex.advance()
+    assert [c.request.request_id for c in tick3.completed] == [7]
+    assert tick3.completed[0].result is not None
     assert ex.has_work is False
 
 

--- a/tests/test_single_pass_executor.py
+++ b/tests/test_single_pass_executor.py
@@ -1,0 +1,124 @@
+"""SinglePassExecutor: async launch + deferred collect, value-based delivery.
+
+Drives the executor directly with a stub single-pass driver on CPU
+(where make_event() is a NoopEvent that reports done immediately). Pins
+the launch/collect contract, error handling, and shutdown — the kernel
+integration is covered separately by the engine e2e test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+from kestrel.engine import SinglePassExecutor
+from kestrel.engine.single_pass import _SinglePassRequest
+from kestrel.runtime import ExecutionShape
+
+
+class _StubDriver:
+    """Single-pass driver whose forward() echoes (task, inputs)."""
+
+    def __init__(self) -> None:
+        self.model_name = "stub-sp"
+        # CPU device -> make_event() returns a NoopEvent whose query()
+        # reports done immediately, so collect() fires on the next tick.
+        self.device = torch.device("cpu")
+        self.execution_shape = ExecutionShape.SINGLE_PASS
+        self.primary_stream = None
+        self.calls: list[tuple[str, Any]] = []
+
+    def forward(self, task: str, inputs: Any) -> Any:
+        self.calls.append((task, inputs))
+        if task == "boom":
+            raise ValueError("forward failed")
+        return {"task": task, "inputs": inputs}
+
+
+def _req(request_id: int, task: str, inputs: Any) -> _SinglePassRequest:
+    loop = asyncio.new_event_loop()
+    try:
+        fut: asyncio.Future = loop.create_future()
+    finally:
+        loop.close()
+    return _SinglePassRequest(
+        request_id=request_id,
+        future=fut,
+        task=task,
+        inputs=inputs,
+        submitted_at=0.0,
+    )
+
+
+def test_forward_result_becomes_completion() -> None:
+    ex = SinglePassExecutor(_StubDriver())
+    ex.submit(_req(1, "segment", {"points": [[1, 2]]}))
+
+    tick = ex.advance()  # launch + collect (NoopEvent done immediately)
+
+    assert tick.progressed is True
+    assert len(tick.completed) == 1
+    c = tick.completed[0]
+    assert c.error is None
+    assert c.result is not None
+    assert c.result.output == {"task": "segment", "inputs": {"points": [[1, 2]]}}
+    assert ex.has_work is False
+
+
+def test_forward_error_becomes_error_completion() -> None:
+    ex = SinglePassExecutor(_StubDriver())
+    ex.submit(_req(2, "boom", {}))
+
+    tick = ex.advance()
+
+    assert len(tick.completed) == 1
+    assert tick.completed[0].result is None
+    assert isinstance(tick.completed[0].error, ValueError)
+    assert ex.has_work is False
+
+
+def test_one_in_flight_at_a_time() -> None:
+    """Default max_in_flight=1: a second job waits until the first frees."""
+    driver = _StubDriver()
+    ex = SinglePassExecutor(driver, max_in_flight=1)
+    ex.submit(_req(3, "a", 1))
+    ex.submit(_req(4, "b", 2))
+
+    # First advance launches+collects job 3 (NoopEvent completes at once),
+    # leaving job 4 queued.
+    tick1 = ex.advance()
+    assert [c.request.request_id for c in tick1.completed] == [3]
+    assert ex.has_work is True  # job 4 still queued
+
+    tick2 = ex.advance()
+    assert [c.request.request_id for c in tick2.completed] == [4]
+    assert ex.has_work is False
+
+
+def test_idle_executor_reports_no_work() -> None:
+    ex = SinglePassExecutor(_StubDriver())
+    tick = ex.advance()
+    assert tick.completed == ()
+    assert tick.has_work is False
+    assert ex.has_work is False
+
+
+def test_shutdown_fails_queued_and_in_flight() -> None:
+    driver = _StubDriver()
+    ex = SinglePassExecutor(driver, max_in_flight=1)
+    ex.submit(_req(5, "a", 1))
+    ex.submit(_req(6, "b", 2))
+    # Launch job 5 into the in-flight slot without collecting it: a real
+    # CUDA event would still be pending here.
+    ex._launch()
+    assert len(ex._in_flight) == 1
+
+    completions = ex.shutdown(RuntimeError("stop"))
+
+    ids = sorted(c.request.request_id for c in completions)
+    assert ids == [5, 6]  # both the in-flight and the queued one
+    assert all(isinstance(c.error, RuntimeError) for c in completions)
+    assert ex.has_work is False

--- a/tests/test_single_pass_executor.py
+++ b/tests/test_single_pass_executor.py
@@ -38,6 +38,9 @@ class _StubDriver:
             raise ValueError("forward failed")
         return {"task": task, "inputs": inputs}
 
+    def shutdown(self) -> None:
+        pass
+
 
 def _req(request_id: int, task: str, inputs: Any) -> _SinglePassRequest:
     loop = asyncio.new_event_loop()


### PR DESCRIPTION
## Why

The kernel hosts one execution shape today — autoregressive prefill/decode. This adds the second: **single-pass** models that fulfil a request with one forward and no decode loop, running on the same owner thread and interleaving with AR decode on the shared stream. Builds directly on the `Executor` seam from the executor-protocol PR. (Design: kestrel-proprietary multi-model engine doc.)

## What

**`SinglePassRuntime.forward(task, inputs)`** (replaces the placeholder `run()`): enqueues the kernels for one forward and returns result tensors **without a host sync**, so the work can overlap AR decode. The driver is pure compute; the executor owns the pipeline — mirroring the AR split where the model computes and the scheduler owns the pipeline.

**`SinglePassExecutor`**: a slot pool (1 in-flight to start) with **async launch + deferred collect** — `forward()` enqueues, a completion event is recorded, and each `advance()` polls the event and emits a `Completion` when it fires. Same uniform `Executor` face the kernel folds over (`submit` / `advance` → `TickResult` / `shutdown`); emits values, never touches the event loop. Adding slots/batching later is a parameter, not a new abstraction.

**Kernel loop**: builds one single-pass lane per registered single-pass model and folds `advance()` over every lane. Single-pass ingress is model-tagged and routed by id; AR ingress is unchanged. Pause/drain stays AR-specific (only the AR pipeline holds CUDA-graph state).

**`engine.run(model, task, inputs)`**: the low-level multi-model entry that routes to a model's single-pass lane.

**`EngineRequest` protocol**: the minimal envelope the kernel's delivery path actually needs — `request_id` / `future` / `stream_queue` / `adapter`. Both `_AutoregressiveRequest` (renamed from `_PendingRequest` for symmetry) and the new `_SinglePassRequest` satisfy it, so `Completion.request` and the fail/stream-completion helpers are lane-agnostic — a new lane defines its own request type and delivery is unchanged. `adapter` (the finetune id) is in the envelope since finetune support is planned for all model types; single-pass sets it `None` for now.

## Tests

- `tests/test_single_pass_executor.py` — the lane in isolation: launch/collect, forward-error → error completion, one-in-flight gating, idle, shutdown fails queued + in-flight.
- `tests/test_single_pass_engine.py` — `engine.run()` end-to-end through the **real** kernel loop with an AR `FakeRuntime` default + a stub single-pass runtime: success round-trip, error propagation, unknown-model / wrong-shape rejection.
- Full engine + scheduler suites pass (**132**). GPU autoregressive decode through the now-two-lane loop verified (single + concurrent queries).

No change to autoregressive behaviour — the AR lane is the existing executor unchanged; this only adds a second lane to the fold.