### PR TITLE
Make Moondream API key optional

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -102,6 +102,7 @@ _LOGGER = logging.getLogger(__name__)
 _MPS_SAMPLER_DOCS_URL = "https://github.com/m87-labs/kestrel/pull/33"
 
 _DEFAULT_API_BASE_URL = "https://api.moondream.ai"
+_DOCS_URL = "https://moondream.ai/docs"
 _ALLOWED_API_BASE_URLS = (
     "https://api-staging.moondream.ai",
     _DEFAULT_API_BASE_URL,
@@ -127,6 +128,7 @@ class InferenceEngine:
         api_key: Optional[str] = None,
         api_base_url: str = _DEFAULT_API_BASE_URL,
         models: Optional[Sequence[str]] = None,
+        adapter_provider_uses_api_key: bool = False,
     ) -> None:
         if runtime is not None:
             cfg_device = runtime_cfg.resolved_device()
@@ -137,6 +139,7 @@ class InferenceEngine:
                 )
         self._runtime_cfg = runtime_cfg
         self._adapter_provider = adapter_provider
+        self._adapter_provider_uses_api_key = adapter_provider_uses_api_key
         self._api_key = api_key
         self._api_base_url = api_base_url
 
@@ -267,24 +270,40 @@ class InferenceEngine:
         api_key: Optional[str] = None,
         models: Optional[Sequence[str]] = None,
     ) -> "InferenceEngine":
-        # Auto-create provider if none provided
+        # Auto-create provider if none provided. Photon telemetry itself does
+        # not require auth; cloud-backed finetune inference does.
         if api_key is None:
             api_key = os.environ.get("MOONDREAM_API_KEY")
+        api_key = PhotonReporter._normalize_api_key(api_key)
         api_base_url = os.environ.get("MOONDREAM_API_BASE_URL", _DEFAULT_API_BASE_URL)
         api_base_url = api_base_url.rstrip("/")
         if api_base_url not in _ALLOWED_API_BASE_URLS:
             api_base_url = _DEFAULT_API_BASE_URL
+        adapter_provider_uses_api_key = False
         if adapter_provider is None and api_key:
-            from kestrel.cloud import MoondreamAdapterProvider
-            from kestrel.models.moondream.config import load_config
+            if PhotonReporter._is_api_key_header_safe(api_key):
+                from kestrel.cloud import MoondreamAdapterProvider
+                from kestrel.models.moondream.config import load_config
 
-            config = load_config()
-            adapter_provider = MoondreamAdapterProvider(
-                text_config=config.text,
-                api_key=api_key,
-                api_base_url=api_base_url,
-                device=torch.device(runtime_cfg.device),
-                dtype=runtime_cfg.resolved_dtype(),
+                config = load_config()
+                adapter_provider = MoondreamAdapterProvider(
+                    text_config=config.text,
+                    api_key=api_key,
+                    api_base_url=api_base_url,
+                    device=torch.device(runtime_cfg.device),
+                    dtype=runtime_cfg.resolved_dtype(),
+                )
+                adapter_provider_uses_api_key = True
+            else:
+                _LOGGER.warning(
+                    "MOONDREAM_API_KEY has non-ASCII or whitespace characters. "
+                    "Finetune inference is disabled. See %s",
+                    _DOCS_URL,
+                )
+        elif adapter_provider is None:
+            _LOGGER.warning(
+                "MOONDREAM_API_KEY is not set. Finetune inference is disabled. "
+                "Set MOONDREAM_API_KEY to enable finetune inference."
             )
 
         engine = cls(
@@ -295,6 +314,7 @@ class InferenceEngine:
             api_key=api_key,
             api_base_url=api_base_url,
             models=models,
+            adapter_provider_uses_api_key=adapter_provider_uses_api_key,
         )
         await engine._initialize()
         return engine
@@ -314,6 +334,17 @@ class InferenceEngine:
             ).start()
         except Exception:
             pass
+        reporter: Optional[PhotonReporter] = None
+        if self._photon_reporter is None:
+            reporter = PhotonReporter(
+                self._runtime_cfg,
+                self._runtime_cfg.resolved_device(),
+                api_key=self._api_key,
+                api_base_url=self._api_base_url,
+            )
+            auth_available = await reporter.validate_api_key()
+            if not auth_available and self._adapter_provider_uses_api_key:
+                self._disable_cloud_adapter_provider()
         if any(model_id not in self._runtimes for model_id in self._model_ids):
             max_lora_rank = (
                 self._adapter_provider.config()["max_lora_rank"]
@@ -349,19 +380,8 @@ class InferenceEngine:
         # ``_init_task is current_task`` check there keeps that
         # recursive call from re-entering this body.
         await self._warmup_query_pipeline()
-        if self._photon_reporter is None:
-            reporter = PhotonReporter(
-                self._runtime_cfg,
-                self.runtime.device,
-                api_key=self._api_key,
-                api_base_url=self._api_base_url,
-                engine=self,
-            )
-            await reporter.validate_api_key()
+        if reporter is not None:
             reporter.start()
-            # Only commit a successfully-validated, started reporter.
-            # If ``validate_api_key`` raises, the next ``_initialize``
-            # call will retry the build + validate.
             self._photon_reporter = reporter
         # Flip the guard last so a failure partway through (runtime
         # construction, warmup, photon) leaves the engine retry-able
@@ -370,6 +390,16 @@ class InferenceEngine:
         # Drop the reference to the completed init task so its
         # captured locals can be garbage-collected.
         self._init_task = None
+
+    def _disable_cloud_adapter_provider(self) -> None:
+        if self._adapter_provider is None:
+            return
+        _LOGGER.warning(
+            "Finetune inference is disabled because no valid MOONDREAM_API_KEY "
+            "is available."
+        )
+        self._adapter_provider = None
+        self._adapter_provider_uses_api_key = False
 
     def _build_configured_runtimes(self, max_lora_rank: Optional[int]) -> None:
         """Build each configured model's runtime from its registered spec.
@@ -841,8 +871,14 @@ class InferenceEngine:
         skill_spec = self._skill_registry().resolve(skill)
         adapter_id = self._normalize_adapter_id(adapter)
         if self._adapter_provider is None and adapter_id is not None:
+            _LOGGER.warning(
+                "Adapter %r was requested, but finetune inference is disabled. "
+                "Set MOONDREAM_API_KEY or pass an adapter_provider to enable it.",
+                adapter_id,
+            )
             raise NotImplementedError(
-                "Adapter support requires an adapter_provider at engine creation."
+                "Finetune inference is disabled because no authenticated "
+                "adapter provider is available."
             )
 
         image_obj: Optional[np.ndarray | bytes] = None
@@ -1517,4 +1553,3 @@ class InferenceEngine:
             except queue.Empty:
                 break
             self._fail_request(req, exc)
-

--- a/kestrel/photon.py
+++ b/kestrel/photon.py
@@ -1,4 +1,4 @@
-"""Photon telemetry reporting and API key validation."""
+"""Photon telemetry reporting and API key handling."""
 
 from __future__ import annotations
 
@@ -18,10 +18,8 @@ from kestrel.config import RuntimeConfig
 
 
 _LOGGER = logging.getLogger(__name__)
-_PRICING_URL = "https://moondream.ai/pricing"
 _DOCS_URL = "https://moondream.ai/docs"
 _TELEMETRY_FLUSH_INTERVAL_SECONDS = 60
-_TELEMETRY_WARNING_INTERVAL_SECONDS = 600
 _MAX_PENDING_REPORTS = 100
 _MAX_REPORTS_PER_UPLOAD = 10
 
@@ -49,14 +47,8 @@ class PhotonReporter:
         *,
         api_key: Optional[str],
         api_base_url: str,
-        engine: Any,
     ) -> None:
-        self._engine = engine
-        # Strip leading/trailing whitespace. Common failure mode: pasting
-        # the key into a .env file leaves a trailing newline, which is an
-        # illegal HTTP header byte and trips httpx.LocalProtocolError —
-        # previously swallowed as "API unreachable" (see _flush_window).
-        self._api_key = api_key.strip() if api_key else api_key
+        self._api_key = self._normalize_api_key(api_key)
         self._api_base_url = api_base_url.rstrip("/")
         self._client = httpx.AsyncClient(
             timeout=10.0,
@@ -73,62 +65,56 @@ class PhotonReporter:
         self._pending_reports: list[dict[str, Any]] = []
         self._stop_event = asyncio.Event()
         self._telemetry_task: Optional[asyncio.Task[None]] = None
-        self._last_telemetry_warning_at = 0.0
 
-    async def validate_api_key(self) -> None:
-        """Validate the API key by sending an initial telemetry flush.
+    async def validate_api_key(self) -> bool:
+        """Flush startup telemetry and return whether finetunes can use auth.
 
-        Raises RuntimeError if the key is missing, invalid, or the
-        account is not in good standing.  Warns and returns if the
-        Moondream API is unreachable (to avoid blocking startup during
-        API outages).
+        Missing or invalid keys never block base inference.
         """
-        # Do not disable Photon telemetry in product/runtime code. Bypassing
-        # this validation or suppressing telemetry violates the Terms of Service.
-        if not self._api_key:
-            raise RuntimeError(
-                "Moondream API key is not set. Pass api_key to PhotonVL() or "
-                "set the MOONDREAM_API_KEY environment variable. See %s" % _DOCS_URL
-            )
-
-        # Pre-validate the key can form a valid HTTP header. Otherwise
-        # `_flush_window`'s broad `except httpx.HTTPError` catches the
-        # client-side LocalProtocolError and returns None — which we treat
-        # as "API unreachable" and silently proceed without auth, bypassing
-        # telemetry. Check explicitly at the one-shot startup path; the
-        # steady-state telemetry loop keeps its permissive catch so an
-        # intermittent outage can't crash it.
-        if not self._api_key.isascii() or any(
-            c.isspace() or not c.isprintable() for c in self._api_key
-        ):
-            raise RuntimeError(
+        if self._api_key is not None and not self._is_api_key_header_safe(self._api_key):
+            self._disable_auth_header()
+            _LOGGER.warning(
                 "MOONDREAM_API_KEY has non-ASCII or whitespace characters that "
-                "make it unusable as an HTTP header. Check for stray newlines, "
-                "tabs, or pasted control characters in the key. See %s" % _DOCS_URL
+                "make it unusable as an HTTP header. Finetune inference is "
+                "disabled. Check for stray whitespace or pasted control "
+                "characters. See %s",
+                _DOCS_URL,
             )
+            await self._flush_window()
+            return False
 
+        had_api_key = self._api_key is not None
         standing = await self._flush_window()
+
+        if standing == "active":
+            return True
+
+        if not had_api_key:
+            return False
 
         if standing is None:
             _LOGGER.warning(
                 "Could not reach the Moondream API. The Photon inference "
-                "engine will start, but usage will not be reported and "
-                "finetunes will not be available while the API is "
-                "unreachable.",
+                "engine will start, but finetune inference is disabled while "
+                "the API is unreachable.",
             )
-            return
+            return False
 
         if standing == "invalid_api_key":
-            raise RuntimeError(
-                "MOONDREAM_API_KEY is not valid. Check that the key is "
-                "correct and try again. See %s" % _DOCS_URL
+            _LOGGER.warning(
+                "MOONDREAM_API_KEY is not valid. Finetune inference is "
+                "disabled. Check that the key is correct. See %s",
+                _DOCS_URL,
             )
+            await self._flush_window(rotate=False)
+            return False
 
-        if standing != "active":
-            raise RuntimeError(
-                "Your account does not have enough credits to start the "
-                "Photon inference engine. Add credits at %s" % _PRICING_URL
-            )
+        _LOGGER.warning(
+            "MOONDREAM_API_KEY is not active (standing=%s). Finetune "
+            "inference is disabled.",
+            standing,
+        )
+        return False
 
     def start(self) -> None:
         if self._telemetry_task is None:
@@ -180,18 +166,15 @@ class PhotonReporter:
             if self._stop_event.is_set():
                 break
 
-    async def _flush_window(self) -> Optional[str]:
+    async def _flush_window(self, *, rotate: bool = True) -> Optional[str]:
         """Flush pending telemetry reports and return account standing.
 
         Returns the standing string from the telemetry response:
         ``"active"``, ``"key_revoked"``, ``"billing_paused"``,
-        ``"inactive"``, ``"error"``, or ``None`` if the flush could not
-        be completed.
+        ``"inactive"``, ``"anonymous"``, ``"error"``, or ``None`` if the
+        flush could not be completed.
         """
-        reports = self._rotate_window()
-
-        if not self._api_key:
-            return None
+        reports = self._rotate_window() if rotate else []
 
         self._pending_reports.extend(reports)
         if len(self._pending_reports) > _MAX_PENDING_REPORTS:
@@ -206,12 +189,14 @@ class PhotonReporter:
                     f"{self._api_base_url}/v1/photon/telemetry",
                     json={"reports": batch},
                 )
-            except httpx.HTTPError as exc:
-                _LOGGER.warning("Photon usage reporting failed: %s", exc)
+            except httpx.HTTPError:
                 return None
 
             if response.status_code == 401:
-                return "invalid_api_key"
+                if self._api_key is not None:
+                    self._disable_auth_header()
+                    return "invalid_api_key"
+                return None
 
             if response.status_code >= 400:
                 return None
@@ -229,31 +214,14 @@ class PhotonReporter:
             if standing is None:
                 standing = "active"
 
-        if standing == "key_revoked":
-            _LOGGER.error(
-                "MOONDREAM_API_KEY has been revoked. The Photon inference "
-                "engine will stop accepting new requests.",
-            )
-            # Schedule engine shutdown as a separate task to avoid
-            # deadlock (engine.shutdown awaits this telemetry task).
-            asyncio.create_task(self._engine.shutdown())
-
-        elif standing == "invalid_api_key":
-            _LOGGER.error(
-                "MOONDREAM_API_KEY is no longer valid. The Photon inference "
-                "engine will stop accepting new requests.",
-            )
-            asyncio.create_task(self._engine.shutdown())
-
-        elif standing is not None and standing != "active":
-            self._maybe_log_telemetry_warning(
-                "Your account has run out of credits. Inference will "
-                "continue for this process, but new processes will fail "
-                "to start. Add credits at %s" % _PRICING_URL,
-                None,
-            )
-
         return standing
+
+    def _disable_auth_header(self) -> None:
+        self._api_key = None
+        try:
+            del self._client.headers["X-Moondream-Auth"]
+        except KeyError:
+            pass
 
     def _rotate_window(self) -> list[dict[str, Any]]:
         now = self._utc_now()
@@ -288,21 +256,6 @@ class PhotonReporter:
 
         return reports
 
-    def _maybe_log_telemetry_warning(
-        self,
-        message: str,
-        error: Optional[BaseException],
-    ) -> None:
-        now = asyncio.get_running_loop().time()
-        if now - self._last_telemetry_warning_at < _TELEMETRY_WARNING_INTERVAL_SECONDS:
-            return
-
-        self._last_telemetry_warning_at = now
-        if error is None:
-            _LOGGER.warning(message)
-            return
-        _LOGGER.warning("%s %s", message, error)
-
     @staticmethod
     def _utc_now() -> datetime:
         return datetime.now(timezone.utc)
@@ -315,6 +268,17 @@ class PhotonReporter:
     def _normalize_finetune(finetune: Optional[str]) -> str:
         normalized = (finetune or "").strip()
         return normalized
+
+    @staticmethod
+    def _normalize_api_key(api_key: Optional[str]) -> Optional[str]:
+        normalized = api_key.strip() if api_key else ""
+        return normalized or None
+
+    @staticmethod
+    def _is_api_key_header_safe(api_key: str) -> bool:
+        return api_key.isascii() and all(
+            not c.isspace() and c.isprintable() for c in api_key
+        )
 
     @staticmethod
     def _describe_active_gpu(runtime_device: torch.device) -> dict[str, Any]:

--- a/tests/test_photon.py
+++ b/tests/test_photon.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+import torch
+
+from kestrel import photon
+from kestrel.photon import PhotonReporter
+
+
+class _FakeAsyncClient:
+    responses: list[httpx.Response] = []
+    instances: list["_FakeAsyncClient"] = []
+
+    def __init__(self, *, timeout: float, headers: dict[str, str] | None = None) -> None:
+        self.timeout = timeout
+        self.headers = dict(headers or {})
+        self.posts: list[dict[str, Any]] = []
+        self.closed = False
+        self.instances.append(self)
+
+    async def post(self, url: str, *, json: dict[str, Any]) -> httpx.Response:
+        self.posts.append({
+            "url": url,
+            "json": json,
+            "headers": dict(self.headers),
+        })
+        return self.responses.pop(0)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _install_fake_client(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[httpx.Response],
+) -> type[_FakeAsyncClient]:
+    _FakeAsyncClient.responses = list(responses)
+    _FakeAsyncClient.instances = []
+    monkeypatch.setattr(photon.httpx, "AsyncClient", _FakeAsyncClient)
+    return _FakeAsyncClient
+
+
+def _runtime_cfg() -> SimpleNamespace:
+    return SimpleNamespace(service_name="test_service", model="moondream2")
+
+
+def test_validate_without_api_key_uploads_anonymous_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = _install_fake_client(
+        monkeypatch,
+        [httpx.Response(200, json={"accepted": True, "standing": "anonymous"})],
+    )
+
+    async def run() -> bool:
+        reporter = PhotonReporter(
+            _runtime_cfg(),
+            torch.device("cpu"),
+            api_key=None,
+            api_base_url="https://api.moondream.ai",
+        )
+        reporter.record_success(finetune=None, input_tokens=3, output_tokens=4)
+        auth_available = await reporter.validate_api_key()
+        await reporter.shutdown()
+        return auth_available
+
+    assert asyncio.run(run()) is False
+
+    client = fake_client.instances[0]
+    assert client.closed is True
+    assert len(client.posts) == 1
+    assert "X-Moondream-Auth" not in client.posts[0]["headers"]
+    report = client.posts[0]["json"]["reports"][0]
+    assert report["request_count"] == 1
+    assert report["input_tokens"] == 3
+    assert report["output_tokens"] == 4
+
+
+def test_invalid_api_key_retries_pending_telemetry_anonymously(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = _install_fake_client(
+        monkeypatch,
+        [
+            httpx.Response(401, json={"error": "Invalid API key"}),
+            httpx.Response(200, json={"accepted": True, "standing": "anonymous"}),
+        ],
+    )
+
+    async def run() -> bool:
+        reporter = PhotonReporter(
+            _runtime_cfg(),
+            torch.device("cpu"),
+            api_key="bad-key",
+            api_base_url="https://api.moondream.ai",
+        )
+        reporter.record_success(finetune="ft_123@7", input_tokens=5, output_tokens=6)
+        auth_available = await reporter.validate_api_key()
+        await reporter.shutdown()
+        return auth_available
+
+    assert asyncio.run(run()) is False
+
+    client = fake_client.instances[0]
+    assert len(client.posts) == 2
+    assert client.posts[0]["headers"]["X-Moondream-Auth"] == "bad-key"
+    assert "X-Moondream-Auth" not in client.posts[1]["headers"]
+
+    first_reports = client.posts[0]["json"]["reports"]
+    retry_reports = client.posts[1]["json"]["reports"]
+    assert len(first_reports) == 1
+    assert len(retry_reports) == 1
+    assert retry_reports[0]["report_id"] == first_reports[0]["report_id"]
+    assert retry_reports[0]["finetune"] == "ft_123@7"
+
+
+def test_active_api_key_keeps_authenticated_features(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = _install_fake_client(
+        monkeypatch,
+        [httpx.Response(200, json={"accepted": True, "standing": "active"})],
+    )
+
+    async def run() -> bool:
+        reporter = PhotonReporter(
+            _runtime_cfg(),
+            torch.device("cpu"),
+            api_key="valid-key",
+            api_base_url="https://api.moondream.ai",
+        )
+        auth_available = await reporter.validate_api_key()
+        await reporter.shutdown()
+        return auth_available
+
+    assert asyncio.run(run()) is True
+
+    client = fake_client.instances[0]
+    assert len(client.posts) == 1
+    assert client.posts[0]["headers"]["X-Moondream-Auth"] == "valid-key"
+
+
+def test_revoked_key_disables_authenticated_features(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = _install_fake_client(
+        monkeypatch,
+        [httpx.Response(200, json={"accepted": True, "standing": "key_revoked"})],
+    )
+
+    async def run() -> bool:
+        reporter = PhotonReporter(
+            _runtime_cfg(),
+            torch.device("cpu"),
+            api_key="revoked-key",
+            api_base_url="https://api.moondream.ai",
+        )
+        auth_available = await reporter.validate_api_key()
+        await reporter.shutdown()
+        return auth_available
+
+    assert asyncio.run(run()) is False
+
+    client = fake_client.instances[0]
+    assert len(client.posts) == 1
+    assert client.headers["X-Moondream-Auth"] == "revoked-key"


### PR DESCRIPTION
## Summary

- Make `MOONDREAM_API_KEY` optional for Photon startup while still flushing Photon telemetry.
- Retry pending telemetry without auth when an authenticated upload returns 401.
- Disable finetune inference when no valid key is available, with warnings/errors focused on that disabled feature.

## Context

Checked `~/code/md-api`, including the `privacy/anonymous-photon-telemetry` branch. There, `/v1/photon/telemetry` accepts missing auth and returns `standing: "anonymous"` for anonymous uploads. Invalid tokens are still rejected before the handler, so the client downgrades to unauthenticated reporting after a 401.

## Validation

- `uv run --no-sync pytest tests/test_photon.py tests/test_multi_model.py -q`
- `python -m py_compile kestrel/photon.py kestrel/engine/core.py tests/test_photon.py`
- `git diff --check -- kestrel/photon.py kestrel/engine/core.py tests/test_photon.py`