### PR TITLE
spec decode: proposer interface + runtime capability hook (no-op)

### DIFF
--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -486,6 +486,9 @@ class MoondreamRuntime:
         self._cfg = cfg
         self.device = cfg.resolved_device()
         self.execution_shape = ExecutionShape.AUTOREGRESSIVE
+        # Speculative decoding is not wired for Moondream; decode one token per
+        # step as before. See kestrel.runtime.spec / the spec-decode design doc.
+        self.spec = None
         self.dtype = cfg.resolved_dtype()
         set_device(self.device)
         # Guards CUDA graph capture so other threads avoid device-wide sync during capture.

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Mapping, Protocol, Sequence
 
+from kestrel.runtime.spec import SpecDecodeCaps
 from kestrel.runtime.state import (
     PrefillClassification,
     PreparedSequence,
@@ -95,6 +96,12 @@ class AutoregressiveRuntime(Runtime, Protocol):
     max_seq_length: int
     image_prefix_length: int
     vocab_size: int
+
+    # Speculative decoding capability. ``None`` (the default on every runtime
+    # today) means one token per decode step, identical to non-speculative
+    # behavior; a non-``None`` value advertises a drafter the scheduler can use.
+    # Inert until scheduler integration reads it.
+    spec: "SpecDecodeCaps | None"
 
     # Streams
     copy_stream: Any

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -101,7 +101,7 @@ class AutoregressiveRuntime(Runtime, Protocol):
     # today) means one token per decode step, identical to non-speculative
     # behavior; a non-``None`` value advertises a drafter the scheduler can use.
     # Inert until scheduler integration reads it.
-    spec: "SpecDecodeCaps | None"
+    spec: SpecDecodeCaps | None
 
     # Streams
     copy_stream: Any

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -31,8 +31,8 @@ class DraftResult:
     acceptance path.
     """
 
-    token_ids: "torch.Tensor"
-    draft_probs: "torch.Tensor | None" = None
+    token_ids: torch.Tensor
+    draft_probs: torch.Tensor | None = None
 
 
 @runtime_checkable

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -1,0 +1,83 @@
+"""Speculative-decoding contract: the proposer interface + capability hook.
+
+This module defines the *seam* the scheduler and runtimes use to support
+speculative decoding (DFlash and, later, other methods). It is intentionally
+inert on its own: a runtime that leaves
+:attr:`~kestrel.runtime.protocol.AutoregressiveRuntime.spec` as ``None`` behaves
+exactly as a non-speculative runtime, so adding this module changes no behavior.
+
+The full design lives in ``docs/speculative-decoding-design.md`` in
+``kestrel-proprietary``. This scaffolding deliberately covers only the pieces a
+proposer and a runtime advertise; the verify/accept and hybrid-state hooks land
+with scheduler integration, where they are actually consumed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import torch
+
+
+@dataclass
+class DraftResult:
+    """Draft tokens proposed for one decode step.
+
+    ``token_ids`` is ``[batch, num_speculative_tokens]`` (int32, on device).
+    ``draft_probs`` is ``[batch, num_speculative_tokens, vocab]`` when the
+    proposer supports lossless rejection sampling; ``None`` selects the greedy
+    acceptance path.
+    """
+
+    token_ids: "torch.Tensor"
+    draft_probs: "torch.Tensor | None" = None
+
+
+@runtime_checkable
+class SpecProposer(Protocol):
+    """Produces draft tokens for the target model to verify.
+
+    Implementations live alongside the model they draft for (e.g. the DFlash
+    drafter in ``kestrel-proprietary``). The context argument types are
+    intentionally left open here; they are pinned down with scheduler
+    integration, the PR that first consumes them.
+    """
+
+    # Drafts proposed per step (K).
+    num_speculative_tokens: int
+
+    # KV slots to reserve ahead per request before appending drafts. DFlash
+    # uses ``K + 1`` (the bonus/last-sampled-token query plus K mask tokens);
+    # a chain EAGLE-style proposer would use ``K``.
+    num_lookahead_tokens: int
+
+    def propose(self, ctx: Any) -> DraftResult:
+        """Run the drafter and return ``[batch, K]`` draft tokens (+ probs)."""
+        ...
+
+    def commit_accept(self, ctx: Any) -> None:
+        """Advance proposer-internal state to the accepted prefix."""
+        ...
+
+
+@dataclass
+class SpecDecodeCaps:
+    """A runtime's speculative-decoding capability.
+
+    A runtime advertises speculative decoding by setting
+    :attr:`AutoregressiveRuntime.spec` to an instance of this; leaving it
+    ``None`` means the runtime decodes one token per step as before.
+
+    ``capture_hidden_layers`` are the target layer indices whose hidden states
+    the proposer consumes (e.g. DFlash's ``target_layer_ids``); an empty tuple
+    means the proposer needs no target hidden states.
+
+    Verify/accept and hybrid-state (GDN) hooks are added with scheduler
+    integration; they are omitted here to avoid specifying an interface ahead of
+    its consumer.
+    """
+
+    proposer: SpecProposer
+    capture_hidden_layers: tuple[int, ...] = ()

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -108,6 +108,8 @@ class FakeRuntime:
         # Identity
         self.model_name = model_name
         self.execution_shape = ExecutionShape.AUTOREGRESSIVE
+        # No speculative decoding in the fake; decode one token per step.
+        self.spec = None
 
         # Capacity / shape
         self.max_batch_size = max_batch_size

--- a/tests/test_spec_interface.py
+++ b/tests/test_spec_interface.py
@@ -6,8 +6,6 @@ No model construction, no GPU.
 
 from __future__ import annotations
 
-import dataclasses
-
 from kestrel.runtime.spec import DraftResult, SpecDecodeCaps, SpecProposer
 
 
@@ -47,7 +45,3 @@ def test_autoregressive_runtime_declares_spec_attribute() -> None:
     from kestrel.runtime.protocol import AutoregressiveRuntime
 
     assert "spec" in AutoregressiveRuntime.__annotations__
-
-
-def test_draft_result_is_a_dataclass() -> None:
-    assert dataclasses.is_dataclass(DraftResult)

--- a/tests/test_spec_interface.py
+++ b/tests/test_spec_interface.py
@@ -1,0 +1,53 @@
+"""Unit tests for the speculative-decoding contract (kestrel.runtime.spec).
+
+Pure-CPU: exercises the inert scaffolding only (types + the capability hook).
+No model construction, no GPU.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from kestrel.runtime.spec import DraftResult, SpecDecodeCaps, SpecProposer
+
+
+def test_draft_result_probs_default_none() -> None:
+    dr = DraftResult(token_ids="<tensor>")  # token_ids is opaque here
+    assert dr.draft_probs is None
+
+
+class _StubProposer:
+    """Minimal structural implementation of SpecProposer."""
+
+    num_speculative_tokens = 16
+    num_lookahead_tokens = 17
+
+    def propose(self, ctx):  # noqa: ANN001 - ctx is intentionally open
+        return DraftResult(token_ids="<tensor>")
+
+    def commit_accept(self, ctx) -> None:  # noqa: ANN001
+        return None
+
+
+def test_stub_satisfies_spec_proposer_protocol() -> None:
+    # runtime_checkable Protocol: structural conformance is enough.
+    assert isinstance(_StubProposer(), SpecProposer)
+
+
+def test_spec_decode_caps_defaults_to_no_hidden_layers() -> None:
+    caps = SpecDecodeCaps(proposer=_StubProposer())
+    assert caps.capture_hidden_layers == ()
+    assert caps.proposer.num_lookahead_tokens == 17
+
+
+def test_autoregressive_runtime_declares_spec_attribute() -> None:
+    # The capability hook is part of the protocol surface, defaulting to None
+    # on conforming runtimes. We assert the annotation exists rather than
+    # constructing a runtime (which needs weights/GPU).
+    from kestrel.runtime.protocol import AutoregressiveRuntime
+
+    assert "spec" in AutoregressiveRuntime.__annotations__
+
+
+def test_draft_result_is_a_dataclass() -> None:
+    assert dataclasses.is_dataclass(DraftResult)


### PR DESCRIPTION
First PR in the speculative-decoding stack. **Purely additive and inert** — no behavior change.

## What
- New `kestrel/runtime/spec.py`: the proposer contract — `DraftResult` (`token_ids [B,K]`, `draft_probs`), `SpecProposer` Protocol (`num_speculative_tokens`, `num_lookahead_tokens`, `propose`, `commit_accept`), and `SpecDecodeCaps` (proposer + `capture_hidden_layers`).
- Optional `spec: SpecDecodeCaps | None` on the `AutoregressiveRuntime` protocol; `MoondreamRuntime` sets `spec = None`.
- CPU unit tests: `tests/test_spec_interface.py`.

## Why this first
It's the dependency root the rest of the stack builds on, and it's pure-Python/CPU (no kernels), so it lands fast and lets the drafter and scheduler-integration PRs proceed in parallel against a fixed contract.

## Safety
Nothing reads `runtime.spec` yet → `spec is None` ⇒ one token per decode step, identical to today (design invariant S1). The scheduler `advance()` branch, the DFlash drafter, GDN handling, and kernels come in later PRs. The verify/accept and hybrid-state hooks are intentionally deferred to the scheduler-integration PR that consumes them, to avoid specifying an interface ahead of its consumer.

## Testing
CPU-only. `tests/test_spec_interface.py` passes on belka (against the real torch venv); import smoke confirms the modified `protocol.py` and `moondream/runtime.py` load cleanly.

Design doc: `docs/speculative-decoding-design.md`.