### PR TITLE
Add runtime vocab size contract

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1493,7 +1493,7 @@ class InferenceEngine:
         if not suppress:
             return
 
-        vocab_size = int(runtime.config.text.vocab_size)
+        vocab_size = int(runtime.vocab_size)
         for token_id in suppress:
             if token_id >= vocab_size:
                 raise ValueError(

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -622,6 +622,10 @@ class MoondreamRuntime:
         return self.page_table.can_reserve_pages(total_length)
 
     @property
+    def vocab_size(self) -> int:
+        return int(self.config.text.vocab_size)
+
+    @property
     def compute_stream(self) -> torch.cuda.Stream | None:
         """Compute stream used by engine-constructed runtime internals."""
         return self._compute_stream

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -92,6 +92,7 @@ class AutoregressiveRuntime(Runtime, Protocol):
     max_batch_slots: int
     max_seq_length: int
     image_prefix_length: int
+    vocab_size: int
 
     # Streams
     copy_stream: Any

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -96,6 +96,7 @@ class FakeRuntime:
         max_batch_slots: int = 2,
         max_seq_length: int = 1024,
         image_prefix_length: int = 0,
+        vocab_size: int = 1024,
         device: torch.device | str = "cpu",
         page_size: int = 1,
         n_prefill_slots: int | None = None,
@@ -113,6 +114,7 @@ class FakeRuntime:
         self.max_batch_slots = max_batch_slots
         self.max_seq_length = max_seq_length
         self.image_prefix_length = image_prefix_length
+        self.vocab_size = vocab_size
 
         # Device + streams
         self.device: torch.device = (

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -402,9 +402,7 @@ def test_extract_private_suppress_next_token_ids_setting() -> None:
 
 def test_validate_suppress_next_token_ids_rejects_bad_request_scope() -> None:
     engine = object.__new__(InferenceEngine)
-    runtime = SimpleNamespace(
-        config=SimpleNamespace(text=SimpleNamespace(vocab_size=4))
-    )
+    runtime = SimpleNamespace(vocab_size=4)
 
     def skill_state(
         *,


### PR DESCRIPTION
## Summary

Adds a model-agnostic `vocab_size` surface to autoregressive runtimes and updates request-level token suppression validation to use it instead of reading a Moondream-shaped `runtime.config.text.vocab_size`.

## Why

Gemma keeps its native config shape under `text_config`, so public engine validation should not require private runtimes to add compatibility aliases for Moondream config layout.

## Validation

- `pytest tests/test_engine.py::test_validate_suppress_next_token_ids_rejects_bad_request_scope -q`
- Private Gemma focused runtime tests on `belka`: `3 passed, 2 deselected`
- Private Gemma full cached engine generation on `belka`: answer `2 + 2 = **4**`