### PR TITLE
Capture Moondream paged-KV metadata in the decode CUDA graph

### DIFF
--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -2087,17 +2087,10 @@ class MoondreamRuntime:
         slot.meta.lora_slot_ids.cpu[batch_size:graph_batch_size].zero_()
 
     def _prepare_decode_graph_step(self, slot: DecodeSlot, batch_size: int) -> None:
+        # Only host-side LoRA metadata stays live here; the paged-KV metadata is
+        # built inside the captured decode graph (see _run_decode_forward).
         if self._lora_workspace is not None:
             self._prepare_decode_lora_metadata(slot, batch_size)
-
-        # Build per-step paged-KV metadata buffers.
-        batch_idx = slot.meta.batch_idx.gpu[:batch_size]
-        self.page_table.populate_paged_kv_metadata(
-            batch_idx=batch_idx,
-            input_pos=slot.meta.input_pos.gpu[:batch_size],
-            out_page_table=slot.paged_kv_page_table[:batch_size],
-            out_seqused_k=slot.paged_kv_seqlens_k[:batch_size],
-        )
 
     def _zero_decode_graph_capture_buffers(self, slot: DecodeSlot) -> None:
         # Use batch index 0 for all entries: page-table row 0 is initialized and
@@ -2170,9 +2163,22 @@ class MoondreamRuntime:
             slot.decode_coord_values[:batch_size],
             slot.decode_size_values[:batch_size],
         )
+        batch_idx = slot.meta.batch_idx.gpu[:batch_size]
+        # Build the paged-KV metadata here, inside the captured decode graph,
+        # rather than eagerly each step. It reads the static (pre-reserved) page
+        # table and the engine-written batch_idx/input_pos buffers and writes the
+        # slot's fixed metadata buffers, so a graph replay reproduces it
+        # bit-identically while folding the launch into the single graph replay
+        # (this is already how build_slot_mapping below is handled).
+        self.page_table.populate_paged_kv_metadata(
+            batch_idx=batch_idx,
+            input_pos=slot.meta.input_pos.gpu[:batch_size],
+            out_page_table=slot.paged_kv_page_table[:batch_size],
+            out_seqused_k=slot.paged_kv_seqlens_k[:batch_size],
+        )
         position_ids = slot.meta.input_pos.gpu[:batch_size].to(torch.long).view(-1, 1)
         slot_mapping = self.page_table.build_slot_mapping(
-            batch_idx=slot.meta.batch_idx.gpu[:batch_size].view(-1, 1),
+            batch_idx=batch_idx.view(-1, 1),
             positions=position_ids,
         )
         lora_workspace = self._lora_workspace


### PR DESCRIPTION
## What

Moves `populate_paged_kv_metadata` out of the live `_prepare_decode_graph_step` and into `_run_decode_forward`, which is captured by the decode CUDA graph. This was the only per-step paged-KV metadata op still launched eagerly each decode step — `build_slot_mapping` right next to it is already built inside the captured forward, so this just brings the metadata build in line. Only the host-side LoRA metadata stays live in `_prepare_decode_graph_step`.

## Why it's safe

`populate_paged_kv_metadata` reads the static (pre-reserved at prefill) page table and the engine-written `batch_idx`/`input_pos` buffers, and writes the slot's fixed metadata buffers. A graph replay reproduces it identically — same argument that already justifies capturing `build_slot_mapping`.

## Measurement (honest: neutral)

ChartQA is heavily prefill-bound on `moondream3-preview` (~768 input vs ~3.3 output tokens/request), so per-step decode prep is a tiny slice. 2×2 interleaved A/B on H100 (pristine `main` vs this change, both with the `fallback_to_torch` layernorm fix; `--max-batch-size 4 --disable-prefix-cache`):

| | Accuracy | Decode tok/s | req/s |
|---|---|---|---|
| baseline ×2 | 84.08% / 84.12% (2102 / 2103) | 132.25 / 131.81 | 39.88 / 39.74 |
| this change ×2 | 84.04% / 84.12% (2101 / 2103) | 131.76 / 132.36 | 39.73 / 39.94 |

Accuracy is within the baseline's own run-to-run band (2102↔2103) and throughput is neutral. The value is consolidating the per-step launch into the single graph replay and matching the Qwen decode runtime — it should help decode-bound serving (long generation), which ChartQA does not exercise.

Depends on (or pairs with) #107, which is required for Moondream to run against current kestrel-kernels.