### PR TITLE
Prep 0.4.2: changelog, version bump, free-local-inference docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes since `v0.1.2` are documented in this file.
 
+## 0.4.2 — 2026-06-06
+
+Local inference is now free and no longer needs an API key. This release also
+updates Kestrel to `kestrel-kernels` 0.4.6, raising Moondream 3 throughput
+across NVIDIA GPUs — with standout gains on Ampere — making high-rank LoRA
+dramatically faster, speeding up decoding on Apple Silicon, and fixing FP8 MoE
+accuracy on older cards.
+
+### Local inference is now free
+
+- Running the inference engine no longer requires a `MOONDREAM_API_KEY` — local
+  inference is now free and starts with no key configured. A key is only needed
+  for finetuned-model inference.
+
+### Performance
+
+- Moondream 3 throughput is up across NVIDIA GPUs on the published ChartQA
+  benchmarks, with by far the largest gains on Ampere: A100 is up ~25–44% on
+  direct queries and up to ~70% with chain-of-thought, at ~25–34% lower median
+  latency, and A10 is up ~30–45%. Jetson Thor is up to ~48% faster at low batch
+  sizes.
+- Constrained decoding (restricting output to a set of allowed tokens) is
+  faster, with the biggest gains at high concurrency — up to ~34% higher decode
+  throughput on B200 and ~11% on RTX 3090, with identical output.
+- Reduced decode CPU overhead on both Apple Silicon (M-series Macs) and in
+  NVIDIA MoE execution, speeding up Moondream 3 decoding.
+
+### LoRA
+
+- High-rank LoRA adapters are dramatically faster: a rank-512 adapter apply
+  dropped from ~140 ms to ~0.9 ms on B200 (2048 routed tokens), and
+  per-request cost now scales with the adapter's rank rather than the maximum
+  supported rank. Ranks up to 512 are supported.
+- LoRA adapters now also work on Apple Silicon and Windows, in addition to
+  NVIDIA. Windows couldn't run adapters before because the previous path
+  required Triton.
+
+### Fixes
+
+- Fixed a numerical issue in FP8 MoE on GPUs that lack native FP8 conversion
+  (A100, A10/A10G, RTX 3090): the software routine that converts activations to
+  FP8 truncated instead of rounding to nearest, biasing every quantized
+  activation about 4% low. Rounding to nearest removes the bias. The effect on
+  generated output was minor, and GPUs with hardware FP8 conversion were
+  unaffected.
+
 ## 0.4.1 — 2026-05-23
 
 This release lifts FP8 MoE performance on NVIDIA B200 through the

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Kestrel provides async, micro-batched inference with streaming support, paged KV
     SM90 (H100, H200, GH200), SM100 (B200), SM110 (Jetson Thor), SM120 (RTX PRO 6000).
     Other CUDA GPUs may work but have not been tested.
   - **Apple Silicon Mac** (M-series) on macOS 13 (Ventura) or later, with native Metal kernels.
-- `MOONDREAM_API_KEY` environment variable or `api_key` parameter (get a key from [moondream.ai](https://moondream.ai))
+- `MOONDREAM_API_KEY` (optional) — only needed for finetuned-model inference (get a key from [moondream.ai](https://moondream.ai))
 
 ## Installation
 
@@ -61,8 +61,9 @@ async def main():
     # Use model="moondream2" or model="moondream3-preview".
     cfg = RuntimeConfig(model="moondream2")
 
-    # Create the engine (loads model and warms up)
-    engine = await InferenceEngine.create(cfg, api_key="your-key-here")
+    # Create the engine (loads model and warms up). No API key needed for
+    # local inference; pass api_key="..." only for finetuned models.
+    engine = await InferenceEngine.create(cfg)
 
     # Load an image (JPEG, PNG, or WebP bytes)
     image = open("photo.jpg", "rb").read()
@@ -244,7 +245,7 @@ RuntimeConfig(
 
 | Variable | Description |
 |----------|-------------|
-| `MOONDREAM_API_KEY` | Required. Get this from [moondream.ai](https://moondream.ai). |
+| `MOONDREAM_API_KEY` | Optional. Only needed for finetuned-model inference. Get this from [moondream.ai](https://moondream.ai). |
 | `HF_HOME` | Override HuggingFace cache directory for downloaded weights (default: `~/.cache/huggingface`). |
 | `HF_TOKEN` | HuggingFace token for gated models like Moondream 3. Alternatively, run `huggingface-cli login`. |
 
@@ -256,6 +257,15 @@ Kestrel can be deployed as a [Triton Inference Server](https://github.com/triton
 
 Throughput and latency for the `query` skill are tracked in [PERFORMANCE.md](./PERFORMANCE.md), with results broken out by GPU.
 
+## Telemetry
+
+Kestrel reports basic usage telemetry to help us decide which hardware platforms
+to prioritize for support and optimization. Each report includes the model in
+use, your GPU type and memory, aggregate request/error and token counts, your
+machine's hostname, and timestamps. Prompts, images, and model outputs are never
+sent.
+
 ## License
 
-Kestrel requires a Moondream API key for billing. See [moondream.ai/pricing](https://moondream.ai/pricing) for plans.
+Local inference is free and requires no API key. Finetuned-model inference
+requires a Moondream API key — see [moondream.ai/pricing](https://moondream.ai/pricing).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kestrel"
-version = "0.4.1"
+version = "0.4.2"
 description = "a fast, efficient inference engine for moondream"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -557,7 +557,7 @@ wheels = [
 
 [[package]]
 name = "kestrel"
-version = "0.4.1"
+version = "0.4.2"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
@@ -583,7 +583,7 @@ eval = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "huggingface-hub", specifier = ">=0.20" },
-    { name = "kestrel-kernels", specifier = "==0.4.1" },
+    { name = "kestrel-kernels", specifier = "==0.4.6" },
     { name = "kestrel-native", specifier = "==0.1.5" },
     { name = "safetensors", specifier = ">=0.4" },
     { name = "tokenizers", specifier = ">=0.15" },
@@ -600,7 +600,7 @@ eval = [
 
 [[package]]
 name = "kestrel-kernels"
-version = "0.4.1"
+version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "kestrel-mps-torch-ext", marker = "sys_platform == 'darwin'" },
@@ -608,41 +608,41 @@ dependencies = [
     { name = "torch-c-dlpack-ext" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/77/2b809465a393a83ca2b205336aad0c5b5677018e7e41b25ca42e7f2ddcb8/kestrel_kernels-0.4.1-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:95e4010ca31a508172a850e13f6e5d0a575b6578d072a02814e196362e24e6b9", size = 431238, upload-time = "2026-05-24T00:11:27.945Z" },
-    { url = "https://files.pythonhosted.org/packages/97/bd/df9ac2fcfde8574ebae4c659c3b8669063e58f9e8070b1b1c4379a7e2f40/kestrel_kernels-0.4.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:8f2751cb052f221c93a5c4ca41d8d815aa97f6c08dc30c0d248c29b802f050c4", size = 31844676, upload-time = "2026-05-24T00:12:14.373Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/d8/2c3071f952ddb1206d3c4ca80b129ee5de50465635a14ab2bfa363eb7afc/kestrel_kernels-0.4.1-cp310-cp310-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:49fcf00282ab062c4f05a6527cdb8ad0951d8ab81424a26fcad45026d898f100", size = 14227732, upload-time = "2026-05-24T00:12:38.518Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/a4/00c7e215d910c0823a4e9a2acb83efa41d10dd8d87480ad633030d472adf/kestrel_kernels-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:d3908dbfa349ace496952f7ea824ed81aac8e4cf7b59e2c1eeb763e8cc75b365", size = 33498266, upload-time = "2026-05-24T00:13:36.302Z" },
-    { url = "https://files.pythonhosted.org/packages/01/5d/7e577688aa49e37da6e3969e3d7f127b927587302aedc3d2a336ff660adf/kestrel_kernels-0.4.1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:35481ea093ce8676ee6c9327fd5369452c158d6e62c201f2503149321a0c4d4b", size = 432471, upload-time = "2026-05-24T00:13:39.625Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/73/f7ecf0788e9f23dee9938b29aaecb08893942ce4fea00f9c191756794ef8/kestrel_kernels-0.4.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:42dc2bd28c9eee253d95e486c8a7e808c2e30cd0afac16fc2b856875dd15e3f5", size = 31844679, upload-time = "2026-05-24T00:14:25.771Z" },
-    { url = "https://files.pythonhosted.org/packages/21/99/d08ccdea067e88e0a644ee90e75a6aeda54cf69bc1e0dae32fadac64f527/kestrel_kernels-0.4.1-cp311-cp311-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:bb3b48df83a53434f5b75493c2f514b4247a7791cebfbe9ee68477200da32950", size = 14227722, upload-time = "2026-05-24T00:14:47.553Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/a8/a4c19ba15c55360da8541d41d47f9fe79160c016e1b966a372f860c6206e/kestrel_kernels-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:eca56815bb40dc669e6da40015c9aa96d3ab55cf86c50702fe28591c932d5026", size = 33498269, upload-time = "2026-05-24T00:15:46.821Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/f3/d52457b088d189363ae725fdb79a6c43eef139e09d90d9d13b44ec8e584f/kestrel_kernels-0.4.1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:065071d0bafb7e70f1dd73d9d442a14ead844a31a5c264bc15d682dcea819ec7", size = 433214, upload-time = "2026-05-24T00:15:49.75Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/ca/4fca838cacd602464c32031de4f5d791c271fabdadc96dd90b8ba718fd23/kestrel_kernels-0.4.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:be4aef72f1b3e35d7e5995e7385c938a7cef24442c5a495d274f31090e2571ee", size = 31844691, upload-time = "2026-05-24T00:16:40.719Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/dd/81d35a08c7ce7486adebcf236376a91336e32b8daa119ff3e4412fb42117/kestrel_kernels-0.4.1-cp312-cp312-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:df56d89486ba7039cb7a8a475122c04fedbbdf35931cc0c28e88f25890e2f8ea", size = 14227684, upload-time = "2026-05-24T00:17:09.388Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/7e/bd2f3ea4c27e6258adf43b8148820cac8969c294cefecdd71aeadc520872/kestrel_kernels-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:a054dd6aa0c5f0f62a455f43a46beebb79749394f59f77fb428ef8d5ad479c6b", size = 33498257, upload-time = "2026-05-24T00:18:44.294Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/ed/3d55c1c888e35c4812d0a0a8abc60f65f4e341ec326134940eff14b25f6e/kestrel_kernels-0.4.1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:12a3a1c74bd31dfd48a0c28fbe7c5daab33f921a274a78a5430969dae02bbe5b", size = 433287, upload-time = "2026-05-24T00:18:47.534Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/dd/d8c15854d3ce962682fad67c252d35d24930f057a279f77874bde2f62fbd/kestrel_kernels-0.4.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:3dc7045ca1766c15f53c9aec5e100b3cb43d585a0bc36bbb38b992af8c281016", size = 31844694, upload-time = "2026-05-24T00:19:43.322Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/a8/3e3878315c73f46cba3faa2d4651b0a0c9f8013fe8a3d0f425357343ce31/kestrel_kernels-0.4.1-cp313-cp313-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:54703e97173ff78a31632faaa427d8de1ac37e475c8ba7f94250bdfb15171d21", size = 14227663, upload-time = "2026-05-24T00:20:12.911Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ea/ade212dbfbc39f82c74fe31632b73c89d266b204ca5f9e71c257877925e1/kestrel_kernels-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:a32c59ada72f6615738971ee9c1bdb3b0917d59918c1cc2a1718c28549996ea2", size = 33498246, upload-time = "2026-05-24T00:21:14.666Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/85/e05e809ac41a8d1e5be98ad5da5dc611de7707cd20800c168d7310feb725/kestrel_kernels-0.4.1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:47e66bfd124279c463140f6f2c8ab6bc9488f9c97a0701e4f69d6c0419260f58", size = 433510, upload-time = "2026-05-24T00:21:17.779Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/8c/aa4c5cc7bef417ca9d2b703c7dc57a18362619e8a33026b46ea80dd2ff74/kestrel_kernels-0.4.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:d290f1e003e68b95cf85c98c9136cca921e05d54d86dd113103688cc8f50a1ea", size = 31844707, upload-time = "2026-05-24T00:22:09.283Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/cf/f32753909564b2b9ee275b4209b82a7a6e1f538bded248d04af44ed689d7/kestrel_kernels-0.4.1-cp314-cp314-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:2b83c56ac5d0be2220bf998baac655af34535638d2c0ba820e9ef060a24f4863", size = 14227155, upload-time = "2026-05-24T00:22:38.719Z" },
-    { url = "https://files.pythonhosted.org/packages/48/3d/57ff85ec644d320cefe581f3e20758a80ded1c0f5628ec78e5921ea14096/kestrel_kernels-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:67f7bd655e1e6a9cdf623f3462da8acdd03310321985331f67b4bffc9ae3e702", size = 33794977, upload-time = "2026-05-24T00:23:33.771Z" },
+    { url = "https://files.pythonhosted.org/packages/38/86/3db23d396ac0695243c05e017394a8b2032fc276652f035c041084b2da5c/kestrel_kernels-0.4.6-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:1028f994a8971ba55ad808bb5c8b58059bc43538f310d5aa8fab271d1383e825", size = 561567, upload-time = "2026-06-07T01:02:43.299Z" },
+    { url = "https://files.pythonhosted.org/packages/22/07/57972dcc38596a3d4d451c50147204ec70235c77a2317522cba3efb799ee/kestrel_kernels-0.4.6-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:a474315d1ac4452a13ab36ffe1f7892f781ead2021d0f891bd974d64d87e864b", size = 45564978, upload-time = "2026-06-07T01:02:46.449Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a2/1dd7844da2af131bdd65ec71715b703984ad17f611a85fb256db40f97ff6/kestrel_kernels-0.4.6-cp310-cp310-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:3f4c5929c9eb13f440e64cd29b37a3c866b2ddc716a59d38b9c2f4026392d937", size = 8043618, upload-time = "2026-06-07T01:02:49.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/575f9c0fa01382ab0a3984f2bb2dfe10949e540d6cb5b95d5a1b63f9629c/kestrel_kernels-0.4.6-cp310-cp310-win_amd64.whl", hash = "sha256:5bc0f4ecfa3222d01803ea8630b051749ea5e76e3a918b0b0f949527c397d539", size = 47253227, upload-time = "2026-06-07T01:02:52.823Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2d/d4d58b663f4a7ddb7e3e66be61b57cb1496b1573412d1d479abb2c75aafe/kestrel_kernels-0.4.6-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:52dc6f9aa70320cfb522e53d8ea9424648c9f73e6e8de72b839205e9a0dcdcfc", size = 562959, upload-time = "2026-06-07T01:02:55.729Z" },
+    { url = "https://files.pythonhosted.org/packages/74/7a/11a26ccfce7f18c09493f497acafc71f35078570f3ce6d7d54cdcc7b0cea/kestrel_kernels-0.4.6-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:03b46ff0057e843f84c54e25a822fb18677652fdd64c622593b7f1050748b6ab", size = 45564984, upload-time = "2026-06-07T01:02:58.532Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7d/06a6f1ac01e87b536dc6be704f6d52c9ad92a9335a9cc2b9f28b43bf4e2c/kestrel_kernels-0.4.6-cp311-cp311-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:48825e2ce309dcb433def71ff78fb8bb5c0f4f9d21339a8c91304e3f79f45377", size = 8043615, upload-time = "2026-06-07T01:03:01.719Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/1d/e4af40705eb1d128ff16f6fc61414d7b5db3b848fdf54322bafe6573c0ae/kestrel_kernels-0.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:8ecb121829d7e724f37587e901a9c8593852ef4974261d04e0d350ae398879f5", size = 47253229, upload-time = "2026-06-07T01:03:04.61Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/57/412acd7327bed028bf241086407bfd6de62bf6468c1fa177f9ad5ba37ab8/kestrel_kernels-0.4.6-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:d75064a4dd26c12959de68a8614ba8b7ad9d4268070904e72d5c50b609fa3934", size = 563703, upload-time = "2026-06-07T01:03:07.303Z" },
+    { url = "https://files.pythonhosted.org/packages/20/99/ccee1039378df83853c11c39c1d79aba73a13c861fb9401ad9e048038208/kestrel_kernels-0.4.6-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:2214c5a5e7ee958e0af0927782206727e5b8f7e9ffae535bfb34e219eaaeafcc", size = 45565011, upload-time = "2026-06-07T01:03:10.347Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a7/59d8664cfa9ebc0cd5d8033801ab31eb54ed7118f4ad3985f28709be178f/kestrel_kernels-0.4.6-cp312-cp312-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:0decd77cfdef2f1b796754e2d256a811bdd577acbf34663b99060a69a58b8851", size = 8043561, upload-time = "2026-06-07T01:03:13.696Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/b77a2ccd65b09ef2292468bd3e2b15b12fa6d4f54432e1145af099a51d5b/kestrel_kernels-0.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:21e300e034a4765d16f438be2cce80f4ed3bb34212e3562bb36774396f546c51", size = 47253221, upload-time = "2026-06-07T01:03:16.728Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/13/3f3d88946ea79a81199b5d2dcdf0aff0d8b6a30d0bebf28b492effd2ea41/kestrel_kernels-0.4.6-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:cf625fa4bcc1ce85c65e85abc5bd684c67f009c8703887d14144e0a6bfbdca1d", size = 563816, upload-time = "2026-06-07T01:03:19.567Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a3/c3be3cfc09a20a978a0a2e9dbbb010713eeaf131f92919af105a5849a566/kestrel_kernels-0.4.6-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:bcf0518988d67658117aee06ebac2a1a56bbd42419358341166c9fcf62eead7d", size = 45564994, upload-time = "2026-06-07T01:03:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/79/19/62b9b68a6ebabfad81103957eb42c170573b7bfccd0bd4202fac760d6be9/kestrel_kernels-0.4.6-cp313-cp313-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:d5be9c27293cb2f0a7f1acb0fbce282a4c81e8747c82763b9c49b9ebb51c1510", size = 11758865, upload-time = "2026-06-07T01:03:26.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/91/ef60a47d6920e120d202a043ad4501659a4ef1ed482cbbb305ca88a7b4f9/kestrel_kernels-0.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:4e3ffaf690a7b67e62a1c3cf532c84d5e36562968d285270092fb64befcd534a", size = 47253214, upload-time = "2026-06-07T01:03:30.253Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/33/ffd4bc01a45af44c08ab2d3a0239b1254a2e37449821f60971fddaf1de1e/kestrel_kernels-0.4.6-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:f97df03ad74601ab0e2b63c072f0255d23413ac99d39b2192a002b8d973c6174", size = 563966, upload-time = "2026-06-07T01:03:33.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/79/586e6e20d53c2a048e4c6d49f90b31bcac742e6c9b24b279273bd20211ce/kestrel_kernels-0.4.6-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:7f60b61f462909ecadb3b6e10796b453d0599854b5f93a4b9047123e64162f1a", size = 45565014, upload-time = "2026-06-07T01:03:36.077Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2a/ba859877875aedf9443d1a866c3edb3632a69b601306653abafe15cf01c1/kestrel_kernels-0.4.6-cp314-cp314-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:205cccf16e8808b1cdecea0a5697404612b6e11d553191355476d6f8746a38d3", size = 11758871, upload-time = "2026-06-07T01:03:39.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a3/15deecc9dccebf2bc1151513310928541e54f6bf5bf1acdd5f184660f512/kestrel_kernels-0.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:8562c17626f49062cbba612a5c11b97561b5aa1cf14f82ce14748e05ae3db1da", size = 47612658, upload-time = "2026-06-07T01:03:42.921Z" },
 ]
 
 [[package]]
 name = "kestrel-mps-torch-ext"
-version = "0.1.0"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/0c/31d4df869bd2e47b30f2824b658f6cb559b5c516cbe4bf5d4473977814d5/kestrel_mps_torch_ext-0.1.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:7fcc9010e248466ddf5955456dfb85b12e7736b8f0d93de8d25b3ef913a60479", size = 209043, upload-time = "2026-05-18T10:53:23.406Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/f0/800c2ec1d9a63e1cb9e91ca51bf9abe8c2e2b91286561292a84c782d4161/kestrel_mps_torch_ext-0.1.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b491416da0315b900459cc5ab1fbd116fb6a3cb0032204ceaf8b49173c85ff7a", size = 214386, upload-time = "2026-05-18T10:53:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/91/48/79e5f127401deeb4b1643787a2a7e030360c99766a1ac52ffbc731b01dcb/kestrel_mps_torch_ext-0.1.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:daf22affa544eebaf36d71bd1d8eeead92e6e3f510b113456c67146d6b1ea796", size = 216133, upload-time = "2026-05-18T10:53:26.151Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/19/2a70eed0dad093bfdb4aa3dd88413abb7fd2db8eef1eb33c3d05edd10611/kestrel_mps_torch_ext-0.1.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:982a8bb20339903086cd7662ed9c48a0dbe419af56755aaaa4b08a827b8e1a56", size = 216410, upload-time = "2026-05-18T10:53:27.799Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ce/26e51ddb682e83b6911b9af71c87c1520a547e01ebc49d5af2eabb339eef/kestrel_mps_torch_ext-0.1.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:63162eb89b10b6e16e7b09c3dc6fddc1d112defe7aa27707417f9ca10c072022", size = 216554, upload-time = "2026-05-18T10:53:29.448Z" },
+    { url = "https://files.pythonhosted.org/packages/24/45/b2d1c72b8e56f02b8eb38a519361a32365c82f065030649fcecc08ca1ad3/kestrel_mps_torch_ext-0.1.1-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:6c99d03330472a649511b97fef9862307117208ffd375e3c826be2be93764c6b", size = 210347, upload-time = "2026-06-06T09:47:08.34Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/d2/7064adb6e1f33307f875b15f7c6fe974a391d7644de40018da648c4c38c1/kestrel_mps_torch_ext-0.1.1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:373946adcd489da9ea1f5d00ba433e7f582a5e8c887b92ea42078c40f4a2f542", size = 215681, upload-time = "2026-06-06T09:47:09.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/7d/ab54edfa1d13cef6a7fe516581e9e00b8ca76b7496c562f9ab375e14f045/kestrel_mps_torch_ext-0.1.1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:1788454f8bee7144d005aac116ef2482ee017ab5ecc1dd725a1935cb27c6c4c6", size = 217452, upload-time = "2026-06-06T09:47:11.558Z" },
+    { url = "https://files.pythonhosted.org/packages/75/24/5abc7c34778b9e85eaa2650d8b09c595cab9e43f56d60ca427c66a6d8dfe/kestrel_mps_torch_ext-0.1.1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:5af9ab20eb59d2f501c77e82f2756630dcaa626a29a43bf48015dadd37d43bdb", size = 217660, upload-time = "2026-06-06T09:47:13.226Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d1/19dfd608caa20b314cacb14089b28ad9a0a28f9cd8e503e515b51a836a2b/kestrel_mps_torch_ext-0.1.1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:f3b1468c5b2113671620183a137f930ab77f1d87dc89f50350179a5d75995b7c", size = 217829, upload-time = "2026-06-06T09:47:14.91Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Release prep for kestrel **0.4.2** (bundles `kestrel-kernels` 0.4.6), plus docs for the now-optional API key.

- **Version**: bump `kestrel` 0.4.1 → 0.4.2, relock `uv.lock` (`kestrel-kernels` 0.4.6, `kestrel-mps-torch-ext` 0.1.1).
- **CHANGELOG**: new 0.4.2 entry, written customer-first:
  - Moondream 3 throughput up across NVIDIA GPUs — standout on Ampere (A100 +25–44% direct / up to +70% CoT, ~25–34% lower latency; A10 +30–45%), Jetson Thor up to +48% at low batch.
  - High-rank LoRA dramatically faster (rank-512 apply ~140 ms → ~0.9 ms on B200); LoRA now also works on Apple Silicon and Windows.
  - Faster constrained decoding (up to ~34% on B200, ~11% on RTX 3090).
  - Fix: sm_80/sm_86 FP8 MoE activation-quant bias (A100, A10/A10G, RTX 3090).
  - Local inference is now free / no API key required.
- **README**: `MOONDREAM_API_KEY` is now optional (only needed for finetuned-model inference); quickstart no longer passes a key; new **Telemetry** section describing what is reported.

## Notes

- The multi-model engine work (already on `main`) is intentionally **not** announced in the changelog.
- Documents the API-key change merged in #90.
- Prep only — no tag/publish in this PR.