### PR TITLE
Stage decode inputs with one H2D copy via PackedBuffer

### DIFF
--- a/kestrel/models/moondream/decode_slot.py
+++ b/kestrel/models/moondream/decode_slot.py
@@ -26,36 +26,67 @@ import torch
 from torch import Tensor
 
 from kestrel.device import make_event
-from kestrel.utils import CpuGpuBuffer
+from kestrel.utils import CpuGpuBuffer, PackedBuffer
 
 
-@dataclass
 class DecodeMetaBuffers:
     """Per-slot pinned host metadata buffers for H2D copies.
 
-    These buffers hold the batch metadata (batch indices, positions, LoRA slots)
-    that are copied to GPU at the start of each decode step. Each slot needs its
-    own buffers to prevent the CPU from overwriting the pinned source while a
-    previous step's H2D copy is still in flight.
+    The per-step decode inputs the scheduler stages every step — ``batch_idx``,
+    ``input_pos`` and ``lora_slot_ids`` — share one :class:`PackedBuffer`, so
+    they upload in a single H2D copy (``copy_inputs_to_gpu``) instead of three.
+    They are exposed as :class:`PackedField` views, so call sites read/write
+    ``.np``/``.cpu``/``.gpu`` exactly as before. The MoE-LoRA ``active_*``
+    buffers are staged separately (only on the LoRA path), so they stay
+    individual CpuGpuBuffers.
 
-    The pinned memory ensures DMA transfers don't require CPU involvement after
-    the copy is initiated.
+    Each slot needs its own buffers to prevent the CPU from overwriting the
+    pinned source while a previous step's H2D copy is still in flight.
     """
 
-    batch_idx: CpuGpuBuffer  # int64 [max_batch] - sequence batch indices
-    input_pos: CpuGpuBuffer  # int32 [max_batch] - token positions
-    lora_slot_ids: CpuGpuBuffer  # int32 [max_batch] - LoRA slot assignments
-    active_token_ids: CpuGpuBuffer  # int32 [max_batch] - token-major MoE LoRA ids
-    active_lora_ids: CpuGpuBuffer  # int32 [max_batch] - active MoE LoRA ids
-    # int32 [max_loras + 4]. Layout:
-    #   [0] active LoRA count
-    #   [1] active max rank
-    #   [2] active token count
-    #   [3:] per-active-LoRA token-start offsets, plus one sentinel end offset
-    # The sentinel lets kernels read each range as meta[3 + i]..meta[4 + i]
-    # without a last-route special case.
-    active_lora_meta: CpuGpuBuffer
-    moe_lora_metadata: Any | None = None
+    def __init__(self, *, max_batch_slots: int, device: torch.device) -> None:
+        self._inputs = PackedBuffer(
+            [
+                ("batch_idx", (max_batch_slots,), torch.int64),  # sequence batch idx
+                ("input_pos", (max_batch_slots,), torch.int32),  # token positions
+                ("lora_slot_ids", (max_batch_slots,), torch.int32),  # LoRA slots
+            ],
+            device=device,
+            pin_memory=True,
+        )
+        # token-major MoE LoRA ids
+        self.active_token_ids = CpuGpuBuffer(
+            max_batch_slots, dtype=torch.int32, device=device, pin_memory=True
+        )
+        # active MoE LoRA ids
+        self.active_lora_ids = CpuGpuBuffer(
+            max_batch_slots, dtype=torch.int32, device=device, pin_memory=True
+        )
+        # int32 [max_loras + 4]; max_loras == max_batch_slots - 1 (slot 0 == no
+        # LoRA), so + 3 here. Layout: [0] active LoRA count, [1] active max rank,
+        # [2] active token count, [3:] per-active-LoRA token-start offsets plus
+        # one sentinel end offset (so kernels read meta[3+i]..meta[4+i] with no
+        # last-route special case).
+        self.active_lora_meta = CpuGpuBuffer(
+            max_batch_slots + 3, dtype=torch.int32, device=device, pin_memory=True
+        )
+        self.moe_lora_metadata: Any | None = None
+
+    @property
+    def batch_idx(self):
+        return self._inputs.batch_idx
+
+    @property
+    def input_pos(self):
+        return self._inputs.input_pos
+
+    @property
+    def lora_slot_ids(self):
+        return self._inputs.lora_slot_ids
+
+    def copy_inputs_to_gpu(self) -> None:
+        """Stage batch_idx/input_pos/lora_slot_ids to the GPU in one H2D copy."""
+        self._inputs.copy_to_gpu()
 
 
 @dataclass
@@ -185,47 +216,9 @@ def create_decode_slot(
     # runtime.py -> decode_slot.py -> scheduler/transfer.py -> scheduler.py -> runtime.py
     from kestrel.scheduler.transfer import RenderBuffer
 
-    # Per-slot pinned host buffers for H2D metadata
-    meta = DecodeMetaBuffers(
-        batch_idx=CpuGpuBuffer(
-            max_batch_slots,
-            dtype=torch.int64,
-            device=device,
-            pin_memory=True,
-        ),
-        input_pos=CpuGpuBuffer(
-            max_batch_slots,
-            dtype=torch.int32,
-            device=device,
-            pin_memory=True,
-        ),
-        lora_slot_ids=CpuGpuBuffer(
-            max_batch_slots,
-            dtype=torch.int32,
-            device=device,
-            pin_memory=True,
-        ),
-        active_token_ids=CpuGpuBuffer(
-            max_batch_slots,
-            dtype=torch.int32,
-            device=device,
-            pin_memory=True,
-        ),
-        active_lora_ids=CpuGpuBuffer(
-            max_batch_slots,
-            dtype=torch.int32,
-            device=device,
-            pin_memory=True,
-        ),
-        active_lora_meta=CpuGpuBuffer(
-            # max_loras == max_batch_slots - 1 because LoRA slot 0 means no LoRA.
-            # The +4 layout above therefore becomes max_batch_slots + 3 here.
-            max_batch_slots + 3,
-            dtype=torch.int32,
-            device=device,
-            pin_memory=True,
-        ),
-    )
+    # Per-slot pinned host buffers for H2D metadata. batch_idx/input_pos/
+    # lora_slot_ids are packed for a single per-step H2D copy.
+    meta = DecodeMetaBuffers(max_batch_slots=max_batch_slots, device=device)
 
     # Per-slot RenderBuffer for D2H copies of sampled ids + logprobs.
     # Moondream's coord/size aux values use a separate runtime-owned

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1091,10 +1091,10 @@ class GenerationScheduler:
                 pos_np[i] = seq.state.length
                 lora_np[i] = seq.state.lora_slot
 
-            # H2D copies for all metadata
-            batch_idx = slot.meta.batch_idx.copy_to_gpu(batch_size)
-            slot.meta.input_pos.copy_to_gpu(batch_size)
-            slot.meta.lora_slot_ids.copy_to_gpu(batch_size)
+            # One H2D copy stages batch_idx/input_pos/lora_slot_ids together
+            # (they share a packed buffer) instead of three separate launches.
+            slot.meta.copy_inputs_to_gpu()
+            batch_idx = slot.meta.batch_idx.gpu[:batch_size]
 
             # Gather decode inputs from _pending_token_ids into slot staging.
             token_ids = slot.decode_token_ids[:batch_size]

--- a/kestrel/utils/__init__.py
+++ b/kestrel/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility helpers for Kestrel."""
 
-from .buffers import CpuGpuBuffer
+from .buffers import CpuGpuBuffer, PackedBuffer, PackedField
 
-__all__ = ["CpuGpuBuffer"]
+__all__ = ["CpuGpuBuffer", "PackedBuffer", "PackedField"]

--- a/kestrel/utils/buffers.py
+++ b/kestrel/utils/buffers.py
@@ -1,6 +1,9 @@
 """Shared host/device buffer helpers."""
 
+from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from math import prod
 from typing import TYPE_CHECKING
 
@@ -132,3 +135,106 @@ class CpuGpuBuffer:
         if n is None:
             return self.cpu.copy_(self.gpu, non_blocking=True)
         return self.cpu[:n].copy_(self.gpu[:n], non_blocking=True)
+
+
+@dataclass
+class PackedField:
+    """A named ``cpu``/``gpu``/``np`` view into a slice of a :class:`PackedBuffer`.
+
+    Exposes the subset of the :class:`CpuGpuBuffer` surface that metadata
+    staging code reads/writes; the three views share storage with the packed
+    buffer, so host-side writes (via ``cpu`` or ``np``) are picked up by the
+    parent buffer's single ``copy_to_gpu``.
+    """
+
+    cpu: torch.Tensor
+    gpu: torch.Tensor
+    np: np.ndarray | None
+
+
+class PackedBuffer:
+    """Pack several named tensors of mixed dtype/shape into one CPU/GPU buffer
+    pair so the whole group stages to the device in a single ``cudaMemcpyAsync``
+    instead of one copy per field.
+
+    The backing store is a flat ``uint8`` buffer; each field is an aligned,
+    contiguous ``view(dtype).view(shape)`` slice exposed as an attribute
+    returning a :class:`PackedField`. This is the staging-time complement to
+    :class:`CpuGpuBuffer`: reach for it wherever several small per-step or
+    per-batch metadata tensors are filled on the host and shipped together
+    (prefill/decode metadata, gather indices, …) to cut per-launch overhead.
+
+    Fields keep their own ``cpu``/``gpu``/``np`` views, so call sites that
+    already use ``CpuGpuBuffer`` fields (``field.np[...] = ...`` on the host,
+    ``field.gpu[...]`` on the device) work unchanged; only the copy collapses
+    from N calls to one ``copy_to_gpu()``.
+
+    ``copy_to_gpu`` transfers the *entire* buffer (every field, full capacity)
+    in one contiguous copy. Unused tails of a field are shipped but never read
+    by consumers that slice to the live length, so size the buffer to the
+    working set rather than a loose upper bound.
+    """
+
+    # Every field starts at an 8-byte boundary, which satisfies the alignment
+    # requirement of ``Tensor.view(dtype)`` for any packed dtype up to 8 bytes.
+    _ALIGN = 8
+
+    def __init__(
+        self,
+        fields: Iterable[tuple[str, Sequence[int], torch.dtype]],
+        *,
+        device: torch.device,
+        pin_memory: bool = False,
+        with_numpy: bool = True,
+    ) -> None:
+        specs = [
+            (str(name), tuple(int(s) for s in shape), dtype)
+            for name, shape, dtype in fields
+        ]
+        offsets: list[tuple[int, int]] = []
+        cursor = 0
+        for _, shape, dtype in specs:
+            elem_size = torch.empty((), dtype=dtype).element_size()
+            nbytes = elem_size * prod(shape)
+            cursor = -(-cursor // self._ALIGN) * self._ALIGN  # round up to align
+            offsets.append((cursor, nbytes))
+            cursor += nbytes
+        total = max(1, -(-cursor // self._ALIGN) * self._ALIGN)
+
+        pin = pin_memory and device.type == "cuda"
+        self.device = device
+        self.nbytes = total
+        self.cpu = torch.zeros(total, dtype=torch.uint8, device="cpu", pin_memory=pin)
+        self.gpu = torch.zeros(total, dtype=torch.uint8, device=device)
+        self._fields: dict[str, PackedField] = {}
+
+        for (name, shape, dtype), (offset, nbytes) in zip(specs, offsets):
+            raw_cpu = self.cpu[offset : offset + nbytes]
+            raw_gpu = self.gpu[offset : offset + nbytes]
+            cpu_view = raw_cpu.view(dtype).view(shape)
+            gpu_view = raw_gpu.view(dtype).view(shape)
+            np_view = (
+                cpu_view.numpy()
+                if with_numpy and dtype != torch.bfloat16
+                else None
+            )
+            self._fields[name] = PackedField(cpu=cpu_view, gpu=gpu_view, np=np_view)
+
+    def __getattr__(self, name: str) -> PackedField:
+        # Only consulted when normal attribute lookup misses, so the real
+        # instance attributes (cpu/gpu/device/_fields) resolve directly.
+        fields = self.__dict__.get("_fields")
+        if fields is not None and name in fields:
+            return fields[name]
+        raise AttributeError(name)
+
+    def field(self, name: str) -> PackedField:
+        return self._fields[name]
+
+    def copy_to_gpu(self) -> torch.Tensor:
+        """Stage every field to the device in one contiguous H2D copy."""
+        return self.gpu.copy_(self.cpu, non_blocking=True)
+
+    def copy_to_cpu(self) -> torch.Tensor:
+        """Copy every field back to the host in one D2H copy (caller syncs)."""
+        return self.cpu.copy_(self.gpu, non_blocking=True)

--- a/scripts/profile_decode.py
+++ b/scripts/profile_decode.py
@@ -397,10 +397,8 @@ def main():
         for i, seq in enumerate(seq_states):
             slot.meta.input_pos.cpu[i] = seq.length
 
-        # H2D copies for metadata
-        slot.meta.batch_idx.copy_to_gpu(args.batch_size)
-        slot.meta.input_pos.copy_to_gpu(args.batch_size)
-        slot.meta.lora_slot_ids.copy_to_gpu(args.batch_size)
+        # One H2D copy stages batch_idx/input_pos/lora_slot_ids together.
+        slot.meta.copy_inputs_to_gpu()
 
         # Stage decode inputs
         slot.decode_token_ids[: args.batch_size].copy_(token_ids, non_blocking=True)

--- a/tests/test_packed_buffer.py
+++ b/tests/test_packed_buffer.py
@@ -1,0 +1,94 @@
+"""Tests for ``kestrel.utils.PackedBuffer``."""
+
+import numpy as np
+import pytest
+import torch
+
+from kestrel.utils import PackedBuffer
+
+CPU = torch.device("cpu")
+
+
+def _build(device: torch.device) -> PackedBuffer:
+    return PackedBuffer(
+        [
+            ("input_ids", (1, 5), torch.long),
+            ("seq_idx", (1, 5), torch.int32),
+            ("position_ids", (3, 1, 5), torch.long),
+            ("batch_indices", (4,), torch.int64),
+            ("last_positions", (4,), torch.int32),
+            ("cu_seq_lens_q", (5,), torch.int32),
+            ("scales", (2,), torch.float32),
+        ],
+        device=device,
+        pin_memory=False,
+    )
+
+
+def test_fields_expose_requested_shape_and_dtype():
+    pb = _build(CPU)
+    assert pb.input_ids.cpu.shape == (1, 5)
+    assert pb.input_ids.cpu.dtype == torch.long
+    assert pb.seq_idx.cpu.dtype == torch.int32
+    assert pb.position_ids.cpu.shape == (3, 1, 5)
+    assert pb.scales.cpu.dtype == torch.float32
+    assert pb.cu_seq_lens_q.cpu.shape == (5,)
+
+
+def test_numpy_view_shares_storage_with_cpu_tensor():
+    pb = _build(CPU)
+    pb.input_ids.np[0, :] = np.arange(5, dtype=np.int64)
+    # Writing through the numpy view must be visible on the torch cpu view.
+    assert torch.equal(pb.input_ids.cpu[0], torch.arange(5, dtype=torch.long))
+
+
+def test_fields_are_disjoint_across_dtypes():
+    pb = _build(CPU)
+    pb.input_ids.cpu.fill_(7)
+    pb.seq_idx.cpu.fill_(3)
+    pb.scales.cpu.fill_(1.5)
+    pb.batch_indices.cpu.copy_(torch.tensor([10, 11, 12, 13]))
+    # Each field keeps its own values — no aliasing between packed regions.
+    assert torch.equal(pb.input_ids.cpu, torch.full((1, 5), 7, dtype=torch.long))
+    assert torch.equal(pb.seq_idx.cpu, torch.full((1, 5), 3, dtype=torch.int32))
+    assert torch.allclose(pb.scales.cpu, torch.tensor([1.5, 1.5]))
+    assert torch.equal(pb.batch_indices.cpu, torch.tensor([10, 11, 12, 13]))
+
+
+def test_single_copy_round_trips_every_field():
+    # On CPU the "gpu" tensor is just a second host tensor, so copy_to_gpu /
+    # copy_to_cpu still exercise the one-shot whole-buffer transfer.
+    pb = _build(CPU)
+    pb.input_ids.cpu[0] = torch.arange(5, dtype=torch.long)
+    pb.seq_idx.cpu[0] = torch.arange(5, dtype=torch.int32)
+    pb.scales.cpu.copy_(torch.tensor([0.25, 0.75]))
+    pb.copy_to_gpu()
+    assert torch.equal(pb.input_ids.gpu[0], torch.arange(5, dtype=torch.long))
+    assert torch.equal(pb.seq_idx.gpu[0], torch.arange(5, dtype=torch.int32))
+    assert torch.allclose(pb.scales.gpu, torch.tensor([0.25, 0.75]))
+
+
+def test_unknown_field_raises_attribute_error():
+    pb = _build(CPU)
+    with pytest.raises(AttributeError):
+        _ = pb.does_not_exist
+
+
+def test_bfloat16_field_has_no_numpy_view():
+    pb = PackedBuffer(
+        [("weights", (4,), torch.bfloat16)], device=CPU, pin_memory=False
+    )
+    assert pb.weights.np is None
+    assert pb.weights.cpu.dtype == torch.bfloat16
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_cuda_round_trip_matches_per_field_copies():
+    dev = torch.device("cuda")
+    pb = _build(dev)
+    pb.input_ids.cpu[0] = torch.arange(5, dtype=torch.long)
+    pb.batch_indices.cpu.copy_(torch.tensor([1, 2, 3, 4]))
+    pb.copy_to_gpu()
+    torch.cuda.synchronize()
+    assert torch.equal(pb.input_ids.gpu[0].cpu(), torch.arange(5, dtype=torch.long))
+    assert torch.equal(pb.batch_indices.gpu.cpu(), torch.tensor([1, 2, 3, 4]))


### PR DESCRIPTION
## What

Packs the per-step decode inputs the scheduler stages every decode step — `batch_idx` / `input_pos` / `lora_slot_ids` — into one `PackedBuffer`, so `_launch_forward_on_stream` issues **one `copy_inputs_to_gpu()` instead of three `cudaMemcpyAsync`**. This is the highest-frequency H2D in the engine (every decode step, both models).

- Moondream `DecodeMetaBuffers`: the 3 inputs share a `PackedBuffer`, exposed as `PackedField` properties; MoE-LoRA `active_*` buffers stay separate (LoRA-only path).
- Shared `scheduler.py`: `slot.meta.copy_inputs_to_gpu()` + one `.gpu[:batch_size]` read.

Graph-safe: the `.gpu` views are stable fixed-buffer slices (same addresses at capture and replay), and `_zero_decode_graph_padding` still corrects the padding rows after the whole-buffer copy.

**Stacked on #109** (PackedBuffer primitive — base branch `utils-packed-buffer`). **Pairs with kestrel-proprietary's Qwen `DecodeMetaBuffers` PR** — the scheduler now calls `copy_inputs_to_gpu()` on `slot.meta`, so both metas must expose it; they land together.

## Measurement

Both models on H100 ChartQA (`--max-batch-size 4 --disable-prefix-cache`):

| | Accuracy | Decode tok/s | req/s |
|---|---|---|---|
| Qwen base ×2 | 59.16% (1479/2500) | 309.2 / 311.0 | 43.22 / 43.49 |
| Qwen change ×2 | 59.16% (1479/2500) | 312.7 / 311.5 | 43.71 / 43.55 |
| Moondream base | 84.12% (2103) | 131.7 | 39.73 |
| Moondream change | 84.08% (2102) | 132.3 | 39.90 |

**`cudaMemcpyAsync` 69,350 → 60,158 (−13%)**, bit-identical (Qwen) / within run-to-run band (Moondream). Throughput **neutral on H100** — copies aren't this GPU's critical path; the per-step launch reduction is expected to matter on host-bound / weaker-CPU targets (Thor, Orin, Mac MPS, low-core hosts).