### PR TITLE
Move compute stream ownership into engine

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -54,7 +54,7 @@ from dataclasses import replace
 
 from kestrel_kernels import get_runtime
 from kestrel.config import RuntimeConfig
-from kestrel.device import set_device, synchronize
+from kestrel.device import make_stream, set_device, synchronize
 from kestrel.runtime import (
     AutoregressiveRuntime,
     ExecutionShape,
@@ -176,6 +176,14 @@ class InferenceEngine:
         self._runtimes: Dict[str, Runtime] = {}
         if runtime is not None:
             self._runtimes[self._default_model] = runtime
+        runtime_device = (
+            runtime.device if runtime is not None else runtime_cfg.resolved_device()
+        )
+        self._compute_stream = (
+            cast(Any, runtime).compute_stream
+            if runtime is not None
+            else make_stream(runtime_device)
+        )
         # ``_initialized`` flips at the very end of ``_initialize`` so
         # any partial failure (warmup, photon validation) leaves the
         # engine retry-able. ``_init_task`` is the asyncio task that's
@@ -430,9 +438,13 @@ class InferenceEngine:
 
         spec = get_spec(model_id)
         if model_id == self._default_model:
-            return spec.runtime(self._runtime_cfg, max_lora_rank=max_lora_rank)
+            return spec.runtime(
+                self._runtime_cfg,
+                max_lora_rank=max_lora_rank,
+                compute_stream=self._compute_stream,
+            )
         cfg = replace(self._runtime_cfg, model=model_id, model_path=None)
-        return spec.runtime(cfg)
+        return spec.runtime(cfg, compute_stream=self._compute_stream)
 
     async def _warmup_query_pipeline(self) -> None:
         """Ensure the high-level query path is exercised before serving traffic."""
@@ -1258,6 +1270,7 @@ class InferenceEngine:
         # CUDA-graph capture, so pause/drain is handled specially below.
         ar_executor = AutoregressiveExecutor(
             runtime,
+            compute_stream=self._compute_stream,
             skills=self._skill_registry(),
             adapter_provider=self._adapter_provider,
             build_generation_request=self._build_generation_request,
@@ -1268,7 +1281,7 @@ class InferenceEngine:
         # folds advance() over every lane; single-pass forwards interleave
         # with autoregressive decode on the shared stream.
         single_pass: Dict[str, SinglePassExecutor] = {
-            name: SinglePassExecutor(rt)
+            name: SinglePassExecutor(rt, compute_stream=self._compute_stream)
             for name, rt in self._runtimes.items()
             if rt.execution_shape is ExecutionShape.SINGLE_PASS
         }

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -160,6 +160,7 @@ class AutoregressiveExecutor:
         self,
         runtime: AutoregressiveRuntime,
         *,
+        compute_stream: Any,
         skills: "SkillRegistry",
         adapter_provider: Optional[AdapterProvider],
         build_generation_request: Callable[
@@ -174,6 +175,7 @@ class AutoregressiveExecutor:
         self._to_engine_result = to_engine_result
         self._scheduler = GenerationScheduler(
             runtime,
+            compute_stream=compute_stream,
             skill_registry=skills,
             adapter_provider=adapter_provider,
         )
@@ -334,5 +336,3 @@ class AutoregressiveExecutor:
                 self._runtime.release_sequence(state)
             except Exception:
                 pass
-
-

--- a/kestrel/engine/single_pass.py
+++ b/kestrel/engine/single_pass.py
@@ -115,13 +115,12 @@ class SinglePassExecutor:
         self,
         runtime: SinglePassRuntime,
         *,
+        compute_stream: Any,
         max_in_flight: int = 1,
     ) -> None:
         self._runtime = runtime
         self._device = runtime.device
-        # Declared on SinglePassRuntime — access directly so a runtime that
-        # forgets it fails loudly instead of silently losing interleaving.
-        self._stream = runtime.primary_stream
+        self._stream = compute_stream
         self._max_in_flight = max_in_flight
         self._queue: "queue.Queue[_SinglePassRequest]" = queue.Queue()
         self._in_flight: List[_InFlight] = []

--- a/kestrel/models/moondream/decode_slot.py
+++ b/kestrel/models/moondream/decode_slot.py
@@ -106,7 +106,7 @@ class DecodeSlot:
     slot_id: int
     meta: DecodeMetaBuffers
     render: object  # RenderBuffer (import deferred to avoid circular import)
-    compute_stream: torch.cuda.Stream
+    compute_stream: torch.cuda.Stream | None
 
     fa3_page_table: Tensor
     fa3_seqused_k: Tensor
@@ -165,8 +165,8 @@ def create_decode_slot(
     hidden_dim: int,
     coord_dtype: torch.dtype,
     size_dtype: torch.dtype,
-    compute_stream: torch.cuda.Stream,
-    copy_stream: torch.cuda.Stream,
+    compute_stream: torch.cuda.Stream | None,
+    copy_stream: torch.cuda.Stream | None,
 ) -> DecodeSlot:
     """Create a DecodeSlot with all per-slot resources allocated.
 

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -141,7 +141,7 @@ class PrefillScratch:
 class PrefillSlot:
     """Per-prefill slot resources.
 
-    Prefill work runs on the primary stream, but can be pipelined from the CPU
+    Prefill work runs on the compute stream, but can be pipelined from the CPU
     side (e.g., commit token0 for request A while the GPU runs request B's
     prefill). Slots avoid clobbering per-prefill buffers when multiple prefills
     are in-flight.
@@ -235,6 +235,7 @@ class MoondreamRuntime:
         *,
         max_lora_rank: int | None = None,
         kv_pool: KVMemoryPool | None = None,
+        compute_stream: torch.cuda.Stream | None,
     ) -> None:
         self._cfg = cfg
         self.device = cfg.resolved_device()
@@ -273,9 +274,9 @@ class MoondreamRuntime:
         if cfg.enable_prefix_cache:
             self.prefix_cache = RadixPrefixCache()
 
-        # Primary stream for all GPU operations. Created early because PageTable
-        # needs it for H2D copies that must synchronize with graph replay.
-        self._primary_stream = make_stream(self.device)
+        # Compute stream for model GPU work. The engine passes one shared
+        # stream when co-hosting multiple execution shapes.
+        self._compute_stream = compute_stream
 
         self.page_table = PageTable(
             n_pages=n_pages,
@@ -283,7 +284,7 @@ class MoondreamRuntime:
             max_batch_size=self.max_batch_slots,
             device=str(self.device),
             prefix_cache=self.prefix_cache,
-            h2d_stream=self._primary_stream,
+            h2d_stream=self._compute_stream,
         )
         self._kv_pool = kv_pool if kv_pool is not None else KVMemoryPool(
             device=self.device
@@ -547,7 +548,7 @@ class MoondreamRuntime:
                 hidden_dim=hidden_dim,
                 coord_dtype=coord_dtype,
                 size_dtype=size_dtype,
-                compute_stream=self._primary_stream,
+                compute_stream=self._compute_stream,
                 copy_stream=self._copy_stream,
             )
             for slot_id in range(2)
@@ -621,14 +622,14 @@ class MoondreamRuntime:
         return self.page_table.can_reserve_pages(total_length)
 
     @property
-    def copy_stream(self) -> torch.cuda.Stream:
-        """Shared copy stream for D2H transfers."""
-        return self._copy_stream
+    def compute_stream(self) -> torch.cuda.Stream | None:
+        """Compute stream used by engine-constructed runtime internals."""
+        return self._compute_stream
 
     @property
-    def primary_stream(self) -> torch.cuda.Stream:
-        """Primary compute stream for all GPU operations."""
-        return self._primary_stream
+    def copy_stream(self) -> torch.cuda.Stream | None:
+        """Shared copy stream for D2H transfers."""
+        return self._copy_stream
 
     @property
     def prefill_slots(self) -> list[PrefillSlot]:
@@ -1450,9 +1451,9 @@ class MoondreamRuntime:
         if batch_size > 1 and any(slot != 0 for slot in lora_slots):
             raise NotImplementedError("Batched prefill does not yet support LoRA slots")
 
-        # Keep all GPU work on the primary stream so all callers share identical
+        # Keep all GPU work on the compute stream so all callers share identical
         # ordering semantics.
-        with stream_context(self._primary_stream):
+        with stream_context(self._compute_stream):
             per_inputs: list[Tensor] = []
             per_positions: list[Tensor] = []
             use_prefix_attn: bool | None = None
@@ -1986,7 +1987,7 @@ class MoondreamRuntime:
 
         if is_new:
             try:
-                with stream_context(self._primary_stream):
+                with stream_context(self._compute_stream):
                     self._lora_workspace.load_slot_(slot, adapter)
             except Exception:
                 # Rollback on load failure

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -94,7 +94,6 @@ class AutoregressiveRuntime(Runtime, Protocol):
     image_prefix_length: int
 
     # Streams
-    primary_stream: Any
     copy_stream: Any
 
     # Slot containers + sequence registry
@@ -195,8 +194,8 @@ class SinglePassRuntime(Runtime, Protocol):
 
     No KV cache, no decode loop. The driver is pure compute: ``forward``
     enqueues the kernels for one forward and returns the result tensors
-    *without* a host sync, so the engine's single-pass executor can let
-    that work overlap autoregressive decode on the shared stream. The
+    *without* a host sync. The engine supplies the compute stream shared
+    with the autoregressive lane when it constructs the runtime. The
     executor owns the completion event, slot, and result delivery (the
     driver↔executor split mirrors the autoregressive path, where the
     model computes and the scheduler owns the pipeline).
@@ -206,13 +205,6 @@ class SinglePassRuntime(Runtime, Protocol):
     not call ``.item()`` / ``.cpu()`` / ``torch.cuda.synchronize`` before
     returning.
     """
-
-    # Stream the executor launches forwards on, so a single-pass forward
-    # and autoregressive decode share one ordered stream (the device's
-    # serialize-on-stream invariant). Declared here — not discovered via
-    # getattr — so a runtime that omits it fails loudly rather than
-    # silently running on the default stream with no interleaving.
-    primary_stream: Any
 
     # Capability names this runtime serves, e.g. ("segment_masks",). The
     # engine advertises these through ModelHandle.tasks / supports() and

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -218,10 +218,12 @@ class GenerationScheduler:
         self,
         runtime: AutoregressiveRuntime,
         *,
+        compute_stream: object,
         skill_registry: SkillRegistry,
         adapter_provider: Optional[AdapterProvider] = None,
     ) -> None:
         self.runtime = runtime
+        self._compute_stream = compute_stream
         self._adapter_provider = adapter_provider
         self.waiting: RequestQueue[GenerationRequest] = RequestQueue()
         self.running: RunningQueue[RequestLifecycle] = RunningQueue()
@@ -367,7 +369,7 @@ class GenerationScheduler:
         """
         progressed = False
         pipeline = self._pipeline
-        with stream_context(self.runtime.primary_stream):
+        with stream_context(self._compute_stream):
             has_launch = pipeline.has_launch_in_flight()
             has_queued = pipeline.queue_depth() > 0
 
@@ -587,7 +589,7 @@ class GenerationScheduler:
     def _finalize_prefill(self, handle: LaunchHandle) -> PendingCommit:
         """Sample first token + start D2H for a prefill.
 
-        IMPORTANT: Caller must already be on the primary stream.
+        IMPORTANT: Caller must already be on the compute stream.
         """
         if handle.kind != "prefill":
             raise AssertionError("prefill finalize requires a prefill handle")
@@ -780,7 +782,7 @@ class GenerationScheduler:
 
             lifecycle.sequence_state = prepared.state
             batch_idx = prepared.state.batch_idx
-            with stream_context(self.runtime.primary_stream):
+            with stream_context(self._compute_stream):
                 self._sampling_temps_by_batch[batch_idx] = request.temperature
                 self._sampling_top_ps_by_batch[batch_idx] = request.top_p
 
@@ -850,7 +852,7 @@ class GenerationScheduler:
                     )
                 lifecycle.prefill_completed_at = time.perf_counter()
                 # Ensure prefill forward completes before cache finalize + release.
-                with stream_context(self.runtime.primary_stream):
+                with stream_context(self._compute_stream):
                     prefill_slot.commit_done_event.record()
                 prefill_slot.commit_done_event.synchronize()
                 self.runtime.finalize_prepared_sequence_after_prefill(prepared_seq)
@@ -1098,7 +1100,7 @@ class GenerationScheduler:
         if handle.kind == "prefill":
             if plan is not None:
                 raise AssertionError("Prefill finalize does not support masks")
-            with stream_context(self.runtime.primary_stream):
+            with stream_context(self._compute_stream):
                 return self._finalize_prefill(handle)
         raise AssertionError(f"Unsupported handle kind {handle.kind!r}")
 

--- a/scripts/profile_decode.py
+++ b/scripts/profile_decode.py
@@ -258,6 +258,7 @@ def main():
     patch_lm_head_with_nvtx()
 
     from kestrel.config import RuntimeConfig
+    from kestrel.device import make_stream
     from kestrel.models.moondream.runtime import MoondreamRuntime, SequenceState, TextToken
 
     device = torch.device("cuda")
@@ -273,7 +274,7 @@ def main():
     )
 
     print(f"Loading model from {args.weights}...")
-    runtime = MoondreamRuntime(runtime_cfg)
+    runtime = MoondreamRuntime(runtime_cfg, compute_stream=make_stream(device))
     config = runtime.config.text
     moe_desc = (
         f"MoE starts at layer {config.moe.start_layer}" if config.moe is not None else "no MoE"

--- a/scripts/profile_vision_encoder.py
+++ b/scripts/profile_vision_encoder.py
@@ -250,6 +250,7 @@ def main() -> None:
     patch_vision_encoder_with_nvtx(detailed=not args.compact)
 
     from kestrel.config import RuntimeConfig
+    from kestrel.device import make_stream
     from kestrel.models.moondream.runtime import MoondreamRuntime
     from kestrel.models.moondream import vision as vision_module
 
@@ -262,7 +263,7 @@ def main() -> None:
     )
 
     print(f"Loading model from {args.weights}...")
-    runtime = MoondreamRuntime(runtime_cfg)
+    runtime = MoondreamRuntime(runtime_cfg, compute_stream=make_stream(device))
     vision_cfg = runtime.config.vision
     vision_model = runtime.model.vision
     print(

--- a/tests/moondream/test_runtime_prefill.py
+++ b/tests/moondream/test_runtime_prefill.py
@@ -37,7 +37,7 @@ def _make_runtime(seq_lens: dict[int, int]) -> tuple[runtime_mod.MoondreamRuntim
     runtime.device = torch.device("cpu")
     runtime.dtype = torch.float32
     runtime.bos_embed = torch.empty(1, 4)
-    runtime._primary_stream = None
+    runtime._compute_stream = None
     runtime.page_table = _FakePageTable()
 
     def build_inputs(prepared, *, image, image_crops):

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -80,6 +80,7 @@ class _FakeDecodeSlot:
 
     def __init__(self, *, slot_id: int) -> None:
         self.slot_id = slot_id
+        self.compute_stream = None
         self.step_done_event = NoopEvent()
         self.commit_done_event = NoopEvent()
 
@@ -117,7 +118,7 @@ class FakeRuntime:
         self.device: torch.device = (
             torch.device(device) if isinstance(device, str) else device
         )
-        self.primary_stream: Any = None
+        self.compute_stream: Any = None
         self.copy_stream: Any = None
 
         # Slot containers + sequence registry. The scheduler treats these

--- a/tests/test_engine_runtime_injection.py
+++ b/tests/test_engine_runtime_injection.py
@@ -28,8 +28,11 @@ def test_engine_holds_injected_runtime() -> None:
     without having to ``await create``."""
 
     runtime = FakeRuntime(model_name="injected", device="cpu")
+    stream = object()
+    runtime.compute_stream = stream
     engine = InferenceEngine(_cpu_cfg(), runtime=runtime)
     assert engine.runtime is runtime
+    assert engine._compute_stream is stream
 
 
 def test_engine_rejects_runtime_with_mismatched_device() -> None:

--- a/tests/test_multi_model.py
+++ b/tests/test_multi_model.py
@@ -33,7 +33,6 @@ class _SPStub:
         self.model_name = model_name
         self.device = torch.device("cpu")
         self.execution_shape = ExecutionShape.SINGLE_PASS
-        self.primary_stream = None
 
     def tasks(self) -> tuple[str, ...]:
         return ("segment",)
@@ -93,6 +92,7 @@ def test_build_configured_runtimes_builds_all_from_specs() -> None:
         eng._default_model = "mm-ar"
         eng._model_ids = ["mm-ar", "mm-sp"]
         eng._runtimes = {}
+        eng._compute_stream = None
 
         eng._build_configured_runtimes(13)
 
@@ -101,10 +101,11 @@ def test_build_configured_runtimes_builds_all_from_specs() -> None:
         assert eng._runtimes["mm-sp"].execution_shape is ExecutionShape.SINGLE_PASS
         # Each runtime is built with a per-model config carrying its own id.
         assert eng._runtimes["mm-sp"].model_name == "mm-sp"
-        # max_lora_rank → default AR only; the single-pass factory is called
-        # without it (single-pass factories don't accept it).
-        assert built_kwargs["mm-ar"] == {"max_lora_rank": 13}
-        assert built_kwargs["mm-sp"] == {}
+        # max_lora_rank → default AR only; compute_stream is supplied to
+        # every runtime factory so both execution shapes share the engine
+        # stream. CPU tests use None for that stream.
+        assert built_kwargs["mm-ar"] == {"max_lora_rank": 13, "compute_stream": None}
+        assert built_kwargs["mm-sp"] == {"compute_stream": None}
     finally:
         _REGISTRY.pop("mm-ar", None)
         _REGISTRY.pop("mm-sp", None)
@@ -126,6 +127,7 @@ def test_build_configured_runtimes_skips_already_built() -> None:
         eng._model_ids = ["preexisting", "mm-sp2"]
         injected = _SPStub("preexisting")
         eng._runtimes = {"preexisting": injected}
+        eng._compute_stream = None
 
         eng._build_configured_runtimes(None)
 

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -30,7 +30,6 @@ class _StubSinglePass:
         self.model_name = model_name
         self.device = torch.device("cpu")
         self.execution_shape = ExecutionShape.SINGLE_PASS
-        self.primary_stream = None
         self.calls: list[tuple[str, Any]] = []
 
     def forward(self, task: str, inputs: Any) -> Any:
@@ -62,6 +61,7 @@ def _engine_with(ar: FakeRuntime, sp: _StubSinglePass) -> InferenceEngine:
     engine._adapter_provider = None
     engine._default_temperature = 0.2
     engine._default_top_p = 0.9
+    engine._compute_stream = None
     engine._skills_override = None
     engine._request_ids = iter(range(1, 1_000_000))
     return engine

--- a/tests/test_single_pass_executor.py
+++ b/tests/test_single_pass_executor.py
@@ -29,7 +29,6 @@ class _StubDriver:
         # reports done immediately, so collect() fires on the next tick.
         self.device = torch.device("cpu")
         self.execution_shape = ExecutionShape.SINGLE_PASS
-        self.primary_stream = None
         self.calls: list[tuple[str, Any]] = []
 
     def forward(self, task: str, inputs: Any) -> Any:
@@ -58,7 +57,7 @@ def _req(request_id: int, task: str, inputs: Any) -> _SinglePassRequest:
 
 
 def test_forward_result_becomes_completion() -> None:
-    ex = SinglePassExecutor(_StubDriver())
+    ex = SinglePassExecutor(_StubDriver(), compute_stream=None)
     ex.submit(_req(1, "segment", {"points": [[1, 2]]}))
 
     tick = ex.advance()  # launch + collect (NoopEvent done immediately)
@@ -73,7 +72,7 @@ def test_forward_result_becomes_completion() -> None:
 
 
 def test_forward_error_becomes_error_completion() -> None:
-    ex = SinglePassExecutor(_StubDriver())
+    ex = SinglePassExecutor(_StubDriver(), compute_stream=None)
     ex.submit(_req(2, "boom", {}))
 
     tick = ex.advance()
@@ -87,7 +86,7 @@ def test_forward_error_becomes_error_completion() -> None:
 def test_one_in_flight_at_a_time() -> None:
     """Default max_in_flight=1: a second job waits until the first frees."""
     driver = _StubDriver()
-    ex = SinglePassExecutor(driver, max_in_flight=1)
+    ex = SinglePassExecutor(driver, compute_stream=None, max_in_flight=1)
     ex.submit(_req(3, "a", 1))
     ex.submit(_req(4, "b", 2))
 
@@ -103,7 +102,7 @@ def test_one_in_flight_at_a_time() -> None:
 
 
 def test_idle_executor_reports_no_work() -> None:
-    ex = SinglePassExecutor(_StubDriver())
+    ex = SinglePassExecutor(_StubDriver(), compute_stream=None)
     tick = ex.advance()
     assert tick.completed == ()
     assert tick.has_work is False
@@ -135,7 +134,7 @@ def test_forward_stays_in_flight_until_event_fires(monkeypatch) -> None:
     event = _PendingEvent(not_done_polls=2)
     monkeypatch.setattr(single_pass_mod, "make_event", lambda device: event)
 
-    ex = SinglePassExecutor(_StubDriver())
+    ex = SinglePassExecutor(_StubDriver(), compute_stream=None)
     ex.submit(_req(7, "segment", {"k": "v"}))
 
     # Tick 1: forward launched, but the event reports not-done — nothing
@@ -160,7 +159,7 @@ def test_forward_stays_in_flight_until_event_fires(monkeypatch) -> None:
 
 def test_shutdown_fails_queued_and_in_flight() -> None:
     driver = _StubDriver()
-    ex = SinglePassExecutor(driver, max_in_flight=1)
+    ex = SinglePassExecutor(driver, compute_stream=None, max_in_flight=1)
     ex.submit(_req(5, "a", 1))
     ex.submit(_req(6, "b", 2))
     # Launch job 5 into the in-flight slot without collecting it: a real


### PR DESCRIPTION
## Summary
- Move the shared compute stream to `InferenceEngine` and pass it through executor/scheduler constructors.
- Require `compute_stream=` along the engine/executor/scheduler/runtime construction path while still allowing the value to be `None` on CPU/MPS.
- Remove `primary_stream` from runtime protocols and update Moondream/PageTable/decode-slot wiring to use the injected stream.

## Validation
- `python -m py_compile kestrel/runtime/protocol.py kestrel/engine/core.py kestrel/engine/executor.py kestrel/engine/single_pass.py kestrel/scheduler/scheduler.py kestrel/models/moondream/runtime.py kestrel/models/moondream/decode_slot.py scripts/profile_decode.py scripts/profile_vision_encoder.py tests/test_engine_runtime_injection.py tests/test_single_pass_engine.py tests/test_single_pass_executor.py tests/test_multi_model.py tests/scheduler/_fake_runtime.py`
- `git diff --check`
- On `belka`: `PYTHONPATH=. ~/code/kestrel/.venv/bin/python -m pytest tests/test_single_pass_executor.py tests/test_single_pass_engine.py tests/test_multi_model.py tests/test_engine_runtime_injection.py tests/moondream/test_runtime_prefill.py tests/scheduler/test_runtime_conformance.py tests/test_autoregressive_executor.py tests/scheduler/test_launch_prefill_step.py tests/scheduler/test_release_sequence.py tests/scheduler/test_pipeline.py -q` (`84 passed`)