### PR TITLE
Add streaming runtime protocol

### DIFF
--- a/kestrel/runtime/__init__.py
+++ b/kestrel/runtime/__init__.py
@@ -12,6 +12,7 @@ from kestrel.runtime.protocol import (
     ExecutionShape,
     Runtime,
     SinglePassRuntime,
+    StreamingRuntime,
 )
 from kestrel.runtime.state import (
     PrefillClassification,
@@ -37,6 +38,7 @@ __all__ = [
     "SequenceState",
     "SinglePassRuntime",
     "SizeToken",
+    "StreamingRuntime",
     "TextToken",
     "Token",
 ]

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -13,6 +13,8 @@ kernel:
   consumes; ``MoondreamRuntime`` implements it.
 - :class:`SinglePassRuntime` — runtimes that fulfill a request with one
   forward (no decode loop).
+- :class:`StreamingRuntime` — runtimes that keep model-owned session
+  state across caller-supplied chunks (for example video frames).
 
 Some attributes are typed as ``Any`` because they expose model-specific
 state the engine + scheduler currently reach into directly (config,
@@ -50,7 +52,7 @@ class ExecutionShape(Enum):
 
     AUTOREGRESSIVE = "autoregressive"
     SINGLE_PASS = "single_pass"
-    # STREAMING = "streaming"  # video / memory-bank models, later
+    STREAMING = "streaming"
 
 
 class Runtime(Protocol):
@@ -217,3 +219,41 @@ class SinglePassRuntime(Runtime, Protocol):
     ) -> Future[Any]: ...
 
     def forward(self, task: str, inputs: Any) -> Any: ...
+
+
+class StreamingRuntime(Runtime, Protocol):
+    """Runtime that advances model-owned state over caller-supplied chunks.
+
+    Streaming runtimes are for non-token models whose state spans a
+    sequence of inputs, such as a video tracker that receives an initial
+    prompt and then one frame at a time. The runtime owns the semantic
+    session state; the engine/executor owns ordering, backpressure,
+    completion events, stream updates, and result delivery.
+
+    Like :class:`SinglePassRuntime`, compute methods must enqueue work and
+    return without a host sync so the executor can interleave steps with
+    other lanes. Implementations must not call ``.item()`` / ``.cpu()`` /
+    ``torch.cuda.synchronize`` before returning from ``start`` or
+    ``step``.
+    """
+
+    # Stream the executor launches session steps on, so streaming steps
+    # share the device's serialize-on-stream invariant with the other
+    # engine lanes.
+    primary_stream: Any
+
+    # Capability names this runtime serves, e.g. ("point",).
+    def tasks(self) -> Sequence[str]: ...
+
+    # Create the model-owned session state from the initial prompt. This
+    # may enqueue initial GPU work, so it follows the same no-host-sync
+    # rule as ``step``.
+    def start(self, task: str, inputs: Any) -> Any: ...
+
+    # Advance an existing session with one caller-supplied chunk/frame and
+    # return model-defined output plus the next session state.
+    def step(self, session: Any, inputs: Any) -> Any: ...
+
+    # Release model-owned session resources. Called once when the engine
+    # closes, cancels, or fails the session.
+    def finish(self, session: Any) -> None: ...

--- a/tests/test_streaming_runtime_protocol.py
+++ b/tests/test_streaming_runtime_protocol.py
@@ -1,0 +1,44 @@
+"""Streaming runtime protocol shape."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kestrel.runtime import ExecutionShape, StreamingRuntime
+
+
+class _StreamingStub:
+    model_name = "streaming-stub"
+    device = None
+    execution_shape = ExecutionShape.STREAMING
+    primary_stream = object()
+
+    def tasks(self) -> tuple[str, ...]:
+        return ("point",)
+
+    def start(self, task: str, inputs: Any) -> dict[str, Any]:
+        return {"task": task, "inputs": inputs}
+
+    def step(self, session: Any, inputs: Any) -> tuple[Any, Any]:
+        return session, inputs
+
+    def finish(self, session: Any) -> None:
+        self.finished = session
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+def test_streaming_execution_shape_is_public() -> None:
+    assert ExecutionShape.STREAMING.value == "streaming"
+
+
+def test_streaming_runtime_protocol_is_exported() -> None:
+    runtime: StreamingRuntime = _StreamingStub()
+    session = runtime.start("point", {"points": [[0.5, 0.5]]})
+    output = runtime.step(session, {"frame": object()})
+    runtime.finish(session)
+
+    assert runtime.execution_shape is ExecutionShape.STREAMING
+    assert runtime.tasks() == ("point",)
+    assert output[0] == session


### PR DESCRIPTION
## Summary
- Adds `ExecutionShape.STREAMING` as the third internal execution shape.
- Defines and exports the generic `StreamingRuntime` protocol for stateful chunk/frame-driven runtimes.
- Adds a focused protocol/export test.

## Validation
- `uv run pytest tests/test_streaming_runtime_protocol.py -q`
- `git diff --check`
- `git diff --cached --check`