### PR TITLE
Surface scheduler startup failures

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -210,6 +210,7 @@ class InferenceEngine:
         self._paused_flag = threading.Event()  # set == paused
         self._paused_event = threading.Event()  # acknowledgment for callers
         self._scheduler_thread: Optional[threading.Thread] = None
+        self._scheduler_error: Optional[BaseException] = None
         self._worker_task: Optional[asyncio.Task[None]] = None
         self._photon_reporter: Optional[PhotonReporter] = None
         self._request_ids = itertools.count()
@@ -331,6 +332,7 @@ class InferenceEngine:
     async def _initialize(self) -> None:
         if self._initialized:
             return
+        self._scheduler_error = None
         loop = asyncio.get_running_loop()
         self._loop = loop
         try:
@@ -820,8 +822,11 @@ class InferenceEngine:
             inputs=inputs,
             submitted_at=time.perf_counter(),
         )
+        self._raise_if_scheduler_failed()
         self._single_pass_queue.put((model, req))
         self._scheduler_event.set()
+        if self._scheduler_error is not None:
+            self._fail_all_pending(self._scheduler_failed_error())
         return await future
 
     def model(self, model_id: Optional[str] = None) -> "ModelHandle":
@@ -947,6 +952,7 @@ class InferenceEngine:
         return future, req_id
 
     async def _ensure_started(self) -> None:
+        self._raise_if_scheduler_failed()
         if self._initialized:
             return
 
@@ -960,6 +966,7 @@ class InferenceEngine:
         # If another caller has init in flight, wait for it.
         if self._init_task is not None and not self._init_task.done():
             await asyncio.shield(self._init_task)
+            self._raise_if_scheduler_failed()
             if self._initialized:
                 return
             # Init failed; fall through to retry below.
@@ -970,6 +977,16 @@ class InferenceEngine:
             # self._init_task`` catches the warmup recursion above).
             self._init_task = asyncio.create_task(self._initialize())
         await asyncio.shield(self._init_task)
+        self._raise_if_scheduler_failed()
+
+    def _scheduler_failed_error(self) -> RuntimeError:
+        exc = RuntimeError("InferenceEngine scheduler is not running")
+        exc.__cause__ = self._scheduler_error
+        return exc
+
+    def _raise_if_scheduler_failed(self) -> None:
+        if self._scheduler_error is not None:
+            raise self._scheduler_failed_error()
 
     async def _worker_loop(self) -> None:
         shutdown_error = RuntimeError("Engine shut down")
@@ -980,6 +997,9 @@ class InferenceEngine:
                 self._scheduler_queue.put(None)
                 self._scheduler_event.set()
                 break
+            if self._scheduler_error is not None:
+                self._fail_request(request, self._scheduler_failed_error())
+                continue
             self._scheduler_queue.put(request)
             self._scheduler_event.set()
 
@@ -1273,30 +1293,37 @@ class InferenceEngine:
 
 
     def _scheduler_loop(self) -> None:
-        runtime = self._runtimes.get(self._default_model)
-        if runtime is None:
+        try:
+            runtime = self._runtimes.get(self._default_model)
+            if runtime is None:
+                raise RuntimeError(
+                    f"No runtime registered for default model {self._default_model!r}"
+                )
+            set_device(runtime.device)
+            # The default (autoregressive) lane. Its pipeline owns the device's
+            # CUDA-graph capture, so pause/drain is handled specially below.
+            ar_executor = AutoregressiveExecutor(
+                runtime,
+                compute_stream=self._compute_stream,
+                skills=self._skill_registry(),
+                adapter_provider=self._adapter_provider,
+                build_generation_request=self._build_generation_request,
+                to_engine_result=self._to_engine_result,
+                wake_event=self._scheduler_event,
+            )
+            # One single-pass lane per registered single-pass model. The kernel
+            # folds advance() over every lane; single-pass forwards interleave
+            # with autoregressive decode on the shared stream.
+            single_pass: Dict[str, SinglePassExecutor] = {
+                name: SinglePassExecutor(rt, compute_stream=self._compute_stream)
+                for name, rt in self._runtimes.items()
+                if rt.execution_shape is ExecutionShape.SINGLE_PASS
+            }
+        except Exception as exc:
+            self._scheduler_error = exc
+            _LOGGER.exception("Scheduler startup failed", exc_info=exc)
+            self._fail_all_pending(self._scheduler_failed_error())
             return
-        set_device(runtime.device)
-
-        # The default (autoregressive) lane. Its pipeline owns the device's
-        # CUDA-graph capture, so pause/drain is handled specially below.
-        ar_executor = AutoregressiveExecutor(
-            runtime,
-            compute_stream=self._compute_stream,
-            skills=self._skill_registry(),
-            adapter_provider=self._adapter_provider,
-            build_generation_request=self._build_generation_request,
-            to_engine_result=self._to_engine_result,
-            wake_event=self._scheduler_event,
-        )
-        # One single-pass lane per registered single-pass model. The kernel
-        # folds advance() over every lane; single-pass forwards interleave
-        # with autoregressive decode on the shared stream.
-        single_pass: Dict[str, SinglePassExecutor] = {
-            name: SinglePassExecutor(rt, compute_stream=self._compute_stream)
-            for name, rt in self._runtimes.items()
-            if rt.execution_shape is ExecutionShape.SINGLE_PASS
-        }
 
         shutdown_requested = False
         wake_event = self._scheduler_event
@@ -1385,6 +1412,7 @@ class InferenceEngine:
                     try:
                         tick = ar_executor.advance()
                     except Exception as exc:
+                        self._scheduler_error = exc
                         _LOGGER.exception("Autoregressive advance failed", exc_info=exc)
                         deliver(ar_executor.shutdown(exc))
                         for lane in single_pass.values():

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1002,6 +1002,8 @@ class InferenceEngine:
                 continue
             self._scheduler_queue.put(request)
             self._scheduler_event.set()
+            if self._scheduler_error is not None:
+                self._fail_all_pending(self._scheduler_failed_error())
 
         while not self._queue.empty():
             pending = self._queue.get_nowait()

--- a/tests/test_engine_runtime_injection.py
+++ b/tests/test_engine_runtime_injection.py
@@ -11,8 +11,11 @@ engines.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
+import kestrel.engine.core as engine_core
 from kestrel.config import RuntimeConfig
 from kestrel.engine import InferenceEngine
 from kestrel.models.registry import ModelSpec, register, _REGISTRY
@@ -89,3 +92,21 @@ def test_engine_cohosted_runtime_reuses_injected_runtime_pool() -> None:
         assert engine._kv_pool is runtime.kv_pool
     finally:
         _REGISTRY.pop("cohosted-ar", None)
+
+
+def test_engine_surfaces_scheduler_startup_failure(monkeypatch) -> None:
+    class BrokenExecutor:
+        def __init__(self, *args, **kwargs) -> None:
+            raise TypeError("scheduler constructor mismatch")
+
+    monkeypatch.setattr(engine_core, "AutoregressiveExecutor", BrokenExecutor)
+    runtime = FakeRuntime(model_name="anything", device="cpu")
+    engine = InferenceEngine(_cpu_cfg(), runtime=runtime)
+
+    async def run() -> None:
+        with pytest.raises(RuntimeError, match="scheduler is not running") as exc:
+            await engine._initialize()
+        assert isinstance(exc.value.__cause__, TypeError)
+        assert "constructor mismatch" in str(exc.value.__cause__)
+
+    asyncio.run(run())

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -48,6 +48,7 @@ def _engine() -> InferenceEngine:
     eng._skills_override = None  # AR runtime owns its skills
     # Runtimes are injected (already built), so the engine is effectively
     # started: _ensure_started() (now awaited by the handle verbs) is a no-op.
+    eng._scheduler_error = None
     eng._initialized = True
     return eng
 

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 
 from kestrel.engine import InferenceEngine
+from kestrel.engine._types import _AutoregressiveRequest
 from kestrel.runtime import ExecutionShape
 
 from tests.scheduler._fake_runtime import FakeRuntime
@@ -129,6 +130,59 @@ def test_run_fails_if_scheduler_dies_after_single_pass_enqueue() -> None:
         assert isinstance(exc.value.__cause__, RuntimeError)
         assert "scheduler crashed" in str(exc.value.__cause__)
         assert engine._single_pass_queue.empty()
+
+    asyncio.run(go())
+
+
+def test_worker_fails_ar_if_scheduler_dies_after_forwarding() -> None:
+    """Regression: AR submit must not hang if scheduler drains before put().
+
+    The worker checks the latched scheduler error before forwarding requests,
+    but the scheduler can fail between that check and ``_scheduler_queue.put``.
+    In that race, the request lands in a queue that no scheduler will consume.
+    """
+
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        sp = _StubSinglePass()
+        engine = _engine_with(ar, sp)
+        engine._loop = asyncio.get_running_loop()
+        engine._queue = asyncio.Queue()
+
+        class _QueueThatFailsAfterPut(_queue.Queue):
+            def put(self, item: Any, *args: Any, **kwargs: Any) -> None:
+                super().put(item, *args, **kwargs)
+                if item is not None:
+                    engine._scheduler_error = RuntimeError("scheduler crashed")
+
+        engine._scheduler_queue = _QueueThatFailsAfterPut()
+        future = asyncio.get_running_loop().create_future()
+        request = _AutoregressiveRequest(
+            request_id=1,
+            prompt="",
+            prompt_tokens=[],
+            image=None,
+            image_hash=None,
+            max_new_tokens=1,
+            temperature=0.0,
+            top_p=1.0,
+            submitted_at=0.0,
+            future=future,
+            stream_queue=None,
+            skill=object(),  # type: ignore[arg-type]
+            request_context=None,
+        )
+
+        await engine._queue.put(request)
+        await engine._queue.put(None)
+        await asyncio.wait_for(engine._worker_loop(), timeout=1.0)
+
+        with pytest.raises(RuntimeError, match="scheduler is not running") as exc:
+            await asyncio.wait_for(future, timeout=1.0)
+        assert isinstance(exc.value.__cause__, RuntimeError)
+        assert "scheduler crashed" in str(exc.value.__cause__)
+        assert engine._scheduler_queue.get_nowait() is None
+        assert engine._scheduler_queue.empty()
 
     asyncio.run(go())
 

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -11,6 +11,7 @@ exercising the kernel's multi-lane fold + ingress routing.
 from __future__ import annotations
 
 import asyncio
+import queue as _queue
 import threading
 from typing import Any
 
@@ -56,6 +57,7 @@ def _engine_with(ar: FakeRuntime, sp: _StubSinglePass) -> InferenceEngine:
     engine._run_gate.set()
     engine._paused_flag = threading.Event()
     engine._paused_event = threading.Event()
+    engine._scheduler_error = None
     engine._shutdown = False
     engine._photon_reporter = None
     engine._adapter_provider = None
@@ -94,6 +96,41 @@ def test_run_routes_single_pass_through_kernel_loop() -> None:
 def test_run_propagates_forward_error() -> None:
     with pytest.raises(ValueError, match="forward failed"):
         asyncio.run(_run("boom", {}))
+
+
+def test_run_fails_if_scheduler_dies_after_single_pass_enqueue() -> None:
+    """Regression: run() must not hang if scheduler failure drains before put().
+
+    The scheduler thread sets ``_scheduler_error`` and drains ingress once on
+    fatal failure. If a single-pass caller enqueues immediately after that
+    drain, there is no kernel left to consume the request. run() must detect
+    the latched failure after enqueue and fail the request itself.
+    """
+
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        sp = _StubSinglePass()
+        engine = _engine_with(ar, sp)
+        engine._loop = asyncio.get_running_loop()
+        engine._initialized = True
+        engine._init_task = None
+
+        class _QueueThatFailsAfterPut(_queue.Queue):
+            def put(self, item: Any, *args: Any, **kwargs: Any) -> None:
+                super().put(item, *args, **kwargs)
+                engine._scheduler_error = RuntimeError("scheduler crashed")
+
+        engine._single_pass_queue = _QueueThatFailsAfterPut()
+
+        with pytest.raises(RuntimeError, match="scheduler is not running") as exc:
+            await asyncio.wait_for(
+                engine.run(sp.model_name, "segment", {"points": []}), timeout=1.0
+            )
+        assert isinstance(exc.value.__cause__, RuntimeError)
+        assert "scheduler crashed" in str(exc.value.__cause__)
+        assert engine._single_pass_queue.empty()
+
+    asyncio.run(go())
 
 
 def test_run_rejects_unknown_model() -> None:


### PR DESCRIPTION
## Summary
- Latch scheduler-thread startup/advance failures on the engine.
- Make warmup and later request submission raise immediately if the scheduler is not running.
- Fail requests that race through the worker after a scheduler failure instead of queueing them to a dead scheduler.

## Root cause
A scheduler-thread exception before the main scheduler loop was not surfaced to the async caller. In the Qwen validation run, a mixed test-host checkout let `core.py` call `AutoregressiveExecutor(..., compute_stream=...)` while the remote `executor.py` still had the older constructor. The scheduler thread died, the model stayed resident on GPU, and the warmup query awaited a future that could never be completed.

## Validation
- `env UV_CACHE_DIR=/tmp/uv-cache-qwen PYTHONPATH=/tmp/kestrel-scheduler-startup-failure uv run --project /tmp/kestrel-qwen35-microbatch/private-models --with pytest pytest /tmp/kestrel-scheduler-startup-failure/tests/test_engine_runtime_injection.py /tmp/kestrel-scheduler-startup-failure/tests/test_multi_model.py -q`
- `p1`: `cd /root/code/kestrel && PYTHONPYCACHEPREFIX=/tmp/kestrel_engine_pycache .venv/bin/python -m pytest tests/test_multi_model.py tests/test_engine_runtime_injection.py -q`
- `p1`: `cd /root/code/kestrel-proprietary && env UV_CACHE_DIR=/tmp/uv-cache-qwen PYTHONPATH=/root/code/kestrel /root/.local/bin/uv run --project private-models --with pytest pytest private-models/tests/qwen35/test_engine_integration.py::test_engine_batches_distinct_qwen_queries -q -s`