### PR TITLE
Add model stream session surface

### DIFF
--- a/kestrel/engine/__init__.py
+++ b/kestrel/engine/__init__.py
@@ -9,6 +9,8 @@ from kestrel.engine._types import (
     EngineMetrics,
     EngineResult,
     EngineStream,
+    ModelStream,
+    ModelStreamUpdate,
     TickResult,
 )
 from kestrel.engine.executor import (
@@ -26,6 +28,8 @@ __all__ = [
     "EngineResult",
     "EngineMetrics",
     "EngineStream",
+    "ModelStream",
+    "ModelStreamUpdate",
     "Executor",
     "AutoregressiveExecutor",
     "SinglePassExecutor",

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -154,6 +154,7 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
         "_error",
         "_closed",
         "_closing",
+        "_close_lock",
     )
 
     def __init__(
@@ -176,6 +177,7 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
         self._error: Optional[BaseException] = None
         self._closed = False
         self._closing = False
+        self._close_lock = asyncio.Lock()
 
     async def send(self, **chunk: Any) -> None:
         """Append one model-defined chunk/frame to the session."""
@@ -229,16 +231,18 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
     async def _request_close(self) -> None:
         if self._closed:
             return
-        if self._closing:
-            return
-        self._closing = True
-        try:
-            await self._close_session(self.session_id)
-            self._closed = True
-        except BaseException:
-            self._closing = False
-            raise
-        self._closing = False
+        async with self._close_lock:
+            if self._closed:
+                return
+            self._closing = True
+            try:
+                await self._close_session(self.session_id)
+            except BaseException:
+                raise
+            else:
+                self._closed = True
+            finally:
+                self._closing = False
 
 
 @dataclass(slots=True)

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -12,7 +12,18 @@ import asyncio
 import hashlib
 from concurrent.futures import Future
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, List, Optional, Protocol, Sequence, Union
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    Union,
+)
 
 import numpy as np
 
@@ -103,6 +114,120 @@ class EngineStream(AsyncIterator[StreamUpdate]):
 
 
 @dataclass(slots=True)
+class ModelStreamUpdate:
+    """One model-defined update from a stateful streaming session."""
+
+    session_id: int
+    task: str
+    output: Dict[str, object]
+
+
+@dataclass(slots=True)
+class _ModelStreamCompletion:
+    result: Optional[EngineResult] = None
+    error: Optional[BaseException] = None
+
+
+_ModelStreamQueueItem = Union[ModelStreamUpdate, _ModelStreamCompletion]
+_ModelStreamQueue = asyncio.Queue[_ModelStreamQueueItem]
+_SendModelStreamChunk = Callable[[int, Dict[str, Any]], Awaitable[None]]
+_CloseModelStream = Callable[[int], Awaitable[None]]
+
+
+class ModelStream(AsyncIterator[ModelStreamUpdate]):
+    """Asynchronous session for stateful model streaming.
+
+    Unlike :class:`EngineStream`, which streams token deltas for one
+    autoregressive request, ``ModelStream`` is caller-driven: the caller
+    sends chunks/frames into a model-owned session and iterates over
+    model-defined updates.
+    """
+
+    __slots__ = (
+        "session_id",
+        "task",
+        "_queue",
+        "_result_future",
+        "_send_chunk",
+        "_close_session",
+        "_final_result",
+        "_error",
+        "_closed",
+    )
+
+    def __init__(
+        self,
+        *,
+        session_id: int,
+        task: str,
+        queue: _ModelStreamQueue,
+        result_future: asyncio.Future[EngineResult],
+        send_chunk: _SendModelStreamChunk,
+        close_session: _CloseModelStream,
+    ) -> None:
+        self.session_id = session_id
+        self.task = task
+        self._queue = queue
+        self._result_future = result_future
+        self._send_chunk = send_chunk
+        self._close_session = close_session
+        self._final_result: Optional[EngineResult] = None
+        self._error: Optional[BaseException] = None
+        self._closed = False
+
+    async def send(self, **chunk: Any) -> None:
+        """Append one model-defined chunk/frame to the session."""
+        if self._closed:
+            raise RuntimeError("model stream is closed")
+        await self._send_chunk(self.session_id, dict(chunk))
+
+    def updates(self) -> "ModelStream":
+        """Return the async update iterator."""
+        return self
+
+    def __aiter__(self) -> "ModelStream":
+        return self
+
+    async def __anext__(self) -> ModelStreamUpdate:
+        while True:
+            item = await self._queue.get()
+            if isinstance(item, _ModelStreamCompletion):
+                if item.error is not None:
+                    self._error = item.error
+                    raise item.error
+                if item.result is not None:
+                    self._final_result = item.result
+                raise StopAsyncIteration
+            return item
+
+    async def close(self) -> EngineResult:
+        """Close the session and return its final result."""
+        if not self._closed:
+            self._closed = True
+            await self._close_session(self.session_id)
+        return await self.result()
+
+    async def result(self) -> EngineResult:
+        if self._final_result is not None:
+            return self._final_result
+        if self._error is not None:
+            raise self._error
+        result = await self._result_future
+        self._final_result = result
+        return result
+
+    async def __aenter__(self) -> "ModelStream":
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        if exc_type is None:
+            await self.close()
+        elif not self._closed:
+            self._closed = True
+            await self._close_session(self.session_id)
+
+
+@dataclass(slots=True)
 class _AutoregressiveRequest:
     request_id: int
     prompt: str
@@ -185,5 +310,4 @@ class TickResult:
     progressed: bool = False
     completed: tuple[Completion, ...] = ()
     has_work: bool = False  # queued or in flight (gates shutdown exit)
-
 

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -192,6 +192,7 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
         while True:
             item = await self._queue.get()
             if isinstance(item, _ModelStreamCompletion):
+                self._closed = True
                 if item.error is not None:
                     self._error = item.error
                     raise item.error
@@ -310,4 +311,3 @@ class TickResult:
     progressed: bool = False
     completed: tuple[Completion, ...] = ()
     has_work: bool = False  # queued or in flight (gates shutdown exit)
-

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -153,6 +153,7 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
         "_final_result",
         "_error",
         "_closed",
+        "_closing",
     )
 
     def __init__(
@@ -174,10 +175,11 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
         self._final_result: Optional[EngineResult] = None
         self._error: Optional[BaseException] = None
         self._closed = False
+        self._closing = False
 
     async def send(self, **chunk: Any) -> None:
         """Append one model-defined chunk/frame to the session."""
-        if self._closed:
+        if self._closed or self._closing:
             raise RuntimeError("model stream is closed")
         await self._send_chunk(self.session_id, dict(chunk))
 
@@ -203,9 +205,7 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
 
     async def close(self) -> EngineResult:
         """Close the session and return its final result."""
-        if not self._closed:
-            await self._close_session(self.session_id)
-            self._closed = True
+        await self._request_close()
         return await self.result()
 
     async def result(self) -> EngineResult:
@@ -223,9 +223,22 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
     async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
         if exc_type is None:
             await self.close()
-        elif not self._closed:
+        else:
+            await self._request_close()
+
+    async def _request_close(self) -> None:
+        if self._closed:
+            return
+        if self._closing:
+            return
+        self._closing = True
+        try:
             await self._close_session(self.session_id)
             self._closed = True
+        except BaseException:
+            self._closing = False
+            raise
+        self._closing = False
 
 
 @dataclass(slots=True)

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -204,8 +204,8 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
     async def close(self) -> EngineResult:
         """Close the session and return its final result."""
         if not self._closed:
-            self._closed = True
             await self._close_session(self.session_id)
+            self._closed = True
         return await self.result()
 
     async def result(self) -> EngineResult:
@@ -224,8 +224,8 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
         if exc_type is None:
             await self.close()
         elif not self._closed:
-            self._closed = True
             await self._close_session(self.session_id)
+            self._closed = True
 
 
 @dataclass(slots=True)

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -85,6 +85,7 @@ from kestrel.engine._types import (
     EngineRequest,
     EngineResult,
     EngineStream,
+    ModelStream,
     _AutoregressiveRequest,
     _StreamCompletion,
     _StreamQueue,
@@ -812,6 +813,44 @@ class InferenceEngine:
         self._scheduler_event.set()
         return await future
 
+    async def stream(
+        self,
+        model: str,
+        task: str,
+        initial_inputs: Mapping[str, object],
+    ) -> ModelStream:
+        """Start a stateful streaming ``task`` on ``model``.
+
+        This is distinct from autoregressive response streaming: the
+        caller supplies chunks/frames after the initial prompt, and a
+        streaming runtime carries model-owned state across those chunks.
+        Kernel/executor wiring lands in the streaming executor branch; the
+        validation here pins the public shape without changing existing
+        AR or single-pass behavior.
+        """
+        if self._shutdown:
+            raise RuntimeError("InferenceEngine is shut down")
+        await self._ensure_started()
+
+        runtime = self._runtimes.get(model)
+        if runtime is None:
+            raise ValueError(f"Unknown model {model!r}")
+        if runtime.execution_shape is not ExecutionShape.STREAMING:
+            raise ValueError(
+                f"Model {model!r} is not a streaming model "
+                f"(execution_shape={runtime.execution_shape.value})"
+            )
+        if task not in tuple(runtime.tasks()):
+            supported = ", ".join(tuple(runtime.tasks())) or "none"
+            raise ValueError(
+                f"Model {model!r} does not support {task!r} "
+                f"(supports: {supported})"
+            )
+
+        raise NotImplementedError(
+            "stateful streaming sessions require the streaming executor"
+        )
+
     def model(self, model_id: Optional[str] = None) -> "ModelHandle":
         """Return a :class:`ModelHandle` bound to ``model_id``.
 
@@ -847,7 +886,7 @@ class InferenceEngine:
         runtime's skills, or the spec's). This keeps reported capabilities
         consistent with execution, works before startup, and does not
         require ``tasks()`` on the autoregressive runtime protocol. Every
-        other (single-pass) model advertises its own ``runtime.tasks()``
+        other non-autoregressive model advertises its own ``runtime.tasks()``
         once built.
         """
         if model_id == self._default_model:

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -102,7 +102,7 @@ class ModelHandle:
             )
         return await self._engine.run(self._model, task, inputs)
 
-    async def stream(self, task: str, **initial_prompt: Any) -> "ModelStream":
+    async def stream(self, task: str, /, **initial_prompt: Any) -> "ModelStream":
         """Start a stateful streaming session on this model.
 
         This is the generic escape hatch for execution shapes where the

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -139,7 +139,7 @@ class ModelHandle:
         self,
         task: str,
         prompt: dict[str, Any],
-    ) -> "EngineResult | EngineStream":
+    ) -> "EngineResult | EngineStream | ModelStream":
         """Route one capability call by the bound model's execution shape.
 
         A single-pass model interprets the whole prompt in its forward pass
@@ -160,6 +160,8 @@ class ModelHandle:
             runtime.execution_shape is ExecutionShape.SINGLE_PASS
         ):
             return await self.run(task, prompt)
+        if runtime is not None and runtime.execution_shape is ExecutionShape.STREAMING:
+            return await self.stream(task, **prompt)
         self._require_default_ar(task)
         settings = prompt.pop("settings", None)
         stream = bool(prompt.get("stream", False))
@@ -168,19 +170,29 @@ class ModelHandle:
             task, image=image, prompt=prompt, settings=settings, stream=stream
         )
 
-    async def query(self, **prompt: Any) -> "EngineResult | EngineStream":
+    async def query(
+        self, **prompt: Any
+    ) -> "EngineResult | EngineStream | ModelStream":
         return await self._capability("query", prompt)
 
-    async def caption(self, **prompt: Any) -> "EngineResult | EngineStream":
+    async def caption(
+        self, **prompt: Any
+    ) -> "EngineResult | EngineStream | ModelStream":
         return await self._capability("caption", prompt)
 
-    async def detect(self, **prompt: Any) -> "EngineResult | EngineStream":
+    async def detect(
+        self, **prompt: Any
+    ) -> "EngineResult | EngineStream | ModelStream":
         return await self._capability("detect", prompt)
 
-    async def point(self, **prompt: Any) -> "EngineResult | EngineStream":
+    async def point(
+        self, **prompt: Any
+    ) -> "EngineResult | EngineStream | ModelStream":
         return await self._capability("point", prompt)
 
-    async def segment(self, **prompt: Any) -> "EngineResult | EngineStream":
+    async def segment(
+        self, **prompt: Any
+    ) -> "EngineResult | EngineStream | ModelStream":
         return await self._capability("segment", prompt)
 
     def __repr__(self) -> str:

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -25,7 +25,7 @@ from kestrel.runtime import ExecutionShape
 
 if TYPE_CHECKING:
     from kestrel.engine.core import InferenceEngine
-    from kestrel.engine._types import EngineResult, EngineStream
+    from kestrel.engine._types import EngineResult, EngineStream, ModelStream
 
 
 class ModelHandle:
@@ -101,6 +101,27 @@ class ModelHandle:
                 f"{runtime.execution_shape.value} — use its typed verbs."
             )
         return await self._engine.run(self._model, task, inputs)
+
+    async def stream(self, task: str, **initial_prompt: Any) -> "ModelStream":
+        """Start a stateful streaming session on this model.
+
+        This is the generic escape hatch for execution shapes where the
+        caller drives model state forward with chunks/frames. It is
+        separate from autoregressive token streaming, which remains a
+        per-request delivery mode selected by capability prompts such as
+        ``stream=True``.
+        """
+        await self._engine._ensure_started()
+        self._require(task)
+        runtime = self._engine._runtimes.get(self._model)
+        if runtime is None:
+            raise ValueError(f"Unknown model {self._model!r}")
+        if runtime.execution_shape is not ExecutionShape.STREAMING:
+            raise ValueError(
+                f"stream() is for streaming models; {self._model!r} is "
+                f"{runtime.execution_shape.value}"
+            )
+        return await self._engine.stream(self._model, task, initial_prompt)
 
     # -- capability vocabulary ----------------------------------------
     #

--- a/kestrel/runtime/__init__.py
+++ b/kestrel/runtime/__init__.py
@@ -12,6 +12,7 @@ from kestrel.runtime.protocol import (
     ExecutionShape,
     Runtime,
     SinglePassRuntime,
+    StreamingRuntime,
 )
 from kestrel.runtime.state import (
     PrefillClassification,
@@ -37,6 +38,7 @@ __all__ = [
     "SequenceState",
     "SinglePassRuntime",
     "SizeToken",
+    "StreamingRuntime",
     "TextToken",
     "Token",
 ]

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -13,6 +13,8 @@ kernel:
   consumes; ``MoondreamRuntime`` implements it.
 - :class:`SinglePassRuntime` — runtimes that fulfill a request with one
   forward (no decode loop).
+- :class:`StreamingRuntime` — runtimes that keep model-owned session
+  state across caller-supplied chunks (for example video frames).
 
 Some attributes are typed as ``Any`` because they expose model-specific
 state the engine + scheduler currently reach into directly (config,
@@ -50,7 +52,7 @@ class ExecutionShape(Enum):
 
     AUTOREGRESSIVE = "autoregressive"
     SINGLE_PASS = "single_pass"
-    # STREAMING = "streaming"  # video / memory-bank models, later
+    STREAMING = "streaming"
 
 
 class Runtime(Protocol):
@@ -217,3 +219,41 @@ class SinglePassRuntime(Runtime, Protocol):
     ) -> Future[Any]: ...
 
     def forward(self, task: str, inputs: Any) -> Any: ...
+
+
+class StreamingRuntime(Runtime, Protocol):
+    """Runtime that advances model-owned state over caller-supplied chunks.
+
+    Streaming runtimes are for non-token models whose state spans a
+    sequence of inputs, such as a video tracker that receives an initial
+    prompt and then one frame at a time. The runtime owns the semantic
+    session state; the engine/executor owns ordering, backpressure,
+    completion events, stream updates, and result delivery.
+
+    Like :class:`SinglePassRuntime`, compute methods must enqueue work and
+    return without a host sync so the executor can interleave steps with
+    other lanes. Implementations must not call ``.item()`` / ``.cpu()`` /
+    ``torch.cuda.synchronize`` before returning from ``start`` or
+    ``step``.
+    """
+
+    # Stream the executor launches session steps on, so streaming steps
+    # share the device's serialize-on-stream invariant with the other
+    # engine lanes.
+    primary_stream: Any
+
+    # Capability names this runtime serves, e.g. ("point",).
+    def tasks(self) -> Sequence[str]: ...
+
+    # Create the model-owned session state from the initial prompt. This
+    # may enqueue initial GPU work, so it follows the same no-host-sync
+    # rule as ``step``.
+    def start(self, task: str, inputs: Any) -> Any: ...
+
+    # Advance an existing session with one caller-supplied chunk/frame and
+    # return model-defined output plus the next session state.
+    def step(self, session: Any, inputs: Any) -> Any: ...
+
+    # Release model-owned session resources. Called once when the engine
+    # closes, cancels, or fails the session.
+    def finish(self, session: Any) -> None: ...

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -226,6 +226,15 @@ def test_capability_verbs_are_uniform_kwargs() -> None:
         )
 
 
+def test_stream_selector_is_positional_only() -> None:
+    import inspect
+
+    params = list(inspect.signature(ModelHandle.stream).parameters.values())
+    assert [p.name for p in params] == ["self", "task", "initial_prompt"]
+    assert params[1].kind is inspect.Parameter.POSITIONAL_ONLY
+    assert params[2].kind is inspect.Parameter.VAR_KEYWORD
+
+
 def test_capability_dispatches_to_run_for_single_pass() -> None:
     """A single-pass model interprets the whole prompt in its forward pass:
     the handle forwards it verbatim (media payload included) to run()."""
@@ -404,6 +413,46 @@ def test_streaming_prompt_can_include_task_field() -> None:
         "task": "point",
         "inputs": {"task": "seed", "points": [[0.25, 0.75]]},
     }
+
+
+def test_streaming_capability_preserves_ar_reserved_prompt_keys() -> None:
+    eng = _engine()
+    eng._runtimes["tracker"] = _StubStreaming("tracker", ("point",))
+    captured: dict[str, Any] = {}
+
+    async def fake_stream(model: str, task: str, inputs: Any) -> str:
+        captured.update(model=model, task=task, inputs=inputs)
+        return "STREAM"
+
+    eng.stream = fake_stream  # type: ignore[method-assign]
+    out = asyncio.run(
+        eng.model("tracker").point(
+            image="frame0",
+            settings={"temperature": 0.0},
+            stream=True,
+            model="payload-model",
+        )
+    )
+
+    assert out == "STREAM"
+    assert captured == {
+        "model": "tracker",
+        "task": "point",
+        "inputs": {
+            "image": "frame0",
+            "settings": {"temperature": 0.0},
+            "stream": True,
+            "model": "payload-model",
+        },
+    }
+
+
+def test_unsupported_streaming_capability_rejects_before_ar_path() -> None:
+    eng = _engine()
+    eng._runtimes["tracker"] = _StubStreaming("tracker", ("point",))
+
+    with pytest.raises(ValueError, match="does not support 'detect'"):
+        asyncio.run(eng.model("tracker").detect(points=[[0.5, 0.5]]))
 
 
 def test_stream_rejects_non_streaming_model() -> None:

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -377,6 +377,35 @@ def test_capability_dispatches_to_stream_for_streaming_model() -> None:
     }
 
 
+def test_streaming_prompt_can_include_task_field() -> None:
+    eng = _engine()
+    eng._runtimes["tracker"] = _StubStreaming("tracker", ("point",))
+    captured: list[dict[str, Any]] = []
+
+    async def fake_stream(model: str, task: str, inputs: Any) -> str:
+        captured.append({"model": model, "task": task, "inputs": inputs})
+        return "STREAM"
+
+    eng.stream = fake_stream  # type: ignore[method-assign]
+    h = eng.model("tracker")
+
+    out = asyncio.run(h.stream("point", task="seed", points=[[0.5, 0.5]]))
+    assert out == "STREAM"
+    assert captured[-1] == {
+        "model": "tracker",
+        "task": "point",
+        "inputs": {"task": "seed", "points": [[0.5, 0.5]]},
+    }
+
+    out = asyncio.run(h.point(task="seed", points=[[0.25, 0.75]]))
+    assert out == "STREAM"
+    assert captured[-1] == {
+        "model": "tracker",
+        "task": "point",
+        "inputs": {"task": "seed", "points": [[0.25, 0.75]]},
+    }
+
+
 def test_stream_rejects_non_streaming_model() -> None:
     eng = _engine()
     with pytest.raises(ValueError, match="stream\\(\\) is for streaming models"):

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -30,6 +30,16 @@ class _StubSinglePass:
         return self._tasks
 
 
+class _StubStreaming:
+    def __init__(self, model_name: str, tasks: tuple[str, ...]) -> None:
+        self.model_name = model_name
+        self.execution_shape = ExecutionShape.STREAMING
+        self._tasks = tasks
+
+    def tasks(self) -> tuple[str, ...]:
+        return self._tasks
+
+
 def _engine() -> InferenceEngine:
     """Minimal engine with an AR default + a single-pass model registered."""
     ar_skills = SkillRegistry([QuerySkill(), CaptionSkill(), SegmentSkill()])
@@ -46,6 +56,7 @@ def _engine() -> InferenceEngine:
         "sp-model": _StubSinglePass("sp-model", ("segment_masks",)),
     }
     eng._skills_override = None  # AR runtime owns its skills
+    eng._shutdown = False
     # Runtimes are injected (already built), so the engine is effectively
     # started: _ensure_started() (now awaited by the handle verbs) is a no-op.
     eng._initialized = True
@@ -320,3 +331,48 @@ def test_run_gates_on_task_then_forwards() -> None:
     # An unknown task is rejected before forwarding.
     with pytest.raises(ValueError, match="does not support 'bogus'"):
         asyncio.run(h.run("bogus", {}))
+
+
+def test_stream_forwards_to_engine_for_streaming_model() -> None:
+    eng = _engine()
+    eng._runtimes["tracker"] = _StubStreaming("tracker", ("point",))
+    captured: dict[str, Any] = {}
+
+    async def fake_stream(model: str, task: str, inputs: Any) -> str:
+        captured.update(model=model, task=task, inputs=inputs)
+        return "STREAM"
+
+    eng.stream = fake_stream  # type: ignore[method-assign]
+    out = asyncio.run(
+        eng.model("tracker").stream("point", points=[[0.5, 0.5]], labels=[1])
+    )
+
+    assert out == "STREAM"
+    assert captured == {
+        "model": "tracker",
+        "task": "point",
+        "inputs": {"points": [[0.5, 0.5]], "labels": [1]},
+    }
+
+
+def test_stream_rejects_non_streaming_model() -> None:
+    eng = _engine()
+    with pytest.raises(ValueError, match="stream\\(\\) is for streaming models"):
+        asyncio.run(eng.model("sp-model").stream("segment_masks", points=[[1, 2]]))
+
+
+def test_engine_stream_validates_shape_and_task() -> None:
+    async def go() -> None:
+        eng = _engine()
+        eng._runtimes["tracker"] = _StubStreaming("tracker", ("point",))
+
+        with pytest.raises(ValueError, match="not a streaming model"):
+            await eng.stream("sp-model", "segment_masks", {})
+
+        with pytest.raises(ValueError, match="does not support 'detect'"):
+            await eng.stream("tracker", "detect", {})
+
+        with pytest.raises(NotImplementedError, match="streaming executor"):
+            await eng.stream("tracker", "point", {"points": [[0.5, 0.5]]})
+
+    asyncio.run(go())

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -355,6 +355,28 @@ def test_stream_forwards_to_engine_for_streaming_model() -> None:
     }
 
 
+def test_capability_dispatches_to_stream_for_streaming_model() -> None:
+    eng = _engine()
+    eng._runtimes["tracker"] = _StubStreaming("tracker", ("point",))
+    captured: dict[str, Any] = {}
+
+    async def fake_stream(model: str, task: str, inputs: Any) -> str:
+        captured.update(model=model, task=task, inputs=inputs)
+        return "STREAM"
+
+    eng.stream = fake_stream  # type: ignore[method-assign]
+    h = eng.model("tracker")
+    out = asyncio.run(h.point(points=[[0.5, 0.5]], labels=[1]))
+
+    assert h.supports("point") is True
+    assert out == "STREAM"
+    assert captured == {
+        "model": "tracker",
+        "task": "point",
+        "inputs": {"points": [[0.5, 0.5]], "labels": [1]},
+    }
+
+
 def test_stream_rejects_non_streaming_model() -> None:
     eng = _engine()
     with pytest.raises(ValueError, match="stream\\(\\) is for streaming models"):

--- a/tests/test_model_stream.py
+++ b/tests/test_model_stream.py
@@ -132,3 +132,49 @@ def test_model_stream_completion_closes_public_session() -> None:
         assert closed == []
 
     asyncio.run(go())
+
+
+def test_model_stream_close_retries_after_cancelled_cleanup() -> None:
+    async def go() -> None:
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = asyncio.get_running_loop().create_future()
+        close_calls = 0
+        first_close_started = asyncio.Event()
+
+        async def send_chunk(session_id: int, chunk: dict[str, Any]) -> None:
+            raise AssertionError("not used")
+
+        async def close_session(session_id: int) -> None:
+            nonlocal close_calls
+            close_calls += 1
+            if close_calls == 1:
+                first_close_started.set()
+                await asyncio.Future()
+            else:
+                result = _result(session_id)
+                future.set_result(result)
+                queue.put_nowait(_ModelStreamCompletion(result=result))
+
+        stream = ModelStream(
+            session_id=11,
+            task="point",
+            queue=queue,
+            result_future=future,
+            send_chunk=send_chunk,
+            close_session=close_session,
+        )
+
+        first_close = asyncio.create_task(stream.close())
+        await first_close_started.wait()
+        first_close.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_close
+
+        result = await stream.close()
+
+        assert close_calls == 2
+        assert result.output == {"done": True}
+        with pytest.raises(RuntimeError, match="closed"):
+            await stream.send(frame="f1")
+
+    asyncio.run(go())

--- a/tests/test_model_stream.py
+++ b/tests/test_model_stream.py
@@ -220,3 +220,198 @@ def test_model_stream_rejects_send_after_close_starts() -> None:
         assert result.output == {"done": True}
 
     asyncio.run(go())
+
+
+def test_model_stream_concurrent_close_requests_share_cleanup() -> None:
+    async def go() -> None:
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = asyncio.get_running_loop().create_future()
+        close_calls = 0
+        close_started = asyncio.Event()
+        release_close = asyncio.Event()
+
+        async def send_chunk(session_id: int, chunk: dict[str, Any]) -> None:
+            raise AssertionError("not used")
+
+        async def close_session(session_id: int) -> None:
+            nonlocal close_calls
+            close_calls += 1
+            close_started.set()
+            await release_close.wait()
+            result = _result(session_id)
+            future.set_result(result)
+            queue.put_nowait(_ModelStreamCompletion(result=result))
+
+        stream = ModelStream(
+            session_id=13,
+            task="point",
+            queue=queue,
+            result_future=future,
+            send_chunk=send_chunk,
+            close_session=close_session,
+        )
+
+        first_close = asyncio.create_task(stream.close())
+        await close_started.wait()
+        second_close = asyncio.create_task(stream.close())
+        await asyncio.sleep(0)
+
+        release_close.set()
+        first_result, second_result = await asyncio.gather(first_close, second_close)
+
+        assert close_calls == 1
+        assert first_result is second_result
+        assert first_result.output == {"done": True}
+
+    asyncio.run(go())
+
+
+def test_model_stream_waiting_close_retries_after_leading_close_cancelled() -> None:
+    async def go() -> None:
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = asyncio.get_running_loop().create_future()
+        close_calls = 0
+        first_close_started = asyncio.Event()
+
+        async def send_chunk(session_id: int, chunk: dict[str, Any]) -> None:
+            raise AssertionError("not used")
+
+        async def close_session(session_id: int) -> None:
+            nonlocal close_calls
+            close_calls += 1
+            if close_calls == 1:
+                first_close_started.set()
+                await asyncio.Future()
+            else:
+                result = _result(session_id)
+                future.set_result(result)
+                queue.put_nowait(_ModelStreamCompletion(result=result))
+
+        stream = ModelStream(
+            session_id=14,
+            task="point",
+            queue=queue,
+            result_future=future,
+            send_chunk=send_chunk,
+            close_session=close_session,
+        )
+
+        first_close = asyncio.create_task(stream.close())
+        await first_close_started.wait()
+        second_close = asyncio.create_task(stream.close())
+        await asyncio.sleep(0)
+
+        first_close.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_close
+
+        result = await asyncio.wait_for(second_close, timeout=1.0)
+
+        assert close_calls == 2
+        assert result.output == {"done": True}
+
+    asyncio.run(go())
+
+
+def test_model_stream_close_failure_allows_send_and_retry() -> None:
+    async def go() -> None:
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = asyncio.get_running_loop().create_future()
+        close_calls = 0
+        sent: list[dict[str, Any]] = []
+
+        async def send_chunk(session_id: int, chunk: dict[str, Any]) -> None:
+            sent.append(chunk)
+
+        async def close_session(session_id: int) -> None:
+            nonlocal close_calls
+            close_calls += 1
+            if close_calls == 1:
+                raise RuntimeError("close failed")
+            result = _result(session_id)
+            future.set_result(result)
+            queue.put_nowait(_ModelStreamCompletion(result=result))
+
+        stream = ModelStream(
+            session_id=15,
+            task="point",
+            queue=queue,
+            result_future=future,
+            send_chunk=send_chunk,
+            close_session=close_session,
+        )
+
+        with pytest.raises(RuntimeError, match="close failed"):
+            await stream.close()
+
+        await stream.send(frame="after-failure")
+        result = await stream.close()
+
+        assert close_calls == 2
+        assert sent == [{"frame": "after-failure"}]
+        assert result.output == {"done": True}
+
+    asyncio.run(go())
+
+
+def test_model_stream_error_completion_closes_public_session() -> None:
+    async def go() -> None:
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = asyncio.get_running_loop().create_future()
+        closed: list[int] = []
+
+        async def send_chunk(session_id: int, chunk: dict[str, Any]) -> None:
+            raise AssertionError("completed stream accepted a chunk")
+
+        async def close_session(session_id: int) -> None:
+            closed.append(session_id)
+
+        stream = ModelStream(
+            session_id=16,
+            task="point",
+            queue=queue,
+            result_future=future,
+            send_chunk=send_chunk,
+            close_session=close_session,
+        )
+        queue.put_nowait(_ModelStreamCompletion(error=ValueError("bad frame")))
+
+        with pytest.raises(ValueError, match="bad frame"):
+            await stream.__anext__()
+        with pytest.raises(RuntimeError, match="closed"):
+            await stream.send(frame="f1")
+        with pytest.raises(ValueError, match="bad frame"):
+            await stream.close()
+        assert closed == []
+
+    asyncio.run(go())
+
+
+def test_model_stream_context_exception_requests_close_without_result_wait() -> None:
+    async def go() -> None:
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = asyncio.get_running_loop().create_future()
+        closed: list[int] = []
+
+        async def send_chunk(session_id: int, chunk: dict[str, Any]) -> None:
+            raise AssertionError("not used")
+
+        async def close_session(session_id: int) -> None:
+            closed.append(session_id)
+
+        stream = ModelStream(
+            session_id=17,
+            task="point",
+            queue=queue,
+            result_future=future,
+            send_chunk=send_chunk,
+            close_session=close_session,
+        )
+
+        await stream.__aexit__(ValueError, ValueError("boom"), None)
+
+        assert closed == [17]
+        with pytest.raises(RuntimeError, match="closed"):
+            await stream.send(frame="f1")
+
+    asyncio.run(go())

--- a/tests/test_model_stream.py
+++ b/tests/test_model_stream.py
@@ -1,0 +1,100 @@
+"""ModelStream session object behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from kestrel.engine import EngineMetrics, EngineResult, ModelStream, ModelStreamUpdate
+from kestrel.engine._types import _ModelStreamCompletion, _ModelStreamQueue
+
+
+def _result(request_id: int) -> EngineResult:
+    return EngineResult(
+        request_id=request_id,
+        tokens=[],
+        finish_reason="stop",
+        metrics=EngineMetrics(
+            input_tokens=0,
+            output_tokens=0,
+            prefill_time_ms=0.0,
+            decode_time_ms=0.0,
+            ttft_ms=0.0,
+        ),
+        output={"done": True},
+    )
+
+
+def test_model_stream_sends_chunks_and_yields_updates() -> None:
+    async def go() -> None:
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = asyncio.get_running_loop().create_future()
+        sent: list[tuple[int, dict[str, Any]]] = []
+        closed: list[int] = []
+
+        async def send_chunk(session_id: int, chunk: dict[str, Any]) -> None:
+            sent.append((session_id, chunk))
+
+        async def close_session(session_id: int) -> None:
+            closed.append(session_id)
+            result = _result(session_id)
+            future.set_result(result)
+            queue.put_nowait(_ModelStreamCompletion(result=result))
+
+        stream = ModelStream(
+            session_id=7,
+            task="point",
+            queue=queue,
+            result_future=future,
+            send_chunk=send_chunk,
+            close_session=close_session,
+        )
+
+        await stream.send(frame="f0")
+        queue.put_nowait(
+            ModelStreamUpdate(
+                session_id=7,
+                task="point",
+                output={"points": [[0.25, 0.75]]},
+            )
+        )
+        update = await stream.__anext__()
+        result = await stream.close()
+
+        assert sent == [(7, {"frame": "f0"})]
+        assert closed == [7]
+        assert update.output == {"points": [[0.25, 0.75]]}
+        assert result.output == {"done": True}
+        with pytest.raises(RuntimeError, match="closed"):
+            await stream.send(frame="f1")
+
+    asyncio.run(go())
+
+
+def test_model_stream_surfaces_completion_errors() -> None:
+    async def go() -> None:
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = asyncio.get_running_loop().create_future()
+
+        async def send_chunk(session_id: int, chunk: dict[str, Any]) -> None:
+            raise AssertionError("not used")
+
+        async def close_session(session_id: int) -> None:
+            raise AssertionError("not used")
+
+        stream = ModelStream(
+            session_id=9,
+            task="point",
+            queue=queue,
+            result_future=future,
+            send_chunk=send_chunk,
+            close_session=close_session,
+        )
+        queue.put_nowait(_ModelStreamCompletion(error=ValueError("bad frame")))
+
+        with pytest.raises(ValueError, match="bad frame"):
+            await stream.__anext__()
+
+    asyncio.run(go())

--- a/tests/test_model_stream.py
+++ b/tests/test_model_stream.py
@@ -178,3 +178,45 @@ def test_model_stream_close_retries_after_cancelled_cleanup() -> None:
             await stream.send(frame="f1")
 
     asyncio.run(go())
+
+
+def test_model_stream_rejects_send_after_close_starts() -> None:
+    async def go() -> None:
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = asyncio.get_running_loop().create_future()
+        sent: list[dict[str, Any]] = []
+        close_started = asyncio.Event()
+        release_close = asyncio.Event()
+
+        async def send_chunk(session_id: int, chunk: dict[str, Any]) -> None:
+            sent.append(chunk)
+
+        async def close_session(session_id: int) -> None:
+            close_started.set()
+            await release_close.wait()
+            result = _result(session_id)
+            future.set_result(result)
+            queue.put_nowait(_ModelStreamCompletion(result=result))
+
+        stream = ModelStream(
+            session_id=12,
+            task="point",
+            queue=queue,
+            result_future=future,
+            send_chunk=send_chunk,
+            close_session=close_session,
+        )
+
+        close_task = asyncio.create_task(stream.close())
+        await close_started.wait()
+
+        with pytest.raises(RuntimeError, match="closed"):
+            await stream.send(frame="late")
+
+        release_close.set()
+        result = await close_task
+
+        assert sent == []
+        assert result.output == {"done": True}
+
+    asyncio.run(go())

--- a/tests/test_model_stream.py
+++ b/tests/test_model_stream.py
@@ -98,3 +98,37 @@ def test_model_stream_surfaces_completion_errors() -> None:
             await stream.__anext__()
 
     asyncio.run(go())
+
+
+def test_model_stream_completion_closes_public_session() -> None:
+    async def go() -> None:
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = asyncio.get_running_loop().create_future()
+        closed: list[int] = []
+
+        async def send_chunk(session_id: int, chunk: dict[str, Any]) -> None:
+            raise AssertionError("completed stream accepted a chunk")
+
+        async def close_session(session_id: int) -> None:
+            closed.append(session_id)
+
+        stream = ModelStream(
+            session_id=10,
+            task="point",
+            queue=queue,
+            result_future=future,
+            send_chunk=send_chunk,
+            close_session=close_session,
+        )
+        result = _result(10)
+        queue.put_nowait(_ModelStreamCompletion(result=result))
+
+        with pytest.raises(StopAsyncIteration):
+            await stream.__anext__()
+
+        with pytest.raises(RuntimeError, match="closed"):
+            await stream.send(frame="f1")
+        assert await stream.close() is result
+        assert closed == []
+
+    asyncio.run(go())

--- a/tests/test_streaming_runtime_protocol.py
+++ b/tests/test_streaming_runtime_protocol.py
@@ -1,0 +1,44 @@
+"""Streaming runtime protocol shape."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kestrel.runtime import ExecutionShape, StreamingRuntime
+
+
+class _StreamingStub:
+    model_name = "streaming-stub"
+    device = None
+    execution_shape = ExecutionShape.STREAMING
+    primary_stream = object()
+
+    def tasks(self) -> tuple[str, ...]:
+        return ("point",)
+
+    def start(self, task: str, inputs: Any) -> dict[str, Any]:
+        return {"task": task, "inputs": inputs}
+
+    def step(self, session: Any, inputs: Any) -> tuple[Any, Any]:
+        return session, inputs
+
+    def finish(self, session: Any) -> None:
+        self.finished = session
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+def test_streaming_execution_shape_is_public() -> None:
+    assert ExecutionShape.STREAMING.value == "streaming"
+
+
+def test_streaming_runtime_protocol_is_exported() -> None:
+    runtime: StreamingRuntime = _StreamingStub()
+    session = runtime.start("point", {"points": [[0.5, 0.5]]})
+    output = runtime.step(session, {"frame": object()})
+    runtime.finish(session)
+
+    assert runtime.execution_shape is ExecutionShape.STREAMING
+    assert runtime.tasks() == ("point",)
+    assert output[0] == session


### PR DESCRIPTION
## Summary
- Adds `ModelStreamUpdate` and `ModelStream` for caller-driven stateful streaming sessions.
- Exposes the generic `ModelHandle.stream(task, **initial_prompt)` and engine-level `stream(model, task, initial_inputs)` validation path.
- Adds focused tests for session send/update/close/error behavior and handle routing.

## Validation
- `uv run pytest tests/test_streaming_runtime_protocol.py tests/test_model_stream.py tests/test_model_handle.py -q`
- `git diff --check`
- `git diff --cached --check`

Stacked on #94.