### PR TITLE
Make all capability verbs uniform **kwargs on ModelHandle

### DIFF
--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -118,9 +118,10 @@ class ModelHandle:
 
         A single-pass model interprets the prompt in its forward pass (via
         ``run``); an autoregressive model validates and builds it through
-        the model's skill. ``settings`` (sampling) and ``stream`` are
-        engine-level concerns, lifted out of the model prompt for the
-        autoregressive path.
+        the model's skill. ``settings`` (sampling) is lifted out as its own
+        argument; ``stream`` is read here to select streaming delivery but
+        left in the prompt, since the skill reads it to configure its
+        streaming state.
         """
         runtime = self._engine._runtimes.get(self._model)
         if runtime is not None and (
@@ -129,7 +130,7 @@ class ModelHandle:
             return await self.run(task, {"image": image, **prompt})
         self._require_default_ar(task)
         settings = prompt.pop("settings", None)
-        stream = bool(prompt.pop("stream", False))
+        stream = bool(prompt.get("stream", False))
         return await self._engine._run_skill(
             task, image=image, prompt=prompt, settings=settings, stream=stream
         )

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -2,12 +2,14 @@
 
 ``engine.model(id)`` returns a ``ModelHandle`` bound to one model. It is
 the primary customer surface: one generic class (no per-model subclass)
-exposing the capability vocabulary as typed methods plus a
-``run(task, inputs)`` escape hatch and ``tasks`` / ``supports``
-introspection. Capability availability is a runtime check — every method
-exists on the class, but calling one a model doesn't serve raises a clear
-error (the deliberate "models are data, capabilities are the typed
-surface" trade: type count scales with capabilities, not models).
+exposing the capability vocabulary as uniform ``verb(image, **prompt)``
+methods plus a ``run(task, inputs)`` escape hatch and ``tasks`` /
+``supports`` introspection. The method names are the typed surface; their
+inputs are model-defined (the bound model validates the prompt). Capability
+availability is a runtime check — every method exists on the class, but
+calling one a model doesn't serve raises a clear error (the deliberate
+"models are data, capabilities are the typed surface" trade: type count
+scales with capabilities, not models).
 
 The handle holds no resources; it forwards to the engine, pinning the
 model id so callers bind a model once instead of repeating ``model=``.
@@ -15,7 +17,7 @@ model id so callers bind a model once instead of repeating ``model=``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 
@@ -79,9 +81,10 @@ class ModelHandle:
     async def run(self, task: str, inputs: Any) -> "EngineResult":
         """Run an arbitrary ``task`` on this model's single-pass lane.
 
-        The escape hatch for single-pass models. Autoregressive models use
-        the typed verbs (``query`` etc.), not ``run`` — ``engine.run``
-        would reject them, so reject here with a clearer message.
+        The escape hatch for single-pass models, and what the capability
+        verbs dispatch to for that shape. Autoregressive models go through
+        the skill path instead — ``engine.run`` would reject them, so reject
+        here with a clearer message.
         """
         self._require(task)
         runtime = self._engine._runtimes.get(self._model)
@@ -94,85 +97,67 @@ class ModelHandle:
             )
         return await self._engine.run(self._model, task, inputs)
 
-    # -- autoregressive capability vocabulary -------------------------
+    # -- capability vocabulary ----------------------------------------
     #
-    # Thin forwarders to the engine's typed verbs. Each gates on the model
-    # serving the capability AND on it being the default AR model (the
-    # verbs don't yet route by model id), then delegates.
-    #
-    # These re-declare the verbs' keyword defaults, so they must stay in
-    # sync with InferenceEngine's — a mismatch silently changes behavior
-    # for the same call through the handle (e.g. query's reasoning=True).
-    # test_model_handle::test_handle_verb_defaults_match_engine guards this.
+    # One task is one method; its inputs are model-defined. Every verb is
+    # therefore uniform — ``verb(image, **prompt)`` — and the raw prompt is
+    # interpreted and validated by the bound model: its skill for an
+    # autoregressive model, its runtime for a single-pass one. The handle
+    # stays model-agnostic and only forwards. The method *names* are the
+    # typed surface (autocomplete + ``tasks``/``supports``); the inputs are
+    # not, by design — a model serving the same capability may accept
+    # different inputs, so a fixed signature couldn't capture them.
+
+    async def _capability(
+        self,
+        task: str,
+        image: Optional[np.ndarray | bytes],
+        prompt: dict[str, Any],
+    ) -> "EngineResult | EngineStream":
+        """Route one capability call by the bound model's execution shape.
+
+        A single-pass model interprets the prompt in its forward pass (via
+        ``run``); an autoregressive model validates and builds it through
+        the model's skill. ``settings`` (sampling) and ``stream`` are
+        engine-level concerns, lifted out of the model prompt for the
+        autoregressive path.
+        """
+        runtime = self._engine._runtimes.get(self._model)
+        if runtime is not None and (
+            runtime.execution_shape is ExecutionShape.SINGLE_PASS
+        ):
+            return await self.run(task, {"image": image, **prompt})
+        self._require_default_ar(task)
+        settings = prompt.pop("settings", None)
+        stream = bool(prompt.pop("stream", False))
+        return await self._engine._run_skill(
+            task, image=image, prompt=prompt, settings=settings, stream=stream
+        )
 
     async def query(
-        self,
-        image: Optional[np.ndarray | bytes] = None,
-        question: Optional[str] = None,
-        reasoning: bool = True,
-        spatial_refs: Optional[Sequence[Sequence[float]]] = None,
-        stream: bool = False,
-        settings: Optional[Mapping[str, object]] = None,
+        self, image: Optional[np.ndarray | bytes] = None, **prompt: Any
     ) -> "EngineResult | EngineStream":
-        # Parameter order/kind mirrors InferenceEngine.query exactly so a
-        # positional call (img, q, reasoning, refs, ...) forwards unchanged.
-        self._require_default_ar("query")
-        return await self._engine.query(
-            image=image,
-            question=question,
-            reasoning=reasoning,
-            spatial_refs=spatial_refs,
-            stream=stream,
-            settings=settings,
-        )
+        return await self._capability("query", image, prompt)
 
     async def caption(
-        self,
-        image: Optional[np.ndarray | bytes],
-        *,
-        length: str = "normal",
-        stream: bool = False,
-        settings: Optional[Mapping[str, object]] = None,
+        self, image: Optional[np.ndarray | bytes] = None, **prompt: Any
     ) -> "EngineResult | EngineStream":
-        self._require_default_ar("caption")
-        return await self._engine.caption(
-            image=image, length=length, stream=stream, settings=settings
-        )
+        return await self._capability("caption", image, prompt)
 
     async def detect(
-        self,
-        image: Optional[np.ndarray | bytes],
-        object: str,
-        settings: Optional[Mapping[str, object]] = None,
-    ) -> "EngineResult":
-        self._require_default_ar("detect")
-        return await self._engine.detect(image, object, settings=settings)
+        self, image: Optional[np.ndarray | bytes] = None, **prompt: Any
+    ) -> "EngineResult | EngineStream":
+        return await self._capability("detect", image, prompt)
 
     async def point(
-        self,
-        image: Optional[np.ndarray | bytes],
-        object: str,
-        settings: Optional[Mapping[str, object]] = None,
-        *,
-        spatial_refs: Optional[Sequence[Sequence[float]]] = None,
-    ) -> "EngineResult":
-        self._require_default_ar("point")
-        return await self._engine.point(
-            image, object, settings, spatial_refs=spatial_refs
-        )
+        self, image: Optional[np.ndarray | bytes] = None, **prompt: Any
+    ) -> "EngineResult | EngineStream":
+        return await self._capability("point", image, prompt)
 
     async def segment(
-        self,
-        image: Optional[np.ndarray | bytes],
-        object: str,
-        *,
-        spatial_refs: Optional[Sequence[Sequence[float]]] = None,
-        settings: Optional[Mapping[str, object]] = None,
-    ) -> "EngineResult":
-        self._require_default_ar("segment")
-        return await self._engine.segment(
-            image, object, spatial_refs=spatial_refs, settings=settings
-        )
+        self, image: Optional[np.ndarray | bytes] = None, **prompt: Any
+    ) -> "EngineResult | EngineStream":
+        return await self._capability("segment", image, prompt)
 
     def __repr__(self) -> str:
         return f"ModelHandle(model_id={self._model!r}, tasks={self.tasks})"

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -2,14 +2,16 @@
 
 ``engine.model(id)`` returns a ``ModelHandle`` bound to one model. It is
 the primary customer surface: one generic class (no per-model subclass)
-exposing the capability vocabulary as uniform ``verb(image, **prompt)``
-methods plus a ``run(task, inputs)`` escape hatch and ``tasks`` /
-``supports`` introspection. The method names are the typed surface; their
-inputs are model-defined (the bound model validates the prompt). Capability
-availability is a runtime check — every method exists on the class, but
-calling one a model doesn't serve raises a clear error (the deliberate
-"models are data, capabilities are the typed surface" trade: type count
-scales with capabilities, not models).
+exposing the capability vocabulary as uniform ``verb(**prompt)`` methods
+plus a ``run(task, inputs)`` escape hatch and ``tasks`` / ``supports``
+introspection. The method names are the typed surface; their inputs are
+entirely model-defined — including the media payload (``image=`` for a
+vision model, ``audio=``/``video=``/``text=`` for others), which the handle
+does not privilege, so the surface is modality-agnostic. The bound model
+validates the prompt. Capability availability is a runtime check — every
+method exists on the class, but calling one a model doesn't serve raises a
+clear error (the deliberate "models are data, capabilities are the typed
+surface" trade: type count scales with capabilities, not models).
 
 The handle holds no resources; it forwards to the engine, pinning the
 model id so callers bind a model once instead of repeating ``model=``.
@@ -17,9 +19,7 @@ model id so callers bind a model once instead of repeating ``model=``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
-
-import numpy as np
+from typing import TYPE_CHECKING, Any
 
 from kestrel.runtime import ExecutionShape
 
@@ -100,65 +100,57 @@ class ModelHandle:
     # -- capability vocabulary ----------------------------------------
     #
     # One task is one method; its inputs are model-defined. Every verb is
-    # therefore uniform — ``verb(image, **prompt)`` — and the raw prompt is
-    # interpreted and validated by the bound model: its skill for an
-    # autoregressive model, its runtime for a single-pass one. The handle
-    # stays model-agnostic and only forwards. The method *names* are the
-    # typed surface (autocomplete + ``tasks``/``supports``); the inputs are
-    # not, by design — a model serving the same capability may accept
-    # different inputs, so a fixed signature couldn't capture them.
+    # therefore uniform — ``verb(**prompt)`` — and the whole prompt, media
+    # payload included (``image=``/``audio=``/...), is interpreted and
+    # validated by the bound model: its skill for an autoregressive model,
+    # its runtime for a single-pass one. The handle stays model-agnostic and
+    # only forwards. The method *names* are the typed surface (autocomplete +
+    # ``tasks``/``supports``); the inputs are not, by design — a model serving
+    # the same capability may accept different inputs (and different
+    # modalities), so a fixed signature couldn't capture them.
 
     async def _capability(
         self,
         task: str,
-        image: Optional[np.ndarray | bytes],
         prompt: dict[str, Any],
     ) -> "EngineResult | EngineStream":
         """Route one capability call by the bound model's execution shape.
 
-        A single-pass model interprets the prompt in its forward pass (via
-        ``run``); an autoregressive model validates and builds it through
-        the model's skill. ``settings`` (sampling) is lifted out as its own
-        argument; ``stream`` is read here to select streaming delivery but
-        left in the prompt, since the skill reads it to configure its
-        streaming state.
+        A single-pass model interprets the whole prompt in its forward pass
+        (via ``run``); an autoregressive model validates and builds it
+        through the model's skill. For the AR path, the engine-level concerns
+        are separated from the model prompt: ``settings`` (sampling) is lifted
+        out as its own argument, and ``image`` is pulled out for the image
+        pipeline; ``stream`` selects streaming delivery but stays in the
+        prompt, since the skill reads it to configure its streaming state.
         """
         runtime = self._engine._runtimes.get(self._model)
         if runtime is not None and (
             runtime.execution_shape is ExecutionShape.SINGLE_PASS
         ):
-            return await self.run(task, {"image": image, **prompt})
+            return await self.run(task, prompt)
         self._require_default_ar(task)
         settings = prompt.pop("settings", None)
         stream = bool(prompt.get("stream", False))
+        image = prompt.pop("image", None)
         return await self._engine._run_skill(
             task, image=image, prompt=prompt, settings=settings, stream=stream
         )
 
-    async def query(
-        self, image: Optional[np.ndarray | bytes] = None, **prompt: Any
-    ) -> "EngineResult | EngineStream":
-        return await self._capability("query", image, prompt)
+    async def query(self, **prompt: Any) -> "EngineResult | EngineStream":
+        return await self._capability("query", prompt)
 
-    async def caption(
-        self, image: Optional[np.ndarray | bytes] = None, **prompt: Any
-    ) -> "EngineResult | EngineStream":
-        return await self._capability("caption", image, prompt)
+    async def caption(self, **prompt: Any) -> "EngineResult | EngineStream":
+        return await self._capability("caption", prompt)
 
-    async def detect(
-        self, image: Optional[np.ndarray | bytes] = None, **prompt: Any
-    ) -> "EngineResult | EngineStream":
-        return await self._capability("detect", image, prompt)
+    async def detect(self, **prompt: Any) -> "EngineResult | EngineStream":
+        return await self._capability("detect", prompt)
 
-    async def point(
-        self, image: Optional[np.ndarray | bytes] = None, **prompt: Any
-    ) -> "EngineResult | EngineStream":
-        return await self._capability("point", image, prompt)
+    async def point(self, **prompt: Any) -> "EngineResult | EngineStream":
+        return await self._capability("point", prompt)
 
-    async def segment(
-        self, image: Optional[np.ndarray | bytes] = None, **prompt: Any
-    ) -> "EngineResult | EngineStream":
-        return await self._capability("segment", image, prompt)
+    async def segment(self, **prompt: Any) -> "EngineResult | EngineStream":
+        return await self._capability("segment", prompt)
 
     def __repr__(self) -> str:
         return f"ModelHandle(model_id={self._model!r}, tasks={self.tasks})"

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -100,46 +100,69 @@ def test_default_handle_tasks_honor_skill_override() -> None:
 def test_unsupported_capability_raises_clearly() -> None:
     eng = _engine()
     sp = eng.model("sp-model")
-    # An AR verb on a non-default model fails loud (not routable).
-    with pytest.raises(NotImplementedError, match="not yet routable"):
-        asyncio.run(sp.query(None, "hi?"))
-    # A task the model doesn't serve, via the generic escape hatch, names it.
+    # A capability verb on a single-pass model dispatches to its run() lane,
+    # which names the task the model doesn't serve.
+    with pytest.raises(ValueError, match="does not support 'query'"):
+        asyncio.run(sp.query(None, question="hi?"))
+    # Same task, via the generic escape hatch.
     with pytest.raises(ValueError, match="does not support 'query'"):
         asyncio.run(sp.run("query", {}))
 
 
-def test_default_ar_verb_forwards_to_engine() -> None:
-    eng = _engine()
-    captured: dict[str, Any] = {}
+def _capture_run_skill(captured: dict[str, Any]):
+    """Return a stub ``_run_skill`` that records how the handle called it."""
 
-    async def fake_query(**kwargs: Any) -> str:
-        captured.update(kwargs)
+    async def run_skill(task: str, *, image: Any, prompt: Any,
+                        settings: Any, stream: Any) -> str:
+        captured.update(
+            task=task, image=image, prompt=prompt, settings=settings, stream=stream
+        )
         return "RESULT"
 
-    eng.query = fake_query  # type: ignore[method-assign]
+    return run_skill
+
+
+def test_default_ar_verb_routes_through_skill() -> None:
+    """A default-AR capability passes its raw prompt to the model's skill
+    via the engine's skill path — the handle adds no model knowledge."""
+    eng = _engine()
+    captured: dict[str, Any] = {}
+    eng._run_skill = _capture_run_skill(captured)  # type: ignore[method-assign]
     h = eng.model("ar-model")  # the default AR model
-    out = asyncio.run(h.query(None, "what is this?", reasoning=True))
+    out = asyncio.run(h.query(None, question="what is this?", reasoning=True))
     assert out == "RESULT"
-    assert captured["question"] == "what is this?"
-    assert captured["reasoning"] is True
+    assert captured["task"] == "query"
+    assert captured["image"] is None
+    assert captured["prompt"] == {"question": "what is this?", "reasoning": True}
 
 
 def test_text_only_query_through_handle() -> None:
-    """A text-only query (no image) must work through the handle, matching
-    engine.query's optional image — regression for image being required."""
+    """A text-only query (no image) must work through the handle — image is
+    optional and defaults to None."""
     eng = _engine()
     captured: dict[str, Any] = {}
-
-    async def fake_query(**kwargs: Any) -> str:
-        captured.update(kwargs)
-        return "RESULT"
-
-    eng.query = fake_query  # type: ignore[method-assign]
+    eng._run_skill = _capture_run_skill(captured)  # type: ignore[method-assign]
     h = eng.model("ar-model")
     out = asyncio.run(h.query(question="just text?"))  # no image
     assert out == "RESULT"
     assert captured["image"] is None
-    assert captured["question"] == "just text?"
+    assert captured["prompt"] == {"question": "just text?"}
+
+
+def test_capability_lifts_settings_and_stream_from_prompt() -> None:
+    """settings (sampling) and stream are engine concerns: lifted out of the
+    model prompt before it reaches the skill."""
+    eng = _engine()
+    captured: dict[str, Any] = {}
+    eng._run_skill = _capture_run_skill(captured)  # type: ignore[method-assign]
+    h = eng.model("ar-model")
+    asyncio.run(
+        h.caption(None, length="short", stream=True, settings={"temperature": 0.5})
+    )
+    assert captured["task"] == "caption"
+    assert captured["prompt"] == {"length": "short"}  # stream + settings removed
+    assert captured["settings"] == {"temperature": 0.5}
+    assert captured["stream"] is True
 
 
 def test_ar_verb_on_non_default_model_fails_loud() -> None:
@@ -155,40 +178,52 @@ def test_ar_verb_on_non_default_model_fails_loud() -> None:
         tasks=lambda: ar_skills.names(),
     )
 
-    async def fake_query(**kwargs: Any) -> str:  # pragma: no cover - must not run
-        raise AssertionError("should not forward for a non-default AR model")
+    async def fake_run_skill(*a: Any, **k: Any) -> str:  # pragma: no cover
+        raise AssertionError("should not route a non-default AR model")
 
-    eng.query = fake_query  # type: ignore[method-assign]
+    eng._run_skill = fake_run_skill  # type: ignore[method-assign]
     h = eng.model("ar-other")
     with pytest.raises(NotImplementedError, match="not yet routable"):
-        asyncio.run(h.query(None, "hi?"))
+        asyncio.run(h.query(None, question="hi?"))
 
 
-def test_handle_verb_signatures_match_engine() -> None:
-    """A handle verb is a thin forwarder; its signature must match
-    InferenceEngine's, or binding a model silently breaks or changes a
-    valid call. The ways it can drift, each seen in review:
-      - default drift changes outcomes (query reasoning),
-      - an engine-optional param made required breaks calls (text-only
-        query), and
-      - reordering / making positional params keyword-only breaks
-        positional calls (query(img, q, reasoning, refs); detect settings).
-    So compare the full ordered parameter list — (name, kind, default) —
-    for every param the handle declares beyond self. Guards all verbs.
+def test_capability_verbs_are_uniform_kwargs() -> None:
+    """Every capability verb is uniform — ``verb(image, **prompt)``. Inputs
+    are model-defined, so the handle declares no per-task typed params. This
+    is the contract that replaces the old handle/engine signature drift
+    guard: there is nothing to drift because the handle no longer mirrors
+    the engine's typed verbs.
     """
     import inspect
 
     for verb in ("query", "caption", "detect", "point", "segment"):
-        eng = inspect.signature(getattr(InferenceEngine, verb)).parameters
-        hnd = inspect.signature(getattr(ModelHandle, verb)).parameters
-        eng_list = [(n, p.kind, p.default) for n, p in eng.items() if n != "self"]
-        hnd_list = [(n, p.kind, p.default) for n, p in hnd.items() if n != "self"]
-        # The handle forwards exactly the engine verb's parameters, so the
-        # ordered (name, kind, default) lists must be identical.
-        assert hnd_list == eng_list, (
-            f"{verb}: handle signature drifted from engine.\n"
-            f"  handle: {hnd_list}\n  engine: {eng_list}"
+        params = list(inspect.signature(getattr(ModelHandle, verb)).parameters.values())
+        assert [p.name for p in params] == ["self", "image", "prompt"], verb
+        assert params[1].default is None, f"{verb}: image must default to None"
+        assert params[2].kind is inspect.Parameter.VAR_KEYWORD, (
+            f"{verb}: prompt must be **kwargs"
         )
+
+
+def test_capability_dispatches_to_run_for_single_pass() -> None:
+    """A single-pass model interprets a capability's prompt in its forward
+    pass: the handle folds the image into the inputs and routes to run()."""
+    eng = _engine()
+    eng._runtimes["sp-seg"] = _StubSinglePass("sp-seg", ("segment",))
+    captured: dict[str, Any] = {}
+
+    async def fake_run(model: str, task: str, inputs: Any) -> str:
+        captured.update(model=model, task=task, inputs=inputs)
+        return "MASKS"
+
+    eng.run = fake_run  # type: ignore[method-assign]
+    h = eng.model("sp-seg")
+    img = object()
+    out = asyncio.run(h.segment(img, points=[[1, 2]], labels=[1]))
+    assert out == "MASKS"
+    assert captured["model"] == "sp-seg"
+    assert captured["task"] == "segment"
+    assert captured["inputs"] == {"image": img, "points": [[1, 2]], "labels": [1]}
 
 
 def test_run_on_ar_model_rejected_with_clear_message() -> None:

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -103,7 +103,7 @@ def test_unsupported_capability_raises_clearly() -> None:
     # A capability verb on a single-pass model dispatches to its run() lane,
     # which names the task the model doesn't serve.
     with pytest.raises(ValueError, match="does not support 'query'"):
-        asyncio.run(sp.query(None, question="hi?"))
+        asyncio.run(sp.query(question="hi?"))
     # Same task, via the generic escape hatch.
     with pytest.raises(ValueError, match="does not support 'query'"):
         asyncio.run(sp.run("query", {}))
@@ -123,16 +123,19 @@ def _capture_run_skill(captured: dict[str, Any]):
 
 
 def test_default_ar_verb_routes_through_skill() -> None:
-    """A default-AR capability passes its raw prompt to the model's skill
-    via the engine's skill path — the handle adds no model knowledge."""
+    """A default-AR capability passes its raw prompt to the model's skill via
+    the engine's skill path — the handle adds no model knowledge. ``image`` is
+    just another prompt key; the handle lifts it out for the engine's image
+    path rather than privileging it in the signature."""
     eng = _engine()
     captured: dict[str, Any] = {}
     eng._run_skill = _capture_run_skill(captured)  # type: ignore[method-assign]
     h = eng.model("ar-model")  # the default AR model
-    out = asyncio.run(h.query(None, question="what is this?", reasoning=True))
+    img = object()
+    out = asyncio.run(h.query(image=img, question="what is this?", reasoning=True))
     assert out == "RESULT"
     assert captured["task"] == "query"
-    assert captured["image"] is None
+    assert captured["image"] is img  # lifted out of the prompt
     assert captured["prompt"] == {"question": "what is this?", "reasoning": True}
 
 
@@ -159,7 +162,7 @@ def test_capability_lifts_settings_and_mirrors_stream() -> None:
     eng._run_skill = _capture_run_skill(captured)  # type: ignore[method-assign]
     h = eng.model("ar-model")
     asyncio.run(
-        h.caption(None, length="short", stream=True, settings={"temperature": 0.5})
+        h.caption(length="short", stream=True, settings={"temperature": 0.5})
     )
     assert captured["task"] == "caption"
     assert captured["settings"] == {"temperature": 0.5}  # lifted out
@@ -187,13 +190,14 @@ def test_ar_verb_on_non_default_model_fails_loud() -> None:
     eng._run_skill = fake_run_skill  # type: ignore[method-assign]
     h = eng.model("ar-other")
     with pytest.raises(NotImplementedError, match="not yet routable"):
-        asyncio.run(h.query(None, question="hi?"))
+        asyncio.run(h.query(question="hi?"))
 
 
 def test_capability_verbs_are_uniform_kwargs() -> None:
-    """Every capability verb is uniform — ``verb(image, **prompt)``. Inputs
-    are model-defined, so the handle declares no per-task typed params. This
-    is the contract that replaces the old handle/engine signature drift
+    """Every capability verb is uniform — ``verb(**prompt)``. Inputs are
+    model-defined (including the media payload — no privileged ``image``
+    param), so the handle declares no per-task or per-modality params. This
+    is the contract that replaced the old handle/engine signature drift
     guard: there is nothing to drift because the handle no longer mirrors
     the engine's typed verbs.
     """
@@ -201,16 +205,15 @@ def test_capability_verbs_are_uniform_kwargs() -> None:
 
     for verb in ("query", "caption", "detect", "point", "segment"):
         params = list(inspect.signature(getattr(ModelHandle, verb)).parameters.values())
-        assert [p.name for p in params] == ["self", "image", "prompt"], verb
-        assert params[1].default is None, f"{verb}: image must default to None"
-        assert params[2].kind is inspect.Parameter.VAR_KEYWORD, (
-            f"{verb}: prompt must be **kwargs"
+        assert [p.name for p in params] == ["self", "prompt"], verb
+        assert params[1].kind is inspect.Parameter.VAR_KEYWORD, (
+            f"{verb}: the only parameter must be **prompt"
         )
 
 
 def test_capability_dispatches_to_run_for_single_pass() -> None:
-    """A single-pass model interprets a capability's prompt in its forward
-    pass: the handle folds the image into the inputs and routes to run()."""
+    """A single-pass model interprets the whole prompt in its forward pass:
+    the handle forwards it verbatim (media payload included) to run()."""
     eng = _engine()
     eng._runtimes["sp-seg"] = _StubSinglePass("sp-seg", ("segment",))
     captured: dict[str, Any] = {}
@@ -222,7 +225,7 @@ def test_capability_dispatches_to_run_for_single_pass() -> None:
     eng.run = fake_run  # type: ignore[method-assign]
     h = eng.model("sp-seg")
     img = object()
-    out = asyncio.run(h.segment(img, points=[[1, 2]], labels=[1]))
+    out = asyncio.run(h.segment(image=img, points=[[1, 2]], labels=[1]))
     assert out == "MASKS"
     assert captured["model"] == "sp-seg"
     assert captured["task"] == "segment"

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -149,9 +149,11 @@ def test_text_only_query_through_handle() -> None:
     assert captured["prompt"] == {"question": "just text?"}
 
 
-def test_capability_lifts_settings_and_stream_from_prompt() -> None:
-    """settings (sampling) and stream are engine concerns: lifted out of the
-    model prompt before it reaches the skill."""
+def test_capability_lifts_settings_and_mirrors_stream() -> None:
+    """settings (sampling) is lifted out of the model prompt as its own arg.
+    stream is passed to the engine to select streaming delivery AND left in
+    the prompt — the skill reads it to enable incremental token deltas
+    (popping it would yield a stream object that never emits)."""
     eng = _engine()
     captured: dict[str, Any] = {}
     eng._run_skill = _capture_run_skill(captured)  # type: ignore[method-assign]
@@ -160,9 +162,10 @@ def test_capability_lifts_settings_and_stream_from_prompt() -> None:
         h.caption(None, length="short", stream=True, settings={"temperature": 0.5})
     )
     assert captured["task"] == "caption"
-    assert captured["prompt"] == {"length": "short"}  # stream + settings removed
-    assert captured["settings"] == {"temperature": 0.5}
-    assert captured["stream"] is True
+    assert captured["settings"] == {"temperature": 0.5}  # lifted out
+    assert captured["stream"] is True  # selects streaming delivery
+    # stream stays in the prompt so the skill builds a streaming request:
+    assert captured["prompt"] == {"length": "short", "stream": True}
 
 
 def test_ar_verb_on_non_default_model_fails_loud() -> None:


### PR DESCRIPTION
Follow-on to the validation-into-skills work. The ratified design says a capability is one task whose **inputs are model-defined**, so the handle shouldn't hard-code per-task typed parameters. This makes every `ModelHandle` verb uniform.

## What changed

- **Every verb is now `verb(image, **prompt)`** — `query`, `caption`, `detect`, `point`, `segment`. The raw prompt is interpreted and validated by the bound model (its skill for autoregressive models, its runtime for single-pass). The method *names* stay the typed surface (autocomplete + `tasks`/`supports`); the inputs are model-defined.
- **Shape-dispatched** through one shared `_capability` helper: single-pass models route to `run(task, …)` (the prompt folded into the forward-pass inputs); autoregressive models route through the model's skill path. `settings` (sampling) and `stream` are lifted out as engine concerns.
- **The handle/engine signature drift guard is gone.** It only existed because the handle duplicated `InferenceEngine`'s typed verb signatures — with uniform `**kwargs` there is nothing to drift. Replaced by a small contract test pinning the uniform shape.

## Why all verbs, not just `segment`

The plan had staged `segment` first, but that special-cases one capability against a principle that applies to all of them — and it isn't hypothetical for the others: another single-pass model is already slated to serve `detect` with a different input shape. Generalizing now avoids a second pass later and keeps the surface consistent.

## Compatibility

- **No behavior change.** Moondream is the only model, so each call routes to the same skill as before — verified end-to-end across `query`/`caption`/`detect`/`point` on GPU. Input defaults (`reasoning=True`, `length="normal"`) already live in the skills, so routing the raw prompt through preserves them.
- `InferenceEngine`'s typed verbs are unchanged (their deprecation is a separate, later step). The handle simply no longer forwards through them — it goes straight to the skill path.

## Trade-off

Handle verbs lose typed-parameter autocomplete (`md.query(img, question=…)` rather than a typed `question` arg). This is the trade the design already ratified ("models are data, capabilities are the typed surface"); per-task I/O is declared by the model for future per-model schema generation.