### PR TITLE
Drop removed fallback_to_torch kwarg from Moondream layernorm calls

### DIFF
--- a/kestrel/models/moondream/layers.py
+++ b/kestrel/models/moondream/layers.py
@@ -38,10 +38,10 @@ class LayerNormWeights:
 
 
 def layer_norm(x: torch.Tensor, w: LayerNormWeights) -> torch.Tensor:
-    # Cross-arch: dispatches to the .so kernel on CUDA, the Metal
-    # kernel on MPS. Anything else (or any unsupported config — fp16 on
-    # CUDA, non-mul-of-8 last dim) falls through to ``F.layer_norm``.
-    return _layernorm_bias(x, w.weight, w.bias, fallback_to_torch=True)
+    # Cross-arch: dispatches to the .so kernel on CUDA, the Metal kernel
+    # on MPS. The kernel handles Moondream's configs directly and raises
+    # on anything unsupported (no torch fallback).
+    return _layernorm_bias(x, w.weight, w.bias)
 
 
 @dataclass

--- a/kestrel/models/moondream/vision.py
+++ b/kestrel/models/moondream/vision.py
@@ -77,14 +77,13 @@ def vision_encoder(
     x = x + module.pos_emb
     early = None
     # Cross-arch: ``_layernorm_bias_into`` dispatches to the .so kernel
-    # on CUDA / the Metal kernel on MPS, falling through to torch on
-    # any unsupported config.
+    # on CUDA / the Metal kernel on MPS. The kernel handles the SigLIP
+    # vision config directly and raises on anything unsupported.
     x_norm_buf = torch.empty(x.shape, device=x.device, dtype=x.dtype)
 
     def _layer_norm(x: torch.Tensor, ln: nn.LayerNorm) -> torch.Tensor:
         _layernorm_bias_into(
             x_norm_buf, x, ln.weight, ln.bias, float(ln.eps),
-            fallback_to_torch=True,
         )
         return x_norm_buf
 

--- a/scripts/profile_vision_encoder.py
+++ b/scripts/profile_vision_encoder.py
@@ -117,7 +117,6 @@ def patch_vision_encoder_with_nvtx(detailed: bool = True) -> None:
                 bias=ln.bias,
                 out=x_norm_buf,
                 eps=float(ln.eps),
-                fallback_to_torch=True,
             )
             return x_norm_buf
 


### PR DESCRIPTION
## What

kestrel-kernels removed the `fallback_to_torch` parameter from `layernorm_bias` / `layernorm_bias_into` — the kernel now handles the supported configs directly (2D/3D, bf16, the SigLIP `N=1152` vision width via the `reload_x` variant) and raises on anything unsupported. The Moondream **text** (`models/moondream/layers.py`) and **vision** (`models/moondream/vision.py`) paths still passed `fallback_to_torch=True`.

Against current kestrel-kernels this makes every Moondream `layer_norm` raise:

```
TypeError: layernorm_bias() got an unexpected keyword argument 'fallback_to_torch'
```

which crashes `moondream3-preview` at decode CUDA-graph capture (and would fail eager decode too). Qwen is unaffected (RMSNorm, different kernel).

## Change

- Drop the stale `fallback_to_torch=True` from both call sites.
- Update the two comments that claimed a torch fallback (no longer true).

## Verified

With this applied to a current kestrel-latest + kestrel-kernels env on H100, `moondream3-preview` ChartQA runs cleanly again (smoke 64: Human acc 64.06%, 41.6 req/s; full run in progress). No other `fallback_to_torch` references remain in the tree.