### PR TITLE
Update Mac mini M4 performance numbers

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -195,8 +195,6 @@ Throughput and latency for the `query` skill, measured on the [ChartQA](https://
 
 ## Mac mini (M4, 16GB)
 
-These Mac mini M4 results use the first 200 ChartQA test charts (`--limit 200`).
-
 ### Moondream 2
 
 | Batch Size | Direct (req/s) | Direct P50 (ms) | CoT (req/s) | CoT P50 (ms) |

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -195,12 +195,14 @@ Throughput and latency for the `query` skill, measured on the [ChartQA](https://
 
 ## Mac mini (M4, 16GB)
 
+These Mac mini M4 results use the first 200 ChartQA test charts (`--limit 200`).
+
 ### Moondream 2
 
 | Batch Size | Direct (req/s) | Direct P50 (ms) | CoT (req/s) | CoT P50 (ms) |
 |-----------|---------------|----------------|-------------|--------------|
-| 1 | 0.70 | 2663.64 | 0.38 | 4183.03 |
-| 4 | 0.84 | 4981.50 | 0.51 | 4808.52 |
+| 1 | 0.70 | 2677.36 | 0.45 | 3679.69 |
+| 4 | 0.84 | 5549.44 | 0.68 | 3484.41 |
 
 ## MacBook Pro (M5 Max, 48GB)
 


### PR DESCRIPTION
## Summary
- Update Mac mini M4 Moondream 2 throughput and latency numbers in `PERFORMANCE.md`.
- Add a note that the Mac mini M4 rows were measured on the first 200 ChartQA test charts with `--limit 200`.

## Verification
- Remote host: `dev@10.0.0.15`, Mac mini M4 16GB.
- Environment: `kestrel-kernels 0.4.5`, `torch-c-dlpack-ext 0.1.5`, `torch 2.12.0`, `kestrel-native 0.1.5`, `datasets 4.3.0`.
- Ran `scripts/chartqa_eval.py --model moondream2 --max-batch-size 1 --limit 200`.
- Ran `scripts/chartqa_eval.py --model moondream2 --max-batch-size 1 --limit 200 --cot`.
- Ran `scripts/chartqa_eval.py --model moondream2 --max-batch-size 4 --limit 200`.
- Ran `scripts/chartqa_eval.py --model moondream2 --max-batch-size 4 --limit 200 --cot`.
- Ran `uv pip check`.