### PR TITLE
Add shared decode graph manager

### DIFF
--- a/kestrel/models/moondream/decode_slot.py
+++ b/kestrel/models/moondream/decode_slot.py
@@ -6,7 +6,7 @@ Each DecodeSlot bundles the GPU resources needed for one decode step:
 - GPU staging buffers for sampled outputs
 - Forward output buffers (logits, hidden_last) for delayed sampling
 - RenderBuffer for D2H copies
-- CUDA graph workspace and captured graphs
+- CUDA graph input/output workspace
 
 With two slots, we can pipeline decode steps: while slot A's forward runs on the GPU,
 slot B's D2H transfer completes and its outputs are committed on CPU. The slots
@@ -20,7 +20,7 @@ Ownership model:
 """
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import torch
 from torch import Tensor
@@ -97,10 +97,8 @@ class DecodeSlot:
         decode_coord_values: GPU buffer for decode coord inputs.
         decode_size_values: GPU buffer for decode size inputs.
 
-        # CUDA graphs (per-slot, optional)
-        cuda_graphs: Captured CUDA graphs keyed by batch size, or None if disabled.
-            Graphs are captured using this slot's buffers (decode_*, meta.*, logits,
-            hidden_last), so replay reads/writes directly to slot buffers.
+        # CUDA graph input/output workspace
+        These fixed-address buffers are used by DecodeGraphManager capture/replay.
     """
 
     slot_id: int
@@ -131,9 +129,6 @@ class DecodeSlot:
     decode_token_ids: Tensor
     decode_coord_values: Tensor  # [max_batch_slots, 1]
     decode_size_values: Tensor   # [max_batch_slots, 2]
-
-    # CUDA graphs (optional) - captured using this slot's buffers
-    cuda_graphs: Optional[dict[int, torch.cuda.CUDAGraph]] = None
 
     # Pre-allocated events for decode-step synchronization (avoids per-step allocation).
     #
@@ -358,7 +353,6 @@ def create_decode_slot(
         decode_token_ids=decode_token_ids,
         decode_coord_values=decode_coord_values,
         decode_size_values=decode_size_values,
-        cuda_graphs=None,  # Captured separately after slot creation
         step_done_event=step_done_event,
         commit_done_event=commit_done_event,
         disallow_mask=disallow_mask,

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -31,9 +31,10 @@ from kestrel.prefix_cache import (
     RadixPrefixCache,
     TreeNode,
 )
+from kestrel.runtime.decode_graph import DecodeGraphManager
 from kestrel.runtime import (
-    ExecutionShape,
     CoordToken,
+    ExecutionShape,
     PrefillClassification,
     PreparedSequence,
     RuntimeDecodeResult,
@@ -450,9 +451,6 @@ class MoondreamRuntime:
         self._spatial_rng = torch.Generator(device=self.device)
         self._spatial_rng.manual_seed(torch.seed())
 
-        # CUDA graph batch sizes for decode (same for all slots).
-        self._graph_batch_sizes: list[int] = []
-
         # Vision encoder CUDA graphs
         self._vision_graphs: dict[int, torch.cuda.CUDAGraph] = {}
         self._vision_input: torch.Tensor | None = None   # [max_crops, 3, 378, 378]
@@ -551,6 +549,17 @@ class MoondreamRuntime:
             )
             for slot_id in range(2)
         ]
+        self._decode_graphs = DecodeGraphManager[DecodeSlot](
+            enabled=self._use_cuda_graphs,
+            device=self.device,
+            max_batch=self.max_batch_size,
+            graph_capture_lock=self.graph_capture_lock,
+            compute_stream=self._compute_stream,
+            run_forward=self._run_decode_forward,
+            prepare_step=self._prepare_decode_graph_step,
+            zero_padding=self._zero_decode_graph_padding,
+            zero_for_capture=self._zero_decode_graph_capture_buffers,
+        )
 
         # Shared pending coord/size values, indexed by batch_idx. These
         # are the runtime-side equivalent of the scheduler's
@@ -1799,64 +1808,57 @@ class MoondreamRuntime:
     def _decode_with_slot(self, slot: DecodeSlot, batch_size: int) -> None:
         """Unified decode using slot buffers. Writes results to slot.logits/hidden_last.
 
-        This method provides identical preparation for both graph and non-graph paths:
-        1. Clear padding region (for graph batch size alignment)
-        2. Build paged-KV metadata buffers
-        3. Execute: either graph.replay() or eager forward
-
-        The only difference between paths is step 3. This ensures debugging with
-        graphs disabled produces identical behavior to the graph path.
-
         Args:
             slot: DecodeSlot with inputs already staged in its buffers.
             batch_size: Actual number of sequences (before padding).
         """
-        use_graph = self._use_cuda_graphs and slot.cuda_graphs is not None
+        self._decode_graphs.run(slot, batch_size)
 
-        # Determine padded batch size for graph alignment
-        if use_graph:
-            graph_batch_size = self._select_graph_batch_size(batch_size)
-            if graph_batch_size is None:
-                raise RuntimeError(
-                    f"Batch size {batch_size} exceeds max graph capacity "
-                    f"{self._graph_batch_sizes[-1] if self._graph_batch_sizes else 0}"
-                )
-            if graph_batch_size not in slot.cuda_graphs:
-                raise RuntimeError(
-                    f"No CUDA graph captured for batch size {graph_batch_size}"
-                )
-        else:
-            graph_batch_size = batch_size
+    def _zero_decode_graph_padding(
+        self,
+        slot: DecodeSlot,
+        batch_size: int,
+        graph_batch_size: int,
+    ) -> None:
+        slot.decode_token_ids[batch_size:graph_batch_size].zero_()
+        slot.decode_coord_values[batch_size:graph_batch_size].zero_()
+        slot.decode_size_values[batch_size:graph_batch_size].zero_()
+        slot.meta.batch_idx.gpu[batch_size:graph_batch_size].zero_()
+        slot.meta.input_pos.gpu[batch_size:graph_batch_size].zero_()
+        slot.meta.lora_slot_ids.gpu[batch_size:graph_batch_size].zero_()
+        slot.meta.lora_slot_ids.cpu[batch_size:graph_batch_size].zero_()
 
-        # Clear padding region for deterministic graph behavior.
-        if graph_batch_size > batch_size:
-            slot.decode_token_ids[batch_size:graph_batch_size].zero_()
-            slot.decode_coord_values[batch_size:graph_batch_size].zero_()
-            slot.decode_size_values[batch_size:graph_batch_size].zero_()
-            slot.meta.batch_idx.gpu[batch_size:graph_batch_size].zero_()
-            slot.meta.input_pos.gpu[batch_size:graph_batch_size].zero_()
-            slot.meta.lora_slot_ids.gpu[batch_size:graph_batch_size].zero_()
-            slot.meta.lora_slot_ids.cpu[batch_size:graph_batch_size].zero_()
-
+    def _prepare_decode_graph_step(self, slot: DecodeSlot, batch_size: int) -> None:
         if self._lora_workspace is not None:
-            self._prepare_decode_lora_metadata(slot, graph_batch_size)
+            self._prepare_decode_lora_metadata(slot, batch_size)
 
-        # Build per-step paged-KV metadata buffers (identical for both paths)
-        # - page_table rows: [B, num_pages]
-        # - paged_kv_seqlens_k: [B] (KV length including the current token after update)
-        batch_idx = slot.meta.batch_idx.gpu[:graph_batch_size]
+        # Build per-step paged-KV metadata buffers.
+        batch_idx = slot.meta.batch_idx.gpu[:batch_size]
         self.page_table.populate_paged_kv_metadata(
             batch_idx=batch_idx,
-            input_pos=slot.meta.input_pos.gpu[:graph_batch_size],
-            out_page_table=slot.paged_kv_page_table[:graph_batch_size],
-            out_seqused_k=slot.paged_kv_seqlens_k[:graph_batch_size],
+            input_pos=slot.meta.input_pos.gpu[:batch_size],
+            out_page_table=slot.paged_kv_page_table[:batch_size],
+            out_seqused_k=slot.paged_kv_seqlens_k[:batch_size],
         )
 
-        # Execute (only difference between paths)
-        if use_graph:
-            slot.cuda_graphs[graph_batch_size].replay()
-        else:
-            self._run_decode_forward(slot, graph_batch_size)
+    def _zero_decode_graph_capture_buffers(self, slot: DecodeSlot) -> None:
+        # Use batch index 0 for all entries: page-table row 0 is initialized and
+        # provides valid memory access patterns during capture warmup/replay.
+        slot.decode_token_ids.zero_()
+        slot.decode_coord_values.zero_()
+        slot.decode_size_values.zero_()
+        slot.meta.batch_idx.gpu.zero_()
+        slot.meta.input_pos.gpu.zero_()
+        slot.meta.input_pos.cpu.zero_()
+        slot.meta.lora_slot_ids.gpu.zero_()
+        slot.meta.active_token_ids.gpu.zero_()
+        slot.meta.active_token_ids.cpu.zero_()
+        slot.meta.active_lora_ids.gpu.zero_()
+        slot.meta.active_lora_ids.cpu.zero_()
+        slot.meta.active_lora_meta.gpu.zero_()
+        slot.meta.active_lora_meta.cpu.zero_()
+        slot.paged_kv_page_table.zero_()
+        slot.paged_kv_seqlens_k.zero_()
 
     def _prepare_decode_lora_metadata(
         self,
@@ -2041,11 +2043,7 @@ class MoondreamRuntime:
             # Clear vision graphs
             self._vision_graphs = {}
 
-            # Clear per-slot decode graph state
-            for slot in self._decode_slots:
-                slot.cuda_graphs = None
-
-            self._graph_batch_sizes = []
+            self._decode_graphs.clear()
 
             self._ensure_cuda_graphs_ready()
             self._capture_vision_graphs()
@@ -2054,17 +2052,7 @@ class MoondreamRuntime:
         """Capture CUDA graphs for all slots using slot buffers directly."""
         if not self._use_cuda_graphs:
             return
-        # Check if graphs already captured (first slot has graphs)
-        if self._decode_slots and self._decode_slots[0].cuda_graphs is not None:
-            return
-
-        # Initialize graph batch sizes once
-        max_effective_batch = max(1, self.max_batch_size)
-        self._graph_batch_sizes = self._make_graph_batch_sizes(max_effective_batch)
-
-        # Capture graphs for each slot using its own buffers
-        for slot in self._decode_slots:
-            slot.cuda_graphs = self._capture_decode_graphs_for_slot(slot)
+        self._decode_graphs.ensure_ready(self._decode_slots)
 
     def _preallocate_workspaces(self) -> None:
         """Pre-allocate all shared workspaces to ensure stable pointers for CUDA graphs.
@@ -2090,102 +2078,6 @@ class MoondreamRuntime:
         # Base MoE workspaces are owned by kestrel-kernels MoeHandle
         # preparation. MoE LoRA scratch is reserved when the LoRA workspace is
         # created so CUDA graph capture sees stable intermediate buffers.
-
-    def _make_graph_batch_sizes(self, max_batch: int) -> list[int]:
-        seeds = [size for size in (1, 2, 4, 8) if size <= max_batch]
-        ramps = list(range(16, max_batch + 1, 16))
-        sizes = sorted({*seeds, *ramps, max_batch})
-        return sizes
-
-    def _capture_decode_graphs_for_slot(
-        self,
-        slot: DecodeSlot,
-    ) -> dict[int, torch.cuda.CUDAGraph]:
-        """Capture CUDA graphs for a decode slot using its own buffers.
-
-        Graphs are captured using the slot's staging buffers (decode_token_ids,
-        meta.batch_idx.gpu, etc.) and output buffers (logits, hidden_last).
-        This ensures graph replay reads from and writes to the same addresses
-        that the non-graph path uses, making behavior identical.
-        """
-        cuda_graphs: dict[int, torch.cuda.CUDAGraph] = {}
-
-        with self.graph_capture_lock:
-            max_batch = slot.decode_token_ids.shape[0]
-            if max_batch == 0:
-                return cuda_graphs
-
-            device = self.device
-
-            # Graph capture must happen on the same stream we use for decode replay.
-            # Otherwise, replayed kernels may read stale paged-KV metadata written
-            # on a different stream, producing incorrect results.
-            with torch.cuda.stream(slot.compute_stream):
-                # Zero all slot buffers for capture.
-                # Use batch index 0 for all entries - row 0 in the page table is
-                # pre-initialized and provides valid memory access patterns.
-                slot.decode_token_ids.zero_()
-                slot.decode_coord_values.zero_()
-                slot.decode_size_values.zero_()
-                slot.meta.batch_idx.gpu.zero_()
-                slot.meta.input_pos.gpu.zero_()
-                slot.meta.input_pos.cpu.zero_()
-                slot.meta.lora_slot_ids.gpu.zero_()
-                slot.meta.active_token_ids.gpu.zero_()
-                slot.meta.active_token_ids.cpu.zero_()
-                slot.meta.active_lora_ids.gpu.zero_()
-                slot.meta.active_lora_ids.cpu.zero_()
-                slot.meta.active_lora_meta.gpu.zero_()
-                slot.meta.active_lora_meta.cpu.zero_()
-                slot.paged_kv_page_table.zero_()
-                slot.paged_kv_seqlens_k.zero_()
-
-                try:
-                    torch.cuda.synchronize(device=device)
-                    for bs in reversed(self._graph_batch_sizes):
-                        graph = torch.cuda.CUDAGraph()
-                        with torch.inference_mode():
-                            if self._lora_workspace is not None:
-                                self._prepare_decode_lora_metadata(slot, bs)
-
-                            # Build per-step paged-KV metadata buffers
-                            batch_idx = slot.meta.batch_idx.gpu[:bs]
-                            self.page_table.populate_paged_kv_metadata(
-                                batch_idx=batch_idx,
-                                input_pos=slot.meta.input_pos.gpu[:bs],
-                                out_page_table=slot.paged_kv_page_table[:bs],
-                                out_seqused_k=slot.paged_kv_seqlens_k[:bs],
-                            )
-
-                            # Warmup run (not captured)
-                            self._run_decode_forward(slot, bs)
-                            torch.cuda.synchronize(device=device)
-
-                            # Capture the graph (each graph gets its own pool for isolation)
-                            with torch.cuda.graph(graph):
-                                self._run_decode_forward(slot, bs)
-
-                        cuda_graphs[bs] = graph
-                        torch.cuda.synchronize(device=device)
-                finally:
-                    # Clear slot buffers after capture
-                    slot.decode_token_ids.zero_()
-                    slot.meta.batch_idx.gpu.zero_()
-                    slot.meta.input_pos.gpu.zero_()
-                    slot.meta.lora_slot_ids.gpu.zero_()
-                    slot.meta.active_token_ids.gpu.zero_()
-                    slot.meta.active_lora_ids.gpu.zero_()
-                    slot.meta.active_lora_meta.gpu.zero_()
-                    slot.paged_kv_page_table.zero_()
-                    slot.paged_kv_seqlens_k.zero_()
-
-        return cuda_graphs
-
-    def _select_graph_batch_size(self, batch_size: int) -> int | None:
-        for size in self._graph_batch_sizes:
-            if size >= batch_size:
-                return size
-        return None
 
     def _allocate_vision_buffers(self) -> None:
         """Allocate stable buffers for vision encoder."""

--- a/kestrel/runtime/decode_graph.py
+++ b/kestrel/runtime/decode_graph.py
@@ -1,0 +1,156 @@
+"""Shared CUDA graph management for autoregressive decode paths."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any, Generic, TypeVar
+
+import torch
+
+from kestrel.device import resolve_device
+
+
+SlotT = TypeVar("SlotT")
+
+
+def make_decode_graph_batch_sizes(max_batch: int) -> list[int]:
+    """Return the decode batch buckets captured for CUDA graph replay."""
+    max_batch = max(1, max_batch)
+    seeds = [size for size in (1, 2, 4, 8) if size <= max_batch]
+    ramps = list(range(16, max_batch + 1, 16))
+    return sorted({*seeds, *ramps, max_batch})
+
+
+class DecodeGraphManager(Generic[SlotT]):
+    """Own CUDA graph capture/replay for fixed-buffer decode slots.
+
+    The manager is model-agnostic: runtimes provide callbacks for slot-specific
+    staging, per-step metadata construction, and the actual decode forward.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        device: torch.device,
+        max_batch: int,
+        graph_capture_lock: Any,
+        compute_stream: torch.cuda.Stream | None,
+        run_forward: Callable[[SlotT, int], None],
+        prepare_step: Callable[[SlotT, int], None],
+        zero_padding: Callable[[SlotT, int, int], None] | None = None,
+        zero_for_capture: Callable[[SlotT], None] | None = None,
+    ) -> None:
+        self.enabled = enabled
+        self.device = resolve_device(device)
+        self.max_batch = max(1, max_batch)
+        self._graph_capture_lock = graph_capture_lock
+        self._compute_stream = compute_stream
+        self._run_forward = run_forward
+        self._prepare_step = prepare_step
+        self._zero_padding = zero_padding or _noop_padding
+        self._zero_for_capture = zero_for_capture
+        self._batch_sizes: list[int] = []
+        self._graphs: dict[int, dict[int, Any]] = {}
+
+    @property
+    def batch_sizes(self) -> list[int]:
+        return list(self._batch_sizes)
+
+    def clear(self) -> None:
+        """Drop all captured decode graphs."""
+        self._graphs.clear()
+        self._batch_sizes = []
+
+    def ensure_ready(self, slots: Sequence[SlotT]) -> None:
+        """Capture missing graph sets for ``slots`` when graph replay is enabled."""
+        if not self.enabled:
+            return
+        if not slots:
+            return
+        if not self._batch_sizes:
+            self._batch_sizes = make_decode_graph_batch_sizes(self.max_batch)
+        if self._zero_for_capture is None:
+            raise RuntimeError("CUDA graph capture requires zero_for_capture")
+
+        if self.device.type == "cuda":
+            torch.cuda.set_device(self.device)
+
+        for slot in slots:
+            # Decode slots are runtime-owned, long-lived objects; clear() drops
+            # graph state before any slot rebuild, so object identity is stable.
+            key = id(slot)
+            if key not in self._graphs:
+                self._graphs[key] = self._capture_slot_graphs(slot)
+
+    def run(self, slot: SlotT, batch_size: int) -> None:
+        """Prepare one decode step and execute via graph replay or eager forward."""
+        graphs = self._graphs.get(id(slot)) if self.enabled else None
+        if graphs is None:
+            graph_batch_size = batch_size
+        else:
+            graph_batch_size = self._select_batch_size(batch_size)
+            if graph_batch_size is None:
+                raise RuntimeError(
+                    f"Batch size {batch_size} exceeds max graph capacity "
+                    f"{self._batch_sizes[-1] if self._batch_sizes else 0}"
+                )
+            if graph_batch_size not in graphs:
+                raise RuntimeError(
+                    f"No CUDA graph captured for batch size {graph_batch_size}"
+                )
+
+        if graph_batch_size > batch_size:
+            self._zero_padding(slot, batch_size, graph_batch_size)
+
+        self._prepare_step(slot, graph_batch_size)
+
+        if graphs is None:
+            self._run_forward(slot, graph_batch_size)
+        else:
+            graphs[graph_batch_size].replay()
+
+    def _select_batch_size(self, batch_size: int) -> int | None:
+        for size in self._batch_sizes:
+            if size >= batch_size:
+                return size
+        return None
+
+    def _capture_slot_graphs(self, slot: SlotT) -> dict[int, Any]:
+        cuda_graphs: dict[int, Any] = {}
+
+        with self._graph_capture_lock:
+            stream = self._compute_stream
+            if stream is None:
+                raise RuntimeError("CUDA graph capture requires a decode compute stream")
+
+            # Capture on the same stream used for replay so kernels see metadata
+            # writes in the same order as eager decode.
+            with torch.cuda.stream(stream):
+                zero_for_capture = self._zero_for_capture
+                if zero_for_capture is None:
+                    raise RuntimeError("CUDA graph capture requires zero_for_capture")
+                zero_for_capture(slot)
+                try:
+                    torch.cuda.synchronize(device=self.device)
+                    for batch_size in reversed(self._batch_sizes):
+                        graph = torch.cuda.CUDAGraph()
+                        with torch.inference_mode():
+                            self._prepare_step(slot, batch_size)
+
+                            self._run_forward(slot, batch_size)
+                            torch.cuda.synchronize(device=self.device)
+
+                            with torch.cuda.graph(graph):
+                                self._run_forward(slot, batch_size)
+
+                        cuda_graphs[batch_size] = graph
+                        torch.cuda.synchronize(device=self.device)
+                finally:
+                    zero_for_capture(slot)
+
+        return cuda_graphs
+
+
+def _noop_padding(_slot: object, _batch_size: int, _graph_batch_size: int) -> None:
+    pass

--- a/tests/test_decode_graph_manager.py
+++ b/tests/test_decode_graph_manager.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from kestrel.runtime.decode_graph import (
+    DecodeGraphManager,
+    make_decode_graph_batch_sizes,
+)
+
+
+@dataclass
+class FakeSlot:
+    slot_id: int
+
+
+class FakeGraph:
+    def __init__(self, events: list[tuple], slot_id: int, batch_size: int) -> None:
+        self._events = events
+        self._slot_id = slot_id
+        self._batch_size = batch_size
+
+    def replay(self) -> None:
+        self._events.append(("replay", self._slot_id, self._batch_size))
+
+
+class FakeDecodeGraphManager(DecodeGraphManager[FakeSlot]):
+    def __init__(self, *args, events: list[tuple], **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.events = events
+
+    def _capture_slot_graphs(self, slot: FakeSlot) -> dict[int, FakeGraph]:
+        self.events.append(("capture", slot.slot_id, tuple(self.batch_sizes)))
+        return {
+            batch_size: FakeGraph(self.events, slot.slot_id, batch_size)
+            for batch_size in self.batch_sizes
+        }
+
+
+def _make_manager(
+    events: list[tuple],
+    *,
+    enabled: bool,
+    max_batch: int,
+    capture: bool = False,
+) -> DecodeGraphManager[FakeSlot]:
+    cls = FakeDecodeGraphManager if capture else DecodeGraphManager
+    kwargs = {"events": events} if capture else {}
+    return cls(
+        enabled=enabled,
+        device=torch.device("cpu"),
+        max_batch=max_batch,
+        graph_capture_lock=contextlib.nullcontext(),
+        compute_stream=None,
+        prepare_step=lambda slot, batch_size: events.append(
+            ("prepare", slot.slot_id, batch_size)
+        ),
+        run_forward=lambda slot, batch_size: events.append(
+            ("forward", slot.slot_id, batch_size)
+        ),
+        zero_for_capture=lambda _slot: None,
+        zero_padding=lambda slot, batch_size, graph_batch_size: events.append(
+            ("pad", slot.slot_id, batch_size, graph_batch_size)
+        ),
+        **kwargs,
+    )
+
+
+def test_make_decode_graph_batch_sizes() -> None:
+    assert make_decode_graph_batch_sizes(1) == [1]
+    assert make_decode_graph_batch_sizes(3) == [1, 2, 3]
+    assert make_decode_graph_batch_sizes(16) == [1, 2, 4, 8, 16]
+    assert make_decode_graph_batch_sizes(33) == [1, 2, 4, 8, 16, 32, 33]
+
+
+def test_run_without_graphs_prepares_and_forwards_exact_batch() -> None:
+    events: list[tuple] = []
+    manager = _make_manager(events, enabled=False, max_batch=8)
+
+    manager.run(FakeSlot(slot_id=0), 3)
+
+    assert events == [
+        ("prepare", 0, 3),
+        ("forward", 0, 3),
+    ]
+
+
+def test_run_replays_padded_graph_batch() -> None:
+    events: list[tuple] = []
+    manager = _make_manager(events, enabled=True, max_batch=8, capture=True)
+    slot = FakeSlot(slot_id=0)
+
+    manager.ensure_ready([slot])
+    manager.run(slot, 3)
+
+    assert events == [
+        ("capture", 0, (1, 2, 4, 8)),
+        ("pad", 0, 3, 4),
+        ("prepare", 0, 4),
+        ("replay", 0, 4),
+    ]
+
+
+def test_enabled_capture_requires_zero_for_capture() -> None:
+    events: list[tuple] = []
+    manager = DecodeGraphManager[FakeSlot](
+        enabled=True,
+        device=torch.device("cpu"),
+        max_batch=2,
+        graph_capture_lock=contextlib.nullcontext(),
+        compute_stream=None,
+        prepare_step=lambda _slot, _batch_size: None,
+        run_forward=lambda _slot, _batch_size: None,
+    )
+
+    with pytest.raises(RuntimeError, match="requires zero_for_capture"):
+        manager.ensure_ready([FakeSlot(slot_id=0)])
+
+
+def test_clear_forces_recapture() -> None:
+    events: list[tuple] = []
+    manager = _make_manager(events, enabled=True, max_batch=2, capture=True)
+    slot = FakeSlot(slot_id=0)
+
+    manager.ensure_ready([slot])
+    manager.ensure_ready([slot])
+    manager.clear()
+    manager.ensure_ready([slot])
+
+    assert events == [
+        ("capture", 0, (1, 2)),
+        ("capture", 0, (1, 2)),
+    ]
+
+
+def test_run_raises_when_batch_exceeds_graph_capacity() -> None:
+    events: list[tuple] = []
+    manager = _make_manager(events, enabled=True, max_batch=2, capture=True)
+    slot = FakeSlot(slot_id=0)
+
+    manager.ensure_ready([slot])
+
+    with pytest.raises(RuntimeError, match="exceeds max graph capacity"):
+        manager.run(slot, 3)


### PR DESCRIPTION
## Summary
- Add a shared `DecodeGraphManager` for autoregressive decode CUDA graph bucket selection, capture, replay, and reset.
- Move Moondream decode graph dictionaries out of `DecodeSlot`; Moondream now supplies model-specific callbacks for padding, metadata prep, capture buffer clearing, and forward execution.
- Add CPU unit coverage for graph bucket selection, eager fallback, padded graph replay, recapture, and capacity errors.

## Tests
- `uv run pytest tests/test_decode_graph_manager.py tests/moondream/test_runtime_prefill.py -q`
- `uv run pytest tests/test_decode_graph_manager.py tests/moondream/test_runtime_prefill.py tests/test_engine_runtime_injection.py tests/test_multi_model.py tests/test_autoregressive_executor.py -q`
- `uv run python -m py_compile kestrel/runtime/decode_graph.py kestrel/models/moondream/runtime.py kestrel/models/moondream/decode_slot.py tests/test_decode_graph_manager.py`
- H100 (`p1`): minimal CUDA graph capture/replay smoke using `DecodeGraphManager` with padded batch replay (`cuda:0`, H100 sm90)