### PR TITLE
Allow strided paged KV update inputs

### DIFF
--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -27,6 +27,33 @@ def _cdiv(x: int | float | torch.Tensor, multiple: int | float | torch.Tensor):
     return (x + multiple - 1) // multiple
 
 
+def _flatten_bshd_tokens(name: str, tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.ndim != 4:
+        raise ValueError(f"{name} must have shape [batch, seq, heads, head_dim]")
+    batch, seq_len, n_heads, head_dim = tensor.shape
+    if tensor.stride(3) != 1 or tensor.stride(2) != head_dim:
+        raise ValueError(
+            f"{name} must be compact across heads/head_dim; "
+            f"got shape={tuple(tensor.shape)} stride={tensor.stride()}"
+        )
+
+    if seq_len == 1:
+        token_stride = tensor.stride(0)
+    else:
+        token_stride = tensor.stride(1)
+    if batch > 1 and seq_len > 1 and tensor.stride(0) != seq_len * token_stride:
+        raise ValueError(
+            f"{name} batch/sequence dimensions cannot be flattened without a copy; "
+            f"got shape={tuple(tensor.shape)} stride={tensor.stride()}"
+        )
+
+    return tensor.as_strided(
+        (batch * seq_len, n_heads, head_dim),
+        (token_stride, tensor.stride(2), tensor.stride(3)),
+        storage_offset=tensor.storage_offset(),
+    )
+
+
 
 class KVMemoryPool:
     """Allocator for paged KV cache storage.
@@ -166,8 +193,8 @@ class PagedKVCache(torch.nn.Module):
         *,
         slot_mapping: torch.Tensor,
     ):
-        k_view = k_val.view(-1, k_val.shape[2], k_val.shape[3])
-        v_view = v_val.view(-1, v_val.shape[2], v_val.shape[3])
+        k_view = _flatten_bshd_tokens("k_val", k_val)
+        v_view = _flatten_bshd_tokens("v_val", v_val)
 
         if slot_mapping.shape != input_pos.shape:
             raise ValueError("slot_mapping must match input_pos shape")

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -74,6 +74,110 @@ def test_pool_normalizes_string_device() -> None:
     assert pool.device == torch.device("cpu")
 
 
+def test_paged_cache_update_accepts_fused_projection_value_slice() -> None:
+    pool = KVMemoryPool(device="cpu")
+    page_table = _make_page_table(page_size=4, n_pages=3)
+    cache = PagedKVCache(
+        page_table,
+        n_heads=2,
+        head_dim=4,
+        dtype=torch.float32,
+        pool=pool,
+    )
+
+    batch = 2
+    seq_len = 3
+    q_size = 16
+    kv_size = 8
+    key = torch.arange(batch * seq_len * kv_size, dtype=torch.float32).reshape(
+        batch, seq_len, 2, 4
+    )
+    fused = torch.arange(
+        batch * seq_len * (q_size + 2 * kv_size),
+        dtype=torch.float32,
+    ).reshape(batch, seq_len, q_size + 2 * kv_size)
+    value = fused[..., q_size + kv_size :].reshape(batch, seq_len, 2, 4)
+
+    assert value.stride(1) > value.shape[2] * value.shape[3]
+    assert value.stride(2) == value.shape[3]
+    assert value.stride(3) == 1
+
+    slot_mapping = torch.tensor([[0, 1, 2], [4, 5, 6]], dtype=torch.int64)
+    input_pos = torch.arange(batch * seq_len).reshape(batch, seq_len)
+
+    cache.update(
+        input_pos=input_pos,
+        k_val=key,
+        v_val=value,
+        slot_mapping=slot_mapping,
+    )
+
+    expected_k = torch.zeros_like(cache.k_cache)
+    expected_v = torch.zeros_like(cache.v_cache)
+    key_flat = key.view(-1, 2, 4)
+    value_flat = value.view(-1, 2, 4)
+    for row, slot in enumerate(slot_mapping.view(-1).tolist()):
+        if slot < 0:
+            continue
+        block = slot // page_table.page_size
+        offset = slot % page_table.page_size
+        expected_k[block, :, offset, :] = key_flat[row]
+        expected_v[block, :, offset, :] = value_flat[row]
+
+    torch.testing.assert_close(cache.k_cache, expected_k)
+    torch.testing.assert_close(cache.v_cache, expected_v)
+
+
+def test_paged_cache_update_accepts_batched_decode_value_slice() -> None:
+    pool = KVMemoryPool(device="cpu")
+    page_table = _make_page_table(page_size=4, n_pages=3)
+    cache = PagedKVCache(
+        page_table,
+        n_heads=2,
+        head_dim=4,
+        dtype=torch.float32,
+        pool=pool,
+    )
+
+    batch = 2
+    seq_len = 1
+    q_size = 16
+    kv_size = 8
+    fused = torch.arange(
+        batch * seq_len * (q_size + 2 * kv_size),
+        dtype=torch.float32,
+    ).reshape(batch, seq_len, q_size + 2 * kv_size)
+    key = fused[..., q_size : q_size + kv_size].reshape(batch, seq_len, 2, 4)
+    value = fused[..., q_size + kv_size :].reshape(batch, seq_len, 2, 4)
+
+    assert value.stride(0) > value.stride(1)
+    assert value.stride(2) == value.shape[3]
+    assert value.stride(3) == 1
+
+    slot_mapping = torch.tensor([[2], [5]], dtype=torch.int64)
+    input_pos = torch.tensor([[0], [0]], dtype=torch.int64)
+
+    cache.update(
+        input_pos=input_pos,
+        k_val=key,
+        v_val=value,
+        slot_mapping=slot_mapping,
+    )
+
+    expected_k = torch.zeros_like(cache.k_cache)
+    expected_v = torch.zeros_like(cache.v_cache)
+    key_flat = key[:, 0]
+    value_flat = value[:, 0]
+    for row, slot in enumerate(slot_mapping.view(-1).tolist()):
+        block = slot // page_table.page_size
+        offset = slot % page_table.page_size
+        expected_k[block, :, offset, :] = key_flat[row]
+        expected_v[block, :, offset, :] = value_flat[row]
+
+    torch.testing.assert_close(cache.k_cache, expected_k)
+    torch.testing.assert_close(cache.v_cache, expected_v)
+
+
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="requires CUDA"
 )


### PR DESCRIPTION
## Summary

- accepts BSHD paged-KV update tensors with compact head/head_dim layout and arbitrary token stride
- flattens update inputs with `as_strided` instead of requiring `.view()`-compatible contiguous storage
- covers fused-QKV value slices and batched decode value slices in `PagedKVCache.update` tests

## Why

Qwen's fused QKV projection produces value slices whose token stride includes the full fused projection width. The KV write kernel can handle that layout as long as each token's `[heads, head_dim]` tile is compact, so the engine should not force model runtimes to materialize a contiguous copy before writing KV.

## Validation

- `p1`: `tests/test_kv_pool.py::test_paged_cache_update_accepts_fused_projection_value_slice`
- `p1`: `tests/test_kv_pool.py::test_paged_cache_update_accepts_batched_decode_value_slice`
