### PR TITLE
Add shared ChatSkill (OpenAI-style multi-turn chat)

### DIFF
--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -301,10 +301,17 @@ class _ReadyAdmission:
     prefix_cache_hit: bool
 
 
-def _hash_image(image: np.ndarray | bytes) -> bytes:
-    """SHA-256 over the raw image input for prefix-cache keying."""
-    raw = image.tobytes() if isinstance(image, np.ndarray) else image
-    return hashlib.sha256(raw).digest()
+def _hash_image(image: "np.ndarray | bytes | Sequence[np.ndarray | bytes]") -> bytes:
+    """SHA-256 over the raw image input(s) for prefix-cache keying.
+
+    A chat request may carry several images (an ordered list); hash them in
+    order so the key reflects the full set.
+    """
+    items = image if isinstance(image, (list, tuple)) else [image]
+    digest = hashlib.sha256()
+    for one in items:
+        digest.update(one.tobytes() if isinstance(one, np.ndarray) else one)
+    return digest.digest()
 
 
 class EngineRequest(Protocol):

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1693,8 +1693,11 @@ class InferenceEngine:
         if req.image is None and image_crops is None:
             image_length = 0
         elif isinstance(req.image, (list, tuple)):
-            # Multi-image chat: each image contributes one patch block.
-            image_length = len(req.image) * runtime.image_prefix_length
+            # Multi-image chat: each image expands one ImageMarker token — which
+            # is already counted in prompt_length — into an image_prefix_length
+            # patch block, so it adds image_prefix_length - 1 KV positions per
+            # image. (target_length = prompt_length + image_length + max_new.)
+            image_length = len(req.image) * (runtime.image_prefix_length - 1)
         else:
             image_length = runtime.image_prefix_length
         adapter = req.adapter

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1690,11 +1690,13 @@ class InferenceEngine:
     ) -> tuple[GenerationRequest, SkillState]:
         prompt_tokens = req.prompt_tokens
         stream_cb = self._build_stream_callback(req)
-        image_length = (
-            runtime.image_prefix_length
-            if (req.image is not None or image_crops is not None)
-            else 0
-        )
+        if req.image is None and image_crops is None:
+            image_length = 0
+        elif isinstance(req.image, (list, tuple)):
+            # Multi-image chat: each image contributes one patch block.
+            image_length = len(req.image) * runtime.image_prefix_length
+        else:
+            image_length = runtime.image_prefix_length
         adapter = req.adapter
         request_obj = GenerationRequest(
             request_id=req.request_id,

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1033,12 +1033,15 @@ class InferenceEngine:
                 "adapter provider is available."
             )
 
-        image_obj: Optional[np.ndarray | bytes] = None
+        image_obj = None
         if image is not None:
             if self.runtime.image_prefix_length == 0:
                 raise ValueError("Runtime does not support image inputs")
-            if not isinstance(image, (np.ndarray, bytes)):
-                raise TypeError("image must be np.ndarray or bytes")
+            # A skill may pass several images (an ordered list, e.g. chat with
+            # multiple images); the runtime that accepts them unpacks the list.
+            items = image if isinstance(image, (list, tuple)) else [image]
+            if not items or not all(isinstance(one, (np.ndarray, bytes)) for one in items):
+                raise TypeError("image must be an np.ndarray/bytes, or a list of them")
             image_obj = image
 
         prompt_str = skill_spec.prompt_text(request_context)

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -660,7 +660,6 @@ class InferenceEngine:
         *,
         reasoning: Optional[bool] = None,
         stream: bool = False,
-        image: Optional[np.ndarray | bytes] = None,
         settings: Optional[Mapping[str, object]] = None,
     ) -> Union[EngineResult, EngineStream]:
         # Omit ``reasoning`` from the prompt when the caller doesn't set it, so
@@ -673,7 +672,7 @@ class InferenceEngine:
             prompt["reasoning"] = reasoning
         return await self._run_skill(
             "chat",
-            image=image,
+            image=None,
             prompt=prompt,
             settings=settings,
             stream=stream,

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -658,19 +658,23 @@ class InferenceEngine:
         self,
         messages: Optional[Sequence[Mapping[str, object]]] = None,
         *,
-        reasoning: bool = False,
+        reasoning: Optional[bool] = None,
         stream: bool = False,
         image: Optional[np.ndarray | bytes] = None,
         settings: Optional[Mapping[str, object]] = None,
     ) -> Union[EngineResult, EngineStream]:
+        # Omit ``reasoning`` from the prompt when the caller doesn't set it, so
+        # ``ChatSkill.build_request`` falls back to the skill's
+        # ``default_reasoning`` (e.g. MoondreamChatSkill defaults it on) —
+        # matching ``ModelHandle.chat()``, which preserves the model default by
+        # not passing the key.
+        prompt: dict[str, object] = {"messages": messages, "stream": stream}
+        if reasoning is not None:
+            prompt["reasoning"] = reasoning
         return await self._run_skill(
             "chat",
             image=image,
-            prompt={
-                "messages": messages,
-                "reasoning": reasoning,
-                "stream": stream,
-            },
+            prompt=prompt,
             settings=settings,
             stream=stream,
         )

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -545,12 +545,15 @@ class InferenceEngine:
         return_logprobs = self._extract_logprobs(settings)
         generated_prefix = self._extract_generated_prefix(settings)
         suppress_next_token_ids = self._extract_suppress_next_token_ids(settings)
+        # A skill may carry media it pulled out of its own prompt (e.g. an
+        # image inside chat messages); prefer it over the top-level argument.
+        effective_image = built.image if built.image is not None else image
         submit_fn = self.submit_streaming if stream else self.submit
         return await submit_fn(
             built.request_context,
             max_new_tokens=built.max_new_tokens,
             adapter=adapter,
-            image=image,
+            image=effective_image,
             temperature=built.temperature,
             top_p=built.top_p,
             _logprobs=return_logprobs,
@@ -646,6 +649,27 @@ class InferenceEngine:
                 "reasoning": reasoning,
                 "stream": stream,
                 "spatial_refs": spatial_refs,
+            },
+            settings=settings,
+            stream=stream,
+        )
+
+    async def chat(
+        self,
+        messages: Optional[Sequence[Mapping[str, object]]] = None,
+        *,
+        reasoning: bool = False,
+        stream: bool = False,
+        image: Optional[np.ndarray | bytes] = None,
+        settings: Optional[Mapping[str, object]] = None,
+    ) -> Union[EngineResult, EngineStream]:
+        return await self._run_skill(
+            "chat",
+            image=image,
+            prompt={
+                "messages": messages,
+                "reasoning": reasoning,
+                "stream": stream,
             },
             settings=settings,
             stream=stream,

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -66,6 +66,12 @@ class _AdmissionCoordinator:
         if req.image is None:
             return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=False)
 
+        if isinstance(req.image, (list, tuple)):
+            # Multi-image chat: the single-image prefix cache and overlap-crop
+            # precompute don't apply (the marker interleaver crops each image
+            # inline). Admit directly with no precomputed crops.
+            return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=False)
+
         if self._runtime.prefix_cache is not None:
             req.image_hash = _hash_image(req.image)
             prefill_tokens = list(req.prompt_tokens) + list(req.generated_prefix.tokens)
@@ -271,7 +277,11 @@ class AutoregressiveExecutor:
             self._admission_failures.append(Completion(request=req, error=exc))
             return
         crops_ready = (
-            req.image is None or ready.prefix_cache_hit or (ready.crops is not None)
+            req.image is None
+            # Multi-image chat crops each image inline (no overlap precompute).
+            or isinstance(req.image, (list, tuple))
+            or ready.prefix_cache_hit
+            or (ready.crops is not None)
         )
         lora_slot_ready = req.adapter is None
         phase = (

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -69,7 +69,18 @@ class _AdmissionCoordinator:
         if isinstance(req.image, (list, tuple)):
             # Multi-image chat: the single-image prefix cache and overlap-crop
             # precompute don't apply (the marker interleaver crops each image
-            # inline). Admit directly with no precomputed crops.
+            # inline). Decode/validate each element up front so unsupported
+            # bytes fail THIS request at admission. Deferring the decode to
+            # encode_image() runs it mid-prefill in scheduler.advance(), where
+            # the exception is treated as a fatal AR-advance failure that drops
+            # every in-flight request rather than just this one.
+            from kestrel.utils.image import decode_to_srgb
+
+            try:
+                req.image = tuple(decode_to_srgb(im) for im in req.image)
+            except Exception as exc:
+                self._fail_request(req, exc)
+                return None
             return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=False)
 
         if self._runtime.prefix_cache is not None:

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -170,6 +170,11 @@ class ModelHandle:
             task, image=image, prompt=prompt, settings=settings, stream=stream
         )
 
+    async def chat(
+        self, **prompt: Any
+    ) -> "EngineResult | EngineStream | ModelStream":
+        return await self._capability("chat", prompt)
+
     async def query(
         self, **prompt: Any
     ) -> "EngineResult | EngineStream | ModelStream":

--- a/kestrel/models/moondream/config.py
+++ b/kestrel/models/moondream/config.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-from kestrel.models.protocols import PrefixSuffix, QueryTemplate
+from kestrel.models.protocols import ChatTemplate, PrefixSuffix, QueryTemplate
 
 
 @dataclass(frozen=True)
@@ -101,6 +101,11 @@ class TokenizerConfig:
                 else None
             ),
         )
+
+    def chat(self) -> Optional[ChatTemplate]:
+        # Moondream has no trained multi-turn chat format; the chat skill
+        # flattens the conversation into the single-turn ``query`` prompt.
+        return None
 
     def detect(self) -> Optional[PrefixSuffix]:
         return self._prefix_suffix("detect")

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -114,6 +114,12 @@ def _disable_parameter_initialization():
             setattr(cls, method_name, original)
 
 
+def _count_image_markers(tokens) -> int:
+    """Number of ImageMarker sentinels in a prompt-token sequence (one per
+    multi-image chat image; each expands to image_prefix_length positions)."""
+    return sum(1 for t in tokens if isinstance(t, ImageMarker))
+
+
 class PrefillScratch:
     """Pre-allocated scratch buffers for prefill to avoid per-layer allocations."""
 
@@ -1288,7 +1294,7 @@ class MoondreamRuntime:
         """Return the current prefix-cache classification for a request."""
 
         tokens_list = list(prompt_tokens)
-        num_image_markers = sum(1 for t in tokens_list if isinstance(t, ImageMarker))
+        num_image_markers = _count_image_markers(tokens_list)
         if num_image_markers > 0:
             image_kv_length = num_image_markers * self.image_prefix_length
             prompt_len = len(tokens_list) - num_image_markers + image_kv_length
@@ -1639,7 +1645,7 @@ class MoondreamRuntime:
         tokens_list = list(prompt_tokens)
 
         # 2. Validate image/hash consistency
-        num_image_markers = sum(1 for t in tokens_list if isinstance(t, ImageMarker))
+        num_image_markers = _count_image_markers(tokens_list)
         has_image = (
             image is not None or image_crops is not None or num_image_markers > 0
         )

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -1196,6 +1196,20 @@ class MoondreamRuntime:
             else:
                 if image is None:
                     raise ValueError("image must be provided when overlap is not supplied")
+                # Multi-image chat passes images straight through here with no
+                # precomputed overlap, so decode raw bytes (image_url data URLs)
+                # and normalize to sRGB exactly as ImagePreprocessor.preprocess
+                # does for the single-image path before cropping.
+                if isinstance(image, (bytes, bytearray)):
+                    import kestrel_native
+
+                    decoded = kestrel_native.decode_image(bytes(image))
+                    if decoded is None:
+                        raise ValueError("Unsupported image format")
+                    image = decoded
+                from kestrel.utils.image import ensure_srgb
+
+                image = ensure_srgb(image)
                 crops, tiling = prepare_crops(image, self.config.vision, self.device, self.dtype)
 
             batch_size = crops.shape[0]

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -1197,19 +1197,13 @@ class MoondreamRuntime:
                 if image is None:
                     raise ValueError("image must be provided when overlap is not supplied")
                 # Multi-image chat passes images straight through here with no
-                # precomputed overlap, so decode raw bytes (image_url data URLs)
-                # and normalize to sRGB exactly as ImagePreprocessor.preprocess
-                # does for the single-image path before cropping.
-                if isinstance(image, (bytes, bytearray)):
-                    import kestrel_native
+                # precomputed overlap. The executor decodes/validates the tuple
+                # at admission, but normalize defensively in case a caller hands
+                # raw bytes straight to encode_image (decode_to_srgb is a no-op
+                # for arrays already in sRGB).
+                from kestrel.utils.image import decode_to_srgb
 
-                    decoded = kestrel_native.decode_image(bytes(image))
-                    if decoded is None:
-                        raise ValueError("Unsupported image format")
-                    image = decoded
-                from kestrel.utils.image import ensure_srgb
-
-                image = ensure_srgb(image)
+                image = decode_to_srgb(image)
                 crops, tiling = prepare_crops(image, self.config.vision, self.device, self.dtype)
 
             batch_size = crops.shape[0]

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -36,6 +36,7 @@ from kestrel.runtime.decode_graph import DecodeGraphManager
 from kestrel.runtime import (
     CoordToken,
     ExecutionShape,
+    ImageMarker,
     PrefillClassification,
     PreparedSequence,
     RuntimeDecodeResult,
@@ -1279,12 +1280,19 @@ class MoondreamRuntime:
         """Return the current prefix-cache classification for a request."""
 
         tokens_list = list(prompt_tokens)
-        image_kv_length = self.image_prefix_length if has_image else 0
-        prompt_len = len(tokens_list) + image_kv_length
+        num_image_markers = sum(1 for t in tokens_list if isinstance(t, ImageMarker))
+        if num_image_markers > 0:
+            image_kv_length = num_image_markers * self.image_prefix_length
+            prompt_len = len(tokens_list) - num_image_markers + image_kv_length
+        else:
+            image_kv_length = self.image_prefix_length if has_image else 0
+            prompt_len = len(tokens_list) + image_kv_length
         can_reuse = False
         skip_positions = 0
 
-        if self.prefix_cache is not None:
+        # The single-image prefix cache doesn't cover the multi-image marker
+        # layout; classify those as full prefill (no reuse).
+        if self.prefix_cache is not None and num_image_markers == 0:
             if has_image:
                 assert image_hash is not None, (
                     "image_hash must be provided when prefix cache is enabled for image prompts"
@@ -1434,38 +1442,88 @@ class MoondreamRuntime:
     def _prepare_full_prefill_inputs(
         self,
         tokens_list: list[Token],
-        image: Optional[np.ndarray],
+        images: Optional[Sequence[Optional[np.ndarray]]],
         image_crops: Optional[OverlapCropOutput],
         prompt_len: int,
         *,
         staging: PrefillInputStaging,
         row: int,
-    ) -> tuple[Tensor, int]:
-        """Prepare inputs for full prefill (cache miss path)."""
-        # Embed prompt tokens
-        if len(tokens_list) > 0:
-            prompt_embed = self._embed_tokens(tokens_list, staging=staging, row=row)
-        else:
-            prompt_embed = None
+    ) -> tuple[Tensor, int, Optional[Tensor]]:
+        """Prepare inputs for full prefill (cache-miss path).
+
+        Returns ``(inputs_embeds, position_start, block_sequence_ids)``. Images
+        are spliced in as image-patch embedding blocks: at each ``ImageMarker``
+        sentinel (multi-image chat path), or after BOS (single-image query
+        path). ``block_sequence_ids`` (int32, one entry per expanded position:
+        image-block id >= 0, or -1 for text) drives the block-bidirectional
+        attention mask; it is ``None`` when there is no image. BOS joins the
+        first image block when the image starts right after it, reproducing the
+        retired ``prefix_lm_730`` mask for a single front image.
+        """
+        marker_positions = [
+            i for i, t in enumerate(tokens_list) if isinstance(t, ImageMarker)
+        ]
 
         segments: list[Tensor] = []
-        if prompt_embed is not None and len(tokens_list) > 0:
-            # Add BOS embed (first token)
-            segments.append(prompt_embed[:, :1, :])
+        block_ids: list[int] = []
 
-        if image is not None or image_crops is not None:
-            image_embed = self.encode_image(image, overlap=image_crops).unsqueeze(0)
-            segments.append(image_embed)
-
-        if prompt_embed is not None and len(tokens_list) > 1:
-            # Add remaining tokens after BOS
-            segments.append(prompt_embed[:, 1:, :])
+        if marker_positions:
+            # Multi-image chat path: images interleaved at ImageMarker sentinels.
+            if images is None:
+                raise RuntimeError("ImageMarker tokens require images")
+            cursor = 0
+            for mpos in marker_positions:
+                if mpos > cursor:
+                    seg = self._embed_tokens(
+                        tokens_list[cursor:mpos], staging=staging, row=row
+                    )
+                    segments.append(seg)
+                    block_ids.extend([-1] * int(seg.shape[1]))
+                marker = tokens_list[mpos]
+                seg = self.encode_image(images[marker.index]).unsqueeze(0)
+                segments.append(seg)
+                block_ids.extend([marker.index] * int(seg.shape[1]))
+                cursor = mpos + 1
+            if cursor < len(tokens_list):
+                seg = self._embed_tokens(
+                    tokens_list[cursor:], staging=staging, row=row
+                )
+                segments.append(seg)
+                block_ids.extend([-1] * int(seg.shape[1]))
+        else:
+            # Single-image query path: BOS, image, then the rest of the prompt.
+            prompt_embed = (
+                self._embed_tokens(tokens_list, staging=staging, row=row)
+                if len(tokens_list) > 0 else None
+            )
+            image = images[0] if images else None
+            has_image = image is not None or image_crops is not None
+            if prompt_embed is not None and len(tokens_list) > 0:
+                segments.append(prompt_embed[:, :1, :])  # BOS
+                block_ids.append(-1)
+            if has_image:
+                seg = self.encode_image(image, overlap=image_crops).unsqueeze(0)
+                segments.append(seg)
+                block_ids.extend([0] * int(seg.shape[1]))
+            if prompt_embed is not None and len(tokens_list) > 1:
+                segments.append(prompt_embed[:, 1:, :])  # remaining tokens
+                block_ids.extend([-1] * (len(tokens_list) - 1))
 
         if not segments:
             segments = [self.bos_embed]
+            block_ids = [-1]
+
+        # BOS joins the first image block when the image starts right after it.
+        if len(block_ids) > 1 and block_ids[0] == -1 and block_ids[1] >= 0:
+            block_ids[0] = block_ids[1]
 
         inputs_embeds = torch.cat(segments, dim=1)
-        return inputs_embeds, 0
+        block_sequence_ids = None
+        if any(b >= 0 for b in block_ids):
+            block_sequence_ids = torch.tensor(
+                block_ids, dtype=torch.int32, device=self.device
+            )
+        return inputs_embeds, 0, block_sequence_ids
 
     def _finalize_cache_after_prefill(
         self,
@@ -1573,7 +1631,10 @@ class MoondreamRuntime:
         tokens_list = list(prompt_tokens)
 
         # 2. Validate image/hash consistency
-        has_image = image is not None or image_crops is not None
+        num_image_markers = sum(1 for t in tokens_list if isinstance(t, ImageMarker))
+        has_image = (
+            image is not None or image_crops is not None or num_image_markers > 0
+        )
         if not has_image:
             assert image_hash is None, "image_hash must be None when no image is provided"
         else:
@@ -1583,14 +1644,22 @@ class MoondreamRuntime:
                 raise ValueError(
                     "Image prompts must include at least one text token after BOS"
                 )
-            if self.prefix_cache is not None:
+            # The single-image prefix cache (keyed by one image_hash) only applies
+            # to the single-image (no-marker) path.
+            if num_image_markers == 0 and self.prefix_cache is not None:
                 assert image_hash is not None, (
                     "image_hash must be provided when prefix cache is enabled for image prompts"
                 )
 
-        # 3. Compute dimensions
-        image_kv_length = self.image_prefix_length if has_image else 0
-        prompt_len = len(tokens_list) + image_kv_length
+        # 3. Compute dimensions. ImageMarker tokens (1 each) expand to an
+        # image_prefix_length patch block; the single-image path adds one block
+        # that is not in the token list.
+        if num_image_markers > 0:
+            image_kv_length = num_image_markers * self.image_prefix_length
+            prompt_len = len(tokens_list) - num_image_markers + image_kv_length
+        else:
+            image_kv_length = self.image_prefix_length if has_image else 0
+            prompt_len = len(tokens_list) + image_kv_length
 
         max_new = max_new_tokens or DEFAULT_MAX_TOKENS
         target_length = prompt_len + max_new
@@ -1599,8 +1668,9 @@ class MoondreamRuntime:
                 f"Requested length {target_length} exceeds max_seq_length={self.max_seq_length}."
             )
 
-        # 4. Build cache tokens (skip when prefix cache is disabled).
-        if self.prefix_cache is None:
+        # 4. Build cache tokens (skip when prefix cache is disabled, or for the
+        # multi-image marker layout which the single-image cache doesn't cover).
+        if self.prefix_cache is None or num_image_markers > 0:
             cache_tokens = []
         else:
             cache_tokens = self._build_cache_tokens(
@@ -1668,7 +1738,10 @@ class MoondreamRuntime:
         prompt_len = state.prompt_length or state.length
         image_kv_length = state.image_length
 
+        block_sequence_ids = None
         if cache_result.can_reuse:
+            # Append/cache-reuse path: prefix is already cached, attention is
+            # plain causal over the new suffix (no image-block mask).
             inputs_embeds, position_start = self._prepare_append_prefill_inputs(
                 tokens_list,
                 cache_result.skip_positions,
@@ -1678,17 +1751,28 @@ class MoondreamRuntime:
                 row=row,
             )
         else:
-            inputs_embeds, position_start = self._prepare_full_prefill_inputs(
-                tokens_list,
-                image,
-                image_crops,
-                prompt_len,
-                staging=staging,
-                row=row,
+            # `image` may be a single array (query path) or an ordered list of
+            # images (multi-image chat); normalize to the list the interleaver
+            # indexes by ImageMarker.index.
+            if image is None:
+                images = None
+            elif isinstance(image, (list, tuple)):
+                images = list(image)
+            else:
+                images = [image]
+            inputs_embeds, position_start, block_sequence_ids = (
+                self._prepare_full_prefill_inputs(
+                    tokens_list,
+                    images,
+                    image_crops,
+                    prompt_len,
+                    staging=staging,
+                    row=row,
+                )
             )
 
         use_prefix_attn = bool(image_kv_length) and not cache_result.can_reuse
-        return inputs_embeds, position_start, use_prefix_attn
+        return inputs_embeds, position_start, use_prefix_attn, block_sequence_ids
 
     def launch_prepared_batch(
         self,
@@ -1733,11 +1817,12 @@ class MoondreamRuntime:
         with stream_context(self._compute_stream):
             per_inputs: list[Tensor] = []
             position_starts: list[int] = []
+            per_block_ids: list[Optional[Tensor]] = []
             use_prefix_attn: bool | None = None
             for row, (prepared, image, image_crops) in enumerate(zip(
                 prepared_sequences, images, image_crops_list
             )):
-                inputs_embeds, position_start, seq_use_prefix_attn = (
+                inputs_embeds, position_start, seq_use_prefix_attn, seq_block_ids = (
                     self._build_prefill_inputs_for_prepared(
                         prepared,
                         image=image,
@@ -1756,6 +1841,7 @@ class MoondreamRuntime:
                     )
                 per_inputs.append(inputs_embeds)
                 position_starts.append(position_start)
+                per_block_ids.append(seq_block_ids)
 
             assert use_prefix_attn is not None
             hidden_dim = self.bos_embed.shape[-1]
@@ -1801,6 +1887,20 @@ class MoondreamRuntime:
                     )
                 inputs_embeds[row, :seq_len, :].copy_(embed_row[0, :, :])
 
+            block_sequence_ids = None
+            if use_prefix_attn:
+                # Assemble per-row image-block ids into [batch, max_seq_len]; the
+                # padded (seqlen-masked) tail stays -1.
+                block_sequence_ids = torch.full(
+                    (batch_size, max_seq_len), -1,
+                    dtype=torch.int32, device=self.device,
+                )
+                for r, seq_block_ids in enumerate(per_block_ids):
+                    if seq_block_ids is not None:
+                        block_sequence_ids[r, : int(seq_block_ids.shape[0])].copy_(
+                            seq_block_ids
+                        )
+
             # Commit page table rows for all batch indices before forward pass.
             self.page_table.commit_block_table(batch_indices)
 
@@ -1812,6 +1912,7 @@ class MoondreamRuntime:
                 batch_idx=slot_batch_idx,
                 lora_slot=lora_slot,
                 use_prefix_attn=use_prefix_attn,
+                block_sequence_ids=block_sequence_ids,
                 paged_kv_seqlens_q=paged_kv_seqlens_q,
                 paged_kv_seqlens_k=paged_kv_seqlens_k,
                 last_token_positions=last_token_positions,
@@ -1936,6 +2037,7 @@ class MoondreamRuntime:
         lora_slot: int = 0,
         *,
         use_prefix_attn: bool,
+        block_sequence_ids: Tensor | None = None,
         paged_kv_seqlens_q: Tensor | None,
         paged_kv_seqlens_k: Tensor,
         last_token_positions: Tensor,
@@ -2037,6 +2139,7 @@ class MoondreamRuntime:
             slot_mapping=slot_mapping,
             mode="prefill",
             use_prefix_attn=use_prefix_attn,
+            block_sequence_ids=block_sequence_ids,
             page_table=paged_kv_page_table,
             paged_kv_seqlens_q=paged_kv_seqlens_q,
             paged_kv_seqlens_k=paged_kv_seqlens_k,

--- a/kestrel/models/moondream/skills/__init__.py
+++ b/kestrel/models/moondream/skills/__init__.py
@@ -12,9 +12,10 @@ model-agnostic kernel.
 
 from functools import cache
 
-from kestrel.skills import ChatSkill, SkillRegistry
+from kestrel.skills import SkillRegistry
 
 from .caption import CaptionRequest, CaptionSkill
+from .chat import MoondreamChatSkill
 from .detect import DetectRequest, DetectSkill
 from .point import PointRequest, PointSkill
 from .query import QueryRequest, QuerySkill
@@ -39,7 +40,7 @@ def build_skill_registry() -> SkillRegistry:
             DetectSkill(),
             CaptionSkill(),
             SegmentSkill(),
-            ChatSkill(),
+            MoondreamChatSkill(),
         ]
     )
 
@@ -48,6 +49,7 @@ __all__ = [
     "build_skill_registry",
     "CaptionRequest",
     "CaptionSkill",
+    "MoondreamChatSkill",
     "DetectRequest",
     "DetectSkill",
     "PointRequest",

--- a/kestrel/models/moondream/skills/__init__.py
+++ b/kestrel/models/moondream/skills/__init__.py
@@ -12,7 +12,7 @@ model-agnostic kernel.
 
 from functools import cache
 
-from kestrel.skills import SkillRegistry
+from kestrel.skills import ChatSkill, SkillRegistry
 
 from .caption import CaptionRequest, CaptionSkill
 from .detect import DetectRequest, DetectSkill
@@ -39,6 +39,7 @@ def build_skill_registry() -> SkillRegistry:
             DetectSkill(),
             CaptionSkill(),
             SegmentSkill(),
+            ChatSkill(),
         ]
     )
 

--- a/kestrel/models/moondream/skills/chat.py
+++ b/kestrel/models/moondream/skills/chat.py
@@ -1,0 +1,121 @@
+"""Moondream's chat capability.
+
+Moondream has no trained multi-turn chat format, so chat is implemented as a
+*subclass* of the shared :class:`~kestrel.skills.chat.ChatSkill` rather than
+by the kernel branching on model specifics. It flattens the conversation into
+the single-turn ``query`` prompt and reuses the query decode path wholesale —
+including moondream2's HF-parity token masking and grounded reasoning — so it
+differs from ``query`` only in the OpenAI-style message I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
+
+from kestrel.skills.base import SkillFinalizeResult, SkillSpec
+from kestrel.skills.chat import ChatMessage, ChatRequest, ChatSkill
+
+from .query import QueryRequest, QuerySkill, QuerySkillState
+
+if False:  # pragma: no cover - type-checking imports
+    from ..runtime import MoondreamRuntime, Token
+    from kestrel.scheduler.types import GenerationRequest
+
+
+class MoondreamChatSkill(ChatSkill):
+    """Chat over Moondream by flattening the conversation into ``query``."""
+
+    def build_prompt_tokens(
+        self,
+        runtime: "MoondreamRuntime",
+        request_context: object,
+    ) -> "Sequence[Token]":
+        if not isinstance(request_context, ChatRequest):
+            raise ValueError(
+                "MoondreamChatSkill.build_prompt_tokens requires a ChatRequest"
+            )
+        query_request = QueryRequest(
+            question=_flatten_messages(request_context.messages),
+            image=request_context.image,
+            reasoning=request_context.reasoning,
+            stream=request_context.stream,
+            spatial_refs=None,
+        )
+        return QuerySkill().build_prompt_tokens(runtime, query_request)
+
+    def create_state(
+        self,
+        runtime: "MoondreamRuntime",
+        request: "GenerationRequest",
+        request_context: object,
+    ) -> "MoondreamChatSkillState":
+        if not isinstance(request_context, ChatRequest):
+            raise ValueError(
+                "MoondreamChatSkill.create_state requires a ChatRequest context"
+            )
+        return MoondreamChatSkillState(self, request, request_context)
+
+
+class MoondreamChatSkillState(QuerySkillState):
+    """Query decode (incl. md2 masking + grounding), emitted as a chat message."""
+
+    def __init__(
+        self,
+        spec: SkillSpec,
+        request: "GenerationRequest",
+        chat_request: ChatRequest,
+    ) -> None:
+        query_request = QueryRequest(
+            question="",
+            image=chat_request.image,
+            reasoning=chat_request.reasoning,
+            stream=chat_request.stream,
+            spatial_refs=None,
+        )
+        super().__init__(spec, request, query_request)
+
+    def finalize(
+        self, runtime: "MoondreamRuntime", *, reason: str
+    ) -> SkillFinalizeResult:
+        result = super().finalize(runtime, reason=reason)
+        answer = result.output.get("answer", "")
+        output: Dict[str, object] = {
+            "message": {"role": "assistant", "content": answer},
+            "finish_reason": reason,
+        }
+        if "reasoning" in result.output:
+            output["reasoning"] = result.output["reasoning"]
+        return SkillFinalizeResult(
+            text=result.text, tokens=result.tokens, output=output
+        )
+
+
+def _flatten_messages(messages: Sequence[ChatMessage]) -> str:
+    """Render a conversation as a single question. A lone user turn (optionally
+    with a system preamble) passes through cleanly; longer histories are
+    labelled best-effort, since Moondream isn't trained on multi-turn chat."""
+    if len(messages) == 1:
+        return messages[0].text
+    system = ""
+    convo: List[ChatMessage] = []
+    for msg in messages:
+        if msg.role == "system":
+            system = msg.text
+        else:
+            convo.append(msg)
+    if len(convo) == 1 and not system:
+        return convo[0].text
+    lines: List[str] = []
+    if system:
+        lines.append(system)
+    for i, msg in enumerate(convo):
+        is_last = i == len(convo) - 1
+        if is_last and msg.role == "user":
+            lines.append(msg.text)
+        else:
+            label = "User" if msg.role == "user" else "Assistant"
+            lines.append(f"{label}: {msg.text}")
+    return "\n\n".join(line for line in lines if line)
+
+
+__all__ = ["MoondreamChatSkill", "MoondreamChatSkillState"]

--- a/kestrel/models/moondream/skills/chat.py
+++ b/kestrel/models/moondream/skills/chat.py
@@ -1,77 +1,109 @@
 """Moondream's chat capability.
 
 Moondream has no trained multi-turn chat format, so chat is implemented as a
-*subclass* of the shared :class:`~kestrel.skills.chat.ChatSkill` rather than
-by the kernel branching on model specifics. It flattens the conversation into
-the single-turn ``query`` prompt and reuses the query decode path wholesale —
-including moondream2's HF-parity token masking and grounded reasoning — so it
-differs from ``query`` only in the OpenAI-style message I/O.
+*subclass* of the shared :class:`~kestrel.skills.chat.ChatSkill`. It renders
+the conversation as a sequence of Moondream ``query`` blocks — one per user
+turn — reusing the query template's tokens (so MD2's doubled-id quirk is
+honored) and the query decode path (incl. md2 token masking and grounded
+reasoning). Each turn's images sit at the start of the turn as ``ImageMarker``
+sentinels, which the runtime replaces with image-embedding blocks.
+
+Per-turn layout (the system message is folded into the first user turn):
+
+    [ImageMarker x K]  <query.prefix>  <user text>  <query.answer_prefix>  <assistant text>
+
+The final user turn ends with the generation opener — ``answer_prefix``, or
+``reasoning_prefix`` when reasoning is on — for the model to complete.
 """
 
 from __future__ import annotations
 
-from typing import Dict, List, Sequence
+from typing import Dict, List
 
-from kestrel.skills.base import BuiltRequest, SkillFinalizeResult, SkillSpec
-from kestrel.skills.chat import ChatMessage, ChatRequest, ChatSkill
+from kestrel.runtime.tokens import ImageMarker, TextToken
+from kestrel.skills.base import SkillFinalizeResult, SkillSpec
+from kestrel.skills.chat import ChatRequest, ChatSkill
 
-from .query import QueryRequest, QuerySkill, QuerySkillState
+from .query import QueryRequest, QuerySkillState
 
 if False:  # pragma: no cover - type-checking imports
-    from typing import Mapping, Optional
-
-    import numpy as np
-
     from ..runtime import MoondreamRuntime, Token
     from kestrel.scheduler.types import GenerationRequest
 
 
-def _single_image(ctx: ChatRequest):
-    """Moondream is single-image; reject more and return the one (or None)."""
-    if len(ctx.images) > 1:
-        raise ValueError("Moondream supports at most one image per request")
-    return ctx.images[0] if ctx.images else None
-
-
 class MoondreamChatSkill(ChatSkill):
-    """Chat over Moondream by flattening the conversation into ``query``."""
+    """Multi-turn, multi-image chat rendered as a sequence of query blocks."""
 
     # Moondream's query path defaults to reasoning on; honor that for chat.
     default_reasoning = True
-
-    def build_request(
-        self,
-        image: "Optional[np.ndarray | bytes]",
-        prompt: "Mapping",
-        settings: "Optional[Mapping]",
-    ) -> BuiltRequest:
-        built = super().build_request(image, prompt, settings)
-        # The base may carry an images tuple; Moondream's pipeline takes one.
-        return BuiltRequest(
-            request_context=built.request_context,
-            max_new_tokens=built.max_new_tokens,
-            temperature=built.temperature,
-            top_p=built.top_p,
-            image=_single_image(built.request_context),
-        )
 
     def build_prompt_tokens(
         self,
         runtime: "MoondreamRuntime",
         request_context: object,
-    ) -> "Sequence[Token]":
+    ) -> "List[Token]":
         if not isinstance(request_context, ChatRequest):
             raise ValueError(
                 "MoondreamChatSkill.build_prompt_tokens requires a ChatRequest"
             )
-        query_request = QueryRequest(
-            question=_flatten_messages(request_context.messages),
-            image=_single_image(request_context),
-            reasoning=request_context.reasoning,
-            stream=request_context.stream,
-            spatial_refs=None,
+        pt = runtime.prompt_template
+        template = pt.query()
+        if template is None:
+            raise ValueError("Moondream prompt template has no query()")
+        tokenizer = runtime.tokenizer
+
+        def ids(seq) -> "List[Token]":
+            return [TextToken(token_id=int(t)) for t in seq]
+
+        def text(value: str) -> "List[Token]":
+            if not value:
+                return []
+            return [TextToken(token_id=int(t)) for t in tokenizer.encode(value).ids]
+
+        messages = list(request_context.messages)
+        # Fold a leading system message into the first user turn's text.
+        pending_system = ""
+        if messages and messages[0].role == "system":
+            pending_system = messages[0].text
+            messages = messages[1:]
+
+        out: "List[Token]" = [TextToken(token_id=int(pt.bos_id))]
+        i = 0
+        n = len(messages)
+        while i < n:
+            msg = messages[i]
+            if msg.role == "user":
+                # Images go at the start of the turn.
+                for part in msg.parts:
+                    if part.image_index is not None:
+                        out.append(ImageMarker(index=part.image_index))
+                out += ids(template.prefix)
+                user_text = msg.text
+                if pending_system:
+                    user_text = (
+                        f"{pending_system}\n\n{user_text}" if user_text else pending_system
+                    )
+                    pending_system = ""
+                out += text(user_text)
+                if i + 1 < n and messages[i + 1].role == "assistant":
+                    out += ids(template.answer_prefix)
+                    out += text(messages[i + 1].text)
+                    i += 2
+                    continue
+                i += 1
+            else:  # a stray assistant turn (no preceding user) — emit its answer
+                out += ids(template.answer_prefix)
+                out += text(msg.text)
+                i += 1
+
+        # Generation opener for the final (user) turn.
+        opener = (
+            template.reasoning_prefix
+            if request_context.reasoning and template.reasoning_prefix
+            else template.answer_prefix
         )
-        return QuerySkill().build_prompt_tokens(runtime, query_request)
+        out += ids(opener)
+        return out
 
     def create_state(
         self,
@@ -95,9 +127,11 @@ class MoondreamChatSkillState(QuerySkillState):
         request: "GenerationRequest",
         chat_request: ChatRequest,
     ) -> None:
+        # The decode state only needs reasoning/stream; images are handled by
+        # the runtime via the prompt's ImageMarkers, not here.
         query_request = QueryRequest(
             question="",
-            image=_single_image(chat_request),
+            image=None,
             reasoning=chat_request.reasoning,
             stream=chat_request.stream,
             spatial_refs=None,
@@ -125,34 +159,6 @@ class MoondreamChatSkillState(QuerySkillState):
             tokens=result.tokens,
             output={"message": message, "finish_reason": reason},
         )
-
-
-def _flatten_messages(messages: Sequence[ChatMessage]) -> str:
-    """Render a conversation as a single question. A lone user turn (optionally
-    with a system preamble) passes through cleanly; longer histories are
-    labelled best-effort, since Moondream isn't trained on multi-turn chat."""
-    if len(messages) == 1:
-        return messages[0].text
-    system = ""
-    convo: List[ChatMessage] = []
-    for msg in messages:
-        if msg.role == "system":
-            system = msg.text
-        else:
-            convo.append(msg)
-    if len(convo) == 1 and not system:
-        return convo[0].text
-    lines: List[str] = []
-    if system:
-        lines.append(system)
-    for i, msg in enumerate(convo):
-        is_last = i == len(convo) - 1
-        if is_last and msg.role == "user":
-            lines.append(msg.text)
-        else:
-            label = "User" if msg.role == "user" else "Assistant"
-            lines.append(f"{label}: {msg.text}")
-    return "\n\n".join(line for line in lines if line)
 
 
 __all__ = ["MoondreamChatSkill", "MoondreamChatSkillState"]

--- a/kestrel/models/moondream/skills/chat.py
+++ b/kestrel/models/moondream/skills/chat.py
@@ -36,6 +36,9 @@ def _single_image(ctx: ChatRequest):
 class MoondreamChatSkill(ChatSkill):
     """Chat over Moondream by flattening the conversation into ``query``."""
 
+    # Moondream's query path defaults to reasoning on; honor that for chat.
+    default_reasoning = True
+
     def build_request(
         self,
         image: "Optional[np.ndarray | bytes]",
@@ -105,15 +108,22 @@ class MoondreamChatSkillState(QuerySkillState):
         self, runtime: "MoondreamRuntime", *, reason: str
     ) -> SkillFinalizeResult:
         result = super().finalize(runtime, reason=reason)
-        answer = result.output.get("answer", "")
-        output: Dict[str, object] = {
-            "message": {"role": "assistant", "content": answer},
-            "finish_reason": reason,
+        message: Dict[str, object] = {
+            "role": "assistant",
+            "content": result.output.get("answer", ""),
         }
-        if "reasoning" in result.output:
-            output["reasoning"] = result.output["reasoning"]
+        # OpenRouter-style: reasoning as a string on the message; Moondream's
+        # spatial grounding (if any) is preserved under reasoning_details.
+        reasoning = result.output.get("reasoning")
+        if reasoning:
+            message["reasoning"] = reasoning.get("text", "")
+            grounding = reasoning.get("grounding")
+            if grounding:
+                message["reasoning_details"] = {"grounding": grounding}
         return SkillFinalizeResult(
-            text=result.text, tokens=result.tokens, output=output
+            text=result.text,
+            tokens=result.tokens,
+            output={"message": message, "finish_reason": reason},
         )
 
 

--- a/kestrel/models/moondream/skills/chat.py
+++ b/kestrel/models/moondream/skills/chat.py
@@ -46,6 +46,19 @@ class MoondreamChatSkill(ChatSkill):
             raise ValueError(
                 "MoondreamChatSkill.build_prompt_tokens requires a ChatRequest"
             )
+        # Moondream renders images only at user turns (one ImageMarker per user
+        # image part). A system/assistant image part is parsed into the image
+        # tuple but never gets a marker here, desyncing the tuple from the
+        # prompt and the length accounting — reject it rather than silently
+        # dropping the image.
+        for m in request_context.messages:
+            if m.role != "user" and any(
+                p.image_index is not None for p in m.parts
+            ):
+                raise ValueError(
+                    "Moondream chat supports images only in user messages; "
+                    f"found image content in a {m.role!r} message"
+                )
         pt = runtime.prompt_template
         template = pt.query()
         if template is None:

--- a/kestrel/models/moondream/skills/chat.py
+++ b/kestrel/models/moondream/skills/chat.py
@@ -12,18 +12,45 @@ from __future__ import annotations
 
 from typing import Dict, List, Sequence
 
-from kestrel.skills.base import SkillFinalizeResult, SkillSpec
+from kestrel.skills.base import BuiltRequest, SkillFinalizeResult, SkillSpec
 from kestrel.skills.chat import ChatMessage, ChatRequest, ChatSkill
 
 from .query import QueryRequest, QuerySkill, QuerySkillState
 
 if False:  # pragma: no cover - type-checking imports
+    from typing import Mapping, Optional
+
+    import numpy as np
+
     from ..runtime import MoondreamRuntime, Token
     from kestrel.scheduler.types import GenerationRequest
 
 
+def _single_image(ctx: ChatRequest):
+    """Moondream is single-image; reject more and return the one (or None)."""
+    if len(ctx.images) > 1:
+        raise ValueError("Moondream supports at most one image per request")
+    return ctx.images[0] if ctx.images else None
+
+
 class MoondreamChatSkill(ChatSkill):
     """Chat over Moondream by flattening the conversation into ``query``."""
+
+    def build_request(
+        self,
+        image: "Optional[np.ndarray | bytes]",
+        prompt: "Mapping",
+        settings: "Optional[Mapping]",
+    ) -> BuiltRequest:
+        built = super().build_request(image, prompt, settings)
+        # The base may carry an images tuple; Moondream's pipeline takes one.
+        return BuiltRequest(
+            request_context=built.request_context,
+            max_new_tokens=built.max_new_tokens,
+            temperature=built.temperature,
+            top_p=built.top_p,
+            image=_single_image(built.request_context),
+        )
 
     def build_prompt_tokens(
         self,
@@ -36,7 +63,7 @@ class MoondreamChatSkill(ChatSkill):
             )
         query_request = QueryRequest(
             question=_flatten_messages(request_context.messages),
-            image=request_context.image,
+            image=_single_image(request_context),
             reasoning=request_context.reasoning,
             stream=request_context.stream,
             spatial_refs=None,
@@ -67,7 +94,7 @@ class MoondreamChatSkillState(QuerySkillState):
     ) -> None:
         query_request = QueryRequest(
             question="",
-            image=chat_request.image,
+            image=_single_image(chat_request),
             reasoning=chat_request.reasoning,
             stream=chat_request.stream,
             spatial_refs=None,

--- a/kestrel/models/moondream/text.py
+++ b/kestrel/models/moondream/text.py
@@ -28,7 +28,7 @@ from kestrel_kernels import get_runtime
 
 _KERNELS = get_runtime()
 _flash_attn_fwd = _KERNELS.attention.flash_attn_fwd
-cute_prefix_lm_mask_730 = _KERNELS.attention.prefix_lm_mask_730
+cute_block_bidirectional_mask = _KERNELS.attention.block_bidirectional_mask
 tau_tail_apply_into = _KERNELS.tau.tau_tail_apply_into
 rotary_embedding = _KERNELS.rotary.rotary_embedding
 _fused_linear_bias_residual_into = _KERNELS.vision.fused_linear_bias_residual_into
@@ -81,6 +81,7 @@ def attn(
     *,
     slot_mapping: torch.Tensor,
     use_prefix_attn: bool = False,
+    block_sequence_ids: torch.Tensor | None = None,
     page_table: torch.Tensor | None = None,
     paged_kv_seqlens_q: torch.Tensor | None = None,
     paged_kv_seqlens_k: torch.Tensor | None = None,
@@ -141,12 +142,19 @@ def attn(
         mask_mod = None
         causal = True
         pack_gqa = False
+        aux_tensors = None
         if use_prefix_attn:
-            # TODO: Make this dynamic (per-request prefix length) when we support
-            # non-fixed image prefixes. For now, hardcode Moondream's BOS+image
-            # prefix length (730 = 1 + 27*27).
+            # Image-block bidirectional (prefix-LM) attention: every image block
+            # attends bidirectionally within itself, the rest is causal. The
+            # per-token `block_sequence_ids` aux tensor (image-block id >= 0, or
+            # -1 for text) drives the mask, so this is dynamic in the number and
+            # position of image blocks (one image after BOS, or several
+            # interleaved across turns) rather than a fixed front prefix.
+            if block_sequence_ids is None:
+                raise RuntimeError("use_prefix_attn requires block_sequence_ids")
             causal = False
-            mask_mod = cute_prefix_lm_mask_730
+            mask_mod = cute_block_bidirectional_mask
+            aux_tensors = [block_sequence_ids]
         out, _ = _flash_attn_fwd(
             q,
             k_cache,
@@ -158,6 +166,7 @@ def attn(
             causal=causal,
             pack_gqa=pack_gqa,
             mask_mod=mask_mod,
+            aux_tensors=aux_tensors,
             k_scale=k_scale,
             v_scale=v_scale,
         )
@@ -194,6 +203,7 @@ def text_decoder(
     *,
     slot_mapping: torch.Tensor,
     use_prefix_attn: bool = False,
+    block_sequence_ids: torch.Tensor | None = None,
     mode: Literal["prefill", "decode"] = "decode",
     page_table: torch.Tensor | None = None,
     paged_kv_seqlens_q: torch.Tensor | None = None,
@@ -226,6 +236,7 @@ def text_decoder(
             mode=mode,
             slot_mapping=slot_mapping,
             use_prefix_attn=use_prefix_attn,
+            block_sequence_ids=block_sequence_ids,
             page_table=page_table,
             paged_kv_seqlens_q=paged_kv_seqlens_q,
             paged_kv_seqlens_k=paged_kv_seqlens_k,

--- a/kestrel/models/protocols.py
+++ b/kestrel/models/protocols.py
@@ -12,8 +12,8 @@ as the HuggingFace ``tokenizers.Tokenizer`` class today; no abstraction
 exists for it yet because there is no concrete second implementation.
 """
 
-from dataclasses import dataclass
-from typing import List, Optional, Protocol, runtime_checkable
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Protocol, runtime_checkable
 
 
 @dataclass(frozen=True)
@@ -38,6 +38,38 @@ class PrefixSuffix:
 
     prefix: List[int]
     suffix: List[int]
+
+
+@dataclass(frozen=True)
+class ChatTemplate:
+    """Token framing for rendering a multi-turn chat into a prompt.
+
+    Each turn is rendered by the chat skill as::
+
+        turn_prefix  <role-word>  role_suffix  <content>  turn_suffix
+
+    The role word (``roles[role]``) and the message content are encoded by
+    the skill via ``runtime.tokenizer``; only the framing/special tokens
+    live here, so a model never has to hard-code the token id of "user" or
+    "assistant". After the final turn the skill appends the assistant
+    opener — ``turn_prefix <assistant-word> role_suffix`` followed by
+    ``assistant_open`` (or ``assistant_open_reasoning`` when reasoning is
+    enabled). ``post_reasoning_prefix`` is force-injected once the model
+    emits ``answer_id`` (the reasoning→answer boundary). ``turn_end_ids``
+    are the token ids that terminate an assistant turn; the scheduler stops
+    decoding on them in addition to ``eos_id``.
+    """
+
+    turn_prefix: List[int]
+    role_suffix: List[int]
+    turn_suffix: List[int]
+    assistant_open: List[int]
+    assistant_open_reasoning: List[int]
+    post_reasoning_prefix: List[int]
+    turn_end_ids: List[int]
+    roles: Dict[str, str]
+    bos: List[int] = field(default_factory=list)
+    supports_system: bool = True
 
 
 @runtime_checkable
@@ -69,6 +101,14 @@ class PromptTemplate(Protocol):
     def query(self) -> Optional[QueryTemplate]:
         """Token sequences for the question-answering skill."""
 
+    def chat(self) -> Optional["ChatTemplate"]:
+        """Token framing for multi-turn chat, or ``None``.
+
+        ``None`` means the model has no native multi-turn chat format; the
+        chat skill then falls back to flattening the conversation into the
+        single-turn ``query`` prompt.
+        """
+
     def detect(self) -> Optional[PrefixSuffix]:
         """Prefix/suffix for the detect skill."""
 
@@ -80,6 +120,7 @@ class PromptTemplate(Protocol):
 
 
 __all__ = [
+    "ChatTemplate",
     "PrefixSuffix",
     "PromptTemplate",
     "QueryTemplate",

--- a/kestrel/runtime/__init__.py
+++ b/kestrel/runtime/__init__.py
@@ -22,6 +22,7 @@ from kestrel.runtime.state import (
 )
 from kestrel.runtime.tokens import (
     CoordToken,
+    ImageMarker,
     SizeToken,
     TextToken,
     Token,
@@ -31,6 +32,7 @@ __all__ = [
     "AutoregressiveRuntime",
     "CoordToken",
     "ExecutionShape",
+    "ImageMarker",
     "PrefillClassification",
     "PreparedSequence",
     "Runtime",

--- a/kestrel/runtime/tokens.py
+++ b/kestrel/runtime/tokens.py
@@ -52,4 +52,26 @@ class SizeToken(NamedTuple):
         return 1
 
 
-Token = TextToken | CoordToken | SizeToken
+class ImageMarker(NamedTuple):
+    """Sentinel marking where an image is spliced into the prompt.
+
+    Deliberately NOT a vocabulary id, so user text can never collide with it.
+    A model's runtime replaces it before the forward pass — Qwen expands it to
+    ``<|vision_start|><|image_pad|>×N<|vision_end|>``; Moondream injects the
+    image-embedding block. ``index`` is the image's position in the request's
+    ordered image list, so each marker maps to a specific image.
+    """
+
+    index: int
+
+    def cache_key(self) -> tuple:
+        """Cache key: (4, index) - 4 discriminates from other token types."""
+        return (4, self.index)
+
+    def kv_length(self) -> int:
+        # A single placeholder slot; the runtime expands it to the image's
+        # real token/embedding length during sequence preparation.
+        return 1
+
+
+Token = TextToken | CoordToken | SizeToken | ImageMarker

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1626,7 +1626,14 @@ class GenerationScheduler:
     def _mark_finished_if_needed(self, seq: RequestLifecycle) -> bool:
         last_token = seq.last_token
         eos_id = self.runtime.prompt_template.eos_id
-        eos_hit = isinstance(last_token, TextToken) and last_token.token_id == eos_id
+        is_text = isinstance(last_token, TextToken)
+        eos_hit = is_text and last_token.token_id == eos_id
+        if is_text and not eos_hit:
+            # A skill (e.g. chat) may terminate a turn on its own token — a
+            # ChatML-style ``<|im_end|>`` can differ from the model's ``eos_id``.
+            stop_ids = seq.skill_state.stop_token_ids(self.runtime)
+            if stop_ids is not None and last_token.token_id in stop_ids:
+                eos_hit = True
         max_new_hit = seq.skill_state.token_count >= seq.request.max_new_tokens
         max_len_hit = seq.total_length >= seq.state.max_length
 

--- a/kestrel/skills/__init__.py
+++ b/kestrel/skills/__init__.py
@@ -26,13 +26,14 @@ from .base import (
     SkillState,
     parse_settings,
 )
-from .chat import ChatMessage, ChatRequest, ChatSkill, ChatSkillState
+from .chat import ChatContentPart, ChatMessage, ChatRequest, ChatSkill, ChatSkillState
 
 __all__ = [
     "AR_DEFAULT_MAX_NEW_TOKENS",
     "AR_DEFAULT_TEMPERATURE",
     "AR_DEFAULT_TOP_P",
     "BuiltRequest",
+    "ChatContentPart",
     "ChatMessage",
     "ChatRequest",
     "ChatSkill",

--- a/kestrel/skills/__init__.py
+++ b/kestrel/skills/__init__.py
@@ -26,13 +26,14 @@ from .base import (
     SkillState,
     parse_settings,
 )
-from .chat import ChatRequest, ChatSkill, ChatSkillState
+from .chat import ChatMessage, ChatRequest, ChatSkill, ChatSkillState
 
 __all__ = [
     "AR_DEFAULT_MAX_NEW_TOKENS",
     "AR_DEFAULT_TEMPERATURE",
     "AR_DEFAULT_TOP_P",
     "BuiltRequest",
+    "ChatMessage",
     "ChatRequest",
     "ChatSkill",
     "ChatSkillState",

--- a/kestrel/skills/__init__.py
+++ b/kestrel/skills/__init__.py
@@ -6,9 +6,11 @@ This package is model-agnostic: it defines what a *skill* is — the
 types they exchange with the kernel (``DecodeStep``, ``BuiltRequest``,
 ``SkillFinalizeResult``, autoregressive sampling defaults).
 
-Concrete capabilities live with their model (e.g.
+Most concrete capabilities live with their model (e.g.
 ``kestrel.models.moondream.skills``), since validation and request-building
-are model-specific.
+are model-specific. The exception is :class:`~kestrel.skills.chat.ChatSkill`,
+a model-agnostic chat capability that any model can serve by exposing a
+``chat()`` prompt template — it lives here so models share one instance.
 """
 
 from .base import (
@@ -24,12 +26,16 @@ from .base import (
     SkillState,
     parse_settings,
 )
+from .chat import ChatRequest, ChatSkill, ChatSkillState
 
 __all__ = [
     "AR_DEFAULT_MAX_NEW_TOKENS",
     "AR_DEFAULT_TEMPERATURE",
     "AR_DEFAULT_TOP_P",
     "BuiltRequest",
+    "ChatRequest",
+    "ChatSkill",
+    "ChatSkillState",
     "DecodeStep",
     "SkillFinalizeResult",
     "SkillRegistry",

--- a/kestrel/skills/base.py
+++ b/kestrel/skills/base.py
@@ -57,6 +57,11 @@ class BuiltRequest:
     max_new_tokens: int
     temperature: float
     top_p: float
+    # Media the skill extracted from its own prompt (e.g. an image carried
+    # inside OpenAI chat messages). When set, the engine sends this through
+    # the image pipeline instead of the top-level ``image`` argument; ``None``
+    # leaves any caller-supplied ``image`` in force.
+    image: "Optional[np.ndarray | bytes]" = None
 
 
 def parse_settings(
@@ -217,6 +222,17 @@ class SkillState:
 
         Complement of allowed_token_ids: these tokens are forced to -inf
         rather than being the only ones kept.
+        """
+        return None
+
+    def stop_token_ids(self, runtime: "MoondreamRuntime") -> Optional[Sequence[int]]:
+        """Optional per-skill token ids that end generation.
+
+        The scheduler stops a sequence when its last token matches the
+        model's ``eos_id``; a skill returns extra ids here to also stop on a
+        capability-specific terminator. The chat skill uses this for a
+        turn-end token (e.g. a ChatML-style ``<|im_end|>``) that differs
+        from the model's ``eos_id``.
         """
         return None
 

--- a/kestrel/skills/chat.py
+++ b/kestrel/skills/chat.py
@@ -101,6 +101,11 @@ class ChatSkill(SkillSpec):
     inherited.
     """
 
+    # Per-model reasoning default when the caller doesn't pass ``reasoning``.
+    # The base is off; a model whose chat format defaults to thinking sets
+    # this True in its subclass (Qwen, Moondream).
+    default_reasoning: bool = False
+
     def __init__(self) -> None:
         super().__init__(name="chat")
 
@@ -154,7 +159,7 @@ class ChatSkill(SkillSpec):
                     )
                     break
 
-        reasoning = bool(prompt.get("reasoning", False))
+        reasoning = bool(prompt.get("reasoning", self.default_reasoning))
         if settings is not None and "reasoning" in settings:
             reasoning = bool(settings["reasoning"])
 
@@ -378,14 +383,18 @@ class ChatSkillState(SkillState):
     ) -> SkillFinalizeResult:
         tokenizer = runtime.tokenizer
         answer_text = tokenizer.decode(self._answer_tokens) if self._answer_tokens else ""
+        # Trim leading whitespace: in reasoning mode the model emits a "\n\n"
+        # separator after the thinking block before the answer proper.
+        answer_text = answer_text.lstrip()
         message: Dict[str, object] = {"role": "assistant", "content": answer_text}
-        output: Dict[str, object] = {"message": message, "finish_reason": reason}
+        # OpenRouter-style: reasoning is a string field on the message, separate
+        # from content (omitted when there's no reasoning).
         if self._reasoning_enabled and self._reasoning_tokens:
-            output["reasoning"] = {"text": tokenizer.decode(self._reasoning_tokens)}
+            message["reasoning"] = tokenizer.decode(self._reasoning_tokens)
         return SkillFinalizeResult(
             text=answer_text,
             tokens=list(self.tokens),
-            output=output,
+            output={"message": message, "finish_reason": reason},
         )
 
 

--- a/kestrel/skills/chat.py
+++ b/kestrel/skills/chat.py
@@ -87,7 +87,7 @@ class ChatRequest:
     """Validated chat payload carried to decode."""
 
     messages: Tuple[ChatMessage, ...]
-    images: Tuple["np.ndarray | bytes", ...]
+    images: Tuple[bytes, ...]
     reasoning: bool
     stream: bool
 
@@ -125,7 +125,7 @@ class ChatSkill(SkillSpec):
         if len(raw) == 0:
             raise ValueError("messages must be a non-empty list")
 
-        images: List["np.ndarray | bytes"] = []
+        images: List[bytes] = []
         messages: List[ChatMessage] = []
         for idx, m in enumerate(raw):
             if not isinstance(m, _Mapping):
@@ -393,7 +393,7 @@ class ChatSkillState(SkillState):
 
 def _parse_content(
     content: object,
-    images: "List[np.ndarray | bytes]",
+    images: List[bytes],
     role: str,
 ) -> List[ChatContentPart]:
     """Parse a message ``content`` into ordered parts, appending any images

--- a/kestrel/skills/chat.py
+++ b/kestrel/skills/chat.py
@@ -147,18 +147,6 @@ class ChatSkill(SkillSpec):
         if not messages[-1].text and not messages[-1].has_image:
             raise ValueError("the last user message must have text or an image")
 
-        # Convenience for non-OpenAI callers: a top-level ``image=`` with no
-        # in-message images is placed at the start of the first user turn.
-        if not images and image is not None:
-            images.append(image)
-            for i, msg in enumerate(messages):
-                if msg.role == "user":
-                    messages[i] = ChatMessage(
-                        role="user",
-                        parts=(ChatContentPart(image_index=0),) + msg.parts,
-                    )
-                    break
-
         reasoning = bool(prompt.get("reasoning", self.default_reasoning))
         if settings is not None and "reasoning" in settings:
             reasoning = bool(settings["reasoning"])
@@ -382,10 +370,12 @@ class ChatSkillState(SkillState):
         self, runtime: "MoondreamRuntime", *, reason: str
     ) -> SkillFinalizeResult:
         tokenizer = runtime.tokenizer
+        # Decode the answer tokens as-is — matching the query skill. The
+        # reasoning→answer boundary is the answer_id token plus the (force-fed,
+        # uncollected) post_reasoning_prefix, so _answer_tokens is already just
+        # the answer; stripping here would mutate legitimate leading whitespace
+        # and desync streamed deltas (decoded un-stripped) from this content.
         answer_text = tokenizer.decode(self._answer_tokens) if self._answer_tokens else ""
-        # Trim leading whitespace: in reasoning mode the model emits a "\n\n"
-        # separator after the thinking block before the answer proper.
-        answer_text = answer_text.lstrip()
         message: Dict[str, object] = {"role": "assistant", "content": answer_text}
         # OpenRouter-style: reasoning is a string field on the message, separate
         # from content (omitted when there's no reasoning).
@@ -423,7 +413,7 @@ def _parse_content(
                 if value is None:
                     raise ValueError("a text content part is missing 'text'")
                 parts.append(ChatContentPart(text=str(value)))
-            elif ptype in ("image_url", "image"):
+            elif ptype == "image_url":
                 if role == "system":
                     raise ValueError("a system message cannot contain images")
                 images.append(_load_image_part(part))
@@ -434,40 +424,22 @@ def _parse_content(
     raise ValueError("message content must be a string or a list of content parts")
 
 
-def _load_image_part(part: "_Mapping") -> "np.ndarray | bytes":
-    if part.get("type") == "image":
-        # Convenience for Python callers: a native image object passed directly.
-        obj = part.get("image")
-        if obj is None:
-            raise ValueError("an image content part is missing 'image'")
-        return _coerce_image(obj)
+def _load_image_part(part: "_Mapping") -> bytes:
     spec = part.get("image_url")
     if isinstance(spec, _Mapping):
         spec = spec.get("url")
     if spec is None:
         raise ValueError("an image_url content part is missing 'url'")
-    return _coerce_image(spec)
-
-
-def _coerce_image(obj: object) -> "np.ndarray | bytes":
-    # Message content can come from untrusted callers (this payload maps onto
-    # an OpenAI HTTP request). A string image is accepted only as a base64
-    # ``data:`` URL — no remote (http) fetches and no server filesystem reads.
-    # In-memory images (raw bytes or a numpy array) pass through for Python
-    # callers; a caller with a file on disk loads it themselves.
-    if isinstance(obj, (bytes, bytearray)):
-        return bytes(obj)
-    if isinstance(obj, np.ndarray):
-        return obj
-    if isinstance(obj, str):
-        value = obj.strip()
-        if value.startswith("data:"):
-            return load_image_bytes_from_base64(value)
+    # The payload maps onto an untrusted OpenAI HTTP request: accept only a
+    # base64 data: URL — no remote (http) fetches and no server filesystem reads.
+    if not isinstance(spec, str):
         raise ValueError(
-            "an image string must be a base64 data: URL; pass raw bytes or a "
-            "numpy array for an in-memory image"
+            f"an image_url 'url' must be a string, got {type(spec).__name__}"
         )
-    raise ValueError(f"unsupported image value of type {type(obj).__name__}")
+    value = spec.strip()
+    if not value.startswith("data:"):
+        raise ValueError("an image_url 'url' must be a base64 data: URL")
+    return load_image_bytes_from_base64(value)
 
 
 __all__ = [

--- a/kestrel/skills/chat.py
+++ b/kestrel/skills/chat.py
@@ -21,7 +21,6 @@ HTTP boundary. The ``output`` shape (``{"message": {...}, "finish_reason":
 
 from __future__ import annotations
 
-import os
 from collections.abc import Mapping as _Mapping, Sequence as _Sequence
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Set, Tuple
@@ -398,6 +397,10 @@ def _load_image_part(part: "_Mapping") -> "np.ndarray | bytes":
 
 
 def _coerce_image(obj: object) -> "np.ndarray | bytes":
+    # Message content can come from untrusted callers (this payload maps onto
+    # an OpenAI HTTP request), so never read a server filesystem path here:
+    # accept only in-memory images and data: URLs. A caller with a file on
+    # disk loads it themselves (raw bytes or a numpy array).
     if isinstance(obj, (bytes, bytearray)):
         return bytes(obj)
     if isinstance(obj, np.ndarray):
@@ -408,14 +411,13 @@ def _coerce_image(obj: object) -> "np.ndarray | bytes":
             return load_image_bytes_from_base64(value)
         if value.startswith(("http://", "https://")):
             raise ValueError(
-                "remote image URLs are not supported yet; pass a data: URL, a "
-                "local file path, raw bytes, or a numpy array"
+                "remote image URLs are not supported yet; pass a data: URL, "
+                "raw bytes, or a numpy array"
             )
-        if os.path.exists(value):
-            with open(value, "rb") as handle:
-                return handle.read()
-        # Last resort: treat the string as a raw base64 payload.
-        return load_image_bytes_from_base64(value)
+        raise ValueError(
+            "an image string must be a data: URL; pass raw bytes or a numpy "
+            "array for an in-memory image"
+        )
     raise ValueError(f"unsupported image value of type {type(obj).__name__}")
 
 

--- a/kestrel/skills/chat.py
+++ b/kestrel/skills/chat.py
@@ -1,24 +1,21 @@
 """Shared, model-agnostic chat skill (OpenAI-compatible message shape).
 
-``ChatSkill`` is a *base* capability: a model "implements" it by exposing a
-``chat()`` template from its ``prompt_template`` (see
-:class:`kestrel.models.protocols.ChatTemplate`). The skill itself owns the
-generic parts — validating OpenAI-style ``messages``, extracting at most one
-image, rendering the conversation into prompt tokens, interpreting the decode
-stream, and materialising an assistant ``message`` — so the same instance
-serves any model.
+``ChatSkill`` is a *base* capability for models with a native multi-turn
+chat format: a model opts in by exposing a ``chat()`` prompt template (see
+:class:`kestrel.models.protocols.ChatTemplate`). The skill owns the generic
+parts — validating OpenAI-style ``messages``, extracting at most one image,
+rendering the conversation into prompt tokens with role markers, interpreting
+the decode stream, and materialising an assistant ``message``.
 
-Two rendering modes, selected per model:
+A model that needs different behaviour *subclasses* this skill rather than
+having the kernel branch on model specifics. For example a model with no
+trained chat format (Moondream) registers a subclass that flattens the
+conversation into its single-turn ``query`` prompt and reuses the query
+decode path — see ``kestrel.models.moondream.skills.chat``.
 
-* ``prompt_template.chat()`` returns a template → native multi-turn rendering
-  with role markers (ChatML-style ``<|im_start|>role ... <|im_end|>`` turns).
-* ``prompt_template.chat()`` returns ``None`` → the conversation is flattened
-  into the single-turn ``query`` prompt (Moondream, which has no trained
-  multi-turn chat format).
-
-Validation is plain Python (raises ``ValueError``); pydantic stays at the HTTP
-boundary. The ``output`` shape (``{"message": {...}, "finish_reason": ...}``)
-maps directly onto an OpenAI chat-completion *choice*, so a future
+Validation is plain Python (raises ``ValueError``); pydantic stays at the
+HTTP boundary. The ``output`` shape (``{"message": {...}, "finish_reason":
+...}``) maps directly onto an OpenAI chat-completion *choice*, so a future
 ``/v1/chat/completions`` route is a thin wrapper.
 """
 
@@ -53,8 +50,12 @@ _ROLES = ("system", "user", "assistant")
 
 
 @dataclass(slots=True)
-class _ChatMessage:
-    """One validated turn: role + flattened text (image handled separately)."""
+class ChatMessage:
+    """One validated turn: role + flattened text (image handled separately).
+
+    Part of the subclass contract: a ``ChatSkill`` subclass receives these
+    via ``ChatRequest.messages``.
+    """
 
     role: str
     text: str
@@ -65,14 +66,20 @@ class _ChatMessage:
 class ChatRequest:
     """Validated chat payload carried to decode."""
 
-    messages: Tuple[_ChatMessage, ...]
+    messages: Tuple[ChatMessage, ...]
     image: "Optional[np.ndarray | bytes]"
     reasoning: bool
     stream: bool
 
 
 class ChatSkill(SkillSpec):
-    """Multi-turn chat capability shared across models."""
+    """Multi-turn chat for models with a native ``chat()`` template.
+
+    Subclass to customise rendering or decode for a model that does not have
+    one (override ``build_prompt_tokens`` / ``create_state``); ``build_request``
+    — OpenAI message validation and image extraction — is model-agnostic and
+    inherited.
+    """
 
     def __init__(self) -> None:
         super().__init__(name="chat")
@@ -93,7 +100,7 @@ class ChatSkill(SkillSpec):
         if len(raw) == 0:
             raise ValueError("messages must be a non-empty list")
 
-        messages: List[_ChatMessage] = []
+        messages: List[ChatMessage] = []
         found_image: "Optional[np.ndarray | bytes]" = None
         for idx, m in enumerate(raw):
             if not isinstance(m, _Mapping):
@@ -114,7 +121,7 @@ class ChatSkill(SkillSpec):
                         "at most one image is supported across chat messages"
                     )
                 found_image = img
-            messages.append(_ChatMessage(role=role, text=text, has_image=img is not None))
+            messages.append(ChatMessage(role=role, text=text, has_image=img is not None))
 
         if messages[-1].role != "user":
             raise ValueError("the last message must be from 'user'")
@@ -164,9 +171,13 @@ class ChatSkill(SkillSpec):
         if not isinstance(request_context, ChatRequest):
             raise ValueError("ChatSkill.build_prompt_tokens requires a ChatRequest")
         chat_tpl = runtime.prompt_template.chat()
-        if chat_tpl is not None:
-            return self._render_chat(runtime, chat_tpl, request_context)
-        return self._render_flattened(runtime, request_context)
+        if chat_tpl is None:
+            raise ValueError(
+                "model has no chat() template; a model without a native chat "
+                "format should register a ChatSkill subclass that renders chat "
+                "its own way (e.g. Moondream flattens into the query prompt)"
+            )
+        return self._render_chat(runtime, chat_tpl, request_context)
 
     def _render_chat(
         self, runtime: "MoondreamRuntime", ct, ctx: ChatRequest
@@ -201,27 +212,6 @@ class ChatSkill(SkillSpec):
         tokens.extend(TextToken(token_id=int(t)) for t in opener)
         return tokens
 
-    def _render_flattened(
-        self, runtime: "MoondreamRuntime", ctx: ChatRequest
-    ) -> List[Token]:
-        pt = runtime.prompt_template
-        template = pt.query()
-        if template is None:
-            raise ValueError("model supports neither a chat nor a query template")
-        question = _flatten_messages(ctx.messages)
-        pre = (
-            template.prefix_when_reasoning
-            if ctx.reasoning and template.prefix_when_reasoning is not None
-            else template.prefix
-        )
-        opener = template.reasoning_prefix if ctx.reasoning else template.answer_prefix
-        encoded = runtime.tokenizer.encode(question).ids if question else []
-        tokens: List[Token] = [TextToken(token_id=int(pt.bos_id))]
-        tokens.extend(TextToken(token_id=int(t)) for t in pre)
-        tokens.extend(TextToken(token_id=int(t)) for t in encoded)
-        tokens.extend(TextToken(token_id=int(t)) for t in opener)
-        return tokens
-
     # -- decode state ------------------------------------------------------
 
     def create_state(
@@ -233,19 +223,14 @@ class ChatSkill(SkillSpec):
         if not isinstance(request_context, ChatRequest):
             raise ValueError("ChatSkill.create_state requires a ChatRequest context")
         chat_tpl = runtime.prompt_template.chat()
-        if chat_tpl is not None:
-            post_reasoning = list(chat_tpl.post_reasoning_prefix)
-            turn_end = list(chat_tpl.turn_end_ids)
-        else:
-            template = runtime.prompt_template.query()
-            post_reasoning = list(template.post_reasoning_prefix) if template else []
-            turn_end = []
+        if chat_tpl is None:
+            raise ValueError("model has no chat() template for ChatSkill")
         return ChatSkillState(
             self,
             request,
             request_context,
-            post_reasoning_prefix=post_reasoning,
-            turn_end_ids=turn_end,
+            post_reasoning_prefix=list(chat_tpl.post_reasoning_prefix),
+            turn_end_ids=list(chat_tpl.turn_end_ids),
         )
 
 
@@ -434,32 +419,4 @@ def _coerce_image(obj: object) -> "np.ndarray | bytes":
     raise ValueError(f"unsupported image value of type {type(obj).__name__}")
 
 
-def _flatten_messages(messages: Sequence[_ChatMessage]) -> str:
-    """Render a conversation as a single question for models without a chat
-    template. A lone user turn (optionally with a system preamble) passes
-    through cleanly; longer histories are labelled best-effort."""
-    if len(messages) == 1:
-        return messages[0].text
-    system = ""
-    convo: List[_ChatMessage] = []
-    for msg in messages:
-        if msg.role == "system":
-            system = msg.text
-        else:
-            convo.append(msg)
-    if len(convo) == 1 and not system:
-        return convo[0].text
-    lines: List[str] = []
-    if system:
-        lines.append(system)
-    for i, msg in enumerate(convo):
-        is_last = i == len(convo) - 1
-        if is_last and msg.role == "user":
-            lines.append(msg.text)
-        else:
-            label = "User" if msg.role == "user" else "Assistant"
-            lines.append(f"{label}: {msg.text}")
-    return "\n\n".join(line for line in lines if line)
-
-
-__all__ = ["ChatRequest", "ChatSkill", "ChatSkillState"]
+__all__ = ["ChatMessage", "ChatRequest", "ChatSkill", "ChatSkillState"]

--- a/kestrel/skills/chat.py
+++ b/kestrel/skills/chat.py
@@ -398,9 +398,10 @@ def _load_image_part(part: "_Mapping") -> "np.ndarray | bytes":
 
 def _coerce_image(obj: object) -> "np.ndarray | bytes":
     # Message content can come from untrusted callers (this payload maps onto
-    # an OpenAI HTTP request), so never read a server filesystem path here:
-    # accept only in-memory images and data: URLs. A caller with a file on
-    # disk loads it themselves (raw bytes or a numpy array).
+    # an OpenAI HTTP request). A string image is accepted only as a base64
+    # ``data:`` URL — no remote (http) fetches and no server filesystem reads.
+    # In-memory images (raw bytes or a numpy array) pass through for Python
+    # callers; a caller with a file on disk loads it themselves.
     if isinstance(obj, (bytes, bytearray)):
         return bytes(obj)
     if isinstance(obj, np.ndarray):
@@ -409,14 +410,9 @@ def _coerce_image(obj: object) -> "np.ndarray | bytes":
         value = obj.strip()
         if value.startswith("data:"):
             return load_image_bytes_from_base64(value)
-        if value.startswith(("http://", "https://")):
-            raise ValueError(
-                "remote image URLs are not supported yet; pass a data: URL, "
-                "raw bytes, or a numpy array"
-            )
         raise ValueError(
-            "an image string must be a data: URL; pass raw bytes or a numpy "
-            "array for an in-memory image"
+            "an image string must be a base64 data: URL; pass raw bytes or a "
+            "numpy array for an in-memory image"
         )
     raise ValueError(f"unsupported image value of type {type(obj).__name__}")
 

--- a/kestrel/skills/chat.py
+++ b/kestrel/skills/chat.py
@@ -1,0 +1,465 @@
+"""Shared, model-agnostic chat skill (OpenAI-compatible message shape).
+
+``ChatSkill`` is a *base* capability: a model "implements" it by exposing a
+``chat()`` template from its ``prompt_template`` (see
+:class:`kestrel.models.protocols.ChatTemplate`). The skill itself owns the
+generic parts — validating OpenAI-style ``messages``, extracting at most one
+image, rendering the conversation into prompt tokens, interpreting the decode
+stream, and materialising an assistant ``message`` — so the same instance
+serves any model.
+
+Two rendering modes, selected per model:
+
+* ``prompt_template.chat()`` returns a template → native multi-turn rendering
+  with role markers (ChatML-style ``<|im_start|>role ... <|im_end|>`` turns).
+* ``prompt_template.chat()`` returns ``None`` → the conversation is flattened
+  into the single-turn ``query`` prompt (Moondream, which has no trained
+  multi-turn chat format).
+
+Validation is plain Python (raises ``ValueError``); pydantic stays at the HTTP
+boundary. The ``output`` shape (``{"message": {...}, "finish_reason": ...}``)
+maps directly onto an OpenAI chat-completion *choice*, so a future
+``/v1/chat/completions`` route is a thin wrapper.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping as _Mapping, Sequence as _Sequence
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+import numpy as np
+
+from kestrel.runtime.tokens import TextToken, Token
+from kestrel.skills.base import (
+    AR_DEFAULT_MAX_NEW_TOKENS,
+    AR_DEFAULT_TEMPERATURE,
+    AR_DEFAULT_TOP_P,
+    BuiltRequest,
+    DecodeStep,
+    SkillFinalizeResult,
+    SkillSpec,
+    SkillState,
+    parse_settings,
+)
+from kestrel.utils.image import load_image_bytes_from_base64
+
+if False:  # pragma: no cover - type-checking imports
+    from kestrel.models.moondream.runtime import MoondreamRuntime
+    from kestrel.scheduler.types import GenerationRequest
+
+_ROLES = ("system", "user", "assistant")
+
+
+@dataclass(slots=True)
+class _ChatMessage:
+    """One validated turn: role + flattened text (image handled separately)."""
+
+    role: str
+    text: str
+    has_image: bool = False
+
+
+@dataclass(slots=True)
+class ChatRequest:
+    """Validated chat payload carried to decode."""
+
+    messages: Tuple[_ChatMessage, ...]
+    image: "Optional[np.ndarray | bytes]"
+    reasoning: bool
+    stream: bool
+
+
+class ChatSkill(SkillSpec):
+    """Multi-turn chat capability shared across models."""
+
+    def __init__(self) -> None:
+        super().__init__(name="chat")
+
+    # -- request building --------------------------------------------------
+
+    def build_request(
+        self,
+        image: "Optional[np.ndarray | bytes]",
+        prompt: "_Mapping",
+        settings: "Optional[_Mapping]",
+    ) -> BuiltRequest:
+        raw = prompt.get("messages")
+        if raw is None:
+            raise ValueError("messages must be provided")
+        if not isinstance(raw, _Sequence) or isinstance(raw, (str, bytes, bytearray)):
+            raise ValueError("messages must be a list of message objects")
+        if len(raw) == 0:
+            raise ValueError("messages must be a non-empty list")
+
+        messages: List[_ChatMessage] = []
+        found_image: "Optional[np.ndarray | bytes]" = None
+        for idx, m in enumerate(raw):
+            if not isinstance(m, _Mapping):
+                raise ValueError(
+                    "each message must be a mapping with 'role' and 'content'"
+                )
+            role = m.get("role")
+            if role not in _ROLES:
+                raise ValueError(
+                    f"message role must be one of {_ROLES}, got {role!r}"
+                )
+            if role == "system" and idx != 0:
+                raise ValueError("a 'system' message must be the first message")
+            text, img = _parse_content(m.get("content"))
+            if img is not None:
+                if found_image is not None:
+                    raise ValueError(
+                        "at most one image is supported across chat messages"
+                    )
+                found_image = img
+            messages.append(_ChatMessage(role=role, text=text, has_image=img is not None))
+
+        if messages[-1].role != "user":
+            raise ValueError("the last message must be from 'user'")
+        if not messages[-1].text and not messages[-1].has_image:
+            raise ValueError("the last user message must have text or an image")
+
+        # Image precedence: one carried inside the messages, else the
+        # top-level ``image=`` argument (a convenience for non-OpenAI callers).
+        resolved_image = found_image if found_image is not None else image
+
+        reasoning = bool(prompt.get("reasoning", False))
+        if settings is not None and "reasoning" in settings:
+            reasoning = bool(settings["reasoning"])
+
+        s = parse_settings(
+            settings,
+            temperature=AR_DEFAULT_TEMPERATURE,
+            top_p=AR_DEFAULT_TOP_P,
+            max_tokens=AR_DEFAULT_MAX_NEW_TOKENS,
+        )
+        request = ChatRequest(
+            messages=tuple(messages),
+            image=resolved_image,
+            reasoning=reasoning,
+            stream=bool(prompt.get("stream", False)),
+        )
+        return BuiltRequest(
+            request_context=request,
+            max_new_tokens=s.max_tokens,
+            temperature=s.temperature,
+            top_p=s.top_p,
+            image=resolved_image,
+        )
+
+    def prompt_text(self, request_context: object) -> str:
+        if isinstance(request_context, ChatRequest) and request_context.messages:
+            return request_context.messages[-1].text
+        return ""
+
+    # -- prompt tokens -----------------------------------------------------
+
+    def build_prompt_tokens(
+        self,
+        runtime: "MoondreamRuntime",
+        request_context: object,
+    ) -> Sequence[Token]:
+        if not isinstance(request_context, ChatRequest):
+            raise ValueError("ChatSkill.build_prompt_tokens requires a ChatRequest")
+        chat_tpl = runtime.prompt_template.chat()
+        if chat_tpl is not None:
+            return self._render_chat(runtime, chat_tpl, request_context)
+        return self._render_flattened(runtime, request_context)
+
+    def _render_chat(
+        self, runtime: "MoondreamRuntime", ct, ctx: ChatRequest
+    ) -> List[Token]:
+        tokenizer = runtime.tokenizer
+        tokens: List[Token] = [TextToken(token_id=int(t)) for t in ct.bos]
+        for msg in ctx.messages:
+            if msg.role == "system" and not ct.supports_system:
+                raise ValueError(
+                    "this model's chat template does not support a system message"
+                )
+            role_word = ct.roles.get(msg.role)
+            if role_word is None:
+                raise ValueError(f"chat template has no role word for {msg.role!r}")
+            tokens.extend(TextToken(token_id=int(t)) for t in ct.turn_prefix)
+            tokens.extend(
+                TextToken(token_id=int(t)) for t in tokenizer.encode(role_word).ids
+            )
+            tokens.extend(TextToken(token_id=int(t)) for t in ct.role_suffix)
+            if msg.text:
+                tokens.extend(
+                    TextToken(token_id=int(t)) for t in tokenizer.encode(msg.text).ids
+                )
+            tokens.extend(TextToken(token_id=int(t)) for t in ct.turn_suffix)
+        # Open the assistant turn for the model to complete.
+        tokens.extend(TextToken(token_id=int(t)) for t in ct.turn_prefix)
+        tokens.extend(
+            TextToken(token_id=int(t)) for t in tokenizer.encode(ct.roles["assistant"]).ids
+        )
+        tokens.extend(TextToken(token_id=int(t)) for t in ct.role_suffix)
+        opener = ct.assistant_open_reasoning if ctx.reasoning else ct.assistant_open
+        tokens.extend(TextToken(token_id=int(t)) for t in opener)
+        return tokens
+
+    def _render_flattened(
+        self, runtime: "MoondreamRuntime", ctx: ChatRequest
+    ) -> List[Token]:
+        pt = runtime.prompt_template
+        template = pt.query()
+        if template is None:
+            raise ValueError("model supports neither a chat nor a query template")
+        question = _flatten_messages(ctx.messages)
+        pre = (
+            template.prefix_when_reasoning
+            if ctx.reasoning and template.prefix_when_reasoning is not None
+            else template.prefix
+        )
+        opener = template.reasoning_prefix if ctx.reasoning else template.answer_prefix
+        encoded = runtime.tokenizer.encode(question).ids if question else []
+        tokens: List[Token] = [TextToken(token_id=int(pt.bos_id))]
+        tokens.extend(TextToken(token_id=int(t)) for t in pre)
+        tokens.extend(TextToken(token_id=int(t)) for t in encoded)
+        tokens.extend(TextToken(token_id=int(t)) for t in opener)
+        return tokens
+
+    # -- decode state ------------------------------------------------------
+
+    def create_state(
+        self,
+        runtime: "MoondreamRuntime",
+        request: "GenerationRequest",
+        request_context: object,
+    ) -> "ChatSkillState":
+        if not isinstance(request_context, ChatRequest):
+            raise ValueError("ChatSkill.create_state requires a ChatRequest context")
+        chat_tpl = runtime.prompt_template.chat()
+        if chat_tpl is not None:
+            post_reasoning = list(chat_tpl.post_reasoning_prefix)
+            turn_end = list(chat_tpl.turn_end_ids)
+        else:
+            template = runtime.prompt_template.query()
+            post_reasoning = list(template.post_reasoning_prefix) if template else []
+            turn_end = []
+        return ChatSkillState(
+            self,
+            request,
+            request_context,
+            post_reasoning_prefix=post_reasoning,
+            turn_end_ids=turn_end,
+        )
+
+
+class ChatSkillState(SkillState):
+    """Buffers an assistant turn (optional thinking block) into a chat message."""
+
+    def __init__(
+        self,
+        spec: SkillSpec,
+        request: "GenerationRequest",
+        chat_request: ChatRequest,
+        *,
+        post_reasoning_prefix: Sequence[int],
+        turn_end_ids: Sequence[int],
+    ) -> None:
+        super().__init__(spec, request)
+        self._request = chat_request
+        self._reasoning_enabled = bool(chat_request.reasoning)
+        self._collecting_reasoning = self._reasoning_enabled
+        self._reasoning_tokens: List[int] = []
+        self._answer_tokens: List[int] = []
+        self._streaming = bool(chat_request.stream)
+        self._answer_stream_offset = 0
+        self._answer_id: Optional[int] = None
+        self._stop_ids: Optional[Set[int]] = None
+        self._post_reasoning_prefix = list(post_reasoning_prefix)
+        # After the reasoning→answer boundary, the model's post-reasoning
+        # opener is replayed one token at a time via allowed_token_ids.
+        self._post_reasoning_tokens: Optional[List[int]] = None
+        self._post_reasoning_idx = 0
+        self._turn_end_ids = list(turn_end_ids)
+
+    def _ensure_ids(self, runtime: "MoondreamRuntime") -> None:
+        if self._answer_id is None:
+            self._answer_id = runtime.prompt_template.answer_id
+        if self._stop_ids is None:
+            self._stop_ids = set(self._turn_end_ids) | {runtime.prompt_template.eos_id}
+
+    def on_prefill(self, runtime: "MoondreamRuntime") -> None:
+        self._ensure_ids(runtime)
+        return None
+
+    def stop_token_ids(self, runtime: "MoondreamRuntime") -> Optional[Sequence[int]]:
+        return self._turn_end_ids or None
+
+    def allowed_token_ids(
+        self, runtime: "MoondreamRuntime"
+    ) -> Optional[Sequence[int]]:
+        if (
+            self._post_reasoning_tokens is not None
+            and self._post_reasoning_idx < len(self._post_reasoning_tokens)
+        ):
+            return [self._post_reasoning_tokens[self._post_reasoning_idx]]
+        return None
+
+    def consume_step(self, runtime: "MoondreamRuntime", step: DecodeStep) -> None:
+        self._ensure_ids(runtime)
+        self.append_token(step.token)
+
+        # Replaying the forced post-reasoning opener: don't collect these.
+        if (
+            self._post_reasoning_tokens is not None
+            and self._post_reasoning_idx < len(self._post_reasoning_tokens)
+        ):
+            self._post_reasoning_idx += 1
+            return None
+
+        token = step.token
+        if not self._reasoning_enabled:
+            self._collect_answer(token)
+            return None
+
+        if self._collecting_reasoning:
+            if isinstance(token, TextToken):
+                if token.token_id == self._answer_id:
+                    # reasoning → answer boundary
+                    self._collecting_reasoning = False
+                    self._post_reasoning_tokens = list(self._post_reasoning_prefix)
+                    self._post_reasoning_idx = 0
+                    self._answer_stream_offset = 0
+                    return None
+                self._reasoning_tokens.append(token.token_id)
+            return None
+
+        self._collect_answer(token)
+        return None
+
+    def _collect_answer(self, token: Token) -> None:
+        assert self._stop_ids is not None
+        if isinstance(token, TextToken) and token.token_id not in self._stop_ids:
+            self._answer_tokens.append(token.token_id)
+
+    def pop_stream_delta(self, runtime: "MoondreamRuntime") -> Optional[str]:
+        if not self._streaming or self._collecting_reasoning:
+            return None
+        if not self._answer_tokens:
+            return None
+        text = runtime.tokenizer.decode(self._answer_tokens)
+        if len(text) <= self._answer_stream_offset:
+            return None
+        chunk = text[self._answer_stream_offset :]
+        self._answer_stream_offset = len(text)
+        return chunk or None
+
+    def finalize(
+        self, runtime: "MoondreamRuntime", *, reason: str
+    ) -> SkillFinalizeResult:
+        tokenizer = runtime.tokenizer
+        answer_text = tokenizer.decode(self._answer_tokens) if self._answer_tokens else ""
+        message: Dict[str, object] = {"role": "assistant", "content": answer_text}
+        output: Dict[str, object] = {"message": message, "finish_reason": reason}
+        if self._reasoning_enabled and self._reasoning_tokens:
+            output["reasoning"] = {"text": tokenizer.decode(self._reasoning_tokens)}
+        return SkillFinalizeResult(
+            text=answer_text,
+            tokens=list(self.tokens),
+            output=output,
+        )
+
+
+# -- helpers --------------------------------------------------------------
+
+
+def _parse_content(content: object) -> Tuple[str, "Optional[np.ndarray | bytes]"]:
+    """Return (text, image) from a message ``content`` (str or parts list)."""
+    if content is None:
+        return "", None
+    if isinstance(content, str):
+        return content, None
+    if isinstance(content, _Sequence) and not isinstance(content, (str, bytes, bytearray)):
+        texts: List[str] = []
+        image: "Optional[np.ndarray | bytes]" = None
+        for part in content:
+            if not isinstance(part, _Mapping):
+                raise ValueError("each content part must be a mapping")
+            ptype = part.get("type")
+            if ptype == "text":
+                value = part.get("text")
+                if value is None:
+                    raise ValueError("a text content part is missing 'text'")
+                texts.append(str(value))
+            elif ptype in ("image_url", "image"):
+                if image is not None:
+                    raise ValueError("a message may contain at most one image")
+                image = _load_image_part(part)
+            else:
+                raise ValueError(f"unsupported content part type: {ptype!r}")
+        return "\n".join(texts), image
+    raise ValueError("message content must be a string or a list of content parts")
+
+
+def _load_image_part(part: "_Mapping") -> "np.ndarray | bytes":
+    if part.get("type") == "image":
+        # Convenience for Python callers: a native image object passed directly.
+        obj = part.get("image")
+        if obj is None:
+            raise ValueError("an image content part is missing 'image'")
+        return _coerce_image(obj)
+    spec = part.get("image_url")
+    if isinstance(spec, _Mapping):
+        spec = spec.get("url")
+    if spec is None:
+        raise ValueError("an image_url content part is missing 'url'")
+    return _coerce_image(spec)
+
+
+def _coerce_image(obj: object) -> "np.ndarray | bytes":
+    if isinstance(obj, (bytes, bytearray)):
+        return bytes(obj)
+    if isinstance(obj, np.ndarray):
+        return obj
+    if isinstance(obj, str):
+        value = obj.strip()
+        if value.startswith("data:"):
+            return load_image_bytes_from_base64(value)
+        if value.startswith(("http://", "https://")):
+            raise ValueError(
+                "remote image URLs are not supported yet; pass a data: URL, a "
+                "local file path, raw bytes, or a numpy array"
+            )
+        if os.path.exists(value):
+            with open(value, "rb") as handle:
+                return handle.read()
+        # Last resort: treat the string as a raw base64 payload.
+        return load_image_bytes_from_base64(value)
+    raise ValueError(f"unsupported image value of type {type(obj).__name__}")
+
+
+def _flatten_messages(messages: Sequence[_ChatMessage]) -> str:
+    """Render a conversation as a single question for models without a chat
+    template. A lone user turn (optionally with a system preamble) passes
+    through cleanly; longer histories are labelled best-effort."""
+    if len(messages) == 1:
+        return messages[0].text
+    system = ""
+    convo: List[_ChatMessage] = []
+    for msg in messages:
+        if msg.role == "system":
+            system = msg.text
+        else:
+            convo.append(msg)
+    if len(convo) == 1 and not system:
+        return convo[0].text
+    lines: List[str] = []
+    if system:
+        lines.append(system)
+    for i, msg in enumerate(convo):
+        is_last = i == len(convo) - 1
+        if is_last and msg.role == "user":
+            lines.append(msg.text)
+        else:
+            label = "User" if msg.role == "user" else "Assistant"
+            lines.append(f"{label}: {msg.text}")
+    return "\n\n".join(line for line in lines if line)
+
+
+__all__ = ["ChatRequest", "ChatSkill", "ChatSkillState"]

--- a/kestrel/skills/chat.py
+++ b/kestrel/skills/chat.py
@@ -3,26 +3,27 @@
 ``ChatSkill`` is a *base* capability for models with a native multi-turn
 chat format: a model opts in by exposing a ``chat()`` prompt template (see
 :class:`kestrel.models.protocols.ChatTemplate`). The skill owns the generic
-parts — validating OpenAI-style ``messages``, extracting at most one image,
-rendering the conversation into prompt tokens with role markers, interpreting
-the decode stream, and materialising an assistant ``message``.
+parts — validating OpenAI-style ``messages``, parsing each message's content
+into an ordered list of text/image parts, rendering the conversation into
+prompt tokens (emitting one ``image_placeholder`` per image **at its content
+position**), interpreting the decode stream, and materialising an assistant
+``message``. The runtime expands each image placeholder to that image's token
+count.
 
 A model that needs different behaviour *subclasses* this skill rather than
-having the kernel branch on model specifics. For example a model with no
-trained chat format (Moondream) registers a subclass that flattens the
-conversation into its single-turn ``query`` prompt and reuses the query
-decode path — see ``kestrel.models.moondream.skills.chat``.
+having the kernel branch on model specifics — e.g. a model with no trained
+chat format (Moondream) flattens the conversation into its single-turn
+``query`` prompt (``kestrel.models.moondream.skills.chat``).
 
 Validation is plain Python (raises ``ValueError``); pydantic stays at the
 HTTP boundary. The ``output`` shape (``{"message": {...}, "finish_reason":
-...}``) maps directly onto an OpenAI chat-completion *choice*, so a future
-``/v1/chat/completions`` route is a thin wrapper.
+...}``) maps directly onto an OpenAI chat-completion *choice*.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping as _Mapping, Sequence as _Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
@@ -49,16 +50,36 @@ _ROLES = ("system", "user", "assistant")
 
 
 @dataclass(slots=True)
+class ChatContentPart:
+    """One ordered piece of a message's content: text or an image reference.
+
+    Exactly one of ``text`` / ``image_index`` is set. ``image_index`` points
+    into :attr:`ChatRequest.images`.
+    """
+
+    text: Optional[str] = None
+    image_index: Optional[int] = None
+
+
+@dataclass(slots=True)
 class ChatMessage:
-    """One validated turn: role + flattened text (image handled separately).
+    """One validated turn: role + ordered content parts.
 
     Part of the subclass contract: a ``ChatSkill`` subclass receives these
     via ``ChatRequest.messages``.
     """
 
     role: str
-    text: str
-    has_image: bool = False
+    parts: Tuple[ChatContentPart, ...]
+
+    @property
+    def text(self) -> str:
+        """Concatenated text of this turn (image parts omitted)."""
+        return "".join(p.text for p in self.parts if p.text is not None)
+
+    @property
+    def has_image(self) -> bool:
+        return any(p.image_index is not None for p in self.parts)
 
 
 @dataclass(slots=True)
@@ -66,7 +87,7 @@ class ChatRequest:
     """Validated chat payload carried to decode."""
 
     messages: Tuple[ChatMessage, ...]
-    image: "Optional[np.ndarray | bytes]"
+    images: Tuple["np.ndarray | bytes", ...]
     reasoning: bool
     stream: bool
 
@@ -74,8 +95,8 @@ class ChatRequest:
 class ChatSkill(SkillSpec):
     """Multi-turn chat for models with a native ``chat()`` template.
 
-    Subclass to customise rendering or decode for a model that does not have
-    one (override ``build_prompt_tokens`` / ``create_state``); ``build_request``
+    Subclass to customise rendering or decode for a model without one
+    (override ``build_prompt_tokens`` / ``create_state``); ``build_request``
     — OpenAI message validation and image extraction — is model-agnostic and
     inherited.
     """
@@ -99,8 +120,8 @@ class ChatSkill(SkillSpec):
         if len(raw) == 0:
             raise ValueError("messages must be a non-empty list")
 
+        images: List["np.ndarray | bytes"] = []
         messages: List[ChatMessage] = []
-        found_image: "Optional[np.ndarray | bytes]" = None
         for idx, m in enumerate(raw):
             if not isinstance(m, _Mapping):
                 raise ValueError(
@@ -113,23 +134,25 @@ class ChatSkill(SkillSpec):
                 )
             if role == "system" and idx != 0:
                 raise ValueError("a 'system' message must be the first message")
-            text, img = _parse_content(m.get("content"))
-            if img is not None:
-                if found_image is not None:
-                    raise ValueError(
-                        "at most one image is supported across chat messages"
-                    )
-                found_image = img
-            messages.append(ChatMessage(role=role, text=text, has_image=img is not None))
+            parts = _parse_content(m.get("content"), images, role)
+            messages.append(ChatMessage(role=role, parts=tuple(parts)))
 
         if messages[-1].role != "user":
             raise ValueError("the last message must be from 'user'")
         if not messages[-1].text and not messages[-1].has_image:
             raise ValueError("the last user message must have text or an image")
 
-        # Image precedence: one carried inside the messages, else the
-        # top-level ``image=`` argument (a convenience for non-OpenAI callers).
-        resolved_image = found_image if found_image is not None else image
+        # Convenience for non-OpenAI callers: a top-level ``image=`` with no
+        # in-message images is placed at the start of the first user turn.
+        if not images and image is not None:
+            images.append(image)
+            for i, msg in enumerate(messages):
+                if msg.role == "user":
+                    messages[i] = ChatMessage(
+                        role="user",
+                        parts=(ChatContentPart(image_index=0),) + msg.parts,
+                    )
+                    break
 
         reasoning = bool(prompt.get("reasoning", False))
         if settings is not None and "reasoning" in settings:
@@ -143,7 +166,7 @@ class ChatSkill(SkillSpec):
         )
         request = ChatRequest(
             messages=tuple(messages),
-            image=resolved_image,
+            images=tuple(images),
             reasoning=reasoning,
             stream=bool(prompt.get("stream", False)),
         )
@@ -152,7 +175,7 @@ class ChatSkill(SkillSpec):
             max_new_tokens=s.max_tokens,
             temperature=s.temperature,
             top_p=s.top_p,
-            image=resolved_image,
+            image=tuple(images) if images else None,
         )
 
     def prompt_text(self, request_context: object) -> str:
@@ -182,33 +205,49 @@ class ChatSkill(SkillSpec):
         self, runtime: "MoondreamRuntime", ct, ctx: ChatRequest
     ) -> List[Token]:
         tokenizer = runtime.tokenizer
-        tokens: List[Token] = [TextToken(token_id=int(t)) for t in ct.bos]
+
+        def emit(ids) -> List[Token]:
+            return [TextToken(token_id=int(t)) for t in ids]
+
+        tokens: List[Token] = emit(ct.bos)
         for msg in ctx.messages:
-            if msg.role == "system" and not ct.supports_system:
-                raise ValueError(
-                    "this model's chat template does not support a system message"
-                )
             role_word = ct.roles.get(msg.role)
             if role_word is None:
                 raise ValueError(f"chat template has no role word for {msg.role!r}")
-            tokens.extend(TextToken(token_id=int(t)) for t in ct.turn_prefix)
-            tokens.extend(
-                TextToken(token_id=int(t)) for t in tokenizer.encode(role_word).ids
-            )
-            tokens.extend(TextToken(token_id=int(t)) for t in ct.role_suffix)
-            if msg.text:
-                tokens.extend(
-                    TextToken(token_id=int(t)) for t in tokenizer.encode(msg.text).ids
-                )
-            tokens.extend(TextToken(token_id=int(t)) for t in ct.turn_suffix)
+            tokens += emit(ct.turn_prefix)
+            tokens += emit(tokenizer.encode(role_word).ids)
+            tokens += emit(ct.role_suffix)
+            tokens += list(self.render_content(tokenizer, msg.parts))
+            tokens += emit(ct.turn_suffix)
         # Open the assistant turn for the model to complete.
-        tokens.extend(TextToken(token_id=int(t)) for t in ct.turn_prefix)
-        tokens.extend(
-            TextToken(token_id=int(t)) for t in tokenizer.encode(ct.roles["assistant"]).ids
-        )
-        tokens.extend(TextToken(token_id=int(t)) for t in ct.role_suffix)
-        opener = ct.assistant_open_reasoning if ctx.reasoning else ct.assistant_open
-        tokens.extend(TextToken(token_id=int(t)) for t in opener)
+        tokens += emit(ct.turn_prefix)
+        tokens += emit(tokenizer.encode(ct.roles["assistant"]).ids)
+        tokens += emit(ct.role_suffix)
+        tokens += emit(ct.assistant_open_reasoning if ctx.reasoning else ct.assistant_open)
+        return tokens
+
+    def render_content(
+        self, tokenizer, parts: "Sequence[ChatContentPart]"
+    ) -> List[Token]:
+        """Render one message's content parts to tokens.
+
+        The base handles text only and rejects images. A multimodal model
+        *subclasses* and overrides this to emit its own image tokens (e.g.
+        ``<|vision_start|><|image_pad|><|vision_end|>``) at each image's
+        position — so the kernel and the shared chat template carry no image
+        concept.
+        """
+        tokens: List[Token] = []
+        for part in parts:
+            if part.image_index is not None:
+                raise ValueError(
+                    "this chat skill does not render images; subclass ChatSkill "
+                    "and override render_content to add image support"
+                )
+            if part.text:
+                tokens.extend(
+                    TextToken(token_id=int(t)) for t in tokenizer.encode(part.text).ids
+                )
         return tokens
 
     # -- decode state ------------------------------------------------------
@@ -353,15 +392,19 @@ class ChatSkillState(SkillState):
 # -- helpers --------------------------------------------------------------
 
 
-def _parse_content(content: object) -> Tuple[str, "Optional[np.ndarray | bytes]"]:
-    """Return (text, image) from a message ``content`` (str or parts list)."""
+def _parse_content(
+    content: object,
+    images: "List[np.ndarray | bytes]",
+    role: str,
+) -> List[ChatContentPart]:
+    """Parse a message ``content`` into ordered parts, appending any images
+    (in order) to ``images`` and referencing them by index."""
     if content is None:
-        return "", None
+        return []
     if isinstance(content, str):
-        return content, None
+        return [ChatContentPart(text=content)]
     if isinstance(content, _Sequence) and not isinstance(content, (str, bytes, bytearray)):
-        texts: List[str] = []
-        image: "Optional[np.ndarray | bytes]" = None
+        parts: List[ChatContentPart] = []
         for part in content:
             if not isinstance(part, _Mapping):
                 raise ValueError("each content part must be a mapping")
@@ -370,14 +413,15 @@ def _parse_content(content: object) -> Tuple[str, "Optional[np.ndarray | bytes]"
                 value = part.get("text")
                 if value is None:
                     raise ValueError("a text content part is missing 'text'")
-                texts.append(str(value))
+                parts.append(ChatContentPart(text=str(value)))
             elif ptype in ("image_url", "image"):
-                if image is not None:
-                    raise ValueError("a message may contain at most one image")
-                image = _load_image_part(part)
+                if role == "system":
+                    raise ValueError("a system message cannot contain images")
+                images.append(_load_image_part(part))
+                parts.append(ChatContentPart(image_index=len(images) - 1))
             else:
                 raise ValueError(f"unsupported content part type: {ptype!r}")
-        return "\n".join(texts), image
+        return parts
     raise ValueError("message content must be a string or a list of content parts")
 
 
@@ -417,4 +461,10 @@ def _coerce_image(obj: object) -> "np.ndarray | bytes":
     raise ValueError(f"unsupported image value of type {type(obj).__name__}")
 
 
-__all__ = ["ChatMessage", "ChatRequest", "ChatSkill", "ChatSkillState"]
+__all__ = [
+    "ChatContentPart",
+    "ChatMessage",
+    "ChatRequest",
+    "ChatSkill",
+    "ChatSkillState",
+]

--- a/kestrel/utils/image.py
+++ b/kestrel/utils/image.py
@@ -40,6 +40,24 @@ def ensure_srgb(image: np.ndarray) -> np.ndarray:
     return np_image
 
 
+def decode_to_srgb(image) -> np.ndarray:
+    """Decode raw image bytes (e.g. an ``image_url`` data URL) to an 8-bit
+    sRGB array; a normalization-only pass for arrays already in memory.
+
+    Raises ``ValueError`` on bytes that aren't a supported image so callers
+    can fail the originating request at admission rather than deep inside a
+    batched prefill.
+    """
+    if isinstance(image, (bytes, bytearray)):
+        import kestrel_native
+
+        decoded = kestrel_native.decode_image(bytes(image))
+        if decoded is None:
+            raise ValueError("Unsupported image format")
+        image = decoded
+    return ensure_srgb(image)
+
+
 def _b64decode(payload: str) -> bytes:
     try:
         return base64.b64decode(payload, validate=True)

--- a/tests/moondream/test_runtime_prefill.py
+++ b/tests/moondream/test_runtime_prefill.py
@@ -45,7 +45,9 @@ def _make_runtime(seq_lens: dict[int, int]) -> tuple[runtime_mod.MoondreamRuntim
         del image, image_crops
         seq_len = seq_lens[prepared.state.batch_idx]
         hidden = torch.full((1, seq_len, 4), float(prepared.state.batch_idx))
-        return hidden, 0, False
+        # (inputs_embeds, position_start, use_prefix_attn, block_sequence_ids);
+        # None = no image blocks for these single-/uniform-token prefill cases.
+        return hidden, 0, False, None
 
     def prefill_impl(
         inputs_embeds,
@@ -59,11 +61,12 @@ def _make_runtime(seq_lens: dict[int, int]) -> tuple[runtime_mod.MoondreamRuntim
         paged_kv_seqlens_k,
         last_token_positions,
         input_staging,
+        block_sequence_ids=None,
     ):
         captured["position_ids_contiguous"] = position_ids.is_contiguous()
         captured["batch_idx_contiguous"] = batch_idx.is_contiguous()
         del attn_mask, position_ids, batch_idx, lora_slot, use_prefix_attn
-        del input_staging
+        del input_staging, block_sequence_ids
         captured["paged_kv_seqlens_q"] = paged_kv_seqlens_q
         captured["paged_kv_seqlens_k"] = paged_kv_seqlens_k
         captured["last_token_positions"] = last_token_positions

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -157,14 +157,16 @@ def test_build_request_extracts_image_from_data_url() -> None:
     assert built.request_context.messages[-1].text == "what is this?"
 
 
-def test_build_request_rejects_filesystem_path_image_url() -> None:
-    # image_url.url is untrusted; a server path must not be read as image bytes.
+@pytest.mark.parametrize("url", ["/etc/passwd", "https://example.com/cat.png"])
+def test_build_request_rejects_non_data_image_url(url: str) -> None:
+    # image_url.url is untrusted: only base64 data: URLs are accepted — no
+    # filesystem reads and no remote fetches.
     msgs = [
         {
             "role": "user",
             "content": [
                 {"type": "text", "text": "x"},
-                {"type": "image_url", "image_url": {"url": "/etc/passwd"}},
+                {"type": "image_url", "image_url": {"url": url}},
             ],
         }
     ]

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -1,0 +1,323 @@
+"""ChatSkill: message validation, prompt-token rendering (native chat
+template vs. flatten-into-query), and decode-state output shape."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import List, Optional
+
+import pytest
+
+from kestrel.models.protocols import ChatTemplate, QueryTemplate
+from kestrel.runtime.tokens import TextToken
+from kestrel.skills.base import DecodeStep
+from kestrel.skills.chat import (
+    ChatRequest,
+    ChatSkill,
+    _ChatMessage,
+    _flatten_messages,
+)
+
+# Synthetic token ids for a Qwen-like chat template.
+IM_START, IM_END, NL, DNL, THINK_S, THINK_E = 900, 901, 198, 271, 800, 801
+
+
+def _qwen_chat_template() -> ChatTemplate:
+    return ChatTemplate(
+        bos=[],
+        turn_prefix=[IM_START],
+        role_suffix=[NL],
+        turn_suffix=[IM_END, NL],
+        assistant_open=[THINK_S, DNL, THINK_E, DNL],
+        assistant_open_reasoning=[THINK_S, NL],
+        post_reasoning_prefix=[DNL],
+        turn_end_ids=[IM_END],
+        roles={"system": "system", "user": "user", "assistant": "assistant"},
+        supports_system=True,
+    )
+
+
+def _md_query_template() -> QueryTemplate:
+    return QueryTemplate(
+        prefix=[10, 11],
+        answer_prefix=[20],
+        reasoning_prefix=[21],
+        post_reasoning_prefix=[3],
+    )
+
+
+@dataclass
+class _PromptTemplate:
+    bos_id: int = 5
+    eos_id: int = 99
+    answer_id: int = THINK_E
+    thinking_id: int = THINK_S
+    coord_id: int = 0
+    size_id: int = 0
+    start_ground_points_id: int = 0
+    end_ground_id: int = 0
+    _chat: Optional[ChatTemplate] = None
+    _query: Optional[QueryTemplate] = None
+
+    def chat(self) -> Optional[ChatTemplate]:
+        return self._chat
+
+    def query(self) -> Optional[QueryTemplate]:
+        return self._query
+
+
+class _Tokenizer:
+    """Reversible char-level fake: encode→code points, decode→chars."""
+
+    def encode(self, text: str) -> SimpleNamespace:
+        return SimpleNamespace(ids=[ord(c) for c in text])
+
+    def decode(self, ids) -> str:
+        return "".join(chr(i) for i in ids)
+
+
+def _chat_runtime() -> SimpleNamespace:
+    return SimpleNamespace(
+        prompt_template=_PromptTemplate(_chat=_qwen_chat_template()),
+        tokenizer=_Tokenizer(),
+    )
+
+
+def _flatten_runtime() -> SimpleNamespace:
+    return SimpleNamespace(
+        prompt_template=_PromptTemplate(answer_id=3, _query=_md_query_template()),
+        tokenizer=_Tokenizer(),
+    )
+
+
+def _ids(tokens) -> List[int]:
+    return [t.token_id for t in tokens]
+
+
+def _ords(text: str) -> List[int]:
+    return [ord(c) for c in text]
+
+
+# -- validation -----------------------------------------------------------
+
+
+def test_build_request_accepts_minimal_conversation() -> None:
+    built = ChatSkill().build_request(
+        None, {"messages": [{"role": "user", "content": "hi"}]}, None
+    )
+    ctx = built.request_context
+    assert isinstance(ctx, ChatRequest)
+    assert [(m.role, m.text) for m in ctx.messages] == [("user", "hi")]
+    assert ctx.reasoning is False  # chat defaults to non-thinking
+
+
+def test_build_request_requires_messages() -> None:
+    with pytest.raises(ValueError, match="messages must be provided"):
+        ChatSkill().build_request(None, {}, None)
+
+
+def test_build_request_rejects_empty_messages() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        ChatSkill().build_request(None, {"messages": []}, None)
+
+
+def test_build_request_rejects_unknown_role() -> None:
+    with pytest.raises(ValueError, match="role"):
+        ChatSkill().build_request(
+            None, {"messages": [{"role": "tool", "content": "x"}]}, None
+        )
+
+
+def test_build_request_system_must_be_first() -> None:
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {"role": "system", "content": "be brief"},
+    ]
+    with pytest.raises(ValueError, match="first message"):
+        ChatSkill().build_request(None, {"messages": msgs}, None)
+
+
+def test_build_request_last_must_be_user() -> None:
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    with pytest.raises(ValueError, match="last message must be from 'user'"):
+        ChatSkill().build_request(None, {"messages": msgs}, None)
+
+
+def test_build_request_rejects_two_images() -> None:
+    img = "data:image/png;base64,aGk="  # b"hi"
+    msgs = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "two?"},
+                {"type": "image_url", "image_url": {"url": img}},
+                {"type": "image_url", "image_url": {"url": img}},
+            ],
+        }
+    ]
+    with pytest.raises(ValueError, match="at most one image"):
+        ChatSkill().build_request(None, {"messages": msgs}, None)
+
+
+def test_build_request_extracts_image_from_data_url() -> None:
+    msgs = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGk="}},
+            ],
+        }
+    ]
+    built = ChatSkill().build_request(None, {"messages": msgs}, None)
+    assert built.image == b"hi"
+    assert built.request_context.image == b"hi"
+    assert built.request_context.messages[-1].text == "what is this?"
+
+
+def test_build_request_reasoning_opt_in_via_settings() -> None:
+    built = ChatSkill().build_request(
+        None, {"messages": [{"role": "user", "content": "hi"}]}, {"reasoning": True}
+    )
+    assert built.request_context.reasoning is True
+
+
+# -- rendering: native chat template --------------------------------------
+
+
+def test_render_single_turn_chat() -> None:
+    runtime = _chat_runtime()
+    ctx = ChatRequest(
+        messages=(_ChatMessage("user", "hi"),),
+        image=None,
+        reasoning=False,
+        stream=False,
+    )
+    tokens = ChatSkill().build_prompt_tokens(runtime, ctx)
+    expected = (
+        [IM_START] + _ords("user") + [NL] + _ords("hi") + [IM_END, NL]
+        + [IM_START] + _ords("assistant") + [NL] + [THINK_S, DNL, THINK_E, DNL]
+    )
+    assert _ids(tokens) == expected
+
+
+def test_render_multi_turn_with_system_and_reasoning() -> None:
+    runtime = _chat_runtime()
+    ctx = ChatRequest(
+        messages=(
+            _ChatMessage("system", "be nice"),
+            _ChatMessage("user", "a"),
+            _ChatMessage("assistant", "b"),
+            _ChatMessage("user", "c"),
+        ),
+        image=None,
+        reasoning=True,
+        stream=False,
+    )
+    tokens = ChatSkill().build_prompt_tokens(runtime, ctx)
+
+    def turn(role: str, text: str) -> List[int]:
+        return [IM_START] + _ords(role) + [NL] + _ords(text) + [IM_END, NL]
+
+    expected = (
+        turn("system", "be nice")
+        + turn("user", "a")
+        + turn("assistant", "b")
+        + turn("user", "c")
+        + [IM_START] + _ords("assistant") + [NL] + [THINK_S, NL]  # reasoning opener
+    )
+    assert _ids(tokens) == expected
+
+
+# -- rendering: flatten into query ----------------------------------------
+
+
+def test_render_flatten_single_turn_matches_query_shape() -> None:
+    runtime = _flatten_runtime()
+    ctx = ChatRequest(
+        messages=(_ChatMessage("user", "hi"),),
+        image=None,
+        reasoning=False,
+        stream=False,
+    )
+    tokens = ChatSkill().build_prompt_tokens(runtime, ctx)
+    # bos + prefix + encoded(question) + answer_prefix
+    assert _ids(tokens) == [5, 10, 11] + _ords("hi") + [20]
+
+
+def test_flatten_messages_labels_history() -> None:
+    msgs = [
+        _ChatMessage("system", "sys"),
+        _ChatMessage("user", "u1"),
+        _ChatMessage("assistant", "a1"),
+        _ChatMessage("user", "u2"),
+    ]
+    assert _flatten_messages(msgs) == "sys\n\nUser: u1\n\nAssistant: a1\n\nu2"
+
+
+def test_flatten_messages_single_user_passthrough() -> None:
+    assert _flatten_messages([_ChatMessage("user", "just this")]) == "just this"
+
+
+# -- decode state ---------------------------------------------------------
+
+
+def _drive(state, runtime, ids: List[int]) -> None:
+    for pos, tid in enumerate(ids):
+        state.consume_step(runtime, DecodeStep(token=TextToken(token_id=tid), position=pos))
+
+
+def test_state_non_reasoning_strips_turn_end_token() -> None:
+    runtime = _chat_runtime()
+    skill = ChatSkill()
+    ctx = ChatRequest(
+        messages=(_ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
+    )
+    state = skill.create_state(runtime, SimpleNamespace(), ctx)
+    assert list(state.stop_token_ids(runtime)) == [IM_END]
+    _drive(state, runtime, _ords("ok") + [IM_END])
+    result = state.finalize(runtime, reason="stop")
+    assert result.output == {
+        "message": {"role": "assistant", "content": "ok"},
+        "finish_reason": "stop",
+    }
+
+
+def test_state_reasoning_splits_thinking_and_answer() -> None:
+    runtime = _chat_runtime()
+    skill = ChatSkill()
+    ctx = ChatRequest(
+        messages=(_ChatMessage("user", "hi"),), image=None, reasoning=True, stream=False
+    )
+    state = skill.create_state(runtime, SimpleNamespace(), ctx)
+    state.on_prefill(runtime)
+    # reasoning text, then the answer_id boundary
+    _drive(state, runtime, _ords("think"))
+    state.consume_step(
+        runtime, DecodeStep(token=TextToken(token_id=THINK_E), position=99)
+    )
+    # the post-reasoning opener is now forced one token at a time
+    assert list(state.allowed_token_ids(runtime)) == [DNL]
+    _drive(state, runtime, [DNL])
+    assert state.allowed_token_ids(runtime) is None
+    _drive(state, runtime, _ords("ans") + [IM_END])
+    result = state.finalize(runtime, reason="stop")
+    assert result.output["message"] == {"role": "assistant", "content": "ans"}
+    assert result.output["reasoning"] == {"text": "think"}
+
+
+def test_state_flatten_path_has_no_extra_stop_tokens() -> None:
+    runtime = _flatten_runtime()
+    skill = ChatSkill()
+    ctx = ChatRequest(
+        messages=(_ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
+    )
+    state = skill.create_state(runtime, SimpleNamespace(), ctx)
+    assert state.stop_token_ids(runtime) is None
+    _drive(state, runtime, _ords("ok") + [99])  # 99 == eos_id, stripped
+    result = state.finalize(runtime, reason="stop")
+    assert result.output["message"]["content"] == "ok"

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -1,5 +1,6 @@
-"""ChatSkill: message validation, native chat-template rendering, decode-state
-output shape, and Moondream's flatten-into-query subclass."""
+"""ChatSkill: message validation, native chat-template rendering (incl.
+multi-image at content positions), decode-state output, and Moondream's
+flatten-into-query subclass."""
 
 from __future__ import annotations
 
@@ -12,10 +13,13 @@ import pytest
 from kestrel.models.protocols import ChatTemplate, QueryTemplate
 from kestrel.runtime.tokens import TextToken
 from kestrel.skills.base import DecodeStep
-from kestrel.skills.chat import ChatMessage, ChatRequest, ChatSkill
+from kestrel.skills.chat import ChatRequest, ChatSkill
 
 # Synthetic token ids for a native (ChatML-like) chat template.
 IM_START, IM_END, NL, DNL, THINK_S, THINK_E = 900, 901, 198, 271, 800, 801
+VS, IPAD, VE = 700, 701, 702  # vision_start, image_pad, vision_end
+
+_IMG = "data:image/png;base64,aGk="  # decodes to b"hi" (content irrelevant here)
 
 
 def _native_chat_template() -> ChatTemplate:
@@ -52,6 +56,20 @@ class _NativePromptTemplate:
         return None
 
 
+class _VisionChatSkill(ChatSkill):
+    """Test-only subclass that renders an image as the vision placeholder —
+    standing in for a model's multimodal chat subclass (e.g. Qwen)."""
+
+    def render_content(self, tokenizer, parts):
+        tokens = []
+        for part in parts:
+            if part.image_index is not None:
+                tokens.extend(TextToken(token_id=t) for t in (VS, IPAD, VE))
+            elif part.text:
+                tokens.extend(TextToken(token_id=t) for t in tokenizer.encode(part.text).ids)
+        return tokens
+
+
 class _Tokenizer:
     """Reversible char-level fake: encode→code points, decode→chars."""
 
@@ -65,8 +83,16 @@ class _Tokenizer:
 def _chat_runtime(chat: bool = True) -> SimpleNamespace:
     tpl = _native_chat_template() if chat else None
     return SimpleNamespace(
-        prompt_template=_NativePromptTemplate(_chat=tpl), tokenizer=_Tokenizer()
+        prompt_template=_NativePromptTemplate(_chat=tpl),
+        tokenizer=_Tokenizer(),
     )
+
+
+def _ctx(messages, reasoning: bool = False) -> ChatRequest:
+    built = ChatSkill().build_request(
+        None, {"messages": messages, "reasoning": reasoning}, None
+    )
+    return built.request_context
 
 
 def _ids(tokens) -> List[int]:
@@ -77,16 +103,14 @@ def _ords(text: str) -> List[int]:
     return [ord(c) for c in text]
 
 
-# -- validation (generic, lives on the base) ------------------------------
+# -- validation -----------------------------------------------------------
 
 
 def test_build_request_accepts_minimal_conversation() -> None:
-    built = ChatSkill().build_request(
-        None, {"messages": [{"role": "user", "content": "hi"}]}, None
-    )
-    ctx = built.request_context
+    ctx = _ctx([{"role": "user", "content": "hi"}])
     assert isinstance(ctx, ChatRequest)
     assert [(m.role, m.text) for m in ctx.messages] == [("user", "hi")]
+    assert ctx.images == ()
     assert ctx.reasoning is False
 
 
@@ -125,51 +149,45 @@ def test_build_request_last_must_be_user() -> None:
         ChatSkill().build_request(None, {"messages": msgs}, None)
 
 
-def test_build_request_rejects_two_images() -> None:
-    img = "data:image/png;base64,aGk="  # b"hi"
+def test_build_request_collects_multiple_images_in_order() -> None:
     msgs = [
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "two?"},
-                {"type": "image_url", "image_url": {"url": img}},
-                {"type": "image_url", "image_url": {"url": img}},
+                {"type": "image_url", "image_url": {"url": _IMG}},
+                {"type": "text", "text": "first?"},
             ],
-        }
-    ]
-    with pytest.raises(ValueError, match="at most one image"):
-        ChatSkill().build_request(None, {"messages": msgs}, None)
-
-
-def test_build_request_extracts_image_from_data_url() -> None:
-    msgs = [
+        },
+        {"role": "assistant", "content": "a"},
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "what is this?"},
-                {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGk="}},
+                {"type": "text", "text": "second?"},
+                {"type": "image_url", "image_url": {"url": _IMG}},
             ],
-        }
+        },
     ]
     built = ChatSkill().build_request(None, {"messages": msgs}, None)
-    assert built.image == b"hi"
-    assert built.request_context.image == b"hi"
-    assert built.request_context.messages[-1].text == "what is this?"
+    ctx = built.request_context
+    assert len(ctx.images) == 2
+    assert built.image == (b"hi", b"hi")
+    # parts carry image indices in conversation order
+    assert ctx.messages[0].parts[0].image_index == 0
+    assert ctx.messages[2].parts[1].image_index == 1
+
+
+def test_build_request_rejects_image_in_system_message() -> None:
+    msgs = [
+        {"role": "system", "content": [{"type": "image_url", "image_url": {"url": _IMG}}]},
+        {"role": "user", "content": "hi"},
+    ]
+    with pytest.raises(ValueError, match="system message cannot contain images"):
+        ChatSkill().build_request(None, {"messages": msgs}, None)
 
 
 @pytest.mark.parametrize("url", ["/etc/passwd", "https://example.com/cat.png"])
 def test_build_request_rejects_non_data_image_url(url: str) -> None:
-    # image_url.url is untrusted: only base64 data: URLs are accepted — no
-    # filesystem reads and no remote fetches.
-    msgs = [
-        {
-            "role": "user",
-            "content": [
-                {"type": "text", "text": "x"},
-                {"type": "image_url", "image_url": {"url": url}},
-            ],
-        }
-    ]
+    msgs = [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": url}}]}]
     with pytest.raises(ValueError, match="data: URL"):
         ChatSkill().build_request(None, {"messages": msgs}, None)
 
@@ -186,10 +204,7 @@ def test_build_request_reasoning_opt_in_via_settings() -> None:
 
 def test_render_single_turn_chat() -> None:
     runtime = _chat_runtime()
-    ctx = ChatRequest(
-        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
-    )
-    tokens = ChatSkill().build_prompt_tokens(runtime, ctx)
+    tokens = ChatSkill().build_prompt_tokens(runtime, _ctx([{"role": "user", "content": "hi"}]))
     expected = (
         [IM_START] + _ords("user") + [NL] + _ords("hi") + [IM_END, NL]
         + [IM_START] + _ords("assistant") + [NL] + [THINK_S, DNL, THINK_E, DNL]
@@ -197,39 +212,57 @@ def test_render_single_turn_chat() -> None:
     assert _ids(tokens) == expected
 
 
-def test_render_multi_turn_with_system_and_reasoning() -> None:
+def test_subclass_renders_multi_image_at_content_positions() -> None:
     runtime = _chat_runtime()
-    ctx = ChatRequest(
-        messages=(
-            ChatMessage("system", "be nice"),
-            ChatMessage("user", "a"),
-            ChatMessage("assistant", "b"),
-            ChatMessage("user", "c"),
-        ),
-        image=None,
-        reasoning=True,
-        stream=False,
-    )
-    tokens = ChatSkill().build_prompt_tokens(runtime, ctx)
-
-    def turn(role: str, text: str) -> List[int]:
-        return [IM_START] + _ords(role) + [NL] + _ords(text) + [IM_END, NL]
-
+    msgs = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": _IMG}},
+                {"type": "text", "text": "a"},
+            ],
+        },
+        {"role": "assistant", "content": "b"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "c"},
+                {"type": "image_url", "image_url": {"url": _IMG}},
+            ],
+        },
+    ]
+    tokens = _VisionChatSkill().build_prompt_tokens(runtime, _ctx(msgs))
     expected = (
-        turn("system", "be nice")
-        + turn("user", "a")
-        + turn("assistant", "b")
-        + turn("user", "c")
-        + [IM_START] + _ords("assistant") + [NL] + [THINK_S, NL]
+        # turn 1: image BEFORE text
+        [IM_START] + _ords("user") + [NL] + [VS, IPAD, VE] + _ords("a") + [IM_END, NL]
+        # turn 2: assistant text
+        + [IM_START] + _ords("assistant") + [NL] + _ords("b") + [IM_END, NL]
+        # turn 3: image AFTER text
+        + [IM_START] + _ords("user") + [NL] + _ords("c") + [VS, IPAD, VE] + [IM_END, NL]
+        # generation opener
+        + [IM_START] + _ords("assistant") + [NL] + [THINK_S, DNL, THINK_E, DNL]
     )
     assert _ids(tokens) == expected
 
 
-def test_base_chat_skill_requires_chat_template() -> None:
-    runtime = _chat_runtime(chat=False)  # chat() returns None
-    ctx = ChatRequest(
-        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
+def test_render_reasoning_opener() -> None:
+    runtime = _chat_runtime()
+    tokens = ChatSkill().build_prompt_tokens(
+        runtime, _ctx([{"role": "user", "content": "hi"}], reasoning=True)
     )
+    assert _ids(tokens)[-2:] == [THINK_S, NL]  # assistant_open_reasoning
+
+
+def test_base_chat_skill_rejects_images() -> None:
+    runtime = _chat_runtime()
+    ctx = _ctx([{"role": "user", "content": [{"type": "image_url", "image_url": {"url": _IMG}}]}])
+    with pytest.raises(ValueError, match="does not render images"):
+        ChatSkill().build_prompt_tokens(runtime, ctx)
+
+
+def test_base_chat_skill_requires_chat_template() -> None:
+    runtime = _chat_runtime(chat=False)
+    ctx = _ctx([{"role": "user", "content": "hi"}])
     with pytest.raises(ValueError, match="no chat\\(\\) template"):
         ChatSkill().build_prompt_tokens(runtime, ctx)
 
@@ -244,10 +277,7 @@ def _drive(state, runtime, ids: List[int]) -> None:
 
 def test_state_non_reasoning_strips_turn_end_token() -> None:
     runtime = _chat_runtime()
-    ctx = ChatRequest(
-        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
-    )
-    state = ChatSkill().create_state(runtime, SimpleNamespace(), ctx)
+    state = ChatSkill().create_state(runtime, SimpleNamespace(), _ctx([{"role": "user", "content": "hi"}]))
     assert list(state.stop_token_ids(runtime)) == [IM_END]
     _drive(state, runtime, _ords("ok") + [IM_END])
     result = state.finalize(runtime, reason="stop")
@@ -259,15 +289,12 @@ def test_state_non_reasoning_strips_turn_end_token() -> None:
 
 def test_state_reasoning_splits_thinking_and_answer() -> None:
     runtime = _chat_runtime()
-    ctx = ChatRequest(
-        messages=(ChatMessage("user", "hi"),), image=None, reasoning=True, stream=False
+    state = ChatSkill().create_state(
+        runtime, SimpleNamespace(), _ctx([{"role": "user", "content": "hi"}], reasoning=True)
     )
-    state = ChatSkill().create_state(runtime, SimpleNamespace(), ctx)
     state.on_prefill(runtime)
     _drive(state, runtime, _ords("think"))
-    state.consume_step(
-        runtime, DecodeStep(token=TextToken(token_id=THINK_E), position=99)
-    )
+    state.consume_step(runtime, DecodeStep(token=TextToken(token_id=THINK_E), position=99))
     assert list(state.allowed_token_ids(runtime)) == [DNL]
     _drive(state, runtime, [DNL])
     assert state.allowed_token_ids(runtime) is None
@@ -309,15 +336,21 @@ def _md_runtime(model_name: str = "moondream2") -> SimpleNamespace:
     )
 
 
+def _md_ctx(messages, reasoning: bool = False) -> ChatRequest:
+    from kestrel.models.moondream.skills.chat import MoondreamChatSkill
+
+    return MoondreamChatSkill().build_request(
+        None, {"messages": messages, "reasoning": reasoning}, None
+    ).request_context
+
+
 def test_moondream_chat_flattens_to_query_tokens() -> None:
     from kestrel.models.moondream.skills.chat import MoondreamChatSkill
     from kestrel.models.moondream.skills.query import QueryRequest, QuerySkill
 
     runtime = _md_runtime()
-    chat_ctx = ChatRequest(
-        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
-    )
-    chat_tokens = MoondreamChatSkill().build_prompt_tokens(runtime, chat_ctx)
+    ctx = _md_ctx([{"role": "user", "content": "hi"}])
+    chat_tokens = MoondreamChatSkill().build_prompt_tokens(runtime, ctx)
     query_tokens = QuerySkill().build_prompt_tokens(
         runtime, QueryRequest(question="hi", image=None, reasoning=False, stream=False)
     )
@@ -327,24 +360,33 @@ def test_moondream_chat_flattens_to_query_tokens() -> None:
 def test_moondream_flatten_messages_labels_history() -> None:
     from kestrel.models.moondream.skills.chat import _flatten_messages
 
-    msgs = [
-        ChatMessage("system", "sys"),
-        ChatMessage("user", "u1"),
-        ChatMessage("assistant", "a1"),
-        ChatMessage("user", "u2"),
-    ]
-    assert _flatten_messages(msgs) == "sys\n\nUser: u1\n\nAssistant: a1\n\nu2"
-    assert _flatten_messages([ChatMessage("user", "just this")]) == "just this"
+    ctx = _md_ctx([
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "u2"},
+    ])
+    assert _flatten_messages(ctx.messages) == "sys\n\nUser: u1\n\nAssistant: a1\n\nu2"
+
+
+def test_moondream_rejects_multiple_images() -> None:
+    from kestrel.models.moondream.skills.chat import MoondreamChatSkill
+
+    msgs = [{"role": "user", "content": [
+        {"type": "image_url", "image_url": {"url": _IMG}},
+        {"type": "image_url", "image_url": {"url": _IMG}},
+    ]}]
+    with pytest.raises(ValueError, match="at most one image"):
+        MoondreamChatSkill().build_request(None, {"messages": msgs}, None)
 
 
 def test_moondream_chat_finalizes_as_message() -> None:
     from kestrel.models.moondream.skills.chat import MoondreamChatSkill
 
     runtime = _md_runtime()
-    ctx = ChatRequest(
-        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
+    state = MoondreamChatSkill().create_state(
+        runtime, SimpleNamespace(), _md_ctx([{"role": "user", "content": "hi"}])
     )
-    state = MoondreamChatSkill().create_state(runtime, SimpleNamespace(), ctx)
     _drive(state, runtime, _ords("Paris"))
     result = state.finalize(runtime, reason="stop")
     assert result.output == {
@@ -360,19 +402,12 @@ def test_moondream_chat_inherits_query_suppression() -> None:
     skill = MoondreamChatSkill()
     rt = _md_runtime("moondream2")
 
-    answer_ctx = ChatRequest(
-        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
-    )
-    answer_state = skill.create_state(rt, SimpleNamespace(), answer_ctx)
+    answer_state = skill.create_state(rt, SimpleNamespace(), _md_ctx([{"role": "user", "content": "hi"}]))
     assert list(answer_state.suppressed_token_ids(rt)) == [3]  # answer_id
 
-    think_ctx = ChatRequest(
-        messages=(ChatMessage("user", "hi"),), image=None, reasoning=True, stream=False
-    )
-    think_state = skill.create_state(rt, SimpleNamespace(), think_ctx)
+    think_state = skill.create_state(rt, SimpleNamespace(), _md_ctx([{"role": "user", "content": "hi"}], reasoning=True))
     assert list(think_state.suppressed_token_ids(rt)) == [0, 6]  # eos_id, size_id
 
-    # Non-moondream2 models are unaffected.
     rt3 = _md_runtime("moondream3-preview")
-    state3 = skill.create_state(rt3, SimpleNamespace(), answer_ctx)
+    state3 = skill.create_state(rt3, SimpleNamespace(), _md_ctx([{"role": "user", "content": "hi"}]))
     assert state3.suppressed_token_ids(rt3) is None

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -1,5 +1,5 @@
-"""ChatSkill: message validation, prompt-token rendering (native chat
-template vs. flatten-into-query), and decode-state output shape."""
+"""ChatSkill: message validation, native chat-template rendering, decode-state
+output shape, and Moondream's flatten-into-query subclass."""
 
 from __future__ import annotations
 
@@ -12,18 +12,13 @@ import pytest
 from kestrel.models.protocols import ChatTemplate, QueryTemplate
 from kestrel.runtime.tokens import TextToken
 from kestrel.skills.base import DecodeStep
-from kestrel.skills.chat import (
-    ChatRequest,
-    ChatSkill,
-    _ChatMessage,
-    _flatten_messages,
-)
+from kestrel.skills.chat import ChatMessage, ChatRequest, ChatSkill
 
-# Synthetic token ids for a Qwen-like chat template.
+# Synthetic token ids for a native (ChatML-like) chat template.
 IM_START, IM_END, NL, DNL, THINK_S, THINK_E = 900, 901, 198, 271, 800, 801
 
 
-def _qwen_chat_template() -> ChatTemplate:
+def _native_chat_template() -> ChatTemplate:
     return ChatTemplate(
         bos=[],
         turn_prefix=[IM_START],
@@ -38,17 +33,8 @@ def _qwen_chat_template() -> ChatTemplate:
     )
 
 
-def _md_query_template() -> QueryTemplate:
-    return QueryTemplate(
-        prefix=[10, 11],
-        answer_prefix=[20],
-        reasoning_prefix=[21],
-        post_reasoning_prefix=[3],
-    )
-
-
 @dataclass
-class _PromptTemplate:
+class _NativePromptTemplate:
     bos_id: int = 5
     eos_id: int = 99
     answer_id: int = THINK_E
@@ -58,13 +44,12 @@ class _PromptTemplate:
     start_ground_points_id: int = 0
     end_ground_id: int = 0
     _chat: Optional[ChatTemplate] = None
-    _query: Optional[QueryTemplate] = None
 
     def chat(self) -> Optional[ChatTemplate]:
         return self._chat
 
     def query(self) -> Optional[QueryTemplate]:
-        return self._query
+        return None
 
 
 class _Tokenizer:
@@ -77,17 +62,10 @@ class _Tokenizer:
         return "".join(chr(i) for i in ids)
 
 
-def _chat_runtime() -> SimpleNamespace:
+def _chat_runtime(chat: bool = True) -> SimpleNamespace:
+    tpl = _native_chat_template() if chat else None
     return SimpleNamespace(
-        prompt_template=_PromptTemplate(_chat=_qwen_chat_template()),
-        tokenizer=_Tokenizer(),
-    )
-
-
-def _flatten_runtime() -> SimpleNamespace:
-    return SimpleNamespace(
-        prompt_template=_PromptTemplate(answer_id=3, _query=_md_query_template()),
-        tokenizer=_Tokenizer(),
+        prompt_template=_NativePromptTemplate(_chat=tpl), tokenizer=_Tokenizer()
     )
 
 
@@ -99,7 +77,7 @@ def _ords(text: str) -> List[int]:
     return [ord(c) for c in text]
 
 
-# -- validation -----------------------------------------------------------
+# -- validation (generic, lives on the base) ------------------------------
 
 
 def test_build_request_accepts_minimal_conversation() -> None:
@@ -109,7 +87,7 @@ def test_build_request_accepts_minimal_conversation() -> None:
     ctx = built.request_context
     assert isinstance(ctx, ChatRequest)
     assert [(m.role, m.text) for m in ctx.messages] == [("user", "hi")]
-    assert ctx.reasoning is False  # chat defaults to non-thinking
+    assert ctx.reasoning is False
 
 
 def test_build_request_requires_messages() -> None:
@@ -186,16 +164,13 @@ def test_build_request_reasoning_opt_in_via_settings() -> None:
     assert built.request_context.reasoning is True
 
 
-# -- rendering: native chat template --------------------------------------
+# -- native chat rendering ------------------------------------------------
 
 
 def test_render_single_turn_chat() -> None:
     runtime = _chat_runtime()
     ctx = ChatRequest(
-        messages=(_ChatMessage("user", "hi"),),
-        image=None,
-        reasoning=False,
-        stream=False,
+        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
     )
     tokens = ChatSkill().build_prompt_tokens(runtime, ctx)
     expected = (
@@ -209,10 +184,10 @@ def test_render_multi_turn_with_system_and_reasoning() -> None:
     runtime = _chat_runtime()
     ctx = ChatRequest(
         messages=(
-            _ChatMessage("system", "be nice"),
-            _ChatMessage("user", "a"),
-            _ChatMessage("assistant", "b"),
-            _ChatMessage("user", "c"),
+            ChatMessage("system", "be nice"),
+            ChatMessage("user", "a"),
+            ChatMessage("assistant", "b"),
+            ChatMessage("user", "c"),
         ),
         image=None,
         reasoning=True,
@@ -228,42 +203,21 @@ def test_render_multi_turn_with_system_and_reasoning() -> None:
         + turn("user", "a")
         + turn("assistant", "b")
         + turn("user", "c")
-        + [IM_START] + _ords("assistant") + [NL] + [THINK_S, NL]  # reasoning opener
+        + [IM_START] + _ords("assistant") + [NL] + [THINK_S, NL]
     )
     assert _ids(tokens) == expected
 
 
-# -- rendering: flatten into query ----------------------------------------
-
-
-def test_render_flatten_single_turn_matches_query_shape() -> None:
-    runtime = _flatten_runtime()
+def test_base_chat_skill_requires_chat_template() -> None:
+    runtime = _chat_runtime(chat=False)  # chat() returns None
     ctx = ChatRequest(
-        messages=(_ChatMessage("user", "hi"),),
-        image=None,
-        reasoning=False,
-        stream=False,
+        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
     )
-    tokens = ChatSkill().build_prompt_tokens(runtime, ctx)
-    # bos + prefix + encoded(question) + answer_prefix
-    assert _ids(tokens) == [5, 10, 11] + _ords("hi") + [20]
+    with pytest.raises(ValueError, match="no chat\\(\\) template"):
+        ChatSkill().build_prompt_tokens(runtime, ctx)
 
 
-def test_flatten_messages_labels_history() -> None:
-    msgs = [
-        _ChatMessage("system", "sys"),
-        _ChatMessage("user", "u1"),
-        _ChatMessage("assistant", "a1"),
-        _ChatMessage("user", "u2"),
-    ]
-    assert _flatten_messages(msgs) == "sys\n\nUser: u1\n\nAssistant: a1\n\nu2"
-
-
-def test_flatten_messages_single_user_passthrough() -> None:
-    assert _flatten_messages([_ChatMessage("user", "just this")]) == "just this"
-
-
-# -- decode state ---------------------------------------------------------
+# -- native decode state --------------------------------------------------
 
 
 def _drive(state, runtime, ids: List[int]) -> None:
@@ -273,11 +227,10 @@ def _drive(state, runtime, ids: List[int]) -> None:
 
 def test_state_non_reasoning_strips_turn_end_token() -> None:
     runtime = _chat_runtime()
-    skill = ChatSkill()
     ctx = ChatRequest(
-        messages=(_ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
+        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
     )
-    state = skill.create_state(runtime, SimpleNamespace(), ctx)
+    state = ChatSkill().create_state(runtime, SimpleNamespace(), ctx)
     assert list(state.stop_token_ids(runtime)) == [IM_END]
     _drive(state, runtime, _ords("ok") + [IM_END])
     result = state.finalize(runtime, reason="stop")
@@ -289,18 +242,15 @@ def test_state_non_reasoning_strips_turn_end_token() -> None:
 
 def test_state_reasoning_splits_thinking_and_answer() -> None:
     runtime = _chat_runtime()
-    skill = ChatSkill()
     ctx = ChatRequest(
-        messages=(_ChatMessage("user", "hi"),), image=None, reasoning=True, stream=False
+        messages=(ChatMessage("user", "hi"),), image=None, reasoning=True, stream=False
     )
-    state = skill.create_state(runtime, SimpleNamespace(), ctx)
+    state = ChatSkill().create_state(runtime, SimpleNamespace(), ctx)
     state.on_prefill(runtime)
-    # reasoning text, then the answer_id boundary
     _drive(state, runtime, _ords("think"))
     state.consume_step(
         runtime, DecodeStep(token=TextToken(token_id=THINK_E), position=99)
     )
-    # the post-reasoning opener is now forced one token at a time
     assert list(state.allowed_token_ids(runtime)) == [DNL]
     _drive(state, runtime, [DNL])
     assert state.allowed_token_ids(runtime) is None
@@ -310,14 +260,102 @@ def test_state_reasoning_splits_thinking_and_answer() -> None:
     assert result.output["reasoning"] == {"text": "think"}
 
 
-def test_state_flatten_path_has_no_extra_stop_tokens() -> None:
-    runtime = _flatten_runtime()
-    skill = ChatSkill()
-    ctx = ChatRequest(
-        messages=(_ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
+# -- Moondream flatten-into-query subclass --------------------------------
+
+
+@dataclass
+class _MdPromptTemplate:
+    bos_id: int = 5
+    eos_id: int = 0
+    answer_id: int = 3
+    thinking_id: int = 4
+    coord_id: int = 5
+    size_id: int = 6
+    start_ground_points_id: int = 7
+    end_ground_id: int = 9
+
+    def chat(self) -> None:
+        return None
+
+    def query(self) -> QueryTemplate:
+        return QueryTemplate(
+            prefix=[10, 11], answer_prefix=[20], reasoning_prefix=[21],
+            post_reasoning_prefix=[3],
+        )
+
+
+def _md_runtime(model_name: str = "moondream2") -> SimpleNamespace:
+    return SimpleNamespace(
+        prompt_template=_MdPromptTemplate(),
+        tokenizer=_Tokenizer(),
+        model_name=model_name,
     )
-    state = skill.create_state(runtime, SimpleNamespace(), ctx)
-    assert state.stop_token_ids(runtime) is None
-    _drive(state, runtime, _ords("ok") + [99])  # 99 == eos_id, stripped
+
+
+def test_moondream_chat_flattens_to_query_tokens() -> None:
+    from kestrel.models.moondream.skills.chat import MoondreamChatSkill
+    from kestrel.models.moondream.skills.query import QueryRequest, QuerySkill
+
+    runtime = _md_runtime()
+    chat_ctx = ChatRequest(
+        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
+    )
+    chat_tokens = MoondreamChatSkill().build_prompt_tokens(runtime, chat_ctx)
+    query_tokens = QuerySkill().build_prompt_tokens(
+        runtime, QueryRequest(question="hi", image=None, reasoning=False, stream=False)
+    )
+    assert _ids(chat_tokens) == _ids(query_tokens)
+
+
+def test_moondream_flatten_messages_labels_history() -> None:
+    from kestrel.models.moondream.skills.chat import _flatten_messages
+
+    msgs = [
+        ChatMessage("system", "sys"),
+        ChatMessage("user", "u1"),
+        ChatMessage("assistant", "a1"),
+        ChatMessage("user", "u2"),
+    ]
+    assert _flatten_messages(msgs) == "sys\n\nUser: u1\n\nAssistant: a1\n\nu2"
+    assert _flatten_messages([ChatMessage("user", "just this")]) == "just this"
+
+
+def test_moondream_chat_finalizes_as_message() -> None:
+    from kestrel.models.moondream.skills.chat import MoondreamChatSkill
+
+    runtime = _md_runtime()
+    ctx = ChatRequest(
+        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
+    )
+    state = MoondreamChatSkill().create_state(runtime, SimpleNamespace(), ctx)
+    _drive(state, runtime, _ords("Paris"))
     result = state.finalize(runtime, reason="stop")
-    assert result.output["message"]["content"] == "ok"
+    assert result.output == {
+        "message": {"role": "assistant", "content": "Paris"},
+        "finish_reason": "stop",
+    }
+
+
+def test_moondream_chat_inherits_query_suppression() -> None:
+    """Codex P2: flattened chat must mirror the query skill's md2 masking."""
+    from kestrel.models.moondream.skills.chat import MoondreamChatSkill
+
+    skill = MoondreamChatSkill()
+    rt = _md_runtime("moondream2")
+
+    answer_ctx = ChatRequest(
+        messages=(ChatMessage("user", "hi"),), image=None, reasoning=False, stream=False
+    )
+    answer_state = skill.create_state(rt, SimpleNamespace(), answer_ctx)
+    assert list(answer_state.suppressed_token_ids(rt)) == [3]  # answer_id
+
+    think_ctx = ChatRequest(
+        messages=(ChatMessage("user", "hi"),), image=None, reasoning=True, stream=False
+    )
+    think_state = skill.create_state(rt, SimpleNamespace(), think_ctx)
+    assert list(think_state.suppressed_token_ids(rt)) == [0, 6]  # eos_id, size_id
+
+    # Non-moondream2 models are unaffected.
+    rt3 = _md_runtime("moondream3-preview")
+    state3 = skill.create_state(rt3, SimpleNamespace(), answer_ctx)
+    assert state3.suppressed_token_ids(rt3) is None

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -11,13 +11,12 @@ from typing import List, Optional
 import pytest
 
 from kestrel.models.protocols import ChatTemplate, QueryTemplate
-from kestrel.runtime.tokens import TextToken
+from kestrel.runtime.tokens import ImageMarker, TextToken
 from kestrel.skills.base import DecodeStep
 from kestrel.skills.chat import ChatRequest, ChatSkill
 
 # Synthetic token ids for a native (ChatML-like) chat template.
 IM_START, IM_END, NL, DNL, THINK_S, THINK_E = 900, 901, 198, 271, 800, 801
-VS, IPAD, VE = 700, 701, 702  # vision_start, image_pad, vision_end
 
 _IMG = "data:image/png;base64,aGk="  # decodes to b"hi" (content irrelevant here)
 
@@ -57,14 +56,14 @@ class _NativePromptTemplate:
 
 
 class _VisionChatSkill(ChatSkill):
-    """Test-only subclass that renders an image as the vision placeholder —
+    """Test-only subclass that renders an image as an ImageMarker sentinel —
     standing in for a model's multimodal chat subclass (e.g. Qwen)."""
 
     def render_content(self, tokenizer, parts):
         tokens = []
         for part in parts:
             if part.image_index is not None:
-                tokens.extend(TextToken(token_id=t) for t in (VS, IPAD, VE))
+                tokens.append(ImageMarker(index=part.image_index))
             elif part.text:
                 tokens.extend(TextToken(token_id=t) for t in tokenizer.encode(part.text).ids)
         return tokens
@@ -97,6 +96,13 @@ def _ctx(messages, reasoning: bool = False) -> ChatRequest:
 
 def _ids(tokens) -> List[int]:
     return [t.token_id for t in tokens]
+
+
+def _norm(tokens):
+    """TextToken -> its id; ImageMarker -> ("IMG", index). For mixed streams."""
+    return [
+        ("IMG", t.index) if isinstance(t, ImageMarker) else t.token_id for t in tokens
+    ]
 
 
 def _ords(text: str) -> List[int]:
@@ -253,16 +259,16 @@ def test_subclass_renders_multi_image_at_content_positions() -> None:
     ]
     tokens = _VisionChatSkill().build_prompt_tokens(runtime, _ctx(msgs))
     expected = (
-        # turn 1: image BEFORE text
-        [IM_START] + _ords("user") + [NL] + [VS, IPAD, VE] + _ords("a") + [IM_END, NL]
+        # turn 1: image marker BEFORE text
+        [IM_START] + _ords("user") + [NL] + [("IMG", 0)] + _ords("a") + [IM_END, NL]
         # turn 2: assistant text
         + [IM_START] + _ords("assistant") + [NL] + _ords("b") + [IM_END, NL]
-        # turn 3: image AFTER text
-        + [IM_START] + _ords("user") + [NL] + _ords("c") + [VS, IPAD, VE] + [IM_END, NL]
+        # turn 3: image marker AFTER text
+        + [IM_START] + _ords("user") + [NL] + _ords("c") + [("IMG", 1)] + [IM_END, NL]
         # generation opener
         + [IM_START] + _ords("assistant") + [NL] + [THINK_S, DNL, THINK_E, DNL]
     )
-    assert _ids(tokens) == expected
+    assert _norm(tokens) == expected
 
 
 def test_render_reasoning_opener() -> None:

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -157,6 +157,21 @@ def test_build_request_extracts_image_from_data_url() -> None:
     assert built.request_context.messages[-1].text == "what is this?"
 
 
+def test_build_request_rejects_filesystem_path_image_url() -> None:
+    # image_url.url is untrusted; a server path must not be read as image bytes.
+    msgs = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "x"},
+                {"type": "image_url", "image_url": {"url": "/etc/passwd"}},
+            ],
+        }
+    ]
+    with pytest.raises(ValueError, match="data: URL"):
+        ChatSkill().build_request(None, {"messages": msgs}, None)
+
+
 def test_build_request_reasoning_opt_in_via_settings() -> None:
     built = ChatSkill().build_request(
         None, {"messages": [{"role": "user", "content": "hi"}]}, {"reasoning": True}

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -199,6 +199,26 @@ def test_build_request_reasoning_opt_in_via_settings() -> None:
     assert built.request_context.reasoning is True
 
 
+def test_base_reasoning_default_off() -> None:
+    built = ChatSkill().build_request(None, {"messages": [{"role": "user", "content": "hi"}]}, None)
+    assert built.request_context.reasoning is False
+
+
+def test_subclass_reasoning_default_on() -> None:
+    class _ThinkingChatSkill(ChatSkill):
+        default_reasoning = True
+
+    built = _ThinkingChatSkill().build_request(
+        None, {"messages": [{"role": "user", "content": "hi"}]}, None
+    )
+    assert built.request_context.reasoning is True
+    # Explicit opt-out still wins.
+    off = _ThinkingChatSkill().build_request(
+        None, {"messages": [{"role": "user", "content": "hi"}], "reasoning": False}, None
+    )
+    assert off.request_context.reasoning is False
+
+
 # -- native chat rendering ------------------------------------------------
 
 
@@ -300,8 +320,12 @@ def test_state_reasoning_splits_thinking_and_answer() -> None:
     assert state.allowed_token_ids(runtime) is None
     _drive(state, runtime, _ords("ans") + [IM_END])
     result = state.finalize(runtime, reason="stop")
-    assert result.output["message"] == {"role": "assistant", "content": "ans"}
-    assert result.output["reasoning"] == {"text": "think"}
+    # OpenRouter style: reasoning is a string on the message, beside content.
+    assert result.output["message"] == {
+        "role": "assistant",
+        "content": "ans",
+        "reasoning": "think",
+    }
 
 
 # -- Moondream flatten-into-query subclass --------------------------------

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -313,6 +313,18 @@ def test_state_non_reasoning_strips_turn_end_token() -> None:
     }
 
 
+def test_state_preserves_leading_whitespace() -> None:
+    # The finalized content must not be lstripped: that diverges from the query
+    # skill and from streamed deltas (which decode un-stripped).
+    runtime = _chat_runtime()
+    state = ChatSkill().create_state(
+        runtime, SimpleNamespace(), _ctx([{"role": "user", "content": "hi"}])
+    )
+    _drive(state, runtime, _ords("  ok") + [IM_END])
+    result = state.finalize(runtime, reason="stop")
+    assert result.output["message"]["content"] == "  ok"
+
+
 def test_state_reasoning_splits_thinking_and_answer() -> None:
     runtime = _chat_runtime()
     state = ChatSkill().create_state(
@@ -424,6 +436,24 @@ def test_moondream_accepts_multiple_images() -> None:
     ]}]
     ctx = MoondreamChatSkill().build_request(None, {"messages": msgs}, None).request_context
     assert len(ctx.images) == 2
+
+
+def test_moondream_rejects_assistant_image() -> None:
+    # Moondream markers only user-turn images; an assistant image would land in
+    # the tuple but never render, desyncing the tuple from the prompt.
+    from kestrel.models.moondream.skills.chat import MoondreamChatSkill
+
+    runtime = _md_runtime()
+    ctx = _md_ctx([
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": [
+            {"type": "image_url", "image_url": {"url": _IMG}},
+            {"type": "text", "text": "a"},
+        ]},
+        {"role": "user", "content": "q2"},
+    ])
+    with pytest.raises(ValueError, match="only in user messages"):
+        MoondreamChatSkill().build_prompt_tokens(runtime, ctx)
 
 
 def test_moondream_chat_finalizes_as_message() -> None:

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -374,7 +374,7 @@ def _md_ctx(messages, reasoning: bool = False) -> ChatRequest:
     ).request_context
 
 
-def test_moondream_chat_flattens_to_query_tokens() -> None:
+def test_moondream_single_turn_equals_query() -> None:
     from kestrel.models.moondream.skills.chat import MoondreamChatSkill
     from kestrel.models.moondream.skills.query import QueryRequest, QuerySkill
 
@@ -387,27 +387,43 @@ def test_moondream_chat_flattens_to_query_tokens() -> None:
     assert _ids(chat_tokens) == _ids(query_tokens)
 
 
-def test_moondream_flatten_messages_labels_history() -> None:
-    from kestrel.models.moondream.skills.chat import _flatten_messages
+def test_moondream_multi_turn_images_at_turn_start() -> None:
+    from kestrel.models.moondream.skills.chat import MoondreamChatSkill
 
+    runtime = _md_runtime()
     ctx = _md_ctx([
         {"role": "system", "content": "sys"},
-        {"role": "user", "content": "u1"},
-        {"role": "assistant", "content": "a1"},
-        {"role": "user", "content": "u2"},
+        {"role": "user", "content": [
+            {"type": "image_url", "image_url": {"url": _IMG}},
+            {"type": "text", "text": "a"},
+        ]},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": [
+            {"type": "text", "text": "c"},
+            {"type": "image_url", "image_url": {"url": _IMG}},  # at end of content...
+        ]},
     ])
-    assert _flatten_messages(ctx.messages) == "sys\n\nUser: u1\n\nAssistant: a1\n\nu2"
+    tokens = MoondreamChatSkill().build_prompt_tokens(runtime, ctx)
+    # bos=5, query prefix=[10,11], answer_prefix=[20]; system folds into turn 1;
+    # both images sit at the START of their turn (the second one too).
+    expected = (
+        [5]
+        + [("IMG", 0)] + [10, 11] + _ords("sys\n\na") + [20] + _ords("b")
+        + [("IMG", 1)] + [10, 11] + _ords("c") + [20]
+    )
+    assert _norm(tokens) == expected
 
 
-def test_moondream_rejects_multiple_images() -> None:
+def test_moondream_accepts_multiple_images() -> None:
     from kestrel.models.moondream.skills.chat import MoondreamChatSkill
 
     msgs = [{"role": "user", "content": [
         {"type": "image_url", "image_url": {"url": _IMG}},
         {"type": "image_url", "image_url": {"url": _IMG}},
+        {"type": "text", "text": "compare"},
     ]}]
-    with pytest.raises(ValueError, match="at most one image"):
-        MoondreamChatSkill().build_request(None, {"messages": msgs}, None)
+    ctx = MoondreamChatSkill().build_request(None, {"messages": msgs}, None).request_context
+    assert len(ctx.images) == 2
 
 
 def test_moondream_chat_finalizes_as_message() -> None:


### PR DESCRIPTION
## Summary
Adds a shared, model-agnostic `ChatSkill` exposing a multi-turn, OpenAI-style chat interface (`handle.chat(messages=[...])`). A model opts in by exposing a `chat()` prompt template; the output is shaped as an OpenAI chat-completion *choice* so a future `/v1/chat/completions` route is a thin wrapper. No HTTP server is added here — this is the client-side capability.

## What's included
- `ChatSkill` / `ChatSkillState` (`kestrel/skills/chat.py`): plain-Python message validation, single-image extraction from `image_url` content parts, prompt-token rendering, reasoning/answer decode, streaming deltas, and finalize to `{"message": {...}, "finish_reason": ...}`.
- `ChatTemplate` + `chat()` on the `PromptTemplate` protocol. Models with a native multi-turn (ChatML-style) format render natively; Moondream — no trained chat format — flattens the conversation into the single-turn `query` prompt.
- `BuiltRequest.image` so a skill can surface media pulled from its own prompt; threaded through `_run_skill`.
- `SkillState.stop_token_ids()`, consulted by the scheduler, so a turn can stop on a turn-end token distinct from `eos_id`.
- `chat` verb on `ModelHandle` and the engine; `ChatSkill` registered for Moondream.

## Validated
New unit tests (`tests/test_chat_skill.py`) plus the existing skill/handle/registry/scheduler/engine suites pass. Live multi-turn chat verified on Moondream (text + image via content parts) and a ChatML-format model (multi-turn memory; turn-end stop).