### PR TITLE
Add PackedBuffer: stage many mixed-dtype fields in one H2D copy

### DIFF
--- a/kestrel/utils/__init__.py
+++ b/kestrel/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility helpers for Kestrel."""
 
-from .buffers import CpuGpuBuffer
+from .buffers import CpuGpuBuffer, PackedBuffer, PackedField
 
-__all__ = ["CpuGpuBuffer"]
+__all__ = ["CpuGpuBuffer", "PackedBuffer", "PackedField"]

--- a/kestrel/utils/buffers.py
+++ b/kestrel/utils/buffers.py
@@ -1,6 +1,9 @@
 """Shared host/device buffer helpers."""
 
+from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from math import prod
 from typing import TYPE_CHECKING
 
@@ -132,3 +135,106 @@ class CpuGpuBuffer:
         if n is None:
             return self.cpu.copy_(self.gpu, non_blocking=True)
         return self.cpu[:n].copy_(self.gpu[:n], non_blocking=True)
+
+
+@dataclass
+class PackedField:
+    """A named ``cpu``/``gpu``/``np`` view into a slice of a :class:`PackedBuffer`.
+
+    Exposes the subset of the :class:`CpuGpuBuffer` surface that metadata
+    staging code reads/writes; the three views share storage with the packed
+    buffer, so host-side writes (via ``cpu`` or ``np``) are picked up by the
+    parent buffer's single ``copy_to_gpu``.
+    """
+
+    cpu: torch.Tensor
+    gpu: torch.Tensor
+    np: np.ndarray | None
+
+
+class PackedBuffer:
+    """Pack several named tensors of mixed dtype/shape into one CPU/GPU buffer
+    pair so the whole group stages to the device in a single ``cudaMemcpyAsync``
+    instead of one copy per field.
+
+    The backing store is a flat ``uint8`` buffer; each field is an aligned,
+    contiguous ``view(dtype).view(shape)`` slice exposed as an attribute
+    returning a :class:`PackedField`. This is the staging-time complement to
+    :class:`CpuGpuBuffer`: reach for it wherever several small per-step or
+    per-batch metadata tensors are filled on the host and shipped together
+    (prefill/decode metadata, gather indices, …) to cut per-launch overhead.
+
+    Fields keep their own ``cpu``/``gpu``/``np`` views, so call sites that
+    already use ``CpuGpuBuffer`` fields (``field.np[...] = ...`` on the host,
+    ``field.gpu[...]`` on the device) work unchanged; only the copy collapses
+    from N calls to one ``copy_to_gpu()``.
+
+    ``copy_to_gpu`` transfers the *entire* buffer (every field, full capacity)
+    in one contiguous copy. Unused tails of a field are shipped but never read
+    by consumers that slice to the live length, so size the buffer to the
+    working set rather than a loose upper bound.
+    """
+
+    # Every field starts at an 8-byte boundary, which satisfies the alignment
+    # requirement of ``Tensor.view(dtype)`` for any packed dtype up to 8 bytes.
+    _ALIGN = 8
+
+    def __init__(
+        self,
+        fields: Iterable[tuple[str, Sequence[int], torch.dtype]],
+        *,
+        device: torch.device,
+        pin_memory: bool = False,
+        with_numpy: bool = True,
+    ) -> None:
+        specs = [
+            (str(name), tuple(int(s) for s in shape), dtype)
+            for name, shape, dtype in fields
+        ]
+        offsets: list[tuple[int, int]] = []
+        cursor = 0
+        for _, shape, dtype in specs:
+            elem_size = torch.empty((), dtype=dtype).element_size()
+            nbytes = elem_size * prod(shape)
+            cursor = -(-cursor // self._ALIGN) * self._ALIGN  # round up to align
+            offsets.append((cursor, nbytes))
+            cursor += nbytes
+        total = max(1, -(-cursor // self._ALIGN) * self._ALIGN)
+
+        pin = pin_memory and device.type == "cuda"
+        self.device = device
+        self.nbytes = total
+        self.cpu = torch.zeros(total, dtype=torch.uint8, device="cpu", pin_memory=pin)
+        self.gpu = torch.zeros(total, dtype=torch.uint8, device=device)
+        self._fields: dict[str, PackedField] = {}
+
+        for (name, shape, dtype), (offset, nbytes) in zip(specs, offsets):
+            raw_cpu = self.cpu[offset : offset + nbytes]
+            raw_gpu = self.gpu[offset : offset + nbytes]
+            cpu_view = raw_cpu.view(dtype).view(shape)
+            gpu_view = raw_gpu.view(dtype).view(shape)
+            np_view = (
+                cpu_view.numpy()
+                if with_numpy and dtype != torch.bfloat16
+                else None
+            )
+            self._fields[name] = PackedField(cpu=cpu_view, gpu=gpu_view, np=np_view)
+
+    def __getattr__(self, name: str) -> PackedField:
+        # Only consulted when normal attribute lookup misses, so the real
+        # instance attributes (cpu/gpu/device/_fields) resolve directly.
+        fields = self.__dict__.get("_fields")
+        if fields is not None and name in fields:
+            return fields[name]
+        raise AttributeError(name)
+
+    def field(self, name: str) -> PackedField:
+        return self._fields[name]
+
+    def copy_to_gpu(self) -> torch.Tensor:
+        """Stage every field to the device in one contiguous H2D copy."""
+        return self.gpu.copy_(self.cpu, non_blocking=True)
+
+    def copy_to_cpu(self) -> torch.Tensor:
+        """Copy every field back to the host in one D2H copy (caller syncs)."""
+        return self.cpu.copy_(self.gpu, non_blocking=True)

--- a/tests/test_packed_buffer.py
+++ b/tests/test_packed_buffer.py
@@ -1,0 +1,94 @@
+"""Tests for ``kestrel.utils.PackedBuffer``."""
+
+import numpy as np
+import pytest
+import torch
+
+from kestrel.utils import PackedBuffer
+
+CPU = torch.device("cpu")
+
+
+def _build(device: torch.device) -> PackedBuffer:
+    return PackedBuffer(
+        [
+            ("input_ids", (1, 5), torch.long),
+            ("seq_idx", (1, 5), torch.int32),
+            ("position_ids", (3, 1, 5), torch.long),
+            ("batch_indices", (4,), torch.int64),
+            ("last_positions", (4,), torch.int32),
+            ("cu_seq_lens_q", (5,), torch.int32),
+            ("scales", (2,), torch.float32),
+        ],
+        device=device,
+        pin_memory=False,
+    )
+
+
+def test_fields_expose_requested_shape_and_dtype():
+    pb = _build(CPU)
+    assert pb.input_ids.cpu.shape == (1, 5)
+    assert pb.input_ids.cpu.dtype == torch.long
+    assert pb.seq_idx.cpu.dtype == torch.int32
+    assert pb.position_ids.cpu.shape == (3, 1, 5)
+    assert pb.scales.cpu.dtype == torch.float32
+    assert pb.cu_seq_lens_q.cpu.shape == (5,)
+
+
+def test_numpy_view_shares_storage_with_cpu_tensor():
+    pb = _build(CPU)
+    pb.input_ids.np[0, :] = np.arange(5, dtype=np.int64)
+    # Writing through the numpy view must be visible on the torch cpu view.
+    assert torch.equal(pb.input_ids.cpu[0], torch.arange(5, dtype=torch.long))
+
+
+def test_fields_are_disjoint_across_dtypes():
+    pb = _build(CPU)
+    pb.input_ids.cpu.fill_(7)
+    pb.seq_idx.cpu.fill_(3)
+    pb.scales.cpu.fill_(1.5)
+    pb.batch_indices.cpu.copy_(torch.tensor([10, 11, 12, 13]))
+    # Each field keeps its own values — no aliasing between packed regions.
+    assert torch.equal(pb.input_ids.cpu, torch.full((1, 5), 7, dtype=torch.long))
+    assert torch.equal(pb.seq_idx.cpu, torch.full((1, 5), 3, dtype=torch.int32))
+    assert torch.allclose(pb.scales.cpu, torch.tensor([1.5, 1.5]))
+    assert torch.equal(pb.batch_indices.cpu, torch.tensor([10, 11, 12, 13]))
+
+
+def test_single_copy_round_trips_every_field():
+    # On CPU the "gpu" tensor is just a second host tensor, so copy_to_gpu /
+    # copy_to_cpu still exercise the one-shot whole-buffer transfer.
+    pb = _build(CPU)
+    pb.input_ids.cpu[0] = torch.arange(5, dtype=torch.long)
+    pb.seq_idx.cpu[0] = torch.arange(5, dtype=torch.int32)
+    pb.scales.cpu.copy_(torch.tensor([0.25, 0.75]))
+    pb.copy_to_gpu()
+    assert torch.equal(pb.input_ids.gpu[0], torch.arange(5, dtype=torch.long))
+    assert torch.equal(pb.seq_idx.gpu[0], torch.arange(5, dtype=torch.int32))
+    assert torch.allclose(pb.scales.gpu, torch.tensor([0.25, 0.75]))
+
+
+def test_unknown_field_raises_attribute_error():
+    pb = _build(CPU)
+    with pytest.raises(AttributeError):
+        _ = pb.does_not_exist
+
+
+def test_bfloat16_field_has_no_numpy_view():
+    pb = PackedBuffer(
+        [("weights", (4,), torch.bfloat16)], device=CPU, pin_memory=False
+    )
+    assert pb.weights.np is None
+    assert pb.weights.cpu.dtype == torch.bfloat16
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_cuda_round_trip_matches_per_field_copies():
+    dev = torch.device("cuda")
+    pb = _build(dev)
+    pb.input_ids.cpu[0] = torch.arange(5, dtype=torch.long)
+    pb.batch_indices.cpu.copy_(torch.tensor([1, 2, 3, 4]))
+    pb.copy_to_gpu()
+    torch.cuda.synchronize()
+    assert torch.equal(pb.input_ids.gpu[0].cpu(), torch.arange(5, dtype=torch.long))
+    assert torch.equal(pb.batch_indices.gpu.cpu(), torch.tensor([1, 2, 3, 4]))


### PR DESCRIPTION
## What

`PackedBuffer` packs several named tensors of **mixed dtype and shape** into a single `uint8` CPU/GPU buffer pair, so a group of small metadata tensors stages to the device in **one `cudaMemcpyAsync`** instead of one copy per field. Each field is an aligned `view(dtype).view(shape)` slice exposing the same `.cpu`/`.gpu`/`.np` surface as `CpuGpuBuffer`, so existing fill code (`field.np[...] = ...` on the host, `field.gpu[...]` on the device) works unchanged — only the copy collapses to a single `copy_to_gpu()` / `copy_to_cpu()`.

A single byte-backed store means there's no need to group fields by dtype; int64/int32/float/etc. all live in one buffer and ship together.

## Why

Profiling Qwen ChartQA showed it's CPU-launch-bound. The H2D metadata copies are one source of per-launch overhead. This is the reusable primitive for collapsing them, intended for per-step / per-batch staging across **prefill and decode, H2D and D2H, for both Qwen and Moondream**. First adopter is Qwen prefill (separate PR, ~11 copies → 1).

Note on expectations: on a fast, well-pipelined device (H100) the launch reduction is largely hidden by GPU compute, so it reads as neutral throughput there. The win is expected on host-bound / weaker-CPU targets (Thor, Orin, Mac MPS, low-core hosts) where per-launch CPU cost is on the critical path.

## Tests

`tests/test_packed_buffer.py`: shared-storage host writes, disjoint mixed-dtype regions, single-copy round-trip, bf16 (no numpy view), unknown-field error, and a CUDA round-trip (skipped without a GPU). All pass on CPU.