### PR TITLE
Use paged KV names in Moondream text path

### DIFF
--- a/kestrel/models/moondream/decode_slot.py
+++ b/kestrel/models/moondream/decode_slot.py
@@ -2,7 +2,7 @@
 
 Each DecodeSlot bundles the GPU resources needed for one decode step:
 - Pinned host buffers for H2D metadata copies (batch_idx, input_pos, lora_slot_ids)
-- Per-slot paged-KV metadata buffers (page_table, seqused_k)
+- Per-slot paged-KV metadata buffers (page table, KV sequence lengths)
 - GPU staging buffers for sampled outputs
 - Forward output buffers (logits, hidden_last) for delayed sampling
 - RenderBuffer for D2H copies
@@ -79,8 +79,8 @@ class DecodeSlot:
             All decode forwards across both slots serialize on this stream
             to preserve sequential token dependencies (invariant I1).
 
-        fa3_page_table: Per-slot page table rows for FA3 paged decode.
-        fa3_seqused_k: Per-slot per-sequence KV lengths for FA3 paged decode.
+        paged_kv_page_table: Per-slot page table rows for paged attention decode.
+        paged_kv_seqlens_k: Per-slot per-sequence KV lengths for paged attention decode.
 
         # GPU staging buffers for sampled outputs (per-slot to avoid clobbering)
         sampled_ids: GPU buffer for sampled token IDs.
@@ -108,8 +108,8 @@ class DecodeSlot:
     render: object  # RenderBuffer (import deferred to avoid circular import)
     compute_stream: torch.cuda.Stream | None
 
-    fa3_page_table: Tensor
-    fa3_seqused_k: Tensor
+    paged_kv_page_table: Tensor
+    paged_kv_seqlens_k: Tensor
 
     # GPU staging for sampled outputs
     sampled_ids: Tensor
@@ -241,12 +241,12 @@ def create_decode_slot(
         copy_stream=copy_stream,
     )
 
-    fa3_page_table = torch.empty(
+    paged_kv_page_table = torch.empty(
         (max_batch_slots, kv_cache_pages),
         dtype=torch.int32,
         device=device,
     )
-    fa3_seqused_k = torch.empty(
+    paged_kv_seqlens_k = torch.empty(
         (max_batch_slots,),
         dtype=torch.int32,
         device=device,
@@ -344,8 +344,8 @@ def create_decode_slot(
         meta=meta,
         render=render,
         compute_stream=compute_stream,
-        fa3_page_table=fa3_page_table,
-        fa3_seqused_k=fa3_seqused_k,
+        paged_kv_page_table=paged_kv_page_table,
+        paged_kv_seqlens_k=paged_kv_seqlens_k,
         sampled_ids=sampled_ids,
         sampled_logprobs=sampled_logprobs,
         coord_staging=coord_staging,

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -1160,12 +1160,12 @@ class MoondreamRuntime:
             skip_positions, prompt_len, dtype=torch.long, device=self.device
         ).unsqueeze(0)
 
-        # FA3 needs to know total KV length (cached + new)
-        fa3_seqused_k = torch.tensor(
+        # Paged attention needs the total KV length (cached + new).
+        paged_kv_seqlens_k = torch.tensor(
             [prompt_len], dtype=torch.int32, device=self.device
         )
 
-        return inputs_embeds, position_ids, fa3_seqused_k
+        return inputs_embeds, position_ids, paged_kv_seqlens_k
 
     def _prepare_full_prefill_inputs(
         self,
@@ -1201,11 +1201,11 @@ class MoondreamRuntime:
         position_ids = torch.arange(
             prompt_len, dtype=torch.long, device=self.device
         ).unsqueeze(0)
-        fa3_seqused_k = torch.tensor(
+        paged_kv_seqlens_k = torch.tensor(
             [prompt_len], dtype=torch.int32, device=self.device
         )
 
-        return inputs_embeds, position_ids, fa3_seqused_k
+        return inputs_embeds, position_ids, paged_kv_seqlens_k
 
     def _finalize_cache_after_prefill(
         self,
@@ -1504,12 +1504,12 @@ class MoondreamRuntime:
                 (batch_size,), dtype=torch.long, device=self.device
             )
             q_is_padded = any(seq_len != max_seq_len for seq_len in seq_lens)
-            fa3_seqused_q = (
+            paged_kv_seqlens_q = (
                 torch.empty((batch_size,), dtype=torch.int32, device=self.device)
                 if q_is_padded
                 else None
             )
-            fa3_seqused_k = torch.tensor(
+            paged_kv_seqlens_k = torch.tensor(
                 [
                     int(prepared.state.prompt_length or prepared.state.length)
                     for prepared in prepared_sequences
@@ -1537,8 +1537,8 @@ class MoondreamRuntime:
                 # Route padded tokens to reserved batch row 0 so they never write
                 # into real sequence KV slots.
                 slot_batch_idx[row, :seq_len].fill_(batch_idx)
-                if fa3_seqused_q is not None:
-                    fa3_seqused_q[row] = seq_len
+                if paged_kv_seqlens_q is not None:
+                    paged_kv_seqlens_q[row] = seq_len
                 last_token_positions[row] = seq_len - 1
 
             # Commit page table rows for all batch indices before forward pass.
@@ -1552,8 +1552,8 @@ class MoondreamRuntime:
                 batch_idx=slot_batch_idx,
                 lora_slot=lora_slot,
                 use_prefix_attn=use_prefix_attn,
-                fa3_seqused_q=fa3_seqused_q,
-                fa3_seqused_k=fa3_seqused_k,
+                paged_kv_seqlens_q=paged_kv_seqlens_q,
+                paged_kv_seqlens_k=paged_kv_seqlens_k,
                 last_token_positions=last_token_positions,
             )
 
@@ -1672,8 +1672,8 @@ class MoondreamRuntime:
         lora_slot: int = 0,
         *,
         use_prefix_attn: bool,
-        fa3_seqused_q: Tensor | None,
-        fa3_seqused_k: Tensor,
+        paged_kv_seqlens_q: Tensor | None,
+        paged_kv_seqlens_k: Tensor,
         last_token_positions: Tensor,
     ) -> tuple[Tensor, Tensor]:
         if batch_idx.ndim != 2:
@@ -1690,8 +1690,8 @@ class MoondreamRuntime:
             batch_idx=batch_idx, positions=position_ids
         )
 
-        # Build FA3 paged attention metadata for prefill
-        fa3_page_table = torch.index_select(
+        # Build paged attention metadata for prefill.
+        paged_kv_page_table = torch.index_select(
             self.page_table.page_table, 0, batch_rows
         )
 
@@ -1769,9 +1769,9 @@ class MoondreamRuntime:
             slot_mapping=slot_mapping,
             mode="prefill",
             use_prefix_attn=use_prefix_attn,
-            page_table=fa3_page_table,
-            fa3_seqused_q=fa3_seqused_q,
-            fa3_seqused_k=fa3_seqused_k,
+            page_table=paged_kv_page_table,
+            paged_kv_seqlens_q=paged_kv_seqlens_q,
+            paged_kv_seqlens_k=paged_kv_seqlens_k,
             lora_workspace=lora_workspace,
             lora_slot_ids=lora_slot_ids,
             moe_lora_metadata=moe_lora_metadata,
@@ -1843,13 +1843,13 @@ class MoondreamRuntime:
 
         # Build per-step paged-KV metadata buffers (identical for both paths)
         # - page_table rows: [B, num_pages]
-        # - seqused_k: [B] (KV length including the current token after update)
+        # - paged_kv_seqlens_k: [B] (KV length including the current token after update)
         batch_idx = slot.meta.batch_idx.gpu[:graph_batch_size]
         self.page_table.populate_paged_kv_metadata(
             batch_idx=batch_idx,
             input_pos=slot.meta.input_pos.gpu[:graph_batch_size],
-            out_page_table=slot.fa3_page_table[:graph_batch_size],
-            out_seqused_k=slot.fa3_seqused_k[:graph_batch_size],
+            out_page_table=slot.paged_kv_page_table[:graph_batch_size],
+            out_seqused_k=slot.paged_kv_seqlens_k[:graph_batch_size],
         )
 
         # Execute (only difference between paths)
@@ -1930,8 +1930,8 @@ class MoondreamRuntime:
             config=self.config.text,
             mode="decode",
             slot_mapping=slot_mapping,
-            page_table=slot.fa3_page_table[:batch_size],
-            fa3_seqused_k=slot.fa3_seqused_k[:batch_size],
+            page_table=slot.paged_kv_page_table[:batch_size],
+            paged_kv_seqlens_k=slot.paged_kv_seqlens_k[:batch_size],
             lora_workspace=lora_workspace,
             lora_slot_ids=lora_slot_ids,
             moe_lora_metadata=moe_lora_metadata,
@@ -2118,8 +2118,8 @@ class MoondreamRuntime:
             device = self.device
 
             # Graph capture must happen on the same stream we use for decode replay.
-            # Otherwise, replayed kernels may read stale metadata (page tables / seqused_k)
-            # written on a different stream, producing incorrect results.
+            # Otherwise, replayed kernels may read stale paged-KV metadata written
+            # on a different stream, producing incorrect results.
             with torch.cuda.stream(slot.compute_stream):
                 # Zero all slot buffers for capture.
                 # Use batch index 0 for all entries - row 0 in the page table is
@@ -2137,8 +2137,8 @@ class MoondreamRuntime:
                 slot.meta.active_lora_ids.cpu.zero_()
                 slot.meta.active_lora_meta.gpu.zero_()
                 slot.meta.active_lora_meta.cpu.zero_()
-                slot.fa3_page_table.zero_()
-                slot.fa3_seqused_k.zero_()
+                slot.paged_kv_page_table.zero_()
+                slot.paged_kv_seqlens_k.zero_()
 
                 try:
                     torch.cuda.synchronize(device=device)
@@ -2153,8 +2153,8 @@ class MoondreamRuntime:
                             self.page_table.populate_paged_kv_metadata(
                                 batch_idx=batch_idx,
                                 input_pos=slot.meta.input_pos.gpu[:bs],
-                                out_page_table=slot.fa3_page_table[:bs],
-                                out_seqused_k=slot.fa3_seqused_k[:bs],
+                                out_page_table=slot.paged_kv_page_table[:bs],
+                                out_seqused_k=slot.paged_kv_seqlens_k[:bs],
                             )
 
                             # Warmup run (not captured)
@@ -2176,8 +2176,8 @@ class MoondreamRuntime:
                     slot.meta.active_token_ids.gpu.zero_()
                     slot.meta.active_lora_ids.gpu.zero_()
                     slot.meta.active_lora_meta.gpu.zero_()
-                    slot.fa3_page_table.zero_()
-                    slot.fa3_seqused_k.zero_()
+                    slot.paged_kv_page_table.zero_()
+                    slot.paged_kv_seqlens_k.zero_()
 
         return cuda_graphs
 

--- a/kestrel/models/moondream/text.py
+++ b/kestrel/models/moondream/text.py
@@ -82,8 +82,8 @@ def attn(
     slot_mapping: torch.Tensor,
     use_prefix_attn: bool = False,
     page_table: torch.Tensor | None = None,
-    fa3_seqused_q: torch.Tensor | None = None,
-    fa3_seqused_k: torch.Tensor | None = None,
+    paged_kv_seqlens_q: torch.Tensor | None = None,
+    paged_kv_seqlens_k: torch.Tensor | None = None,
     residual: torch.Tensor | None = None,
     scratch_pool: dict | None = None,
 ) -> torch.Tensor:
@@ -125,8 +125,8 @@ def attn(
 
     if kv_cache is None:
         raise RuntimeError("paged attention requires a KV cache")
-    if page_table is None or fa3_seqused_k is None:
-        raise RuntimeError("paged attention requires page_table and seqused_k")
+    if page_table is None or paged_kv_seqlens_k is None:
+        raise RuntimeError("paged attention requires page_table and paged KV lengths")
 
     kv_cache.update(position_ids, k, v, slot_mapping=slot_mapping)
 
@@ -152,8 +152,8 @@ def attn(
             k_cache,
             v_cache,
             page_table=page_table,
-            seqused_q=fa3_seqused_q,
-            seqused_k=fa3_seqused_k,
+            seqused_q=paged_kv_seqlens_q,
+            seqused_k=paged_kv_seqlens_k,
             paged_kv_non_tma=True,
             causal=causal,
             pack_gqa=pack_gqa,
@@ -167,8 +167,8 @@ def attn(
             k_cache,
             v_cache,
             page_table=page_table,
-            seqused_q=fa3_seqused_q,
-            seqused_k=fa3_seqused_k,
+            seqused_q=paged_kv_seqlens_q,
+            seqused_k=paged_kv_seqlens_k,
             paged_kv_non_tma=True,
             causal=True,
             k_scale=k_scale,
@@ -196,8 +196,8 @@ def text_decoder(
     use_prefix_attn: bool = False,
     mode: Literal["prefill", "decode"] = "decode",
     page_table: torch.Tensor | None = None,
-    fa3_seqused_q: torch.Tensor | None = None,
-    fa3_seqused_k: torch.Tensor | None = None,
+    paged_kv_seqlens_q: torch.Tensor | None = None,
+    paged_kv_seqlens_k: torch.Tensor | None = None,
     lora_workspace: TextLoRAWorkspace | None = None,
     lora_slot_ids: torch.Tensor | None = None,
     moe_lora_metadata: Any | None = None,
@@ -227,8 +227,8 @@ def text_decoder(
             slot_mapping=slot_mapping,
             use_prefix_attn=use_prefix_attn,
             page_table=page_table,
-            fa3_seqused_q=fa3_seqused_q,
-            fa3_seqused_k=fa3_seqused_k,
+            paged_kv_seqlens_q=paged_kv_seqlens_q,
+            paged_kv_seqlens_k=paged_kv_seqlens_k,
             residual=x,
             scratch_pool=scratch_pool,
         )

--- a/scripts/profile_decode.py
+++ b/scripts/profile_decode.py
@@ -46,7 +46,7 @@ Key output sections:
 | Component | Count | Notes |
 |-----------|-------|-------|
 | layernorm | 25 | 24 pre-attn + 1 final |
-| attention | 24 | QKV + rotary + FA3 + out_proj |
+| attention | 24 | QKV + rotary + paged attention + out_proj |
 | dense_mlp | 4 | Layers 0-3 |
 | moe_mlp | 20 | Layers 4-23 |
 | lm_head | 1 | Final projection |
@@ -112,7 +112,7 @@ def patch_text_decoder_with_nvtx():
     def instrumented_text_decoder(
         x, module, attn_mask, position_ids, config, *,
         slot_mapping, use_prefix_attn=False, mode="decode",
-        page_table=None, fa3_seqused_q=None, fa3_seqused_k=None,
+        page_table=None, paged_kv_seqlens_q=None, paged_kv_seqlens_k=None,
         lora_workspace=None, lora_slot_ids=None, single_lora_id=None,
         dense_lora_scratch=None,
         scratch_pool=None,
@@ -146,8 +146,8 @@ def patch_text_decoder_with_nvtx():
                     slot_mapping=slot_mapping,
                     use_prefix_attn=use_prefix_attn,
                     page_table=page_table,
-                    fa3_seqused_q=fa3_seqused_q,
-                    fa3_seqused_k=fa3_seqused_k,
+                    paged_kv_seqlens_q=paged_kv_seqlens_q,
+                    paged_kv_seqlens_k=paged_kv_seqlens_k,
                     residual=x,
                 )
                 nvtx.range_pop()

--- a/tests/moondream/test_runtime_prefill.py
+++ b/tests/moondream/test_runtime_prefill.py
@@ -55,13 +55,13 @@ def _make_runtime(seq_lens: dict[int, int]) -> tuple[runtime_mod.MoondreamRuntim
         lora_slot=0,
         *,
         use_prefix_attn,
-        fa3_seqused_q,
-        fa3_seqused_k,
+        paged_kv_seqlens_q,
+        paged_kv_seqlens_k,
         last_token_positions,
     ):
         del attn_mask, position_ids, batch_idx, lora_slot, use_prefix_attn
-        captured["fa3_seqused_q"] = fa3_seqused_q
-        captured["fa3_seqused_k"] = fa3_seqused_k
+        captured["paged_kv_seqlens_q"] = paged_kv_seqlens_q
+        captured["paged_kv_seqlens_k"] = paged_kv_seqlens_k
         captured["last_token_positions"] = last_token_positions
         batch_size = inputs_embeds.shape[0]
         return inputs_embeds, torch.zeros((batch_size, 8), dtype=inputs_embeds.dtype)
@@ -71,7 +71,7 @@ def _make_runtime(seq_lens: dict[int, int]) -> tuple[runtime_mod.MoondreamRuntim
     return runtime, captured
 
 
-def test_launch_prepared_batch_omits_seqused_q_for_uniform_q_lengths() -> None:
+def test_launch_prepared_batch_omits_paged_kv_q_lengths_for_uniform_q_lengths() -> None:
     runtime, captured = _make_runtime({1: 3, 2: 3})
     slot = runtime_mod.PrefillSlot(
         slot_id=0,
@@ -91,9 +91,9 @@ def test_launch_prepared_batch_omits_seqused_q_for_uniform_q_lengths() -> None:
     )
 
     assert logits.shape == (2, 8)
-    assert captured["fa3_seqused_q"] is None
+    assert captured["paged_kv_seqlens_q"] is None
     torch.testing.assert_close(
-        captured["fa3_seqused_k"],
+        captured["paged_kv_seqlens_k"],
         torch.tensor([10, 11], dtype=torch.int32),
     )
     torch.testing.assert_close(
@@ -102,7 +102,7 @@ def test_launch_prepared_batch_omits_seqused_q_for_uniform_q_lengths() -> None:
     )
 
 
-def test_launch_prepared_batch_omits_seqused_q_for_single_token_append() -> None:
+def test_launch_prepared_batch_omits_paged_kv_q_lengths_for_single_token_append() -> None:
     runtime, captured = _make_runtime({1: 1, 2: 1})
     slot = runtime_mod.PrefillSlot(
         slot_id=0,
@@ -122,14 +122,14 @@ def test_launch_prepared_batch_omits_seqused_q_for_single_token_append() -> None
     )
 
     assert logits.shape == (2, 8)
-    assert captured["fa3_seqused_q"] is None
+    assert captured["paged_kv_seqlens_q"] is None
     torch.testing.assert_close(
         captured["last_token_positions"],
         torch.tensor([0, 0], dtype=torch.long),
     )
 
 
-def test_launch_prepared_batch_keeps_seqused_q_for_padded_q_lengths() -> None:
+def test_launch_prepared_batch_keeps_paged_kv_q_lengths_for_padded_q_lengths() -> None:
     runtime, captured = _make_runtime({1: 1, 2: 3})
     slot = runtime_mod.PrefillSlot(
         slot_id=0,
@@ -150,7 +150,7 @@ def test_launch_prepared_batch_keeps_seqused_q_for_padded_q_lengths() -> None:
 
     assert logits.shape == (2, 8)
     torch.testing.assert_close(
-        captured["fa3_seqused_q"],
+        captured["paged_kv_seqlens_q"],
         torch.tensor([1, 3], dtype=torch.int32),
     )
     torch.testing.assert_close(


### PR DESCRIPTION
## Summary
- Rename Moondream/runtime-facing `fa3_*` paged attention metadata to generic paged-KV names.
- Update the shared text decoder call surface and decode slot metadata fields to avoid variant-specific FA3 wording.
- Refresh the Moondream prefill tests and decode profiler label to use paged attention terminology.

## Tests
- `uv run pytest tests/moondream/test_runtime_prefill.py -q`
- `git diff --check`