### PR TITLE
Use runtime paged KV metadata op

### DIFF
--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -7,23 +7,14 @@ from typing import Optional
 import numpy as np
 import torch
 
-try:
-    import triton
-    import triton.language as tl
-except ImportError:  # pragma: no cover - optional on aarch64/Jetson
-    triton = None
-    tl = None
-
 from kestrel_kernels import get_runtime
 
 from kestrel.device import resolve_device
 from kestrel.utils import CpuGpuBuffer
 
-try:
-    _KERNELS = get_runtime()
-    reshape_and_cache_flash_cuda = _KERNELS.cache.reshape_and_cache_flash
-except Exception:  # pragma: no cover - runtime compatibility fallback
-    reshape_and_cache_flash_cuda = None
+_KERNELS = get_runtime()
+reshape_and_cache_flash_cuda = _KERNELS.cache.reshape_and_cache_flash
+build_paged_kv_metadata_runtime = _KERNELS.cache.build_paged_kv_metadata
 
 
 def _maybe_stream_context(stream: torch.cuda.Stream | None):
@@ -35,32 +26,6 @@ def _maybe_stream_context(stream: torch.cuda.Stream | None):
 def _cdiv(x: int | float | torch.Tensor, multiple: int | float | torch.Tensor):
     return (x + multiple - 1) // multiple
 
-
-def _build_fa3_decode_metadata_torch(
-    *,
-    page_table: torch.Tensor,
-    batch_idx: torch.Tensor,
-    input_pos: torch.Tensor,
-    out_page_table: torch.Tensor,
-    out_seqused_k: torch.Tensor,
-    n_pages: int,
-    page_size: int,
-) -> None:
-    """Torch fallback for FA3 decode metadata when Triton is unavailable."""
-    batch_size = batch_idx.shape[0]
-    if batch_size == 0:
-        return
-
-    batch_idx_i64 = batch_idx.to(dtype=torch.long)
-    seqlen = input_pos.to(dtype=torch.long) + 1
-    num_pages = ((seqlen + (page_size - 1)) // page_size).clamp(max=n_pages)
-
-    rows = page_table.index_select(0, batch_idx_i64)
-    row_view = out_page_table[:batch_size]
-    row_view.zero_()
-    valid_mask = torch.arange(n_pages, device=row_view.device).unsqueeze(0) < num_pages.unsqueeze(1)
-    row_view[valid_mask] = rows[valid_mask]
-    out_seqused_k[:batch_size].copy_(seqlen.to(dtype=torch.int32))
 
 
 class KVMemoryPool:
@@ -430,7 +395,7 @@ class PageTable:
         self.num_blocks_per_row[batch_idx] = 0
         self._dirty_rows.discard(batch_idx)
 
-    def populate_fa3_decode_metadata(
+    def populate_paged_kv_metadata(
         self,
         *,
         batch_idx: torch.Tensor,
@@ -438,7 +403,7 @@ class PageTable:
         out_page_table: torch.Tensor,
         out_seqused_k: torch.Tensor,
     ) -> None:
-        """Populate FA3 paged-KV metadata buffers using a fused Triton kernel."""
+        """Populate compact paged-KV metadata buffers for active decode rows."""
         if batch_idx.ndim != 1:
             raise ValueError("batch_idx must be 1D for paged-KV metadata")
         if input_pos.ndim != 1:
@@ -470,9 +435,7 @@ class PageTable:
             raise ValueError("out_page_table must be contiguous in the last dimension")
 
         device = self.page_table.device
-        # All buffers must live on the compute device. The torch fallback
-        # path below runs on any backend (CPU / CUDA / MPS); the Triton
-        # kernel path below is guarded by ``triton is None``.
+        # All buffers must live on the compute device.
         if batch_idx.device != device or input_pos.device != device:
             raise ValueError(
                 f"batch_idx/input_pos must live on {device}, "
@@ -493,37 +456,13 @@ class PageTable:
         if batch_size == 0:
             return
 
-        # The Triton kernel only runs on CUDA. Triton may be importable on
-        # non-CUDA hosts (e.g. a CUDA machine running ``--device cpu`` or a
-        # Mac with a manual triton install), so check the tensor device —
-        # not just ``triton is None``.
-        if triton is None or device.type != "cuda":
-            _build_fa3_decode_metadata_torch(
-                page_table=self.page_table,
-                batch_idx=batch_idx,
-                input_pos=input_pos,
-                out_page_table=out_page_table,
-                out_seqused_k=out_seqused_k,
-                n_pages=self.n_pages,
-                page_size=self.page_size,
-            )
-            return
-
-        BLOCK_PAGES = 128
-        grid = (batch_size, triton.cdiv(self.n_pages, BLOCK_PAGES))
-        _build_fa3_decode_metadata_kernel[grid](
+        build_paged_kv_metadata_runtime(
             self.page_table,
-            self.page_table.stride(0),
             batch_idx,
             input_pos,
             out_page_table,
-            out_page_table.stride(0),
             out_seqused_k,
-            self.n_pages,
-            batch_size,
-            BLOCK_PAGES=BLOCK_PAGES,
-            PAGE_SIZE=self.page_size,
-            num_warps=4,
+            self.page_size,
         )
 
     def build_slot_mapping(
@@ -774,46 +713,3 @@ class PageTable:
             reclaimable = self.prefix_cache.reclaimable_page_count()
             return available + reclaimable >= pages_needed
         return False
-
-
-if triton is not None:
-
-    @triton.jit
-    def _build_fa3_decode_metadata_kernel(
-        page_table_ptr,
-        page_table_stride,
-        batch_idx_ptr,
-        input_pos_ptr,
-        out_page_table_ptr,
-        out_page_table_stride,
-        out_seqused_k_ptr,
-        n_pages,
-        batch_size,
-        BLOCK_PAGES: tl.constexpr,
-        PAGE_SIZE: tl.constexpr,
-    ):
-        batch_id = tl.program_id(0)
-        tile_id = tl.program_id(1)
-
-        batch_mask = batch_id < batch_size
-        batch_idx = tl.load(batch_idx_ptr + batch_id, mask=batch_mask, other=0).to(tl.int64)
-        seqlen = tl.load(input_pos_ptr + batch_id, mask=batch_mask, other=0).to(tl.int64)
-        seqlen = seqlen + 1
-        num_pages = (seqlen + (PAGE_SIZE - 1)) // PAGE_SIZE
-        n_pages_i64 = tl.full((), n_pages, dtype=tl.int64)
-        num_pages = tl.where(num_pages < n_pages_i64, num_pages, n_pages_i64)
-
-        page_stride = tl.full((), page_table_stride, dtype=tl.int64)
-        out_stride = tl.full((), out_page_table_stride, dtype=tl.int64)
-
-        offs = tile_id * BLOCK_PAGES + tl.arange(0, BLOCK_PAGES)
-        offs = offs.to(tl.int64)
-        mask = offs < num_pages
-
-        in_ptr = page_table_ptr + batch_idx * page_stride + offs
-        out_ptr = out_page_table_ptr + batch_id * out_stride + offs
-        values = tl.load(in_ptr, mask=mask & batch_mask, other=0)
-        tl.store(out_ptr, values, mask=mask & batch_mask)
-
-        write_seq = (tile_id == 0) & batch_mask
-        tl.store(out_seqused_k_ptr + batch_id, seqlen, mask=write_seq)

--- a/kestrel/models/moondream/decode_slot.py
+++ b/kestrel/models/moondream/decode_slot.py
@@ -2,7 +2,7 @@
 
 Each DecodeSlot bundles the GPU resources needed for one decode step:
 - Pinned host buffers for H2D metadata copies (batch_idx, input_pos, lora_slot_ids)
-- Per-slot FA3 paged-KV metadata buffers (page_table, seqused_k)
+- Per-slot paged-KV metadata buffers (page_table, seqused_k)
 - GPU staging buffers for sampled outputs
 - Forward output buffers (logits, hidden_last) for delayed sampling
 - RenderBuffer for D2H copies

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -532,7 +532,7 @@ class MoondreamRuntime:
             )
 
         # Create two ping-pong decode slots for pipelined decoding.
-        # Each slot has its own staging buffers, FA3 paged-KV metadata buffers,
+        # Each slot has its own staging buffers, paged-KV metadata buffers,
         # and RenderBuffer, but they share the decode compute stream and copy stream.
         vocab_size = self.model.text.lm_head.weight.shape[0]
         hidden_dim = self.model.text.lm_head.weight.shape[1]
@@ -1793,7 +1793,7 @@ class MoondreamRuntime:
 
         This method provides identical preparation for both graph and non-graph paths:
         1. Clear padding region (for graph batch size alignment)
-        2. Build FA3 paged-KV metadata buffers
+        2. Build paged-KV metadata buffers
         3. Execute: either graph.replay() or eager forward
 
         The only difference between paths is step 3. This ensures debugging with
@@ -1833,11 +1833,11 @@ class MoondreamRuntime:
         if self._lora_workspace is not None:
             self._prepare_decode_lora_metadata(slot, graph_batch_size)
 
-        # Build FA3 per-step metadata buffers (identical for both paths)
+        # Build per-step paged-KV metadata buffers (identical for both paths)
         # - page_table rows: [B, num_pages]
         # - seqused_k: [B] (KV length including the current token after update)
         batch_idx = slot.meta.batch_idx.gpu[:graph_batch_size]
-        self.page_table.populate_fa3_decode_metadata(
+        self.page_table.populate_paged_kv_metadata(
             batch_idx=batch_idx,
             input_pos=slot.meta.input_pos.gpu[:graph_batch_size],
             out_page_table=slot.fa3_page_table[:graph_batch_size],
@@ -2140,9 +2140,9 @@ class MoondreamRuntime:
                             if self._lora_workspace is not None:
                                 self._prepare_decode_lora_metadata(slot, bs)
 
-                            # Build FA3 per-step metadata buffers
+                            # Build per-step paged-KV metadata buffers
                             batch_idx = slot.meta.batch_idx.gpu[:bs]
-                            self.page_table.populate_fa3_decode_metadata(
+                            self.page_table.populate_paged_kv_metadata(
                                 batch_idx=batch_idx,
                                 input_pos=slot.meta.input_pos.gpu[:bs],
                                 out_page_table=slot.fa3_page_table[:bs],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "torch-c-dlpack-ext>=0.1.3",
     "httpx>=0.27",
     "kestrel-native==0.1.5",
-    "kestrel-kernels==0.4.1",
+    "kestrel-kernels==0.4.6",
     "huggingface-hub>=0.20",
 ]
 

--- a/tests/test_page_table.py
+++ b/tests/test_page_table.py
@@ -45,6 +45,40 @@ def _make_runtime_for_cache(
 # Basic PageTable Tests (no prefix cache)
 # =============================================================================
 
+def test_populate_paged_kv_metadata_copies_active_pages_and_preserves_tail() -> None:
+    page_table = PageTable(n_pages=16, page_size=4, max_batch_size=8, device="cpu")
+    page_table.reserve(1, 9)
+    page_table.reserve(2, 17)
+    page_table.commit_block_table([1, 2])
+
+    batch_idx = torch.tensor([2, 1], dtype=torch.int64)
+    input_pos = torch.tensor([7, 8], dtype=torch.int32)
+    out_page_table = torch.full((2, page_table.n_pages), -99, dtype=torch.int32)
+    out_seqused_k = torch.full((2,), -1, dtype=torch.int32)
+
+    page_table.populate_paged_kv_metadata(
+        batch_idx=batch_idx,
+        input_pos=input_pos,
+        out_page_table=out_page_table,
+        out_seqused_k=out_seqused_k,
+    )
+
+    torch.testing.assert_close(
+        out_seqused_k,
+        torch.tensor([8, 9], dtype=torch.int32),
+    )
+    torch.testing.assert_close(out_page_table[0, :2], page_table.page_table[2, :2])
+    torch.testing.assert_close(out_page_table[1, :3], page_table.page_table[1, :3])
+    torch.testing.assert_close(
+        out_page_table[0, 2:],
+        torch.full((page_table.n_pages - 2,), -99, dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        out_page_table[1, 3:],
+        torch.full((page_table.n_pages - 3,), -99, dtype=torch.int32),
+    )
+
+
 
 class TestAllocatePagesBasic:
     """Tests for allocate_pages without prefix cache."""


### PR DESCRIPTION
## Summary

Routes decode paged-KV metadata construction through the required `kestrel-kernels` cache runtime operation.

- removes the local Triton metadata kernel from `kv_cache.py`
- renames the PageTable helper to `populate_paged_kv_metadata`
- preserves the existing metadata contract: valid page entries are copied and unused tail entries are left unchanged
- updates Moondream decode call sites to use the renamed helper
- adds a CPU PageTable test for `seqused_k`, valid page copies, and tail preservation
- bumps the `kestrel-kernels` dependency pin to `0.4.6`, the release line containing `cache.build_paged_kv_metadata`

This lets callers use the bundled CuTe implementation without requiring Triton to be installed.

## Validation

Local:

- `PYTHONPYCACHEPREFIX=/tmp/kestrel_pycache python -m py_compile kestrel/kv_cache.py kestrel/models/moondream/runtime.py kestrel/models/moondream/decode_slot.py tests/test_page_table.py`
- `git diff --check -- pyproject.toml kestrel/kv_cache.py kestrel/models/moondream/runtime.py kestrel/models/moondream/decode_slot.py tests/test_page_table.py`

Remote `belka`:

- synced a minimal test tree to `/tmp/kestrel-paged-kv-min`
- installed `kestrel-native==0.1.5` into the existing CUDA 12.6 test venv
- `PYTHONPATH=. /tmp/kestrel-kernels-paged-kv/.venv-cu126-fast/bin/python -m pytest tests/test_page_table.py::test_populate_paged_kv_metadata_copies_active_pages_and_preserves_tail -q`: `1 passed`

## Follow-up

`uv lock --upgrade-package kestrel-kernels` currently cannot resolve `kestrel-kernels==0.4.6` because that release is not on the package index yet. Refresh `uv.lock` after publishing `kestrel-kernels 0.4.6`.