### PR TITLE
Wire streaming executor into engine

### DIFF
--- a/kestrel/engine/__init__.py
+++ b/kestrel/engine/__init__.py
@@ -19,6 +19,7 @@ from kestrel.engine.executor import (
     _AdmissionCoordinator,
 )
 from kestrel.engine.single_pass import SinglePassExecutor
+from kestrel.engine.streaming import StreamingExecutor
 from kestrel.engine.handle import ModelHandle
 from kestrel.engine._types import _AutoregressiveRequest
 from kestrel.engine.core import InferenceEngine
@@ -33,6 +34,7 @@ __all__ = [
     "Executor",
     "AutoregressiveExecutor",
     "SinglePassExecutor",
+    "StreamingExecutor",
     "ModelHandle",
     "Completion",
     "TickResult",

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -246,6 +246,33 @@ class ModelStream(AsyncIterator[ModelStreamUpdate]):
 
 
 @dataclass(slots=True)
+class _StreamingSessionRequest:
+    """A stateful streaming session start request.
+
+    Satisfies the common ``EngineRequest`` envelope for terminal delivery
+    and carries this lane's model-stream queue for per-step updates.
+    """
+
+    request_id: int
+    future: asyncio.Future[EngineResult]
+    task: str
+    initial_inputs: Dict[str, Any]
+    submitted_at: float
+    model_stream_queue: Optional[_ModelStreamQueue]
+    adapter: Optional[str] = None
+    stream_queue: Optional[_StreamQueue] = None
+
+
+@dataclass(slots=True)
+class _StreamingChunk:
+    """One caller-supplied chunk/frame or close request for a session."""
+
+    session_id: int
+    inputs: Dict[str, Any] = field(default_factory=dict)
+    close: bool = False
+
+
+@dataclass(slots=True)
 class _AutoregressiveRequest:
     request_id: int
     prompt: str
@@ -327,4 +354,5 @@ class TickResult:
 
     progressed: bool = False
     completed: tuple[Completion, ...] = ()
+    model_stream_updates: tuple[ModelStreamUpdate, ...] = ()
     has_work: bool = False  # queued or in flight (gates shutdown exit)

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -86,13 +86,19 @@ from kestrel.engine._types import (
     EngineResult,
     EngineStream,
     ModelStream,
+    ModelStreamUpdate,
     _AutoregressiveRequest,
+    _ModelStreamCompletion,
+    _ModelStreamQueue,
     _StreamCompletion,
     _StreamQueue,
     _StreamQueueItem,
+    _StreamingChunk,
+    _StreamingSessionRequest,
 )
 from kestrel.engine.executor import AutoregressiveExecutor
 from kestrel.engine.single_pass import SinglePassExecutor, _SinglePassRequest
+from kestrel.engine.streaming import StreamingExecutor
 from kestrel.engine.handle import ModelHandle
 
 
@@ -205,6 +211,16 @@ class InferenceEngine:
         self._single_pass_queue: "queue.Queue[tuple[str, _SinglePassRequest]]" = (
             queue.Queue()
         )
+        # Stateful streaming ingress: starts and chunks are tagged by model
+        # id so the kernel routes them to that model's streaming lane.
+        self._streaming_start_queue: (
+            "queue.Queue[tuple[str, _StreamingSessionRequest]]"
+        ) = queue.Queue()
+        self._streaming_chunk_queue: "queue.Queue[tuple[str, _StreamingChunk]]" = (
+            queue.Queue()
+        )
+        self._model_stream_models: Dict[int, str] = {}
+        self._model_stream_queues: Dict[int, _ModelStreamQueue] = {}
         self._scheduler_event = threading.Event()
         self._run_gate = threading.Event()
         self._run_gate.set()  # set == running
@@ -841,9 +857,8 @@ class InferenceEngine:
         This is distinct from autoregressive response streaming: the
         caller supplies chunks/frames after the initial prompt, and a
         streaming runtime carries model-owned state across those chunks.
-        Kernel/executor wiring lands in the streaming executor branch; the
-        validation here pins the public shape without changing existing
-        AR or single-pass behavior.
+        The returned ``ModelStream`` is caller-driven: callers ``send``
+        chunks/frames and iterate over model-defined updates.
         """
         if self._shutdown:
             raise RuntimeError("InferenceEngine is shut down")
@@ -864,9 +879,54 @@ class InferenceEngine:
                 f"(supports: {supported})"
             )
 
-        raise NotImplementedError(
-            "stateful streaming sessions require the streaming executor"
+        loop = asyncio.get_running_loop()
+        session_id = next(self._request_ids)
+        queue: _ModelStreamQueue = asyncio.Queue()
+        future: asyncio.Future[EngineResult] = loop.create_future()
+        req = _StreamingSessionRequest(
+            request_id=session_id,
+            future=future,
+            task=task,
+            initial_inputs=dict(initial_inputs),
+            submitted_at=time.perf_counter(),
+            model_stream_queue=queue,
         )
+        self._model_stream_models[session_id] = model
+        self._model_stream_queues[session_id] = queue
+        self._streaming_start_queue.put((model, req))
+        self._scheduler_event.set()
+        return ModelStream(
+            session_id=session_id,
+            task=task,
+            queue=queue,
+            result_future=future,
+            send_chunk=self._send_model_stream_chunk,
+            close_session=self._close_model_stream,
+        )
+
+    async def _send_model_stream_chunk(
+        self,
+        session_id: int,
+        chunk: Dict[str, Any],
+    ) -> None:
+        if self._shutdown:
+            raise RuntimeError("InferenceEngine is shut down")
+        model = self._model_stream_models.get(session_id)
+        if model is None:
+            raise RuntimeError(f"Unknown or closed model stream {session_id}")
+        self._streaming_chunk_queue.put(
+            (model, _StreamingChunk(session_id=session_id, inputs=chunk))
+        )
+        self._scheduler_event.set()
+
+    async def _close_model_stream(self, session_id: int) -> None:
+        model = self._model_stream_models.get(session_id)
+        if model is None:
+            return
+        self._streaming_chunk_queue.put(
+            (model, _StreamingChunk(session_id=session_id, close=True))
+        )
+        self._scheduler_event.set()
 
     def model(self, model_id: Optional[str] = None) -> "ModelHandle":
         """Return a :class:`ModelHandle` bound to ``model_id``.
@@ -1320,12 +1380,38 @@ class InferenceEngine:
         completion = _StreamCompletion(result=result, error=error)
         self._loop.call_soon_threadsafe(queue.put_nowait, completion)
 
+    def _complete_model_stream(
+        self,
+        req: EngineRequest,
+        *,
+        result: Optional[EngineResult] = None,
+        error: Optional[BaseException] = None,
+    ) -> None:
+        queue = getattr(req, "model_stream_queue", None)
+        if queue is None:
+            return
+        req.model_stream_queue = None
+        self._model_stream_models.pop(req.request_id, None)
+        self._model_stream_queues.pop(req.request_id, None)
+        completion = _ModelStreamCompletion(result=result, error=error)
+        self._loop.call_soon_threadsafe(queue.put_nowait, completion)
+
+    def _deliver_model_stream_update(
+        self,
+        update: ModelStreamUpdate,
+    ) -> None:
+        queue = self._model_stream_queues.get(update.session_id)
+        if queue is None:
+            return
+        self._loop.call_soon_threadsafe(queue.put_nowait, update)
+
     def _fail_request(self, req: EngineRequest, error: BaseException) -> None:
         future = req.future
         if future and not future.done():
             assert self._loop is not None
             self._loop.call_soon_threadsafe(future.set_exception, error)
         self._complete_stream(req, error=error)
+        self._complete_model_stream(req, error=error)
         if self._photon_reporter is not None:
             try:
                 self._photon_reporter.record_error(finetune=req.adapter)
@@ -1359,6 +1445,11 @@ class InferenceEngine:
                 name: SinglePassExecutor(rt, compute_stream=self._compute_stream)
                 for name, rt in self._runtimes.items()
                 if rt.execution_shape is ExecutionShape.SINGLE_PASS
+            }
+            streaming: Dict[str, StreamingExecutor] = {
+                name: StreamingExecutor(rt, compute_stream=self._compute_stream)
+                for name, rt in self._runtimes.items()
+                if rt.execution_shape is ExecutionShape.STREAMING
             }
         except Exception as exc:
             self._scheduler_error = exc
@@ -1395,11 +1486,18 @@ class InferenceEngine:
                 if future and not future.done():
                     loop.call_soon_threadsafe(future.set_result, engine_result)
                 self._complete_stream(req, result=engine_result)
+                self._complete_model_stream(req, result=engine_result)
+
+        def deliver_model_stream_updates(
+            updates: tuple[ModelStreamUpdate, ...]
+        ) -> None:
+            for update in updates:
+                self._deliver_model_stream_update(update)
 
         def any_work() -> bool:
             return ar_executor.has_work or any(
                 sp.has_work for sp in single_pass.values()
-            )
+            ) or any(stream.has_work for stream in streaming.values())
 
         try:
             with torch.inference_mode():
@@ -1446,6 +1544,30 @@ class InferenceEngine:
                         else:
                             lane.submit(req)
                         progressed = True
+                    # Streaming session starts (model-tagged).
+                    while True:
+                        try:
+                            model, req = self._streaming_start_queue.get_nowait()
+                        except queue.Empty:
+                            break
+                        lane = streaming.get(model)
+                        if lane is None:  # pragma: no cover - guarded in stream()
+                            self._fail_request(
+                                req, ValueError(f"No streaming lane for {model!r}")
+                            )
+                        else:
+                            lane.submit(req)
+                        progressed = True
+                    # Streaming chunks / close commands (model-tagged).
+                    while True:
+                        try:
+                            model, chunk = self._streaming_chunk_queue.get_nowait()
+                        except queue.Empty:
+                            break
+                        lane = streaming.get(model)
+                        if lane is not None:
+                            lane.submit_chunk(chunk)
+                        progressed = True
 
                     # Advance the autoregressive lane. Its pipeline is the
                     # shared device state, so a failure here is fatal to the
@@ -1457,6 +1579,8 @@ class InferenceEngine:
                         _LOGGER.exception("Autoregressive advance failed", exc_info=exc)
                         deliver(ar_executor.shutdown(exc))
                         for lane in single_pass.values():
+                            deliver(lane.shutdown(exc))
+                        for lane in streaming.values():
                             deliver(lane.shutdown(exc))
                         self._fail_all_pending(exc)
                         return
@@ -1481,6 +1605,26 @@ class InferenceEngine:
                             deliver(sp_tick.completed)
                         progressed = sp_tick.progressed or progressed
 
+                    # Advance each streaming lane in isolation; a runtime
+                    # session failure should fail only that lane/session.
+                    for name, lane in streaming.items():
+                        try:
+                            stream_tick = lane.advance()
+                        except Exception as exc:
+                            _LOGGER.exception(
+                                "Streaming advance failed for %s", name, exc_info=exc
+                            )
+                            deliver(lane.shutdown(exc))
+                            progressed = True
+                            continue
+                        if stream_tick.model_stream_updates:
+                            deliver_model_stream_updates(
+                                stream_tick.model_stream_updates
+                            )
+                        if stream_tick.completed:
+                            deliver(stream_tick.completed)
+                        progressed = stream_tick.progressed or progressed
+
                     if shutdown_requested and not any_work():
                         break
 
@@ -1494,7 +1638,11 @@ class InferenceEngine:
                         # could sleep past the GPU finishing and leave
                         # engine.run() unresolved until an unrelated request
                         # happens to wake the loop.
-                        if any(sp.has_in_flight for sp in single_pass.values()):
+                        if any(
+                            sp.has_in_flight for sp in single_pass.values()
+                        ) or any(
+                            stream.has_in_flight for stream in streaming.values()
+                        ):
                             wake_event.wait(timeout=_SINGLE_PASS_POLL_INTERVAL_S)
                         else:
                             wake_event.wait()
@@ -1502,6 +1650,8 @@ class InferenceEngine:
         finally:
             deliver(ar_executor.shutdown())
             for lane in single_pass.values():
+                deliver(lane.shutdown())
+            for lane in streaming.values():
                 deliver(lane.shutdown())
             self._fail_all_pending()
 
@@ -1647,3 +1797,14 @@ class InferenceEngine:
             except queue.Empty:
                 break
             self._fail_request(req, exc)
+        while True:
+            try:
+                _model, req = self._streaming_start_queue.get_nowait()
+            except queue.Empty:
+                break
+            self._fail_request(req, exc)
+        while True:
+            try:
+                self._streaming_chunk_queue.get_nowait()
+            except queue.Empty:
+                break

--- a/kestrel/engine/streaming.py
+++ b/kestrel/engine/streaming.py
@@ -1,0 +1,339 @@
+"""The stateful streaming executor lane."""
+
+from __future__ import annotations
+
+import logging
+import queue
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from kestrel.device import make_event, stream_context
+from kestrel.runtime import StreamingRuntime
+
+from kestrel.engine._types import (
+    Completion,
+    EngineMetrics,
+    EngineResult,
+    ModelStreamUpdate,
+    TickResult,
+    _StreamingChunk,
+    _StreamingSessionRequest,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _stream_output(output: Any) -> Dict[str, object]:
+    return output if isinstance(output, dict) else {"result": output}
+
+
+def _stream_result(request_id: int, output: Any | None = None) -> EngineResult:
+    return EngineResult(
+        request_id=request_id,
+        tokens=[],
+        finish_reason="stop",
+        metrics=EngineMetrics(
+            input_tokens=0,
+            output_tokens=0,
+            prefill_time_ms=0.0,
+            decode_time_ms=0.0,
+            ttft_ms=0.0,
+        ),
+        output=_stream_output({"closed": True} if output is None else output),
+    )
+
+
+@dataclass(slots=True)
+class _Session:
+    request: _StreamingSessionRequest
+    state: Any
+    pending: List[_StreamingChunk] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class _PendingStart:
+    request: _StreamingSessionRequest
+    state: Any
+    done_event: Any
+    error: Optional[BaseException] = None
+
+
+@dataclass(slots=True)
+class _PendingStep:
+    session_id: int
+    request: _StreamingSessionRequest
+    output: Any
+    next_state: Any
+    done_event: Any
+    error: Optional[BaseException] = None
+
+
+class StreamingExecutor:
+    """Executor lane for stateful runtime sessions.
+
+    First cut: one in-flight start/step globally. The session table and
+    per-session queues are already explicit, so adding slots or batching
+    later changes policy rather than the API shape.
+    """
+
+    def __init__(
+        self,
+        runtime: StreamingRuntime,
+        *,
+        compute_stream: Any,
+        max_in_flight: int = 1,
+    ) -> None:
+        self._runtime = runtime
+        self._device = runtime.device
+        self._stream = compute_stream
+        self._max_in_flight = max_in_flight
+        self._starts: "queue.Queue[_StreamingSessionRequest]" = queue.Queue()
+        self._sessions: Dict[int, _Session] = {}
+        self._pending_chunks: Dict[int, List[_StreamingChunk]] = {}
+        self._starting: List[_PendingStart] = []
+        self._in_flight: List[_PendingStep] = []
+
+    # -- ingress (event-loop thread) ----------------------------------
+
+    def submit(self, request: _StreamingSessionRequest) -> None:
+        self._starts.put(request)
+
+    def submit_chunk(self, chunk: _StreamingChunk) -> None:
+        session = self._sessions.get(chunk.session_id)
+        if session is not None:
+            session.pending.append(chunk)
+            return
+        self._pending_chunks.setdefault(chunk.session_id, []).append(chunk)
+
+    # -- step (kernel thread) -----------------------------------------
+
+    @property
+    def has_work(self) -> bool:
+        return (
+            not self._starts.empty()
+            or bool(self._starting)
+            or bool(self._in_flight)
+            or any(session.pending for session in self._sessions.values())
+            or bool(self._pending_chunks)
+        )
+
+    @property
+    def has_in_flight(self) -> bool:
+        return bool(self._starting) or bool(self._in_flight)
+
+    def advance(self) -> TickResult:
+        progressed = self._launch_starts()
+        start_completions = self._collect_starts()
+        progressed = progressed or bool(start_completions)
+        progressed = self._launch_steps() or progressed
+        updates, completions = self._collect_steps()
+        progressed = progressed or bool(updates) or bool(completions)
+
+        return TickResult(
+            progressed=progressed,
+            completed=tuple(start_completions + completions),
+            model_stream_updates=tuple(updates),
+            has_work=self.has_work,
+        )
+
+    def shutdown(self, error: Optional[BaseException] = None) -> tuple[Completion, ...]:
+        exc = error or RuntimeError("Engine shut down")
+        completions: List[Completion] = []
+        for start in self._starting:
+            completions.append(Completion(request=start.request, error=exc))
+        self._starting = []
+        completed_request_ids: set[int] = set()
+        for step in self._in_flight:
+            session = self._sessions.pop(step.session_id, None)
+            if session is not None:
+                self._finish_session(session)
+            request_id = step.request.request_id
+            if request_id not in completed_request_ids:
+                completions.append(Completion(request=step.request, error=exc))
+                completed_request_ids.add(request_id)
+        self._in_flight = []
+        for session in self._sessions.values():
+            self._finish_session(session)
+            completions.append(Completion(request=session.request, error=exc))
+        self._sessions.clear()
+        while True:
+            try:
+                req = self._starts.get_nowait()
+            except queue.Empty:
+                break
+            completions.append(Completion(request=req, error=exc))
+        self._pending_chunks.clear()
+        return tuple(completions)
+
+    # -- launch / collect ---------------------------------------------
+
+    def _launch_starts(self) -> bool:
+        launched = False
+        while self._capacity_available():
+            try:
+                req = self._starts.get_nowait()
+            except queue.Empty:
+                break
+            launched = self._launch_start(req) or launched
+        return launched
+
+    def _launch_start(self, req: _StreamingSessionRequest) -> bool:
+        try:
+            with stream_context(self._stream):
+                state = self._runtime.start(req.task, req.initial_inputs)
+                done_event = make_event(self._device)
+                done_event.record()
+        except Exception as exc:
+            self._starting.append(
+                _PendingStart(request=req, state=None, done_event=None, error=exc)
+            )
+            return True
+        self._starting.append(
+            _PendingStart(request=req, state=state, done_event=done_event)
+        )
+        return True
+
+    def _collect_starts(self) -> List[Completion]:
+        if not self._starting:
+            return []
+        still: List[_PendingStart] = []
+        completed: List[Completion] = []
+        for start in self._starting:
+            if start.error is not None:
+                self._pending_chunks.pop(start.request.request_id, None)
+                completed.append(Completion(request=start.request, error=start.error))
+            elif start.done_event.query():
+                session = _Session(request=start.request, state=start.state)
+                session.pending.extend(
+                    self._pending_chunks.pop(start.request.request_id, [])
+                )
+                self._sessions[start.request.request_id] = session
+            else:
+                still.append(start)
+        self._starting = still
+        return completed
+
+    def _launch_steps(self) -> bool:
+        launched = False
+        while self._capacity_available():
+            next_item = self._next_ready_chunk()
+            if next_item is None:
+                break
+            session_id, session, chunk = next_item
+            if chunk.close:
+                self._finish_session(session)
+                self._sessions.pop(session_id, None)
+                self._in_flight.append(
+                    _PendingStep(
+                        session_id=session_id,
+                        request=session.request,
+                        output={"closed": True},
+                        next_state=None,
+                        done_event=make_event(self._device),
+                    )
+                )
+                self._in_flight[-1].done_event.record()
+                launched = True
+                continue
+            launched = self._launch_step(session_id, session, chunk) or launched
+        return launched
+
+    def _launch_step(
+        self,
+        session_id: int,
+        session: _Session,
+        chunk: _StreamingChunk,
+    ) -> bool:
+        try:
+            with stream_context(self._stream):
+                output = self._runtime.step(session.state, chunk.inputs)
+                update, next_state = self._split_step_output(output, session.state)
+                done_event = make_event(self._device)
+                done_event.record()
+        except Exception as exc:
+            self._in_flight.append(
+                _PendingStep(
+                    session_id=session_id,
+                    request=session.request,
+                    output=None,
+                    next_state=session.state,
+                    done_event=None,
+                    error=exc,
+                )
+            )
+            return True
+        self._in_flight.append(
+            _PendingStep(
+                session_id=session_id,
+                request=session.request,
+                output=update,
+                next_state=next_state,
+                done_event=done_event,
+            )
+        )
+        return True
+
+    def _collect_steps(self) -> tuple[List[ModelStreamUpdate], List[Completion]]:
+        if not self._in_flight:
+            return [], []
+        still: List[_PendingStep] = []
+        updates: List[ModelStreamUpdate] = []
+        completed: List[Completion] = []
+        for step in self._in_flight:
+            if step.error is not None:
+                session = self._sessions.pop(step.session_id, None)
+                if session is not None:
+                    self._finish_session(session)
+                completed.append(Completion(request=step.request, error=step.error))
+            elif step.done_event.query():
+                if step.next_state is None:
+                    completed.append(
+                        Completion(
+                            request=step.request,
+                            result=_stream_result(
+                                step.request.request_id,
+                                step.output,
+                            ),
+                        )
+                    )
+                else:
+                    session = self._sessions.get(step.session_id)
+                    if session is not None:
+                        session.state = step.next_state
+                    updates.append(
+                        ModelStreamUpdate(
+                            session_id=step.session_id,
+                            task=step.request.task,
+                            output=_stream_output(step.output),
+                        )
+                    )
+            else:
+                still.append(step)
+        self._in_flight = still
+        return updates, completed
+
+    # -- helpers ------------------------------------------------------
+
+    def _capacity_available(self) -> bool:
+        return len(self._starting) + len(self._in_flight) < self._max_in_flight
+
+    def _next_ready_chunk(self) -> Optional[tuple[int, _Session, _StreamingChunk]]:
+        for session_id, session in list(self._sessions.items()):
+            if not session.pending:
+                continue
+            return session_id, session, session.pending.pop(0)
+        return None
+
+    def _finish_session(self, session: _Session) -> None:
+        try:
+            self._runtime.finish(session.state)
+        except Exception:
+            _LOGGER.exception("Streaming runtime finish failed")
+
+    def _split_step_output(self, output: Any, current_state: Any) -> tuple[Any, Any]:
+        if isinstance(output, tuple) and len(output) == 2:
+            return output[0], output[1]
+        return output, current_state
+
+
+__all__ = ["StreamingExecutor", "_StreamingChunk", "_StreamingSessionRequest"]

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -9,6 +9,7 @@ that contract with stub runtimes — no GPU.
 from __future__ import annotations
 
 import asyncio
+import queue
 from types import SimpleNamespace
 from typing import Any
 
@@ -57,6 +58,12 @@ def _engine() -> InferenceEngine:
     }
     eng._skills_override = None  # AR runtime owns its skills
     eng._shutdown = False
+    eng._streaming_start_queue = queue.Queue()
+    eng._streaming_chunk_queue = queue.Queue()
+    eng._model_stream_models = {}
+    eng._model_stream_queues = {}
+    eng._scheduler_event = SimpleNamespace(set=lambda: None)
+    eng._request_ids = iter(range(1, 1_000_000))
     # Runtimes are injected (already built), so the engine is effectively
     # started: _ensure_started() (now awaited by the handle verbs) is a no-op.
     eng._scheduler_error = None
@@ -473,7 +480,11 @@ def test_engine_stream_validates_shape_and_task() -> None:
         with pytest.raises(ValueError, match="does not support 'detect'"):
             await eng.stream("tracker", "detect", {})
 
-        with pytest.raises(NotImplementedError, match="streaming executor"):
-            await eng.stream("tracker", "point", {"points": [[0.5, 0.5]]})
+        stream = await eng.stream("tracker", "point", {"points": [[0.5, 0.5]]})
+        model, req = eng._streaming_start_queue.get_nowait()
+        assert stream.session_id == req.request_id
+        assert model == "tracker"
+        assert req.task == "point"
+        assert req.initial_inputs == {"points": [[0.5, 0.5]]}
 
     asyncio.run(go())

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -53,6 +53,10 @@ def _engine_with(ar: FakeRuntime, sp: _StubSinglePass) -> InferenceEngine:
     engine._runtimes = {ar.model_name: ar, sp.model_name: sp}
     engine._scheduler_queue = _queue.Queue()
     engine._single_pass_queue = _queue.Queue()
+    engine._streaming_start_queue = _queue.Queue()
+    engine._streaming_chunk_queue = _queue.Queue()
+    engine._model_stream_models = {}
+    engine._model_stream_queues = {}
     engine._scheduler_event = threading.Event()
     engine._run_gate = threading.Event()
     engine._run_gate.set()

--- a/tests/test_streaming_engine.py
+++ b/tests/test_streaming_engine.py
@@ -1,0 +1,109 @@
+"""engine.stream() routes stateful streaming work through the kernel loop."""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+from typing import Any
+
+import torch
+
+from kestrel.engine import InferenceEngine
+from kestrel.runtime import ExecutionShape
+
+from tests.scheduler._fake_runtime import FakeRuntime
+
+
+class _StubStreamingRuntime:
+    def __init__(self, model_name: str = "tracker") -> None:
+        self.model_name = model_name
+        self.device = torch.device("cpu")
+        self.execution_shape = ExecutionShape.STREAMING
+        self.calls: list[tuple[str, Any]] = []
+        self.finished: list[Any] = []
+
+    def tasks(self) -> tuple[str, ...]:
+        return ("point",)
+
+    def start(self, task: str, inputs: Any) -> dict[str, Any]:
+        self.calls.append(("start", task, inputs))
+        return {"step": 0, "seed": inputs}
+
+    def step(self, session: Any, inputs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        self.calls.append(("step", session, inputs))
+        next_session = dict(session)
+        next_session["step"] += 1
+        return {"points": inputs["frame"], "step": next_session["step"]}, next_session
+
+    def finish(self, session: Any) -> None:
+        self.finished.append(session)
+
+    def shutdown(self) -> None:
+        pass
+
+
+def _engine_with(ar: FakeRuntime, streaming: _StubStreamingRuntime) -> InferenceEngine:
+    engine = object.__new__(InferenceEngine)
+    engine._default_model = ar.model_name
+    engine._runtimes = {ar.model_name: ar, streaming.model_name: streaming}
+    engine._scheduler_queue = queue.Queue()
+    engine._single_pass_queue = queue.Queue()
+    engine._streaming_start_queue = queue.Queue()
+    engine._streaming_chunk_queue = queue.Queue()
+    engine._model_stream_models = {}
+    engine._model_stream_queues = {}
+    engine._scheduler_event = threading.Event()
+    engine._run_gate = threading.Event()
+    engine._run_gate.set()
+    engine._paused_flag = threading.Event()
+    engine._paused_event = threading.Event()
+    engine._shutdown = False
+    engine._scheduler_error = None
+    engine._photon_reporter = None
+    engine._adapter_provider = None
+    engine._default_temperature = 0.2
+    engine._default_top_p = 0.9
+    engine._compute_stream = None
+    engine._skills_override = None
+    engine._request_ids = iter(range(1, 1_000_000))
+    return engine
+
+
+def test_stream_routes_updates_and_close_through_kernel_loop() -> None:
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        tracker = _StubStreamingRuntime()
+        engine = _engine_with(ar, tracker)
+        engine._loop = asyncio.get_running_loop()
+        engine._initialized = True
+        engine._init_task = None
+
+        thread = threading.Thread(
+            target=engine._scheduler_loop,
+            name="kernel",
+            daemon=True,
+        )
+        thread.start()
+        try:
+            stream = await engine.stream(
+                tracker.model_name,
+                "point",
+                {"points": [[0.5, 0.5]]},
+            )
+            await stream.send(frame=[[0.25, 0.75]])
+            update = await asyncio.wait_for(stream.__anext__(), timeout=5.0)
+            result = await asyncio.wait_for(stream.close(), timeout=5.0)
+
+            assert update.output == {"points": [[0.25, 0.75]], "step": 1}
+            assert result.output == {"closed": True}
+            assert tracker.finished == [
+                {"step": 1, "seed": {"points": [[0.5, 0.5]]}}
+            ]
+        finally:
+            engine._shutdown = True
+            engine._scheduler_queue.put(None)
+            engine._scheduler_event.set()
+            thread.join(timeout=5.0)
+
+    asyncio.run(go())

--- a/tests/test_streaming_executor.py
+++ b/tests/test_streaming_executor.py
@@ -1,0 +1,192 @@
+"""StreamingExecutor: stateful start/chunk/close execution."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+import torch
+
+from kestrel.engine import StreamingExecutor
+from kestrel.engine._types import _ModelStreamQueue, _StreamingChunk
+from kestrel.engine.streaming import _StreamingSessionRequest
+from kestrel.runtime import ExecutionShape
+
+
+class _StubStreamingRuntime:
+    def __init__(self) -> None:
+        self.model_name = "tracker"
+        self.device = torch.device("cpu")
+        self.execution_shape = ExecutionShape.STREAMING
+        self.calls: list[tuple[str, Any]] = []
+        self.finished: list[Any] = []
+
+    def tasks(self) -> tuple[str, ...]:
+        return ("point",)
+
+    def start(self, task: str, inputs: Any) -> dict[str, Any]:
+        self.calls.append(("start", task, inputs))
+        if task == "boom-start":
+            raise ValueError("start failed")
+        return {"step": 0, "seed": inputs}
+
+    def step(self, session: Any, inputs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        self.calls.append(("step", session, inputs))
+        if inputs.get("boom"):
+            raise ValueError("step failed")
+        next_session = dict(session)
+        next_session["step"] += 1
+        return {"points": inputs["frame"], "step": next_session["step"]}, next_session
+
+    def finish(self, session: Any) -> None:
+        self.finished.append(session)
+
+    def shutdown(self) -> None:
+        pass
+
+
+def _req(request_id: int, task: str = "point") -> _StreamingSessionRequest:
+    loop = asyncio.new_event_loop()
+    try:
+        future: asyncio.Future = loop.create_future()
+        queue: _ModelStreamQueue = asyncio.Queue()
+    finally:
+        loop.close()
+    return _StreamingSessionRequest(
+        request_id=request_id,
+        future=future,
+        task=task,
+        initial_inputs={"points": [[0.5, 0.5]]},
+        submitted_at=0.0,
+        model_stream_queue=queue,
+    )
+
+
+def test_streaming_executor_yields_updates_and_close_completion() -> None:
+    runtime = _StubStreamingRuntime()
+    ex = StreamingExecutor(runtime, compute_stream=None)
+    req = _req(1)
+
+    ex.submit(req)
+    tick0 = ex.advance()
+    assert tick0.completed == ()
+    assert tick0.model_stream_updates == ()
+    assert ex.has_work is False
+
+    ex.submit_chunk(_StreamingChunk(session_id=1, inputs={"frame": [[0.1, 0.2]]}))
+    tick1 = ex.advance()
+    assert tick1.completed == ()
+    assert len(tick1.model_stream_updates) == 1
+    assert tick1.model_stream_updates[0].output == {
+        "points": [[0.1, 0.2]],
+        "step": 1,
+    }
+
+    ex.submit_chunk(_StreamingChunk(session_id=1, close=True))
+    tick2 = ex.advance()
+    assert tick2.model_stream_updates == ()
+    assert len(tick2.completed) == 1
+    assert tick2.completed[0].result is not None
+    assert tick2.completed[0].result.output == {"closed": True}
+    assert runtime.finished == [{"step": 1, "seed": {"points": [[0.5, 0.5]]}}]
+    assert ex.has_work is False
+
+
+def test_chunks_sent_before_start_finishes_are_buffered() -> None:
+    runtime = _StubStreamingRuntime()
+    ex = StreamingExecutor(runtime, compute_stream=None)
+    req = _req(2)
+
+    ex.submit(req)
+    ex.submit_chunk(_StreamingChunk(session_id=2, inputs={"frame": [[0.3, 0.4]]}))
+
+    tick = ex.advance()
+
+    assert len(tick.model_stream_updates) == 1
+    assert tick.model_stream_updates[0].session_id == 2
+    assert tick.model_stream_updates[0].output["points"] == [[0.3, 0.4]]
+
+
+def test_step_error_completes_session_with_error() -> None:
+    runtime = _StubStreamingRuntime()
+    ex = StreamingExecutor(runtime, compute_stream=None)
+    req = _req(3)
+
+    ex.submit(req)
+    ex.advance()
+    ex.submit_chunk(_StreamingChunk(session_id=3, inputs={"boom": True}))
+    tick = ex.advance()
+
+    assert len(tick.completed) == 1
+    assert isinstance(tick.completed[0].error, ValueError)
+    assert runtime.finished == [{"step": 0, "seed": {"points": [[0.5, 0.5]]}}]
+    assert ex.has_work is False
+
+
+def test_start_error_drops_buffered_chunks() -> None:
+    runtime = _StubStreamingRuntime()
+    ex = StreamingExecutor(runtime, compute_stream=None)
+    req = _req(6, task="boom-start")
+
+    ex.submit(req)
+    ex.submit_chunk(_StreamingChunk(session_id=6, inputs={"frame": [[0.1, 0.2]]}))
+    tick = ex.advance()
+
+    assert len(tick.completed) == 1
+    assert isinstance(tick.completed[0].error, ValueError)
+    assert ex.has_work is False
+
+
+def test_shutdown_fails_starting_and_active_sessions() -> None:
+    runtime = _StubStreamingRuntime()
+    ex = StreamingExecutor(runtime, compute_stream=None)
+    active = _req(4)
+    queued = _req(5)
+
+    ex.submit(active)
+    ex.advance()
+    ex.submit(queued)
+
+    completions = ex.shutdown(RuntimeError("stop"))
+    ids = sorted(c.request.request_id for c in completions)
+
+    assert ids == [4, 5]
+    assert all(isinstance(c.error, RuntimeError) for c in completions)
+    assert ex.has_work is False
+
+
+def test_shutdown_deduplicates_in_flight_session_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeEvent:
+        def __init__(self, ready: bool) -> None:
+            self.ready = ready
+
+        def record(self) -> None:
+            pass
+
+        def query(self) -> bool:
+            return self.ready
+
+    events = [_FakeEvent(True), _FakeEvent(False)]
+
+    def fake_make_event(device: torch.device) -> _FakeEvent:
+        return events.pop(0)
+
+    monkeypatch.setattr("kestrel.engine.streaming.make_event", fake_make_event)
+    runtime = _StubStreamingRuntime()
+    ex = StreamingExecutor(runtime, compute_stream=None)
+    req = _req(7)
+
+    ex.submit(req)
+    ex.submit_chunk(_StreamingChunk(session_id=7, inputs={"frame": [[0.7, 0.8]]}))
+    tick = ex.advance()
+    completions = ex.shutdown(RuntimeError("stop"))
+
+    assert tick.completed == ()
+    assert tick.model_stream_updates == ()
+    assert [c.request.request_id for c in completions] == [7]
+    assert all(isinstance(c.error, RuntimeError) for c in completions)
+    assert runtime.finished == [{"step": 0, "seed": {"points": [[0.5, 0.5]]}}]
+    assert ex.has_work is False


### PR DESCRIPTION
## Summary
- Adds `StreamingExecutor` for stateful start/chunk/close sessions using the existing async launch/deferred collect lane pattern.
- Wires streaming starts and chunks into the engine scheduler loop, update delivery, terminal completion, shutdown, and polling.
- Adds executor and kernel-loop tests, and keeps existing single-pass lane tests in the targeted validation set.

## Validation
- `uv run pytest tests/test_streaming_executor.py tests/test_streaming_engine.py tests/test_model_stream.py tests/test_model_handle.py tests/test_single_pass_executor.py tests/test_single_pass_engine.py -q`
- `git diff --check`
- `git diff --cached --check`

Stacked on #95.