### PR TITLE
Drop MOONDREAM_API_KEY gate from chartqa_eval

### DIFF
--- a/scripts/chartqa_eval.py
+++ b/scripts/chartqa_eval.py
@@ -42,42 +42,6 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 
-def _load_dotenv(path: Path) -> None:
-    for raw_line in path.read_text().splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        key = key.strip()
-        if key.startswith("export "):
-            key = key[len("export ") :].strip()
-        if not key or os.environ.get(key):
-            continue
-        value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-            value = value[1:-1]
-        os.environ[key] = value
-
-
-def ensure_moondream_api_key() -> None:
-    if os.environ.get("MOONDREAM_API_KEY"):
-        return
-
-    env_path = REPO_ROOT / ".env"
-    if env_path.exists():
-        _load_dotenv(env_path)
-        if os.environ.get("MOONDREAM_API_KEY"):
-            return
-        detail = f"{env_path} exists but does not define MOONDREAM_API_KEY"
-    else:
-        detail = f"{env_path} does not exist"
-
-    raise RuntimeError(
-        "MOONDREAM_API_KEY is not set. chartqa_eval.py checked the process "
-        f"environment and tried to load {env_path}; {detail}."
-    )
-
-
 from kestrel.config import RuntimeConfig
 from kestrel.engine import EngineMetrics, InferenceEngine
 
@@ -256,7 +220,6 @@ def execute_program_source(source: str, timeout: float = 10.0) -> str:
 
 
 async def create_engine(cfg: EvalConfig) -> InferenceEngine:
-    ensure_moondream_api_key()
     runtime_kwargs: Dict[str, Any] = dict(
         model=cfg.model,
         max_batch_size=cfg.max_batch_size,


### PR DESCRIPTION
`create_engine()` called `ensure_moondream_api_key()` for every model, raising if `MOONDREAM_API_KEY` was unset. The key isn't needed to run the benchmark — model weights and the ChartQA dataset load from their own sources — and the gate blocked evaluating non-moondream models (e.g. Qwen 3.5).

Removes the check and its now-unused `_load_dotenv` helper. No other call sites reference either function.

Surfaced while benchmarking Qwen 3.5 GDN prefill (kestrel-proprietary #253): the documented `chartqa_eval.py --model Qwen/Qwen3.5-2B` invocation failed here before reaching inference.