### PR TITLE
Fix profiler scripts after runtime/decoder/vision API drift

### DIFF
--- a/scripts/profile_decode.py
+++ b/scripts/profile_decode.py
@@ -116,6 +116,9 @@ def patch_text_decoder_with_nvtx():
         lora_workspace=None, lora_slot_ids=None, single_lora_id=None,
         dense_lora_scratch=None,
         scratch_pool=None,
+        # Absorb decoder kwargs added after this mirror was written so the
+        # profiler keeps loading; forward the ones the mirrored calls take.
+        **extra_kwargs,
     ):
         clear_scratch_pool = None
         if scratch_pool is not None:
@@ -162,8 +165,7 @@ def patch_text_decoder_with_nvtx():
                         config.moe.experts_per_token,
                         mode=mode,
                         lora_workspace=moe_workspace,
-                        lora_slot_ids=lora_slot_ids,
-                        single_lora_id=single_lora_id,
+                        moe_lora_metadata=extra_kwargs.get("moe_lora_metadata"),
                     )
                     nvtx.range_pop()
                 else:

--- a/scripts/profile_vision_encoder.py
+++ b/scripts/profile_vision_encoder.py
@@ -111,7 +111,7 @@ def patch_vision_encoder_with_nvtx(detailed: bool = True) -> None:
         def _layer_norm(x_in: torch.Tensor, ln: torch.nn.LayerNorm) -> torch.Tensor:
             if x_norm_buf is None:
                 return F.layer_norm(x_in, ln.normalized_shape, ln.weight, ln.bias, float(ln.eps))
-            vision_module.layernorm_bias_into(
+            vision_module._layernorm_bias_into(
                 x=x_in,
                 weight=ln.weight,
                 bias=ln.bias,
@@ -331,6 +331,21 @@ def main() -> None:
         for _ in range(args.warmup):
             run_forward()
         torch.cuda.synchronize()
+
+        # Steady-state CUDA-event timing (printed like profile_decode's
+        # PROFILE line) so the script is useful without an nsys wrapper.
+        _start = torch.cuda.Event(enable_timing=True)
+        _end = torch.cuda.Event(enable_timing=True)
+        _timed_iters = 20
+        _start.record()
+        for _ in range(_timed_iters):
+            run_forward()
+        _end.record()
+        torch.cuda.synchronize()
+        print(
+            f"PROFILE: vision_forward avg_ms="
+            f"{_start.elapsed_time(_end) / _timed_iters:.3f}"
+        )
 
         print(f"Running {args.iters} profiled iterations...")
         for _ in range(args.iters):


### PR DESCRIPTION
The standalone profilers had drifted from the current APIs and no longer ran:

- `scripts/profile_decode.py`
  - `MoondreamRuntime` now requires `kv_pool`; construct a `KVMemoryPool` for it.
  - The NVTX-instrumented decoder mirror now absorbs unknown kwargs (so future decoder kwarg additions don't break loading) and forwards `moe_lora_metadata` to `moe_mlp`, matching the current signature — `lora_slot_ids`/`single_lora_id` are no longer MoE args.
- `scripts/profile_vision_encoder.py`
  - Follow the `_layernorm_bias_into` rename.
  - Print a steady-state CUDA-event `PROFILE: vision_forward avg_ms=` line after warmup, so the script gives a usable end-to-end number without wrapping it in nsys.

Verified on a B200 (evee1) against Moondream 3: decode profiling at bs1/16/64 and the vision profile both run end to end.