### PR TITLE
Add engine.model() -> ModelHandle, the per-model surface

### DIFF
--- a/kestrel/__init__.py
+++ b/kestrel/__init__.py
@@ -1,5 +1,5 @@
 """Kestrel inference package."""
 
-from .engine import InferenceEngine, EngineResult, EngineMetrics
+from .engine import InferenceEngine, EngineResult, EngineMetrics, ModelHandle
 
-__all__ = ["InferenceEngine", "EngineResult", "EngineMetrics"]
+__all__ = ["InferenceEngine", "EngineResult", "EngineMetrics", "ModelHandle"]

--- a/kestrel/engine/__init__.py
+++ b/kestrel/engine/__init__.py
@@ -17,6 +17,7 @@ from kestrel.engine.executor import (
     _AdmissionCoordinator,
 )
 from kestrel.engine.single_pass import SinglePassExecutor
+from kestrel.engine.handle import ModelHandle
 from kestrel.engine._types import _AutoregressiveRequest
 from kestrel.engine.core import InferenceEngine
 
@@ -28,6 +29,7 @@ __all__ = [
     "Executor",
     "AutoregressiveExecutor",
     "SinglePassExecutor",
+    "ModelHandle",
     "Completion",
     "TickResult",
 ]

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -93,6 +93,7 @@ from kestrel.engine._types import (
 )
 from kestrel.engine.executor import AutoregressiveExecutor
 from kestrel.engine.single_pass import SinglePassExecutor, _SinglePassRequest
+from kestrel.engine.handle import ModelHandle
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -900,6 +901,49 @@ class InferenceEngine:
         self._single_pass_queue.put((model, req))
         self._scheduler_event.set()
         return await future
+
+    def model(self, model_id: Optional[str] = None) -> "ModelHandle":
+        """Return a :class:`ModelHandle` bound to ``model_id``.
+
+        The primary surface: bind a model once, then call its capability
+        methods (``query`` / ``segment_masks`` / ...) or ``run``. Defaults
+        to the configured default model.
+
+        Validates against the *configured* models, so a handle can be taken
+        before the engine is started (runtimes are built lazily in
+        ``_initialize``); the handle's async methods trigger startup. Raises
+        if the id isn't a configured model.
+        """
+        target = model_id or self._default_model
+        if target not in self._configured_models():
+            known = ", ".join(sorted(self._configured_models())) or "none"
+            raise ValueError(f"Unknown model {target!r} (configured: {known})")
+        return ModelHandle(self, target)
+
+    def _configured_models(self) -> set[str]:
+        """Model ids this engine serves — built or pending build.
+
+        Built runtimes plus the configured default, so model() works both
+        before and after ``_initialize`` populates ``_runtimes``.
+        """
+        return set(self._runtimes) | {self._default_model}
+
+    def _tasks_for(self, model_id: str) -> tuple[str, ...]:
+        """Capability names a registered model serves.
+
+        Single-pass models advertise the tasks their runtime declares;
+        autoregressive models advertise the engine's skill vocabulary
+        (known without the runtime built, so this works pre-init for the
+        default model). Unbuilt non-default models can't report tasks
+        until startup.
+        """
+        runtime = self._runtimes.get(model_id)
+        if runtime is not None and runtime.execution_shape is ExecutionShape.SINGLE_PASS:
+            return tuple(runtime.tasks())
+        if runtime is None and model_id != self._default_model:
+            raise ValueError(f"Unknown model {model_id!r}")
+        # Built AR runtime, or the default AR model not yet built.
+        return self._skills.names()
 
     async def _submit_request(
         self,

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -96,13 +96,18 @@ class ModelHandle:
     # Thin forwarders to the engine's typed verbs. Each gates on the model
     # serving the capability AND on it being the default AR model (the
     # verbs don't yet route by model id), then delegates.
+    #
+    # These re-declare the verbs' keyword defaults, so they must stay in
+    # sync with InferenceEngine's — a mismatch silently changes behavior
+    # for the same call through the handle (e.g. query's reasoning=True).
+    # test_model_handle::test_handle_verb_defaults_match_engine guards this.
 
     async def query(
         self,
         image: Optional[np.ndarray | bytes],
         question: str,
         *,
-        reasoning: bool = False,
+        reasoning: bool = True,  # match InferenceEngine.query — see note below
         stream: bool = False,
         settings: Optional[Mapping[str, object]] = None,
         spatial_refs: Optional[Sequence[Sequence[float]]] = None,

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -1,0 +1,142 @@
+"""ModelHandle — the per-model view onto the engine.
+
+``engine.model(id)`` returns a ``ModelHandle`` bound to one model. It is
+the primary customer surface: one generic class (no per-model subclass)
+exposing the capability vocabulary as typed methods plus a
+``run(task, inputs)`` escape hatch and ``tasks`` / ``supports``
+introspection. Capability availability is a runtime check — every method
+exists on the class, but calling one a model doesn't serve raises a clear
+error (the deliberate "models are data, capabilities are the typed
+surface" trade: type count scales with capabilities, not models).
+
+The handle holds no resources; it forwards to the engine, pinning the
+model id so callers bind a model once instead of repeating ``model=``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
+
+import numpy as np
+
+from kestrel.runtime import ExecutionShape
+
+if TYPE_CHECKING:
+    from kestrel.engine.core import InferenceEngine
+    from kestrel.engine._types import EngineResult, EngineStream
+
+
+class ModelHandle:
+    """A capability-bearing view onto one registered model."""
+
+    def __init__(self, engine: "InferenceEngine", model_id: str) -> None:
+        self._engine = engine
+        self._model = model_id
+
+    @property
+    def model_id(self) -> str:
+        return self._model
+
+    # -- introspection ------------------------------------------------
+
+    @property
+    def tasks(self) -> tuple[str, ...]:
+        """Capability names this model serves."""
+        return self._engine._tasks_for(self._model)
+
+    def supports(self, task: str) -> bool:
+        return task in self.tasks
+
+    def _require(self, task: str) -> None:
+        if task not in self.tasks:
+            raise ValueError(
+                f"Model {self._model!r} does not support {task!r} "
+                f"(supports: {', '.join(self.tasks) or 'none'})"
+            )
+
+    # -- generic escape hatch -----------------------------------------
+
+    async def run(self, task: str, inputs: Any) -> "EngineResult":
+        """Run an arbitrary ``task`` on this model (single-pass lane)."""
+        self._require(task)
+        return await self._engine.run(self._model, task, inputs)
+
+    # -- autoregressive capability vocabulary -------------------------
+    #
+    # Thin, model-pinned forwarders to the engine's typed verbs. Each
+    # gates on the model actually serving the capability, then delegates.
+
+    async def query(
+        self,
+        image: Optional[np.ndarray | bytes],
+        question: str,
+        *,
+        reasoning: bool = False,
+        stream: bool = False,
+        settings: Optional[Mapping[str, object]] = None,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = None,
+    ) -> "EngineResult | EngineStream":
+        self._require("query")
+        return await self._engine.query(
+            image=image,
+            question=question,
+            reasoning=reasoning,
+            stream=stream,
+            settings=settings,
+            spatial_refs=spatial_refs,
+        )
+
+    async def caption(
+        self,
+        image: Optional[np.ndarray | bytes],
+        *,
+        length: str = "normal",
+        stream: bool = False,
+        settings: Optional[Mapping[str, object]] = None,
+    ) -> "EngineResult | EngineStream":
+        self._require("caption")
+        return await self._engine.caption(
+            image=image, length=length, stream=stream, settings=settings
+        )
+
+    async def detect(
+        self,
+        image: Optional[np.ndarray | bytes],
+        object: str,
+        *,
+        settings: Optional[Mapping[str, object]] = None,
+    ) -> "EngineResult":
+        self._require("detect")
+        return await self._engine.detect(image, object, settings=settings)
+
+    async def point(
+        self,
+        image: Optional[np.ndarray | bytes],
+        object: str,
+        settings: Optional[Mapping[str, object]] = None,
+        *,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = None,
+    ) -> "EngineResult":
+        self._require("point")
+        return await self._engine.point(
+            image, object, settings, spatial_refs=spatial_refs
+        )
+
+    async def segment(
+        self,
+        image: Optional[np.ndarray | bytes],
+        object: str,
+        *,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = None,
+        settings: Optional[Mapping[str, object]] = None,
+    ) -> "EngineResult":
+        self._require("segment")
+        return await self._engine.segment(
+            image, object, spatial_refs=spatial_refs, settings=settings
+        )
+
+    def __repr__(self) -> str:
+        return f"ModelHandle(model_id={self._model!r}, tasks={self.tasks})"
+
+
+__all__ = ["ModelHandle"]

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -54,17 +54,48 @@ class ModelHandle:
                 f"(supports: {', '.join(self.tasks) or 'none'})"
             )
 
+    def _require_default_ar(self, task: str) -> None:
+        """Guard the autoregressive verbs.
+
+        The engine's typed verbs (query/caption/...) currently route only
+        to the default autoregressive model — they take no model id. So a
+        handle for any *other* model must not silently misroute through
+        them. Until per-model AR routing exists, fail loud instead.
+        """
+        self._require(task)
+        if self._model != self._engine._default_model:
+            raise NotImplementedError(
+                f"{task!r} on {self._model!r} is not yet routable: the "
+                "autoregressive verbs target the default model "
+                f"({self._engine._default_model!r}). Per-model AR routing "
+                "is a future step."
+            )
+
     # -- generic escape hatch -----------------------------------------
 
     async def run(self, task: str, inputs: Any) -> "EngineResult":
-        """Run an arbitrary ``task`` on this model (single-pass lane)."""
+        """Run an arbitrary ``task`` on this model's single-pass lane.
+
+        The escape hatch for single-pass models. Autoregressive models use
+        the typed verbs (``query`` etc.), not ``run`` — ``engine.run``
+        would reject them, so reject here with a clearer message.
+        """
         self._require(task)
+        runtime = self._engine._runtimes.get(self._model)
+        if runtime is not None and runtime.execution_shape is not (
+            ExecutionShape.SINGLE_PASS
+        ):
+            raise ValueError(
+                f"run() is for single-pass models; {self._model!r} is "
+                f"{runtime.execution_shape.value} — use its typed verbs."
+            )
         return await self._engine.run(self._model, task, inputs)
 
     # -- autoregressive capability vocabulary -------------------------
     #
-    # Thin, model-pinned forwarders to the engine's typed verbs. Each
-    # gates on the model actually serving the capability, then delegates.
+    # Thin forwarders to the engine's typed verbs. Each gates on the model
+    # serving the capability AND on it being the default AR model (the
+    # verbs don't yet route by model id), then delegates.
 
     async def query(
         self,
@@ -76,7 +107,7 @@ class ModelHandle:
         settings: Optional[Mapping[str, object]] = None,
         spatial_refs: Optional[Sequence[Sequence[float]]] = None,
     ) -> "EngineResult | EngineStream":
-        self._require("query")
+        self._require_default_ar("query")
         return await self._engine.query(
             image=image,
             question=question,
@@ -94,7 +125,7 @@ class ModelHandle:
         stream: bool = False,
         settings: Optional[Mapping[str, object]] = None,
     ) -> "EngineResult | EngineStream":
-        self._require("caption")
+        self._require_default_ar("caption")
         return await self._engine.caption(
             image=image, length=length, stream=stream, settings=settings
         )
@@ -106,7 +137,7 @@ class ModelHandle:
         *,
         settings: Optional[Mapping[str, object]] = None,
     ) -> "EngineResult":
-        self._require("detect")
+        self._require_default_ar("detect")
         return await self._engine.detect(image, object, settings=settings)
 
     async def point(
@@ -117,7 +148,7 @@ class ModelHandle:
         *,
         spatial_refs: Optional[Sequence[Sequence[float]]] = None,
     ) -> "EngineResult":
-        self._require("point")
+        self._require_default_ar("point")
         return await self._engine.point(
             image, object, settings, spatial_refs=spatial_refs
         )
@@ -130,7 +161,7 @@ class ModelHandle:
         spatial_refs: Optional[Sequence[Sequence[float]]] = None,
         settings: Optional[Mapping[str, object]] = None,
     ) -> "EngineResult":
-        self._require("segment")
+        self._require_default_ar("segment")
         return await self._engine.segment(
             image, object, spatial_refs=spatial_refs, settings=settings
         )

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -104,8 +104,8 @@ class ModelHandle:
 
     async def query(
         self,
-        image: Optional[np.ndarray | bytes],
-        question: str,
+        image: Optional[np.ndarray | bytes] = None,
+        question: Optional[str] = None,
         *,
         reasoning: bool = True,  # match InferenceEngine.query — see note below
         stream: bool = False,

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -106,20 +106,21 @@ class ModelHandle:
         self,
         image: Optional[np.ndarray | bytes] = None,
         question: Optional[str] = None,
-        *,
-        reasoning: bool = True,  # match InferenceEngine.query — see note below
+        reasoning: bool = True,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = None,
         stream: bool = False,
         settings: Optional[Mapping[str, object]] = None,
-        spatial_refs: Optional[Sequence[Sequence[float]]] = None,
     ) -> "EngineResult | EngineStream":
+        # Parameter order/kind mirrors InferenceEngine.query exactly so a
+        # positional call (img, q, reasoning, refs, ...) forwards unchanged.
         self._require_default_ar("query")
         return await self._engine.query(
             image=image,
             question=question,
             reasoning=reasoning,
+            spatial_refs=spatial_refs,
             stream=stream,
             settings=settings,
-            spatial_refs=spatial_refs,
         )
 
     async def caption(
@@ -139,7 +140,6 @@ class ModelHandle:
         self,
         image: Optional[np.ndarray | bytes],
         object: str,
-        *,
         settings: Optional[Mapping[str, object]] = None,
     ) -> "EngineResult":
         self._require_default_ar("detect")

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -214,6 +214,12 @@ class SinglePassRuntime(Runtime, Protocol):
     # silently running on the default stream with no interleaving.
     primary_stream: Any
 
+    # Capability names this runtime serves, e.g. ("segment_masks",). The
+    # engine advertises these through ModelHandle.tasks / supports() and
+    # validates run(model, task, ...) against them, so it's part of the
+    # contract — declared here, not discovered via getattr.
+    def tasks(self) -> Sequence[str]: ...
+
     def preprocess_image_async(
         self, image: np.ndarray | bytes
     ) -> Future[Any]: ...

--- a/kestrel/skills/base.py
+++ b/kestrel/skills/base.py
@@ -133,6 +133,10 @@ class SkillRegistry:
     def default(self) -> SkillSpec:
         return self._skills[self._default]  # type: ignore[index]
 
+    def names(self) -> tuple[str, ...]:
+        """Registered skill names, in registration order."""
+        return tuple(self._skills)
+
     def resolve(self, skill: str) -> SkillSpec:
         try:
             return self._skills[skill]

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -119,6 +119,27 @@ def test_ar_verb_on_non_default_model_fails_loud() -> None:
         asyncio.run(h.query(None, "hi?"))
 
 
+def test_handle_verb_defaults_match_engine() -> None:
+    """A handle verb is a thin forwarder; its keyword defaults must match
+    InferenceEngine's, or the same call drifts behavior through the handle
+    (e.g. query's reasoning default). Introspect both, compare shared
+    keyword params — guards all verbs, not just the one Codex caught."""
+    import inspect
+
+    for verb in ("query", "caption", "detect", "point", "segment"):
+        eng_params = inspect.signature(getattr(InferenceEngine, verb)).parameters
+        h_params = inspect.signature(getattr(ModelHandle, verb)).parameters
+        for name, h_p in h_params.items():
+            if name == "self" or h_p.default is inspect.Parameter.empty:
+                continue
+            eng_p = eng_params.get(name)
+            assert eng_p is not None, f"{verb}: handle has param {name!r} engine lacks"
+            assert h_p.default == eng_p.default, (
+                f"{verb}: default for {name!r} drifted — "
+                f"handle={h_p.default!r} engine={eng_p.default!r}"
+            )
+
+
 def test_run_on_ar_model_rejected_with_clear_message() -> None:
     """run() is the single-pass escape hatch; on an AR model it should say
     so, not die downstream in engine.run()."""

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -1,0 +1,125 @@
+"""ModelHandle: per-model view, capability gating, verb forwarding.
+
+ModelHandle is one generic class for every model; capability
+availability is a runtime check (tasks()/supports), and unsupported
+calls raise rather than silently doing the wrong thing. These tests pin
+that contract with stub runtimes — no GPU.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from kestrel.engine import InferenceEngine, ModelHandle
+from kestrel.runtime import ExecutionShape
+from kestrel.skills import SkillRegistry, QuerySkill, CaptionSkill, SegmentSkill
+
+
+class _StubSinglePass:
+    def __init__(self, model_name: str, tasks: tuple[str, ...]) -> None:
+        self.model_name = model_name
+        self.execution_shape = ExecutionShape.SINGLE_PASS
+        self._tasks = tasks
+
+    def tasks(self) -> tuple[str, ...]:
+        return self._tasks
+
+
+def _engine() -> InferenceEngine:
+    """Minimal engine with an AR default + a single-pass model registered."""
+    eng = object.__new__(InferenceEngine)
+    eng._default_model = "ar-model"
+    eng._runtimes = {
+        "ar-model": SimpleNamespace(
+            model_name="ar-model", execution_shape=ExecutionShape.AUTOREGRESSIVE
+        ),
+        "sp-model": _StubSinglePass("sp-model", ("segment_masks",)),
+    }
+    eng._skills = SkillRegistry([QuerySkill(), CaptionSkill(), SegmentSkill()])
+    return eng
+
+
+def test_model_returns_handle_bound_to_id() -> None:
+    eng = _engine()
+    h = eng.model("sp-model")
+    assert isinstance(h, ModelHandle)
+    assert h.model_id == "sp-model"
+
+
+def test_model_defaults_to_default_model() -> None:
+    eng = _engine()
+    assert eng.model().model_id == "ar-model"
+
+
+def test_model_rejects_unknown_id() -> None:
+    eng = _engine()
+    with pytest.raises(ValueError, match="Unknown model 'nope'.*configured"):
+        eng.model("nope")
+
+
+def test_ar_handle_advertises_skill_vocabulary() -> None:
+    eng = _engine()
+    h = eng.model("ar-model")
+    assert h.tasks == ("query", "caption", "segment")
+    assert h.supports("query") is True
+    assert h.supports("segment_masks") is False
+
+
+def test_single_pass_handle_advertises_runtime_tasks() -> None:
+    eng = _engine()
+    h = eng.model("sp-model")
+    assert h.tasks == ("segment_masks",)
+    assert h.supports("segment_masks") is True
+    assert h.supports("query") is False
+
+
+def test_unsupported_capability_raises_clearly() -> None:
+    eng = _engine()
+    sp = eng.model("sp-model")
+    # query is an AR skill; the single-pass model doesn't serve it.
+    with pytest.raises(ValueError, match="does not support 'query'"):
+        asyncio.run(sp.query(None, "hi?"))
+
+
+def test_ar_verb_forwards_to_engine_pinned_to_model() -> None:
+    eng = _engine()
+    captured: dict[str, Any] = {}
+
+    async def fake_query(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "RESULT"
+
+    eng.query = fake_query  # type: ignore[method-assign]
+    h = eng.model("ar-model")
+    out = asyncio.run(h.query(None, "what is this?", reasoning=True))
+    assert out == "RESULT"
+    assert captured["question"] == "what is this?"
+    assert captured["reasoning"] is True
+
+
+def test_run_gates_on_task_then_forwards() -> None:
+    eng = _engine()
+    captured: dict[str, Any] = {}
+
+    async def fake_run(model: str, task: str, inputs: Any) -> str:
+        captured.update(model=model, task=task, inputs=inputs)
+        return "MASKS"
+
+    eng.run = fake_run  # type: ignore[method-assign]
+    h = eng.model("sp-model")
+
+    out = asyncio.run(h.run("segment_masks", {"points": [[1, 2]]}))
+    assert out == "MASKS"
+    assert captured == {
+        "model": "sp-model",
+        "task": "segment_masks",
+        "inputs": {"points": [[1, 2]]},
+    }
+
+    # An unknown task is rejected before forwarding.
+    with pytest.raises(ValueError, match="does not support 'bogus'"):
+        asyncio.run(h.run("bogus", {}))

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -138,36 +138,30 @@ def test_ar_verb_on_non_default_model_fails_loud() -> None:
 
 
 def test_handle_verb_signatures_match_engine() -> None:
-    """A handle verb is a thin forwarder; its signature must not diverge
-    from InferenceEngine's, or binding a model silently changes behavior:
-      - a default drift changes outcomes (e.g. query reasoning), and
-      - making an engine-optional param required breaks valid calls
-        (e.g. text-only query(question=...) with no image).
-    Introspect both and assert, for every shared param, same default AND
-    same required-ness. Guards all verbs, not just the ones Codex caught."""
+    """A handle verb is a thin forwarder; its signature must match
+    InferenceEngine's, or binding a model silently breaks or changes a
+    valid call. The ways it can drift, each seen in review:
+      - default drift changes outcomes (query reasoning),
+      - an engine-optional param made required breaks calls (text-only
+        query), and
+      - reordering / making positional params keyword-only breaks
+        positional calls (query(img, q, reasoning, refs); detect settings).
+    So compare the full ordered parameter list — (name, kind, default) —
+    for every param the handle declares beyond self. Guards all verbs.
+    """
     import inspect
 
-    empty = inspect.Parameter.empty
     for verb in ("query", "caption", "detect", "point", "segment"):
-        eng_params = inspect.signature(getattr(InferenceEngine, verb)).parameters
-        h_params = inspect.signature(getattr(ModelHandle, verb)).parameters
-        for name, h_p in h_params.items():
-            if name == "self":
-                continue
-            eng_p = eng_params.get(name)
-            assert eng_p is not None, f"{verb}: handle has param {name!r} engine lacks"
-            # Required-ness must match: an engine-optional param must not be
-            # required on the handle (that breaks otherwise-valid calls).
-            assert (h_p.default is empty) == (eng_p.default is empty), (
-                f"{verb}: required-ness for {name!r} drifted — "
-                f"handle {'required' if h_p.default is empty else 'optional'}, "
-                f"engine {'required' if eng_p.default is empty else 'optional'}"
-            )
-            if h_p.default is not empty:
-                assert h_p.default == eng_p.default, (
-                    f"{verb}: default for {name!r} drifted — "
-                    f"handle={h_p.default!r} engine={eng_p.default!r}"
-                )
+        eng = inspect.signature(getattr(InferenceEngine, verb)).parameters
+        hnd = inspect.signature(getattr(ModelHandle, verb)).parameters
+        eng_list = [(n, p.kind, p.default) for n, p in eng.items() if n != "self"]
+        hnd_list = [(n, p.kind, p.default) for n, p in hnd.items() if n != "self"]
+        # The handle forwards exactly the engine verb's parameters, so the
+        # ordered (name, kind, default) lists must be identical.
+        assert hnd_list == eng_list, (
+            f"{verb}: handle signature drifted from engine.\n"
+            f"  handle: {hnd_list}\n  engine: {eng_list}"
+        )
 
 
 def test_run_on_ar_model_rejected_with_clear_message() -> None:

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -85,7 +85,7 @@ def test_unsupported_capability_raises_clearly() -> None:
         asyncio.run(sp.query(None, "hi?"))
 
 
-def test_ar_verb_forwards_to_engine_pinned_to_model() -> None:
+def test_default_ar_verb_forwards_to_engine() -> None:
     eng = _engine()
     captured: dict[str, Any] = {}
 
@@ -94,11 +94,38 @@ def test_ar_verb_forwards_to_engine_pinned_to_model() -> None:
         return "RESULT"
 
     eng.query = fake_query  # type: ignore[method-assign]
-    h = eng.model("ar-model")
+    h = eng.model("ar-model")  # the default AR model
     out = asyncio.run(h.query(None, "what is this?", reasoning=True))
     assert out == "RESULT"
     assert captured["question"] == "what is this?"
     assert captured["reasoning"] is True
+
+
+def test_ar_verb_on_non_default_model_fails_loud() -> None:
+    """The AR verbs don't route by model id yet, so a non-default AR
+    handle must refuse rather than silently hit the default model."""
+    eng = _engine()
+    # Register a second AR model; the verbs can't route to it.
+    eng._runtimes["ar-other"] = SimpleNamespace(
+        model_name="ar-other", execution_shape=ExecutionShape.AUTOREGRESSIVE
+    )
+
+    async def fake_query(**kwargs: Any) -> str:  # pragma: no cover - must not run
+        raise AssertionError("should not forward for a non-default AR model")
+
+    eng.query = fake_query  # type: ignore[method-assign]
+    h = eng.model("ar-other")
+    with pytest.raises(NotImplementedError, match="not yet routable"):
+        asyncio.run(h.query(None, "hi?"))
+
+
+def test_run_on_ar_model_rejected_with_clear_message() -> None:
+    """run() is the single-pass escape hatch; on an AR model it should say
+    so, not die downstream in engine.run()."""
+    eng = _engine()
+    h = eng.model("ar-model")
+    with pytest.raises(ValueError, match="run\\(\\) is for single-pass"):
+        asyncio.run(h.run("query", {}))
 
 
 def test_run_gates_on_task_then_forwards() -> None:

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -101,6 +101,24 @@ def test_default_ar_verb_forwards_to_engine() -> None:
     assert captured["reasoning"] is True
 
 
+def test_text_only_query_through_handle() -> None:
+    """A text-only query (no image) must work through the handle, matching
+    engine.query's optional image — regression for image being required."""
+    eng = _engine()
+    captured: dict[str, Any] = {}
+
+    async def fake_query(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "RESULT"
+
+    eng.query = fake_query  # type: ignore[method-assign]
+    h = eng.model("ar-model")
+    out = asyncio.run(h.query(question="just text?"))  # no image
+    assert out == "RESULT"
+    assert captured["image"] is None
+    assert captured["question"] == "just text?"
+
+
 def test_ar_verb_on_non_default_model_fails_loud() -> None:
     """The AR verbs don't route by model id yet, so a non-default AR
     handle must refuse rather than silently hit the default model."""
@@ -119,25 +137,37 @@ def test_ar_verb_on_non_default_model_fails_loud() -> None:
         asyncio.run(h.query(None, "hi?"))
 
 
-def test_handle_verb_defaults_match_engine() -> None:
-    """A handle verb is a thin forwarder; its keyword defaults must match
-    InferenceEngine's, or the same call drifts behavior through the handle
-    (e.g. query's reasoning default). Introspect both, compare shared
-    keyword params — guards all verbs, not just the one Codex caught."""
+def test_handle_verb_signatures_match_engine() -> None:
+    """A handle verb is a thin forwarder; its signature must not diverge
+    from InferenceEngine's, or binding a model silently changes behavior:
+      - a default drift changes outcomes (e.g. query reasoning), and
+      - making an engine-optional param required breaks valid calls
+        (e.g. text-only query(question=...) with no image).
+    Introspect both and assert, for every shared param, same default AND
+    same required-ness. Guards all verbs, not just the ones Codex caught."""
     import inspect
 
+    empty = inspect.Parameter.empty
     for verb in ("query", "caption", "detect", "point", "segment"):
         eng_params = inspect.signature(getattr(InferenceEngine, verb)).parameters
         h_params = inspect.signature(getattr(ModelHandle, verb)).parameters
         for name, h_p in h_params.items():
-            if name == "self" or h_p.default is inspect.Parameter.empty:
+            if name == "self":
                 continue
             eng_p = eng_params.get(name)
             assert eng_p is not None, f"{verb}: handle has param {name!r} engine lacks"
-            assert h_p.default == eng_p.default, (
-                f"{verb}: default for {name!r} drifted — "
-                f"handle={h_p.default!r} engine={eng_p.default!r}"
+            # Required-ness must match: an engine-optional param must not be
+            # required on the handle (that breaks otherwise-valid calls).
+            assert (h_p.default is empty) == (eng_p.default is empty), (
+                f"{verb}: required-ness for {name!r} drifted — "
+                f"handle {'required' if h_p.default is empty else 'optional'}, "
+                f"engine {'required' if eng_p.default is empty else 'optional'}"
             )
+            if h_p.default is not empty:
+                assert h_p.default == eng_p.default, (
+                    f"{verb}: default for {name!r} drifted — "
+                    f"handle={h_p.default!r} engine={eng_p.default!r}"
+                )
 
 
 def test_run_on_ar_model_rejected_with_clear_message() -> None:


### PR DESCRIPTION
## Why

The engine now hosts multiple models behind one kernel, but the public surface is still the single-model `engine.query(...)` verbs. This adds the per-model surface the design calls for: `engine.model(id)` returns a handle you bind once and call capabilities on. (Design: the co-hosted multi-model engine doc.)

## What

`engine.model(id) -> ModelHandle` — **one generic handle class** for every model (no per-model subtype):

- Capability methods (`query` / `caption` / `detect` / `point` / `segment`) forward to the engine, pinned to the model — so callers bind a model once instead of repeating `model=`.
- `run(task, inputs)` — the single-pass escape hatch (routes to the model's single-pass lane).
- `tasks` / `supports(task)` — introspection.

**Capability availability is a runtime check**, not per-model types: every method exists on the handle, but calling one a model doesn't serve raises a clear error. Autoregressive models advertise the engine's skill vocabulary; single-pass models advertise their runtime's `tasks()`. This is the deliberate "models are data, capabilities are the typed surface" trade — type/method count scales with the bounded capability vocabulary, never with model count.

`model()` validates against *configured* models and works before the engine is started (runtimes build lazily in `_initialize`); the handle's async methods trigger startup.

## Scope / sequencing

This is the additive first half. Existing `InferenceEngine.query/...` verbs are **unchanged and still work** — turning them into deprecated shims that delegate to the handle (and adding the typed `segment_masks` vocabulary entry) is the next PR, kept separate so this diff stays focused and the AR path stays untouched.

## Tests

- `tests/test_model_handle.py` — handle binding, default model, unknown-id rejection, AR-vs-single-pass task advertisement, capability gating (unsupported call raises), and verb/`run` forwarding.
- Full suite: 349 passed, 4 skipped (excluding one pre-existing `test_moe_lora` failure — a kernel-wheel API skew on the test host, unrelated: `ImportError` for `apply_moe_lora_batched`, fails identically on clean main).
- GPU e2e: `engine.model("moondream2").query(...)` decodes correctly through the handle.