### PR TITLE
Start engine before handle task/shape checks for co-hosted models

### DIFF
--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -85,7 +85,12 @@ class ModelHandle:
         verbs dispatch to for that shape. Autoregressive models go through
         the skill path instead — ``engine.run`` would reject them, so reject
         here with a clearer message.
+
+        Starts the engine first: a co-hosted model's runtime (and thus its
+        tasks/shape) only exists once built, so the task check below must run
+        against a started engine, not raise "unknown model" pre-start.
         """
+        await self._engine._ensure_started()
         self._require(task)
         runtime = self._engine._runtimes.get(self._model)
         if runtime is not None and runtime.execution_shape is not (
@@ -123,7 +128,12 @@ class ModelHandle:
         out as its own argument, and ``image`` is pulled out for the image
         pipeline; ``stream`` selects streaming delivery but stays in the
         prompt, since the skill reads it to configure its streaming state.
+
+        Starts the engine first so shape dispatch sees a built runtime: a
+        co-hosted single-pass model isn't in ``_runtimes`` until startup, and
+        without it this would misroute to the autoregressive path.
         """
+        await self._engine._ensure_started()
         runtime = self._engine._runtimes.get(self._model)
         if runtime is not None and (
             runtime.execution_shape is ExecutionShape.SINGLE_PASS

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -46,6 +46,9 @@ def _engine() -> InferenceEngine:
         "sp-model": _StubSinglePass("sp-model", ("segment_masks",)),
     }
     eng._skills_override = None  # AR runtime owns its skills
+    # Runtimes are injected (already built), so the engine is effectively
+    # started: _ensure_started() (now awaited by the handle verbs) is a no-op.
+    eng._initialized = True
     return eng
 
 
@@ -231,6 +234,59 @@ def test_capability_dispatches_to_run_for_single_pass() -> None:
     assert captured["model"] == "sp-seg"
     assert captured["task"] == "segment"
     assert captured["inputs"] == {"image": img, "points": [[1, 2]], "labels": [1]}
+
+
+def _prestart_engine_building(captured: dict[str, Any]) -> InferenceEngine:
+    """A not-yet-started engine whose (stubbed) startup builds a co-hosted
+    single-pass runtime — mirrors eager ``models=[...]`` construction."""
+    eng = object.__new__(InferenceEngine)
+    eng._default_model = "ar"
+    eng._model_ids = ["ar", "sp"]
+    eng._runtimes = {}  # nothing built yet (pre-start)
+    eng._initialized = False
+
+    async def fake_ensure_started() -> None:
+        eng._runtimes["sp"] = _StubSinglePass("sp", ("segment",))
+        eng._initialized = True
+
+    async def fake_run(model: str, task: str, inputs: Any) -> str:
+        captured.update(model=model, task=task, inputs=inputs)
+        return "OK"
+
+    eng._ensure_started = fake_ensure_started  # type: ignore[method-assign]
+    eng.run = fake_run  # type: ignore[method-assign]
+    return eng
+
+
+def test_handle_run_starts_engine_before_task_check() -> None:
+    """A co-hosted model's run() must start the engine before checking tasks:
+    the runtime (and thus its tasks) only exists post-build, so a pre-start
+    call must trigger startup, not raise "unknown model". Regression for the
+    eager-construction handle contract (Codex #81)."""
+    captured: dict[str, Any] = {}
+    eng = _prestart_engine_building(captured)
+    out = asyncio.run(eng.model("sp").run("segment", {"points": [[1, 2]]}))
+    assert out == "OK"
+    assert captured == {
+        "model": "sp",
+        "task": "segment",
+        "inputs": {"points": [[1, 2]]},
+    }
+
+
+def test_handle_capability_starts_engine_for_cohosted_single_pass() -> None:
+    """The same pre-start guarantee for a capability verb: it must start the
+    engine so shape dispatch sees the built single-pass runtime rather than
+    misrouting to the autoregressive path."""
+    captured: dict[str, Any] = {}
+    eng = _prestart_engine_building(captured)
+    out = asyncio.run(eng.model("sp").segment(points=[[3, 4]]))
+    assert out == "OK"
+    assert captured == {
+        "model": "sp",
+        "task": "segment",
+        "inputs": {"points": [[3, 4]]},
+    }
 
 
 def test_run_on_ar_model_rejected_with_clear_message() -> None:


### PR DESCRIPTION
Addresses the Codex P2 from #81 (whose work is already in `main` as `231ca12`, so this is a small follow-up PR).

## The bug

`ModelHandle.run()` and the capability verbs inspected `_runtimes` / `tasks` **before** triggering startup. With eager `models=[...]` construction, a co-hosted model's runtime only exists after startup, so a pre-start handle call on one:

- `engine.model("sp").run(task, ...)` → `_require(task)` → `_tasks_for("sp")` → runtime not built → `ValueError("Unknown model 'sp'")`
- `engine.model("sp").segment(...)` → `_capability` sees `runtime=None` → falls to the autoregressive path → `NotImplementedError("not yet routable")`

Both violate the handle's documented contract ("a handle can be taken before the engine is started; the handle's async methods trigger startup"). `engine.run("sp", ...)` worked only because it calls `_ensure_started()` first.

## The fix

`run()` and `_capability()` now `await self._engine._ensure_started()` before checking tasks/shape, so the co-hosted runtime is built and its tasks/`execution_shape` are known. No change for the default model (already started lazily via the skill path) or for already-started engines.

## Validation

- New regression tests: pre-start `run()` and a pre-start capability verb on a co-hosted single-pass model both trigger startup and dispatch (rather than raising). 
- GPU end-to-end: on a fresh, unstarted engine with `models=["<default>", "<stub-sp>"]`, `engine.model("stub-sp").run(...)` and `.segment(...)` both build the runtimes and dispatch to the single-pass lane.
- Full suite green (the 3 `test_moe_lora` failures are a pre-existing kernel-build skew, unrelated).