### PR TITLE
Share KV pool across runtimes

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -174,6 +174,7 @@ class InferenceEngine:
         # addresses runtimes by id and routes by ``execution_shape``, never by
         # interrogating the object.
         self._runtimes: Dict[str, Runtime] = {}
+        self._kv_pool = runtime.kv_pool if runtime is not None else None
         if runtime is not None:
             self._runtimes[self._default_model] = runtime
         runtime_device = (
@@ -429,22 +430,33 @@ class InferenceEngine:
         A co-hosted model gets a per-model config — its own ``model`` id, and
         ``model_path`` reset so it resolves for that model (a single-pass
         spec declares no weight file, so its path stays ``None`` and the
-        factory owns loading). ``max_lora_rank`` is the default
-        autoregressive model's concern (supplied by the adapter provider);
-        co-hosted models are built without it, since single-pass factories
-        don't accept it.
+        factory owns loading). Runtime factories receive common engine-owned
+        resources such as the compute stream and KV pool. ``max_lora_rank`` is
+        the default autoregressive model's concern, supplied by the adapter
+        provider only for that model.
         """
         from kestrel.models import get_spec
 
         spec = get_spec(model_id)
+        kwargs: dict[str, Any] = {
+            "compute_stream": self._compute_stream,
+            "kv_pool": self._shared_kv_pool(),
+        }
         if model_id == self._default_model:
             return spec.runtime(
                 self._runtime_cfg,
                 max_lora_rank=max_lora_rank,
-                compute_stream=self._compute_stream,
+                **kwargs,
             )
         cfg = replace(self._runtime_cfg, model=model_id, model_path=None)
-        return spec.runtime(cfg, compute_stream=self._compute_stream)
+        return spec.runtime(cfg, **kwargs)
+
+    def _shared_kv_pool(self):
+        if self._kv_pool is None:
+            from kestrel.kv_cache import KVMemoryPool
+
+            self._kv_pool = KVMemoryPool(device=self._runtime_cfg.resolved_device())
+        return self._kv_pool
 
     async def _warmup_query_pipeline(self) -> None:
         """Ensure the high-level query path is exercised before serving traffic."""

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -234,7 +234,7 @@ class MoondreamRuntime:
         cfg: RuntimeConfig,
         *,
         max_lora_rank: int | None = None,
-        kv_pool: KVMemoryPool | None = None,
+        kv_pool: KVMemoryPool,
         compute_stream: torch.cuda.Stream | None,
     ) -> None:
         self._cfg = cfg
@@ -286,9 +286,7 @@ class MoondreamRuntime:
             prefix_cache=self.prefix_cache,
             h2d_stream=self._compute_stream,
         )
-        self._kv_pool = kv_pool if kv_pool is not None else KVMemoryPool(
-            device=self.device
-        )
+        self._kv_pool = kv_pool
         if self._kv_pool.device != self.device:
             raise ValueError(
                 f"kv_pool.device ({self._kv_pool.device}) must match runtime "
@@ -625,6 +623,11 @@ class MoondreamRuntime:
     def compute_stream(self) -> torch.cuda.Stream | None:
         """Compute stream used by engine-constructed runtime internals."""
         return self._compute_stream
+
+    @property
+    def kv_pool(self) -> KVMemoryPool:
+        """KV memory pool owned by the engine/runtime construction path."""
+        return self._kv_pool
 
     @property
     def copy_stream(self) -> torch.cuda.Stream | None:

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -106,6 +106,7 @@ class AutoregressiveRuntime(Runtime, Protocol):
     # Engine + scheduler infrastructure
     prefix_cache: Any  # ``RadixPrefixCache | None`` on MoondreamRuntime
     graph_capture_lock: Any  # context manager serializing CUDA-graph capture
+    kv_pool: Any  # Engine-owned KV memory pool shared with co-hosted AR runtimes
 
     # Model-specific state callers reach into today.
     # Narrowing these is a follow-up.

--- a/scripts/profile_decode.py
+++ b/scripts/profile_decode.py
@@ -259,6 +259,7 @@ def main():
 
     from kestrel.config import RuntimeConfig
     from kestrel.device import make_stream
+    from kestrel.kv_cache import KVMemoryPool
     from kestrel.models.moondream.runtime import MoondreamRuntime, SequenceState, TextToken
 
     device = torch.device("cuda")
@@ -274,7 +275,11 @@ def main():
     )
 
     print(f"Loading model from {args.weights}...")
-    runtime = MoondreamRuntime(runtime_cfg, compute_stream=make_stream(device))
+    runtime = MoondreamRuntime(
+        runtime_cfg,
+        kv_pool=KVMemoryPool(device=device),
+        compute_stream=make_stream(device),
+    )
     config = runtime.config.text
     moe_desc = (
         f"MoE starts at layer {config.moe.start_layer}" if config.moe is not None else "no MoE"

--- a/scripts/profile_vision_encoder.py
+++ b/scripts/profile_vision_encoder.py
@@ -251,6 +251,7 @@ def main() -> None:
 
     from kestrel.config import RuntimeConfig
     from kestrel.device import make_stream
+    from kestrel.kv_cache import KVMemoryPool
     from kestrel.models.moondream.runtime import MoondreamRuntime
     from kestrel.models.moondream import vision as vision_module
 
@@ -263,7 +264,11 @@ def main() -> None:
     )
 
     print(f"Loading model from {args.weights}...")
-    runtime = MoondreamRuntime(runtime_cfg, compute_stream=make_stream(device))
+    runtime = MoondreamRuntime(
+        runtime_cfg,
+        kv_pool=KVMemoryPool(device=device),
+        compute_stream=make_stream(device),
+    )
     vision_cfg = runtime.config.vision
     vision_model = runtime.model.vision
     print(

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -120,6 +120,7 @@ class FakeRuntime:
         )
         self.compute_stream: Any = None
         self.copy_stream: Any = None
+        self.kv_pool: Any = object()
 
         # Slot containers + sequence registry. The scheduler treats these
         # as fixed-capacity arrays — sizing its staging pool from

--- a/tests/test_engine_runtime_injection.py
+++ b/tests/test_engine_runtime_injection.py
@@ -15,6 +15,7 @@ import pytest
 
 from kestrel.config import RuntimeConfig
 from kestrel.engine import InferenceEngine
+from kestrel.models.registry import ModelSpec, register, _REGISTRY
 
 from tests.scheduler._fake_runtime import FakeRuntime
 
@@ -33,6 +34,7 @@ def test_engine_holds_injected_runtime() -> None:
     engine = InferenceEngine(_cpu_cfg(), runtime=runtime)
     assert engine.runtime is runtime
     assert engine._compute_stream is stream
+    assert engine._kv_pool is runtime.kv_pool
 
 
 def test_engine_rejects_runtime_with_mismatched_device() -> None:
@@ -65,3 +67,25 @@ def test_engine_registers_injected_runtime_under_config_model_id() -> None:
     assert engine._default_model == "moondream2"
     assert engine._runtimes == {"moondream2": runtime}
     assert engine.runtime is runtime
+
+
+def test_engine_cohosted_runtime_reuses_injected_runtime_pool() -> None:
+    """An injected default runtime supplies the shared KV pool for later builds."""
+
+    seen: dict[str, object] = {}
+
+    def factory(cfg: RuntimeConfig, **kwargs):
+        seen[cfg.model] = kwargs["kv_pool"]
+        return FakeRuntime(model_name=cfg.model, device="cpu")
+
+    register(ModelSpec(name="cohosted-ar", runtime=factory))
+    try:
+        runtime = FakeRuntime(model_name="anything", device="cpu")
+        engine = InferenceEngine(_cpu_cfg(), runtime=runtime, models=["cohosted-ar"])
+        engine._build_configured_runtimes(max_lora_rank=None)
+
+        assert engine._runtimes["moondream2"] is runtime
+        assert seen["cohosted-ar"] is runtime.kv_pool
+        assert engine._kv_pool is runtime.kv_pool
+    finally:
+        _REGISTRY.pop("cohosted-ar", None)

--- a/tests/test_multi_model.py
+++ b/tests/test_multi_model.py
@@ -8,6 +8,7 @@ factories — no GPU, no real weights:
     pre-start via ``model()`` / ``_configured_models``;
   - ``_build_configured_runtimes`` builds every model from its spec,
     including a *tokenizer-free* single-pass spec (ModelSpec generalization);
+  - the shared KV pool is engine-owned and passed through runtime factory kwargs;
   - ``max_lora_rank`` is forwarded only to the default AR model.
 """
 
@@ -93,6 +94,7 @@ def test_build_configured_runtimes_builds_all_from_specs() -> None:
         eng._model_ids = ["mm-ar", "mm-sp"]
         eng._runtimes = {}
         eng._compute_stream = None
+        eng._kv_pool = None
 
         eng._build_configured_runtimes(13)
 
@@ -103,9 +105,15 @@ def test_build_configured_runtimes_builds_all_from_specs() -> None:
         assert eng._runtimes["mm-sp"].model_name == "mm-sp"
         # max_lora_rank → default AR only; compute_stream is supplied to
         # every runtime factory so both execution shapes share the engine
-        # stream. CPU tests use None for that stream.
-        assert built_kwargs["mm-ar"] == {"max_lora_rank": 13, "compute_stream": None}
-        assert built_kwargs["mm-sp"] == {"compute_stream": None}
+        # stream. The engine-owned kv_pool is also supplied via the common
+        # runtime factory kwargs contract.
+        assert built_kwargs["mm-ar"]["max_lora_rank"] == 13
+        assert built_kwargs["mm-ar"]["compute_stream"] is None
+        assert built_kwargs["mm-ar"]["kv_pool"] is eng._kv_pool
+        assert built_kwargs["mm-sp"] == {
+            "compute_stream": None,
+            "kv_pool": eng._kv_pool,
+        }
     finally:
         _REGISTRY.pop("mm-ar", None)
         _REGISTRY.pop("mm-sp", None)
@@ -128,6 +136,7 @@ def test_build_configured_runtimes_skips_already_built() -> None:
         injected = _SPStub("preexisting")
         eng._runtimes = {"preexisting": injected}
         eng._compute_stream = None
+        eng._kv_pool = None
 
         eng._build_configured_runtimes(None)
 


### PR DESCRIPTION
## Summary
- make the engine lazily create one shared `KVMemoryPool`
- pass the shared pool through the common runtime factory kwargs contract, alongside `compute_stream`
- make `MoondreamRuntime` require `kv_pool` instead of allocating a fallback pool
- update direct profiling scripts to pass explicit pool ownership

## Tests
- `PYTHONPYCACHEPREFIX=/tmp/kestrel_engine_pycache python -m py_compile kestrel/engine/core.py kestrel/models/moondream/runtime.py tests/test_multi_model.py scripts/profile_vision_encoder.py scripts/profile_decode.py`
- `PYTHONPATH=/tmp/kestrel-shared-kv-pr uv run --project /tmp/kestrel-qwen35-microbatch/private-models --with pytest pytest /tmp/kestrel-shared-kv-pr/tests/test_multi_model.py -q`
- `p1: cd /root/code/kestrel && PYTHONPYCACHEPREFIX=/tmp/kestrel_engine_pycache .venv/bin/python -m pytest tests/test_multi_model.py -q`