### PR TITLE
spec decode: scheduler macro-step + depth-1 overlap

### DIFF
--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -352,8 +352,27 @@ class AutoregressiveExecutor:
             runtime_sequences = list(self._runtime.active_sequences.values())
         except Exception:  # pragma: no cover - defensive cleanup
             return
+        # On a spec runtime the rows registered in ``active_sequences`` are
+        # decoder-owned: a fixed, persistently-reserved pool backing the
+        # captured verify/draft CUDA graphs. ``runtime.release_sequence``
+        # would erase those pages out from under the graphs and never call
+        # ``decoder.retire``, so reclaim each row through the decoder the
+        # same way ``GenerationScheduler._retire_spec_row`` does (the single
+        # spec-path retire contract). The adapter slot a spec admit acquired
+        # is not part of that pool, so release it here too -- the spec path
+        # never runs through ``release_sequence`` -> ``release_adapter_slot``
+        # (``release_adapter_slot`` is a no-op for ``lora_slot == 0``).
+        spec = getattr(self._runtime, "spec", None)
+        decoder = getattr(spec, "decoder", None) if spec is not None else None
         for state in runtime_sequences:
             try:
-                self._runtime.release_sequence(state)
+                if decoder is not None:
+                    decoder.retire(state)
+                    self._runtime.active_sequences.pop(state.batch_idx, None)
+                    self._runtime.release_adapter_slot(
+                        getattr(state, "lora_slot", 0)
+                    )
+                else:
+                    self._runtime.release_sequence(state)
             except Exception:
                 pass

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -1032,6 +1032,7 @@ class MoondreamRuntime:
             sequences: Sequence,
             batch_idx: Tensor,
             side_values: object,
+            token_logprobs: list[float] | None = None,
         ) -> list[Token]:
             """Type a spec macro-step's committed run into coord/size tokens.
 
@@ -1052,6 +1053,19 @@ class MoondreamRuntime:
             committed hiddens into one ``[total, hidden_dim]`` batch, decode
             coord/size in a single ``compute_spatial_values`` call under each
             sequence's sampling knobs, then render the typed tokens.
+
+            ``token_logprobs`` (optional) is the flat per-committed-position
+            vocab-token logprob list (parallel to ``token_ids_cpu``) the scheduler
+            staged from the spec decoder's verify logits. When supplied, it is
+            mutated **in place** so each spatial position's entry gains its
+            coord/size head logprob -- mirroring the non-spec ``post_sample`` path,
+            where ``compute_spatial_values`` adds the spatial head's selected-bin
+            logprob to the vocab logprob in-place. The spec decoder only gathers
+            the vocab logprob (it never runs the spatial head), so without this the
+            scheduler would under-report logprobs for ``coord_id`` / ``size_id``
+            tokens (and the spatial admit token, which routes through this hook).
+            ``None`` (no request wanted logprobs) leaves the spatial decode purely
+            value-producing, exactly as before.
             """
             from kestrel.runtime.spec import SpecSideValues
 
@@ -1117,6 +1131,26 @@ class MoondreamRuntime:
             top_ps = torch.cat(top_p_parts, dim=0)
             token_ids = flat_ids.to(device=device, dtype=torch.long)
 
+            # When the request wants logprobs, seed a packed device buffer with the
+            # per-position vocab logprobs (already in the packed sequences-major
+            # order ``hidden_last`` is built in -- ``hidden_rows`` and ``flat_ids``
+            # share that order, and ``token_logprobs`` is parallel to
+            # ``token_ids_cpu`` / ``flat_ids``) so ``compute_spatial_values`` adds
+            # each spatial position's coord/size head logprob in-place, exactly like
+            # the non-spec ``post_sample`` path. Then copy the combined values back
+            # into the caller's flat list so the scheduler stages the combined
+            # vocab + spatial-head logprob.
+            logprobs_buf: Tensor | None = None
+            if token_logprobs is not None:
+                if len(token_logprobs) != total:
+                    raise ValueError(
+                        "materialize_spec_tokens: token_logprobs length "
+                        f"{len(token_logprobs)} != flat token count {total}"
+                    )
+                logprobs_buf = torch.tensor(
+                    token_logprobs, device=device, dtype=torch.float32
+                )
+
             coord_out = torch.empty((total, 1), device=device, dtype=torch.float32)
             size_out = torch.empty((total, 2), device=device, dtype=torch.float32)
             compute_spatial_values(
@@ -1126,13 +1160,17 @@ class MoondreamRuntime:
                 spatial_tables,
                 temperatures=temperatures,
                 top_ps=top_ps,
-                token_logprobs=None,
+                token_logprobs=logprobs_buf,
                 coord_id=coord_id,
                 size_id=size_id,
                 out_coord=coord_out,
                 out_size=size_out,
                 rng=spatial_rng,
             )
+            if logprobs_buf is not None:
+                assert token_logprobs is not None
+                combined = logprobs_buf.cpu().tolist()
+                token_logprobs[:] = combined
             from kestrel.scheduler.tokens import render_tokens_from_packed
             return render_tokens_from_packed(
                 token_ids_cpu,

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -1027,6 +1027,121 @@ class MoondreamRuntime:
                 size_id=size_id,
             )
 
+        def materialize_spec_tokens(
+            token_ids_cpu: Tensor,
+            sequences: Sequence,
+            batch_idx: Tensor,
+            side_values: object,
+        ) -> list[Token]:
+            """Type a spec macro-step's committed run into coord/size tokens.
+
+            Speculative analog of ``materialize_tokens``. A macro-step commits a
+            *variable run* of positions per sequence, so the spatial decode the
+            non-spec ``post_sample`` does one-position-at-a-time runs here over
+            **all** committed positions at once, reading the target's final
+            ``hidden_last`` for each committed position out of the macro-step's
+            :class:`~kestrel.runtime.spec.SpecSideValues` (rather than the slot's
+            ``post_sample`` aux staging, which holds a single step's values).
+
+            ``side_values.hidden`` is ``[num_sequences, K + 1, hidden_dim]`` (the
+            verify-block final hidden, indexed by ``sequences`` order); only the
+            leading ``n_i`` positions of row ``i`` are committed, where ``n_i`` is
+            that sequence's committed-run length. ``token_ids_cpu`` / ``batch_idx``
+            are flat over all committed positions (``sequences``-major, contiguous
+            per sequence). We slice ``hidden[i, :n_i]`` per sequence, pack the
+            committed hiddens into one ``[total, hidden_dim]`` batch, decode
+            coord/size in a single ``compute_spatial_values`` call under each
+            sequence's sampling knobs, then render the typed tokens.
+            """
+            from kestrel.runtime.spec import SpecSideValues
+
+            if not isinstance(side_values, SpecSideValues):
+                raise TypeError(
+                    "materialize_spec_tokens requires a SpecSideValues; got "
+                    f"{type(side_values).__name__}"
+                )
+            seqs = list(sequences)
+            flat_ids = token_ids_cpu.view(-1)
+            total = int(flat_ids.shape[0])
+            if total == 0:
+                return []
+
+            # Per-sequence committed-run lengths (``n_i``). Prefer the producer's
+            # explicit ``counts``; otherwise recover them from the flat per-token
+            # ``batch_idx`` (each active sequence owns a distinct pool row, and the
+            # flat layout is sequences-major + contiguous), so the slice of
+            # ``hidden[i]`` matches the actually-committed run (which may be capped
+            # below ``accept_counts[i] + 1`` by the scheduler's commit cap).
+            counts = side_values.counts
+            if counts is None:
+                flat_rows = batch_idx.view(-1).tolist()
+                counts = []
+                cursor = 0
+                for seq in seqs:
+                    row = seq.state.batch_idx
+                    n = 0
+                    while cursor + n < total and flat_rows[cursor + n] == row:
+                        n += 1
+                    counts.append(n)
+                    cursor += n
+            if len(counts) != len(seqs):
+                raise ValueError(
+                    "materialize_spec_tokens: counts length "
+                    f"{len(counts)} != num sequences {len(seqs)}"
+                )
+            if sum(int(c) for c in counts) != total:
+                raise ValueError(
+                    "materialize_spec_tokens: committed counts "
+                    f"{counts} do not sum to flat token count {total}"
+                )
+
+            hidden = side_values.hidden  # [num_sequences, K+1, hidden_dim]
+            device = hidden.device
+            # Gather the committed final-hidden for every committed position into
+            # one packed ``[total, hidden_dim]`` batch (sequences-major), plus the
+            # parallel per-position requests / sampling knobs.
+            hidden_rows: list[Tensor] = []
+            requests: list = []
+            temp_parts: list[Tensor] = []
+            top_p_parts: list[Tensor] = []
+            for i, (seq, n) in enumerate(zip(seqs, counts)):
+                n = int(n)
+                if n == 0:
+                    continue
+                hidden_rows.append(hidden[i, :n])
+                requests.extend(seq.request for _ in range(n))
+                temp_parts.append(side_values.temperatures[i].expand(n))
+                top_p_parts.append(side_values.top_ps[i].expand(n))
+            hidden_last = torch.cat(hidden_rows, dim=0)  # [total, hidden_dim]
+            temperatures = torch.cat(temp_parts, dim=0)
+            top_ps = torch.cat(top_p_parts, dim=0)
+            token_ids = flat_ids.to(device=device, dtype=torch.long)
+
+            coord_out = torch.empty((total, 1), device=device, dtype=torch.float32)
+            size_out = torch.empty((total, 2), device=device, dtype=torch.float32)
+            compute_spatial_values(
+                token_ids,
+                hidden_last,
+                requests,
+                spatial_tables,
+                temperatures=temperatures,
+                top_ps=top_ps,
+                token_logprobs=None,
+                coord_id=coord_id,
+                size_id=size_id,
+                out_coord=coord_out,
+                out_size=size_out,
+                rng=spatial_rng,
+            )
+            from kestrel.scheduler.tokens import render_tokens_from_packed
+            return render_tokens_from_packed(
+                token_ids_cpu,
+                coord_out.cpu(),
+                size_out.cpu(),
+                coord_id=coord_id,
+                size_id=size_id,
+            )
+
         def prepare_decode_inputs(
             slot: DecodeSlot,
             batch_idx: Tensor,
@@ -1044,6 +1159,7 @@ class MoondreamRuntime:
         return SamplingHooks(
             post_sample=post_sample,
             materialize_tokens=materialize_tokens,
+            materialize_spec_tokens=materialize_spec_tokens,
             prepare_decode_inputs=prepare_decode_inputs,
         )
 

--- a/kestrel/models/moondream/skills/caption.py
+++ b/kestrel/models/moondream/skills/caption.py
@@ -105,6 +105,16 @@ class CaptionSkill(SkillSpec):
 class CaptionSkillState(SkillState):
     """Skill state that accumulates caption text."""
 
+    # The caption mask is position-independent: ``suppressed_token_ids`` returns
+    # the same constant set (``[answer_id]`` for moondream2, else ``None``) at
+    # every decode position -- it never transitions within a committed run. The
+    # spec scheduler treats any active constraint as stateful unless told
+    # otherwise, so declare the mask constant here; without this, the constant
+    # ``answer_id`` suppression would force caption spec decode to one committed
+    # token per macro-step (``commit_caps = 1``), throwing away the multi-token
+    # speculative accept for no correctness benefit.
+    mask_is_stateful = False
+
     def __init__(
         self,
         spec: SkillSpec,

--- a/kestrel/models/moondream/skills/detect.py
+++ b/kestrel/models/moondream/skills/detect.py
@@ -109,6 +109,20 @@ class DetectSkill(SkillSpec):
 class DetectSkillState(SkillState):
     """Skill state that decodes x/y/size triples into bounding boxes."""
 
+    # The detect mask is stateful: ``allowed_token_ids`` is always ACTIVE (a
+    # non-empty whitelist at every position, so the row never starts
+    # unconstrained) and cycles per committed token through the x -> y -> size
+    # stages -- ``[coord_id, eos_id]`` (x), ``[coord_id]`` (y), ``[size_id]``
+    # (size). A single spec macro-step commits a variable run under ONE mask, so
+    # the run's 2nd..Nth positions would verify under the stale 1st-position
+    # whitelist (e.g. suppressing the required ``size_id``, or accepting a
+    # ``coord`` where ``size`` is required). The scheduler's behavioural fallback
+    # already caps this row (its allowed set is always truthy), but declare it
+    # explicitly so the verdict is pinned on the class rather than relying on
+    # that fallback: capped to one committed token per macro-step, the per-step
+    # mask is exact.
+    mask_is_stateful = True
+
     def __init__(
         self,
         spec: SkillSpec,

--- a/kestrel/models/moondream/skills/point.py
+++ b/kestrel/models/moondream/skills/point.py
@@ -111,6 +111,19 @@ class PointSkill(SkillSpec):
 class PointSkillState(SkillState):
     """Skill state that aggregates emitted points from coord tokens."""
 
+    # The point mask is stateful: ``allowed_token_ids`` is always ACTIVE (a
+    # non-empty whitelist at every position, so the row never starts
+    # unconstrained) and toggles per committed coord token between
+    # ``[coord_id]`` (awaiting y) and ``[coord_id, eos_id]`` (awaiting the next
+    # x / end). A single spec macro-step commits a variable run under ONE mask,
+    # so the run's 2nd..Nth positions would verify under the stale 1st-position
+    # whitelist (e.g. accepting an ``eos_id`` where only ``coord_id`` is
+    # allowed). The scheduler's behavioural fallback already caps this row (its
+    # allowed set is always truthy), but declare it explicitly so the verdict is
+    # pinned on the class rather than relying on that fallback: capped to one
+    # committed token per macro-step, the per-step mask is exact.
+    mask_is_stateful = True
+
     def __init__(
         self,
         spec: SkillSpec,

--- a/kestrel/models/moondream/skills/query.py
+++ b/kestrel/models/moondream/skills/query.py
@@ -135,6 +135,28 @@ class QuerySkill(SkillSpec):
 class QuerySkillState(SkillState):
     """Skill state that buffers tokens and exposes plain text outputs."""
 
+    # The query mask is genuinely stateful: it transitions INACTIVE -> ACTIVE
+    # mid-run. While collecting reasoning, ``allowed_token_ids`` is ``None`` and
+    # (for non-moondream2 models) ``suppressed_token_ids`` is ``None`` too -- no
+    # active constraint. Once the model emits ``answer_id``, the state flips to
+    # forcing ``post_reasoning_prefix`` one id at a time via
+    # ``allowed_token_ids``. A single spec macro-step commits a variable run
+    # under ONE mask, so a run that begins in reasoning (mask = None) and crosses
+    # ``answer_id`` would verify the post-boundary tokens under the stale,
+    # unconstrained first-position mask -- accepting them WITHOUT the required
+    # prefix constraint and corrupting the output. The scheduler's behavioural
+    # fallback ("any ACTIVE constraint is stateful") cannot see this transition
+    # because both masks are ``None`` at the run's first position, so declare the
+    # mask stateful explicitly: the scheduler then caps such a row to one
+    # committed token per macro-step, forcing exactly one constraint transition
+    # per run (the regime where the per-step mask is exact). Always-cap is the
+    # correctness-first verdict; a transition-only cap is not expressible here
+    # because the boundary (when the model emits ``answer_id``) is model-decided
+    # and unknowable before the run commits. Tradeoff (follow-up): this also caps
+    # the long unconstrained answer/reasoning phases, costing intra-step
+    # speculation on those rows.
+    mask_is_stateful = True
+
     def __init__(
         self,
         spec: SkillSpec,

--- a/kestrel/models/moondream/skills/segment.py
+++ b/kestrel/models/moondream/skills/segment.py
@@ -118,6 +118,13 @@ class SegmentSkill(SkillSpec):
 class SegmentSkillState(SkillState):
     """Skill state that interprets coord/size tokens and SVG path text."""
 
+    # Segment never constrains decoding: it overrides neither
+    # ``allowed_token_ids`` nor ``suppressed_token_ids`` (both stay the base
+    # ``None``), so its mask is trivially position-independent. Declare it
+    # non-stateful so the spec scheduler keeps the full multi-token speculative
+    # accept rather than ever capping the row to one committed token per step.
+    mask_is_stateful = False
+
     def __init__(
         self,
         spec: SkillSpec,

--- a/kestrel/runtime/sampling.py
+++ b/kestrel/runtime/sampling.py
@@ -65,7 +65,8 @@ class SamplingHooks:
     # rather than being forced into this hook.
     materialize_tokens: Callable[..., list] | None = None
 
-    # materialize_spec_tokens(token_ids_cpu, sequences, batch_idx, side_values) -> list[Token]
+    # materialize_spec_tokens(token_ids_cpu, sequences, batch_idx, side_values,
+    #                         token_logprobs=None) -> list[Token]
     # Speculative-decode analog of ``materialize_tokens``. ``side_values`` is the
     # macro-step's :class:`~kestrel.runtime.spec.SpecSideValues` (the target's
     # per-committed-position final hidden + sampling knobs), from which a spatial
@@ -74,6 +75,14 @@ class SamplingHooks:
     # ``None``; the scheduler then materialises plain ``TextToken``s (and never
     # passes ``SpecSideValues`` into ``materialize_tokens``, whose handle shape it
     # does not match).
+    #
+    # ``token_logprobs`` (optional) is the flat per-committed-position vocab-token
+    # logprob list (parallel to ``token_ids_cpu``) the scheduler staged from the
+    # spec decoder. A spatial runtime mutates it **in place** to add each spatial
+    # position's coord/size head logprob, mirroring the non-spec ``post_sample``
+    # path (where ``compute_spatial_values`` folds the spatial head logprob into
+    # the vocab logprob in-place); the spec decoder only gathers the vocab logprob.
+    # ``None`` means no request wanted logprobs (decode is value-producing only).
     materialize_spec_tokens: Callable[..., list] | None = None
 
     # prepare_decode_inputs(slot, batch_idx, batch_size) -> None

--- a/kestrel/runtime/sampling.py
+++ b/kestrel/runtime/sampling.py
@@ -57,7 +57,24 @@ class SamplingHooks:
 
     # materialize_tokens(token_ids_cpu, sequences, batch_idx, step_handle) -> list[Token]
     # Default: TextToken-only materialisation, step_handle ignored.
+    # ``step_handle`` is the *non-spec* ``post_sample`` return value (e.g.
+    # Moondream's ``(slot, batch_size)`` aux handle). The speculative path's
+    # per-step side-values have a different shape (``SpecSideValues``) and a
+    # different decode (values come from a packed per-position hidden, not from
+    # slot-local staging), so they go through ``materialize_spec_tokens`` below
+    # rather than being forced into this hook.
     materialize_tokens: Callable[..., list] | None = None
+
+    # materialize_spec_tokens(token_ids_cpu, sequences, batch_idx, side_values) -> list[Token]
+    # Speculative-decode analog of ``materialize_tokens``. ``side_values`` is the
+    # macro-step's :class:`~kestrel.runtime.spec.SpecSideValues` (the target's
+    # per-committed-position final hidden + sampling knobs), from which a spatial
+    # runtime decodes coord/size ids into ``CoordToken`` / ``SizeToken``. A
+    # runtime that does not type spatial tokens on the spec path leaves this
+    # ``None``; the scheduler then materialises plain ``TextToken``s (and never
+    # passes ``SpecSideValues`` into ``materialize_tokens``, whose handle shape it
+    # does not match).
+    materialize_spec_tokens: Callable[..., list] | None = None
 
     # prepare_decode_inputs(slot, batch_idx, batch_size) -> None
     # Default: no-op. Runtime gathers any aux decode inputs into slot.

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -15,7 +15,7 @@ with scheduler integration, where they are actually consumed.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, Sequence, runtime_checkable
 
 if TYPE_CHECKING:
     import torch
@@ -63,6 +63,75 @@ class SpecProposer(Protocol):
 
 
 @dataclass
+class SpecStepResult:
+    """Per-sequence outcome of one speculative *macro-step*.
+
+    A macro-step drafts ``K`` tokens per active sequence, verifies them in one
+    target forward, greedily accepts the longest matching prefix, and commits
+    ``a_i + 1`` tokens for sequence ``i`` (the ``a_i`` accepted drafts plus the
+    bonus token at the first rejection). Sequences therefore advance a
+    *variable* number of tokens in a single step.
+
+    ``tokens`` is parallel to the ``sequences`` the scheduler passed to
+    :meth:`SpecDecoder.step`: ``tokens[i]`` is the list of newly committed token
+    ids for ``sequences[i]`` (length ``a_i + 1``, always ``>= 1``).
+    ``accept_counts[i]`` is ``a_i`` (drafts accepted, excludes the bonus); it is
+    diagnostic — ``len(tokens[i]) == accept_counts[i] + 1``.
+    """
+
+    tokens: list[list[int]]
+    accept_counts: list[int]
+
+
+@runtime_checkable
+class SpecDecoder(Protocol):
+    """The per-macro-step entry point a runtime exposes to the scheduler.
+
+    The scheduler drives this once per decode macro-step in place of the
+    one-token ``decode_with_slot`` path. Each call drafts, verify-replays,
+    greedily accepts, and commits the accepted prefix into the runtime's
+    persistent KV / hybrid-state pools for the supplied active sequences,
+    returning the per-sequence accepted tokens.
+
+    The runtime owns all device-side state (the persistent decode pool, the
+    reused verify/draft CUDA graphs, the GDN ring buffers). The scheduler only
+    supplies which sequences are active this step and consumes the returned
+    tokens — it stays model-agnostic.
+
+    Lifecycle: a sequence is introduced with :meth:`admit` (which prefills its
+    prompt into a pool row and returns the first sampled token), advanced with
+    repeated :meth:`step` calls, and removed with :meth:`retire` when it
+    finishes. ``admit`` returns the bonus/first token the way prefill does, so
+    the scheduler stages it exactly like the non-spec first decode token.
+    """
+
+    # K draft tokens proposed per sequence per macro-step (proposer's K).
+    num_speculative_tokens: int
+
+    # Number of free pool rows available to admit new sequences right now.
+    @property
+    def free_slots(self) -> int: ...
+
+    def admit(self, state: Any, prompt_token_ids: Sequence[int]) -> int:
+        """Prefill ``prompt_token_ids`` into a free pool row for ``state``.
+
+        Assigns the row's device batch index onto ``state.batch_idx`` (so the
+        scheduler's KV/finish bookkeeping addresses the same storage the spec
+        loop commits into) and returns the first sampled (greedy/bonus) token
+        id, mirroring prefill.
+        """
+        ...
+
+    def step(self, states: Sequence[Any]) -> SpecStepResult:
+        """Run one macro-step over the active ``states`` and commit accepts."""
+        ...
+
+    def retire(self, state: Any) -> None:
+        """Release the pool row held by a finished sequence's ``state``."""
+        ...
+
+
+@dataclass
 class SpecDecodeCaps:
     """A runtime's speculative-decoding capability.
 
@@ -74,10 +143,13 @@ class SpecDecodeCaps:
     the proposer consumes (e.g. DFlash's ``target_layer_ids``); an empty tuple
     means the proposer needs no target hidden states.
 
-    Verify/accept and hybrid-state (GDN) hooks are added with scheduler
-    integration; they are omitted here to avoid specifying an interface ahead of
-    its consumer.
+    ``decoder`` is the runtime's :class:`SpecDecoder` — the per-macro-step
+    entry point the scheduler drives (draft + verify + accept + commit). It is
+    optional only so the inert scaffolding (and its CPU-only tests) can still
+    build a ``SpecDecodeCaps`` that merely advertises a proposer; a runtime that
+    actually wants the scheduler to speculate must set it.
     """
 
     proposer: SpecProposer
     capture_hidden_layers: tuple[int, ...] = ()
+    decoder: SpecDecoder | None = None

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -62,46 +62,128 @@ class SpecProposer(Protocol):
         ...
 
 
+class SpecSideValues:
+    """Per-macro-step typed-token side-values the runtime needs to *type* the
+    committed ids (turn raw vocab ids into ``CoordToken`` / ``SizeToken`` / …).
+
+    A multimodal runtime (Moondream) decodes some committed ids into spatial
+    values from the target's last hidden state: a committed ``coord_id`` becomes
+    a :class:`CoordToken` whose ``pos`` is sampled from the spatial head applied
+    to that position's final hidden state, and likewise ``size_id`` →
+    :class:`SizeToken`. The non-spec decode path does this in
+    ``SamplingHooks.post_sample`` (``compute_spatial_values(token_ids,
+    hidden_last, …)``) — one position per step. A spec macro-step commits a
+    *variable run* of positions per sequence, so it carries the final hidden
+    state **at every committed position**, packed, plus the per-sequence sampling
+    knobs ``compute_spatial_values`` needs.
+
+    Fields (device tensors, indexed by ``i`` parallel to the active
+    ``sequences`` / :attr:`SpecStepResult.tokens`):
+
+    * ``hidden`` ``[num_sequences, K + 1, hidden_dim]`` — the target's **final**
+      ``last_hidden_state`` over sequence ``i``'s whole verify block. Only the
+      leading ``a_i + 1`` positions (``j <= accept_counts[i]``) are committed;
+      ``hidden[i, j]`` is the ``hidden_last`` for committed position ``j`` (the
+      same tensor the non-spec ``post_sample`` reads). Keeping the full block on
+      device (rather than pre-packing the variable run) avoids any per-step host
+      sync in ``step``; the runtime slices by ``accept_counts``.
+    * ``temperatures`` / ``top_ps`` ``[num_sequences]`` — the per-sequence
+      sampling temperature / top-p (broadcast across that sequence's committed
+      positions), so the spatial decode samples under the request's settings.
+    * ``counts`` — ``list[int]`` of ``a_i + 1`` per sequence when the producer
+      pre-split the rows, or ``None`` (the common path) meaning "slice the
+      leading ``accept_counts[i] + 1`` positions of ``hidden[i]``".
+
+    The runtime consumes this in its ``materialize_tokens`` hook (e.g. Moondream
+    runs ``compute_spatial_values(committed_ids, hidden[i, j], …)`` to turn
+    coord/size ids into ``CoordToken`` / ``SizeToken``); a text-only runtime
+    ignores it entirely (the committed ids materialize as ``TextToken``).
+    """
+
+    __slots__ = ("hidden", "temperatures", "top_ps", "counts")
+
+    def __init__(
+        self,
+        hidden: "torch.Tensor",
+        temperatures: "torch.Tensor",
+        top_ps: "torch.Tensor",
+        counts: "list[int] | None" = None,
+    ) -> None:
+        self.hidden = hidden
+        self.temperatures = temperatures
+        self.top_ps = top_ps
+        self.counts = counts
+
+
 class SpecStepResult:
     """Per-sequence outcome of one speculative *macro-step*.
 
     A macro-step drafts ``K`` tokens per active sequence, verifies them in one
-    target forward, greedily accepts the longest matching prefix, and commits
-    ``a_i + 1`` tokens for sequence ``i`` (the ``a_i`` accepted drafts plus the
-    bonus token at the first rejection). Sequences therefore advance a
-    *variable* number of tokens in a single step.
+    target forward, accepts the longest matching prefix (greedy) or runs modified
+    rejection sampling (``temperature > 0``), and commits ``a_i + 1`` tokens for
+    sequence ``i`` (the ``a_i`` accepted drafts plus the bonus / replacement
+    token at the first rejection). Sequences therefore advance a *variable*
+    number of tokens in a single step.
 
-    ``tokens`` is parallel to the ``sequences`` the scheduler passed to
-    :meth:`SpecDecoder.step`: ``tokens[i]`` is the list of newly committed token
-    ids for ``sequences[i]`` (length ``a_i + 1``, always ``>= 1``).
-    ``accept_counts[i]`` is ``a_i`` (drafts accepted, excludes the bonus); it is
-    diagnostic — ``len(tokens[i]) == accept_counts[i] + 1``.
+    Everything below is **parallel to the ``sequences``** the scheduler passed to
+    :meth:`SpecDecoder.step` (``i`` indexes that list):
 
-    The fields resolve **lazily**. A proposer may build this from an in-flight
-    D2H of its committed-token buffer so ``step`` never stalls the GPU on a
-    readback; the first access to :attr:`tokens` / :attr:`accept_counts` blocks
-    on that transfer. The async scheduler defers that access to a later step, so
-    the wait overlaps GPU work (see ``docs/speculative-decoding-design.md`` §12).
-    Eager construction (``SpecStepResult(tokens=..., accept_counts=...)``) stays
-    valid for synchronous callers and tests.
+    * ``tokens[i]`` — the list of newly committed token ids for ``sequences[i]``
+      (length ``a_i + 1``, always ``>= 1``).
+    * ``accept_counts[i]`` — ``a_i`` (drafts accepted, excludes the bonus);
+      diagnostic — ``len(tokens[i]) == accept_counts[i] + 1``.
+    * ``logprobs`` — ``None`` when no active sequence requested logprobs;
+      otherwise ``logprobs[i]`` is the per-committed-token logprob list (same
+      length as ``tokens[i]``), each the ``log_softmax`` of the target verify
+      logits — under the request's temperature/top-p — at that position,
+      gathered at the committed id. This is the spec analog of the non-spec
+      per-token logprob; the scheduler stages it through ``stage_token`` exactly
+      like the single-token path.
+    * ``side_values`` — ``None`` for a text-only runtime; otherwise a
+      :class:`SpecSideValues` carrying the target final-hidden + sampling knobs
+      at every committed position so the runtime's ``materialize_tokens`` hook
+      can type coord/size ids. It is *not* lazy (it holds device tensors read on
+      the compute side at ``step`` time); ``tokens`` / ``accept_counts`` /
+      ``logprobs`` resolve lazily off an in-flight D2H.
+
+    Lazy resolution: a proposer builds this from an in-flight D2H of its
+    committed-token / logprob buffers so ``step`` never stalls the GPU on a
+    readback; the first access to :attr:`tokens` / :attr:`accept_counts` /
+    :attr:`logprobs` blocks on that transfer. The async scheduler defers that
+    access to a later step, so the wait overlaps GPU work (see
+    ``docs/speculative-decoding-design.md`` §12). Eager construction
+    (``SpecStepResult(tokens=..., accept_counts=..., logprobs=...)``) stays valid
+    for synchronous callers and tests.
     """
 
-    __slots__ = ("_tokens", "_accept_counts", "_resolve")
+    __slots__ = (
+        "_tokens",
+        "_accept_counts",
+        "_logprobs",
+        "_resolve",
+        "side_values",
+    )
 
     def __init__(
         self,
         tokens: "list[list[int]] | None" = None,
         accept_counts: "list[int] | None" = None,
+        logprobs: "list[list[float]] | None" = None,
         *,
         resolve: "Any | None" = None,
+        side_values: "SpecSideValues | None" = None,
     ) -> None:
         self._resolve = resolve
         self._tokens = tokens
         self._accept_counts = accept_counts
+        self._logprobs = logprobs
+        # Side-values are produced eagerly on the compute side (device tensors);
+        # they do not participate in the lazy token/logprob D2H.
+        self.side_values = side_values
 
     def _ensure(self) -> None:
         if self._resolve is not None:
-            self._tokens, self._accept_counts = self._resolve()
+            self._tokens, self._accept_counts, self._logprobs = self._resolve()
             self._resolve = None
 
     @property
@@ -113,6 +195,17 @@ class SpecStepResult:
     def accept_counts(self) -> "list[int]":
         self._ensure()
         return self._accept_counts
+
+    @property
+    def logprobs(self) -> "list[list[float]] | None":
+        """Per-committed-token logprobs parallel to :attr:`tokens`, or ``None``.
+
+        ``None`` means no active sequence this step requested logprobs (the
+        proposer skipped the gather). When present, ``logprobs[i]`` has the same
+        length as ``tokens[i]``.
+        """
+        self._ensure()
+        return self._logprobs
 
 
 @runtime_checkable
@@ -144,18 +237,52 @@ class SpecDecoder(Protocol):
     @property
     def free_slots(self) -> int: ...
 
-    def admit(self, state: Any, prompt_token_ids: Sequence[int]) -> int:
+    def admit(
+        self,
+        state: Any,
+        prompt_token_ids: Sequence[int],
+        *,
+        image: Any | None = None,
+        allowed_token_ids: Sequence[int] | None = None,
+        suppressed_token_ids: Sequence[int] | None = None,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+    ) -> int:
         """Prefill ``prompt_token_ids`` into a free pool row for ``state``.
 
         Assigns the row's device batch index onto ``state.batch_idx`` (so the
         scheduler's KV/finish bookkeeping addresses the same storage the spec
         loop commits into) and returns the first sampled (greedy/bonus) token
         id, mirroring prefill.
+
+        Multimodal + constrained-decode admission (so the spec path covers the
+        same requests the non-spec path does, with no fallback):
+
+        * ``image`` — the request's image(s) (the runtime's preprocessed image
+          inputs, or whatever object the runtime's image preprocessing accepts).
+          When set, the prompt is prefilled *with the image KV prefix* exactly
+          like a normal image prefill (vision block spliced + vision encoder
+          run), not text-only. ``None`` keeps the text-only prefill.
+        * ``allowed_token_ids`` / ``suppressed_token_ids`` — the sequence's skill
+          mask (point/detect/query constrain the vocabulary). Stored per row and
+          applied to **both** the drafter and the verify on every :meth:`step`,
+          so masked decoding stays lossless and high-acceptance. ``None`` leaves
+          the row unmasked.
+        * ``temperature`` / ``top_p`` — the request's sampling knobs, recorded so
+          :meth:`step` runs the matching greedy/rejection-sampling path and the
+          per-token logprobs / spatial decode use the request's settings.
         """
         ...
 
     def step(self, states: Sequence[Any]) -> SpecStepResult:
-        """Run one macro-step over the active ``states`` and commit accepts."""
+        """Run one macro-step over the active ``states`` and commit accepts.
+
+        Applies each row's admit-time token mask to the drafter + verify,
+        returns a :class:`SpecStepResult` carrying the committed ids, accept
+        counts, per-token logprobs (when any active sequence wants them), and the
+        typed-token :class:`SpecSideValues` (when the runtime types coord/size
+        ids). See :class:`SpecStepResult`.
+        """
         ...
 
     def retire(self, state: Any) -> None:

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -245,15 +245,25 @@ class SpecDecoder(Protocol):
         image: Any | None = None,
         allowed_token_ids: Sequence[int] | None = None,
         suppressed_token_ids: Sequence[int] | None = None,
+        suppress_next_token_ids: Sequence[int] | None = None,
         temperature: float = 0.0,
         top_p: float = 1.0,
-    ) -> int:
+    ) -> "tuple[int, float | None]":
         """Prefill ``prompt_token_ids`` into a free pool row for ``state``.
 
         Assigns the row's device batch index onto ``state.batch_idx`` (so the
         scheduler's KV/finish bookkeeping addresses the same storage the spec
-        loop commits into) and returns the first sampled (greedy/bonus) token
-        id, mirroring prefill.
+        loop commits into) and returns ``(first_token_id, first_logprob)`` for
+        the first sampled (greedy/bonus) token, mirroring prefill.
+
+        ``first_logprob`` is the sampler's selected-token logprob for that first
+        token (under the request's temperature/top-p) when ``state`` requests
+        logprobs (``state.return_logprobs`` truthy), matching the non-spec
+        prefill path which computes and transfers ``sampled_logprobs`` for
+        token0; it is ``None`` when the request did not ask for logprobs (the
+        gather is skipped). Returning the real value avoids the ``0.0``
+        greedy-approximation placeholder for non-greedy requests
+        (``temperature > 0``, e.g. the query/caption default).
 
         Multimodal + constrained-decode admission (so the spec path covers the
         same requests the non-spec path does, with no fallback):
@@ -268,6 +278,12 @@ class SpecDecoder(Protocol):
           applied to **both** the drafter and the verify on every :meth:`step`,
           so masked decoding stays lossless and high-acceptance. ``None`` leaves
           the row unmasked.
+        * ``suppress_next_token_ids`` — the request-level *one-shot* suppression
+          (``GenerationRequest.suppress_next_token_ids``) that the non-spec path
+          applies only to a request's first generated token. ``admit`` samples
+          that very token, so it must blacklist these ids for this first sample
+          (and only this one — :meth:`step` never re-applies it). ``None`` leaves
+          the first sample unsuppressed.
         * ``temperature`` / ``top_p`` — the request's sampling knobs, recorded so
           :meth:`step` runs the matching greedy/rejection-sampling path and the
           per-token logprobs / spatial decode use the request's settings.

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -245,6 +245,7 @@ class SpecDecoder(Protocol):
         prompt_tokens: "Sequence[Token]",
         *,
         image: Any | None = None,
+        image_crops: Any | None = None,
         allowed_token_ids: Sequence[int] | None = None,
         suppressed_token_ids: Sequence[int] | None = None,
         suppress_next_token_ids: Sequence[int] | None = None,
@@ -285,6 +286,15 @@ class SpecDecoder(Protocol):
           When set, the prompt is prefilled *with the image KV prefix* exactly
           like a normal image prefill (vision block spliced + vision encoder
           run), not text-only. ``None`` keeps the text-only prefill.
+        * ``image_crops`` — the request's multi-crop tiles
+          (``GenerationRequest.image_crops``, the high-resolution overlap crops
+          Moondream tiles a large image into). The non-spec
+          ``prepare_sequence`` forwards this alongside ``image`` and the vision
+          encoder reads it as the ``overlap`` so the crop tiles -- not just the
+          global/thumbnail image -- are encoded into the KV prefix. Omitting it
+          for a multi-crop request would prefill only the global image and
+          diverge from the non-spec path. ``None`` for a single-crop / text-only
+          request (the encoder then uses ``image`` alone).
         * ``allowed_token_ids`` / ``suppressed_token_ids`` — the sequence's skill
           mask at admit (point/detect/query constrain the vocabulary). Stored per
           row and applied to **both** the drafter and the verify, so masked

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING, Any, Protocol, Sequence, runtime_checkable
 if TYPE_CHECKING:
     import torch
 
+    from kestrel.runtime.tokens import Token
+
 
 @dataclass
 class DraftResult:
@@ -240,7 +242,7 @@ class SpecDecoder(Protocol):
     def admit(
         self,
         state: Any,
-        prompt_token_ids: Sequence[int],
+        prompt_tokens: "Sequence[Token]",
         *,
         image: Any | None = None,
         allowed_token_ids: Sequence[int] | None = None,
@@ -249,7 +251,17 @@ class SpecDecoder(Protocol):
         temperature: float = 0.0,
         top_p: float = 1.0,
     ) -> "tuple[int, float | None]":
-        """Prefill ``prompt_token_ids`` into a free pool row for ``state``.
+        """Prefill ``prompt_tokens`` into a free pool row for ``state``.
+
+        ``prompt_tokens`` is the request's *typed* prefill sequence -- the same
+        ``Sequence[Token]`` the non-spec ``AutoregressiveRuntime.prepare_sequence``
+        receives, **not** a text-only ``Sequence[int]``. It can contain
+        ``ImageMarker`` tokens (multi-image chat prompts) and, for a resumed
+        request, ``CoordToken`` / ``SizeToken`` in the generated prefix; the
+        decoder expands ``ImageMarker``s with the image KV prefix exactly like
+        ``prepare_sequence`` and reads the typed ids. Stripping these to raw ids
+        on the scheduler side is what dropped image/spatial prefill context, so
+        the typed list is passed through whole.
 
         Assigns the row's device batch index onto ``state.batch_idx`` (so the
         scheduler's KV/finish bookkeeping addresses the same storage the spec

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -62,7 +62,6 @@ class SpecProposer(Protocol):
         ...
 
 
-@dataclass
 class SpecStepResult:
     """Per-sequence outcome of one speculative *macro-step*.
 
@@ -77,10 +76,43 @@ class SpecStepResult:
     ids for ``sequences[i]`` (length ``a_i + 1``, always ``>= 1``).
     ``accept_counts[i]`` is ``a_i`` (drafts accepted, excludes the bonus); it is
     diagnostic — ``len(tokens[i]) == accept_counts[i] + 1``.
+
+    The fields resolve **lazily**. A proposer may build this from an in-flight
+    D2H of its committed-token buffer so ``step`` never stalls the GPU on a
+    readback; the first access to :attr:`tokens` / :attr:`accept_counts` blocks
+    on that transfer. The async scheduler defers that access to a later step, so
+    the wait overlaps GPU work (see ``docs/speculative-decoding-design.md`` §12).
+    Eager construction (``SpecStepResult(tokens=..., accept_counts=...)``) stays
+    valid for synchronous callers and tests.
     """
 
-    tokens: list[list[int]]
-    accept_counts: list[int]
+    __slots__ = ("_tokens", "_accept_counts", "_resolve")
+
+    def __init__(
+        self,
+        tokens: "list[list[int]] | None" = None,
+        accept_counts: "list[int] | None" = None,
+        *,
+        resolve: "Any | None" = None,
+    ) -> None:
+        self._resolve = resolve
+        self._tokens = tokens
+        self._accept_counts = accept_counts
+
+    def _ensure(self) -> None:
+        if self._resolve is not None:
+            self._tokens, self._accept_counts = self._resolve()
+            self._resolve = None
+
+    @property
+    def tokens(self) -> "list[list[int]]":
+        self._ensure()
+        return self._tokens
+
+    @property
+    def accept_counts(self) -> "list[int]":
+        self._ensure()
+        return self._accept_counts
 
 
 @runtime_checkable

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -286,10 +286,13 @@ class SpecDecoder(Protocol):
           like a normal image prefill (vision block spliced + vision encoder
           run), not text-only. ``None`` keeps the text-only prefill.
         * ``allowed_token_ids`` / ``suppressed_token_ids`` — the sequence's skill
-          mask (point/detect/query constrain the vocabulary). Stored per row and
-          applied to **both** the drafter and the verify on every :meth:`step`,
-          so masked decoding stays lossless and high-acceptance. ``None`` leaves
-          the row unmasked.
+          mask at admit (point/detect/query constrain the vocabulary). Stored per
+          row and applied to **both** the drafter and the verify, so masked
+          decoding stays lossless and high-acceptance. This is the row's
+          *initial* mask; :meth:`step` re-supplies the mask per macro-step (the
+          scheduler recomputes it from the live skill state) and that per-step
+          value overrides the stored one for stateful skills whose allowed set
+          evolves. ``None`` leaves the row unmasked.
         * ``suppress_next_token_ids`` — the request-level *one-shot* suppression
           (``GenerationRequest.suppress_next_token_ids``) that the non-spec path
           applies only to a request's first generated token. ``admit`` samples
@@ -302,14 +305,38 @@ class SpecDecoder(Protocol):
         """
         ...
 
-    def step(self, states: Sequence[Any]) -> SpecStepResult:
+    def step(
+        self,
+        states: Sequence[Any],
+        *,
+        allowed_token_ids: Sequence[Sequence[int] | None] | None = None,
+        suppressed_token_ids: Sequence[Sequence[int] | None] | None = None,
+    ) -> SpecStepResult:
         """Run one macro-step over the active ``states`` and commit accepts.
 
-        Applies each row's admit-time token mask to the drafter + verify,
-        returns a :class:`SpecStepResult` carrying the committed ids, accept
+        Returns a :class:`SpecStepResult` carrying the committed ids, accept
         counts, per-token logprobs (when any active sequence wants them), and the
         typed-token :class:`SpecSideValues` (when the runtime types coord/size
         ids). See :class:`SpecStepResult`.
+
+        ``allowed_token_ids`` / ``suppressed_token_ids`` are the per-row skill
+        masks the scheduler recomputes from each sequence's *current* skill state
+        THIS macro-step (parallel to ``states``; entry ``i`` is the mask for
+        ``states[i]``, ``None`` for an unconstrained or finalized/zombie row).
+        They REPLACE the admit-time mask for this step. Stateful constrained
+        skills (point/detect) evolve their allowed set per committed token, so a
+        mask snapshotted once at ``admit`` goes stale after the first position;
+        the scheduler builds these post-commit (after the prior run's
+        ``consume_step`` ran) exactly like the non-spec sampler re-queries the
+        mask each step. ``None`` for the whole argument keeps the admit-time mask
+        (back-compat for a runtime/caller that does not refresh).
+
+        NOTE: a macro-step commits a *variable* run of ``a_i + 1`` tokens; for a
+        per-token-stateful skill the allowed set can change *within* one run. A
+        single per-step mask is exact only when at most one constraint transition
+        occurs per committed run -- the regime the non-spec one-token-per-step
+        path always satisfies. Tighter intra-run constraint enforcement (advancing
+        the mask per accepted draft) is the decoder's responsibility.
         """
         ...
 

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -315,12 +315,14 @@ class SpecDecoder(Protocol):
         """
         ...
 
+
     def step(
         self,
         states: Sequence[Any],
         *,
         allowed_token_ids: Sequence[Sequence[int] | None] | None = None,
         suppressed_token_ids: Sequence[Sequence[int] | None] | None = None,
+        commit_caps: Sequence[int | None] | None = None,
     ) -> SpecStepResult:
         """Run one macro-step over the active ``states`` and commit accepts.
 
@@ -341,12 +343,33 @@ class SpecDecoder(Protocol):
         mask each step. ``None`` for the whole argument keeps the admit-time mask
         (back-compat for a runtime/caller that does not refresh).
 
-        NOTE: a macro-step commits a *variable* run of ``a_i + 1`` tokens; for a
-        per-token-stateful skill the allowed set can change *within* one run. A
-        single per-step mask is exact only when at most one constraint transition
-        occurs per committed run -- the regime the non-spec one-token-per-step
-        path always satisfies. Tighter intra-run constraint enforcement (advancing
-        the mask per accepted draft) is the decoder's responsibility.
+        ``commit_caps`` is the per-row upper bound on how many tokens this
+        macro-step may commit for ``states[i]`` (parallel to ``states``; ``None``
+        for a row means uncapped -- commit the full accepted run). A single
+        per-step mask is exact only when at most one constraint transition occurs
+        per committed run: a macro-step commits a *variable* run of ``a_i + 1``
+        tokens, but the scheduler hands one mask for the whole run, so for a
+        per-token-*stateful* skill (detect cycles x->y->size; point toggles
+        ``[coord, eos]`` <-> ``[coord]`` after each coordinate; query injects a
+        fixed post-reasoning prefix one id at a time) the allowed/suppressed set
+        the run's 2nd..Nth positions should obey has already changed and the run
+        would be verified under a stale (1st-position) mask. The scheduler
+        therefore sets ``commit_caps[i] = 1`` for a stateful-masked row so that
+        row advances exactly one token per macro-step (one constraint transition
+        per run -- the regime where the single per-step mask IS exact, identical
+        to the non-spec one-token-per-step path), and re-queries the mask from the
+        now-current skill state next step. The decoder MUST NOT commit more than
+        ``commit_caps[i]`` tokens for that row (truncate the accepted run to the
+        cap and keep its KV/pool advance consistent with the truncated run).
+        ``None`` for the whole argument leaves every row uncapped (back-compat for
+        a runtime/caller that does not constrain stateful runs).
+
+        NOTE: capping a stateful row to one token is the scheduler-side analog of
+        the non-spec sampler only ever advancing one token per refreshed mask; it
+        trades that row's intra-step speculation for exact constrained decode.
+        Tighter intra-run enforcement (advancing the mask per accepted draft so a
+        stateful row can still commit multiple tokens) remains an optional decoder
+        refinement, but is not required for correctness once the cap is honored.
         """
         ...
 

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -814,6 +814,55 @@ class GenerationScheduler:
             # request cleanly; ``admit`` has not run yet so ``state.batch_idx`` is
             # still its ``-1`` sentinel and no pool row is retired.
             try:
+                # Prefix-cache image hit: materialize the overlap crop tiles
+                # before ``admit``.
+                #
+                # The admission coordinator (``engine/executor.py``) short-circuits
+                # a single-image request whose prompt HITS the prefix cache --
+                # ``_AdmissionCoordinator.submit`` returns ``prefix_cache_hit=True``
+                # *without* running image preprocessing, so ``_admit_ready`` marks
+                # the request launchable (``crops_ready=True``) with
+                # ``request.image_crops`` still ``None``. The NON-spec prefill path
+                # is safe with no crops because ``prepare_sequence`` takes the
+                # cache-reuse branch (``_prepare_append_prefill_inputs``) and never
+                # re-encodes the image -- it reuses the cached KV prefix pages.
+                #
+                # The spec ``decoder.admit`` has no cache-reuse path: it
+                # *re-prefills* the prompt into a fresh pool row and splices the
+                # image KV prefix by running the vision encoder
+                # (``encode_image(image, overlap=image_crops)``). Handing it
+                # ``image_crops=None`` for a multi-crop image would encode only the
+                # global/thumbnail image (the no-overlap ``prepare_crops`` path),
+                # giving an incomplete image prefill that diverges from the
+                # non-spec output -- or, on a decoder build that requires the crop
+                # tiles, fail outright. So a prefix-cache image hit must never
+                # reach ``admit`` with an image and ``image_crops=None``: run the
+                # SAME overlap-crop preprocessing the coordinator skipped (the
+                # async future, resolved synchronously here -- the spec path is
+                # already synchronous) and populate ``request.image_crops`` so the
+                # decoder prefills the full multi-crop image.
+                #
+                # Gated narrowly on a *single* image with no crops: multi-image
+                # chat (``image`` is a list/tuple) is never a single-image
+                # prefix-cache hit and crops each image inline inside the encoder,
+                # so it legitimately carries no precomputed overlap and must be
+                # left untouched. A non-cache-hit single-image request already had
+                # its crops materialized by the coordinator before becoming
+                # launchable, so ``request.image_crops`` is already set and this is
+                # a no-op. This preprocessing runs INSIDE the per-request ``try``
+                # so a decode/crop failure fails just this request via
+                # ``_fail_admitted_spec_request`` (no pool row reserved yet --
+                # ``state.batch_idx`` is still its ``-1`` sentinel -- so it only
+                # releases the LoRA slot and fails the request cleanly).
+                if (
+                    request.image is not None
+                    and request.image_crops is None
+                    and not isinstance(request.image, (list, tuple))
+                ):
+                    request.image_crops = self.runtime.preprocess_image_async(
+                        request.image
+                    ).result()
+
                 request.skill_state.on_prefill(self.runtime)
 
                 # Per-sequence constrained-decode mask (skill whitelist/blacklist),

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -17,6 +17,7 @@ from kestrel.runtime import (
     PrefillClassification,
     PreparedSequence,
     AutoregressiveRuntime,
+    SequenceState,
     TextToken,
     Token,
 )
@@ -397,7 +398,14 @@ class GenerationScheduler:
         * depth-1 speculation (zombies): the next forward is launched only
           after committing the step two behind it, so a sequence that ends
           rides exactly one in-flight step — no extra zombie waste.
+
+        When the runtime advertises speculative decoding (``runtime.spec`` is
+        not ``None``) the loop drives the spec macro-step path instead; the
+        single-token pipeline below runs unchanged when ``runtime.spec`` is
+        ``None`` (byte-for-byte identical behavior).
         """
+        if self.runtime.spec is not None:
+            return self._advance_spec()
         progressed = False
         pipeline = self._pipeline
         with stream_context(self._compute_stream):
@@ -493,6 +501,114 @@ class GenerationScheduler:
             if step is not None:
                 self.commit_step(step)
                 pipeline.on_step_completed()
+
+    # ------------------------------------------------------------------
+    # Speculative decode path
+    #
+    # When ``runtime.spec`` is set the runtime exposes a per-macro-step
+    # decoder (draft + verify + greedy-accept + commit, see
+    # ``kestrel.runtime.spec.SpecDecoder``). One macro-step advances each active
+    # sequence by a *variable* amount (a_i + 1 tokens). The runtime owns all
+    # device state (persistent pool + reused CUDA graphs + GDN ring buffers); the
+    # scheduler only admits/retires sequences and stages the returned tokens.
+    #
+    # This path is deliberately synchronous (the spec decoder samples + commits
+    # on the GPU itself and reads accept counts back to the host each step), so
+    # it does not use the single-token depth-1 pipeline above. The non-spec path
+    # is untouched.
+    # ------------------------------------------------------------------
+
+    def _advance_spec(self) -> bool:
+        progressed = False
+        with stream_context(self._compute_stream):
+            progressed |= self._spec_admit()
+            progressed |= self._spec_decode_step()
+        return progressed
+
+    def _spec_admit(self) -> bool:
+        """Admit waiting requests into free spec rows (prefill + first token)."""
+        decoder = self.runtime.spec.decoder
+        if decoder is None:
+            raise RuntimeError("runtime.spec set without a decoder")
+        progressed = False
+        while decoder.free_slots > 0:
+            request = next(
+                (r for r in self.waiting if self._is_launchable_request(r)), None
+            )
+            if request is None:
+                break
+            lifecycle = request.lifecycle
+            prompt_ids = [int(t.token_id) for t in request.prefill_tokens]
+            # Admission capacity is the decoder's free rows: the spec decoder
+            # owns a fixed, pre-reserved pool of page-table rows (its captured
+            # graphs depend on them), so ``runtime.can_reserve`` -- which gates on
+            # the shared page/slot pool those rows have already claimed -- does
+            # not apply here.
+            self.waiting.remove(request)
+            lifecycle.prefill_started_at = time.perf_counter()
+            lifecycle.transition(RequestPhase.PREFILLING)
+            # batch_idx is assigned by ``admit`` (it picks the spec pool row).
+            state = SequenceState(
+                batch_idx=-1,
+                length=len(prompt_ids),
+                max_length=request.target_length,
+                prompt_length=len(prompt_ids),
+                lora_slot=request.lora_slot,
+            )
+            try:
+                with torch.inference_mode():
+                    first_token_id = decoder.admit(state, prompt_ids)
+            except Exception as exc:
+                self._fail_request_early(request, exc)
+                progressed = True
+                continue
+
+            lifecycle.sequence_state = state
+            lifecycle.prefill_completed_at = time.perf_counter()
+            self.runtime.active_sequences[state.batch_idx] = state
+            request.skill_state.on_prefill(self.runtime)
+
+            # Stage the first (prefill/bonus) token exactly like the non-spec
+            # prefill path: consume_step + streaming + finish check.
+            token = TextToken(token_id=int(first_token_id))
+            lifecycle.stage_token(self.runtime, token, logprob=None)
+            progressed = True
+            if self._mark_finished_if_needed(lifecycle):
+                lifecycle.finalized = True
+                decoder.retire(state)
+                self.runtime.active_sequences.pop(state.batch_idx, None)
+                continue
+            self.running.push(lifecycle)
+        return progressed
+
+    def _spec_decode_step(self) -> bool:
+        """Run one spec macro-step over the active running sequences."""
+        decoder = self.runtime.spec.decoder
+        active = [
+            seq
+            for seq in self.running
+            if not seq.finished and seq.sequence_state is not None
+        ]
+        if not active:
+            return False
+
+        states = [seq.state for seq in active]
+        with torch.inference_mode():
+            result = decoder.step(states)
+
+        for seq, new_token_ids in zip(active, result.tokens):
+            for token_id in new_token_ids:
+                # Advance KV length to mirror the committed token.
+                seq.state.advance()
+                token = TextToken(token_id=int(token_id))
+                seq.stage_token(self.runtime, token, logprob=None)
+                if self._mark_finished_if_needed(seq):
+                    seq.finalized = True
+                    self.running.remove(seq)
+                    decoder.retire(seq.state)
+                    self.runtime.active_sequences.pop(seq.state.batch_idx, None)
+                    break
+        return True
 
     def pop_completed(self) -> List[SchedulerResult]:
         """Retrieve all completed results accumulated so far."""
@@ -1326,6 +1442,12 @@ class GenerationScheduler:
         was finalized earlier (in _mark_finished_if_needed or schedule_decode_step)
         but resource release was deferred because inflight_refs > 0.
         """
+        # Speculative decoding: the spec decoder owns the page-table rows (a
+        # fixed, persistently-reserved pool backing its captured CUDA graphs).
+        # Releasing the batch_idx here would erase pages out from under those
+        # graphs; row reuse is handled by ``decoder.retire`` at finish instead.
+        if self.runtime.spec is not None:
+            return
         if seq.state.batch_idx in self.runtime.active_sequences:
             try:
                 # The generated prefix was part of prefill, so only tokens

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -778,34 +778,49 @@ class GenerationScheduler:
             # ``allowed_token_ids`` depends on inside ``on_prefill``. The hook
             # only reads ``runtime.prompt_template`` (no dependency on the
             # forward having run), so running it here is safe.
-            request.skill_state.on_prefill(self.runtime)
-
-            # Per-sequence constrained-decode mask (skill whitelist/blacklist),
-            # forwarded into ``admit`` so the spec path constrains the drafter +
-            # verify exactly like the non-spec sampler's whitelist-then-blacklist
-            # -- no gating to a text-only/unconstrained fallback. ``None`` leaves
-            # the row unmasked.
-            allowed_token_ids = request.skill_state.allowed_token_ids(self.runtime)
-            suppressed_token_ids = request.skill_state.suppressed_token_ids(
-                self.runtime
-            )
-            # Request-level *one-shot* suppression. The non-spec path applies
-            # ``suppress_next_token_ids`` to a request's first generated token
-            # only (``_build_mask_spec`` gates it on
-            # ``token_count == generated_prefix_length``). ``admit`` samples that
-            # exact first token, so forward the suppression here -- otherwise a
-            # suppressed id can be sampled at admit, staged, and the one-shot
-            # window closes (``token_count`` advances) before ``step`` could ever
-            # apply it. ``None`` when the request set no one-shot suppression or
-            # already generated past its prefix (resumed request).
-            suppress_next_token_ids = None
-            if (
-                request.suppress_next_token_ids
-                and request.skill_state.token_count
-                == request.generated_prefix_length
-            ):
-                suppress_next_token_ids = request.suppress_next_token_ids
+            #
+            # The ``on_prefill`` hook and the mask queries below run INSIDE the
+            # same ``try`` as ``admit``: a skill whose ``on_prefill`` /
+            # ``allowed_token_ids`` / ``suppressed_token_ids`` raises does so
+            # after this request has already left ``waiting``, transitioned to
+            # ``PREFILLING``, and acquired its LoRA slot. Outside the ``try`` that
+            # would bypass the admit-failure cleanup -- leaking the LoRA slot and
+            # leaving the request stuck in ``PREFILLING`` (it is gone from
+            # ``waiting`` and ``lifecycle.sequence_state`` is never set, so no
+            # finish/zombie path retires it) until the scheduler later crashes on
+            # it. The ``except`` below already releases the slot and fails the
+            # request cleanly; ``admit`` has not run yet so ``state.batch_idx`` is
+            # still its ``-1`` sentinel and no pool row is retired.
             try:
+                request.skill_state.on_prefill(self.runtime)
+
+                # Per-sequence constrained-decode mask (skill whitelist/blacklist),
+                # forwarded into ``admit`` so the spec path constrains the drafter +
+                # verify exactly like the non-spec sampler's whitelist-then-blacklist
+                # -- no gating to a text-only/unconstrained fallback. ``None`` leaves
+                # the row unmasked.
+                allowed_token_ids = request.skill_state.allowed_token_ids(
+                    self.runtime
+                )
+                suppressed_token_ids = request.skill_state.suppressed_token_ids(
+                    self.runtime
+                )
+                # Request-level *one-shot* suppression. The non-spec path applies
+                # ``suppress_next_token_ids`` to a request's first generated token
+                # only (``_build_mask_spec`` gates it on
+                # ``token_count == generated_prefix_length``). ``admit`` samples that
+                # exact first token, so forward the suppression here -- otherwise a
+                # suppressed id can be sampled at admit, staged, and the one-shot
+                # window closes (``token_count`` advances) before ``step`` could ever
+                # apply it. ``None`` when the request set no one-shot suppression or
+                # already generated past its prefix (resumed request).
+                suppress_next_token_ids = None
+                if (
+                    request.suppress_next_token_ids
+                    and request.skill_state.token_count
+                    == request.generated_prefix_length
+                ):
+                    suppress_next_token_ids = request.suppress_next_token_ids
                 with torch.inference_mode():
                     # Pass the request's image AND its multi-crop tiles
                     # (``image_crops``) -- exactly what the non-spec

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -497,12 +497,25 @@ class GenerationScheduler:
         return progressed
 
     def _drain_pipeline(self) -> None:
-        """Drain the pipeline before prefill - complete all in-flight work.
+        """Drain in-flight work before prefill / before an engine pause.
 
         Respects Phase 1 commit-before-finalize ordering: complete all queued
         steps before finalizing any in-flight forward. This ensures grammar
         state is updated before computing masks for constrained decoding.
+
+        The engine PAUSE path calls this (``Executor.drain``) before mutating
+        runtime state under ``graph_capture_lock`` (e.g. rebuilding CUDA graphs).
+        The spec macro-step path commits through ``_pending_spec``, which the
+        non-spec pipeline drain below does not touch, so drain spec work first:
+        if a pause lands after a macro-step was launched (``_pending_spec`` set)
+        and before the next ``advance``, the spec result would otherwise stay
+        uncommitted while the runtime/graphs are mutated under an active spec row
+        -- corrupting that row and delaying its completion/retirement until
+        resume. ``_drain_spec`` commits the in-flight macro-step (no new launch)
+        until ``_pending_spec`` is empty. In non-spec mode it is a no-op.
         """
+        self._drain_spec()
+
         pipeline = self._pipeline
 
         # 1. Complete all queued steps first (commit-before-finalize)
@@ -573,6 +586,31 @@ class GenerationScheduler:
                 break
             lifecycle = request.lifecycle
 
+            # Zero-length generation: the non-spec path has a dedicated branch
+            # (see the ``max_new_tokens <= 0`` case in ``_launch_prefill_step``)
+            # that finalizes the request as ``"length"`` WITHOUT sampling/staging
+            # a first token. ``decoder.admit`` has no prefill-only mode -- its
+            # contract is to prefill *and* sample/stage token0 -- so routing a
+            # 0-token request through it would stream/return one extra token and
+            # briefly consume a spec pool row. Match the non-spec contract:
+            # finalize with zero generated tokens, no admit, no row. The spec
+            # decoder's persistently-reserved pool gains nothing from a prefill it
+            # would immediately retire, so skipping admission entirely is both
+            # correct and leaves the row free for real work.
+            if request.max_new_tokens <= 0:
+                self.waiting.remove(request)
+                # No spec row, so no ``sequence_state``; ``build_metrics`` then
+                # falls back to ``request.prompt_length`` exactly like the
+                # non-spec 0-length path (which also leaves ``sequence_state``
+                # unset). ``_finalize_sequence`` -> ``_release_sequence``
+                # early-returns for a spec runtime before touching the (absent)
+                # state, so this is safe with ``sequence_state is None``.
+                lifecycle.prefill_started_at = time.perf_counter()
+                lifecycle.prefill_completed_at = lifecycle.prefill_started_at
+                self._finalize_sequence(lifecycle, "length")
+                progressed = True
+                continue
+
             # Acquire the LoRA slot before admission, mirroring the normal
             # prefill path. Without this, adapter requests admitted to the spec
             # path keep ``request.lora_slot == 0`` and silently run on the
@@ -636,14 +674,31 @@ class GenerationScheduler:
             self.waiting.remove(request)
             lifecycle.prefill_started_at = time.perf_counter()
             lifecycle.transition(RequestPhase.PREFILLING)
-            # batch_idx is assigned by ``admit`` (it picks the spec pool row).
-            # ``length`` / ``prompt_length`` are the token *count* (markers count
-            # as one each; ``admit`` expands them and owns the real KV length).
+            # ``length`` / ``prompt_length`` must be the row's *KV* prompt length,
+            # exactly what the non-spec ``prepare_sequence`` records (it expands
+            # image markers / a single-image prefix into the KV prompt length, see
+            # ``moondream/runtime.py``). ``len(prompt_tokens)`` counts each
+            # ``ImageMarker`` as one token but the image occupies
+            # ``image_prefix_length`` KV slots, so the count excludes the image KV
+            # prefix. ``request.image_length`` is exactly that prefix
+            # (``image_prefix_length`` for a single image; ``num_images *
+            # (image_prefix_length - 1)`` for the multi-image marker layout, where
+            # each marker is already one token in ``prompt_tokens``), so
+            # ``len(prompt_tokens) + request.image_length`` reconstructs the KV
+            # prompt length for both layouts and leaves text-only requests
+            # (``image_length == 0``) unchanged. Without this, ``build_metrics``
+            # (which reports ``sequence_state.prompt_length``) under-reports image
+            # prompt tokens and ``output_length`` (``length - prompt_length``) is
+            # off by the image prefix. ``batch_idx`` is assigned by ``admit`` (it
+            # picks the spec pool row); carry ``image_length`` so downstream
+            # KV/total-length accounting on the state stays consistent.
+            kv_prompt_length = len(prompt_tokens) + request.image_length
             state = SequenceState(
                 batch_idx=-1,
-                length=len(prompt_tokens),
+                length=kv_prompt_length,
                 max_length=request.target_length,
-                prompt_length=len(prompt_tokens),
+                prompt_length=kv_prompt_length,
+                image_length=request.image_length,
                 lora_slot=request.lora_slot,
             )
             # The spec decoder reads ``return_logprobs`` off the state to decide
@@ -833,6 +888,27 @@ class GenerationScheduler:
             self._commit_spec(pending)
 
         return bool(active) or pending is not None
+
+    def _drain_spec(self) -> None:
+        """Commit any in-flight spec macro-step, launching no new work.
+
+        ``_spec_decode_step`` overlaps depth-1 by launching the next macro-step
+        *before* committing the previous one, so between ticks a launched-but-
+        uncommitted step lives in ``_pending_spec``. Unlike ``_spec_decode_step``
+        this deliberately does NOT launch a new step -- it only flushes the
+        outstanding one -- so it is safe to call from the pause/drain path
+        (``_drain_pipeline``) without admitting more spec work while the engine is
+        trying to quiesce. ``_commit_spec`` finalizes/retires any sequence that
+        ended in the committed run and never repopulates ``_pending_spec``, so a
+        single commit empties it; the loop is defensive and converges. No-op when
+        the runtime does not speculate (``_pending_spec`` stays ``None``).
+        """
+        while self._pending_spec is not None:
+            pending = self._pending_spec
+            self._pending_spec = None
+            with stream_context(self._compute_stream):
+                with torch.inference_mode():
+                    self._commit_spec(pending)
 
     def _materialize_spec_tokens(
         self,

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -333,6 +333,10 @@ class GenerationScheduler:
         self._sampling_rng.manual_seed(torch.seed())
         self._pipeline = PipelineState()
         self._last_deferred_request_id: int | None = None
+        # Depth-1 spec overlap: the previously-launched macro-step's
+        # (sequences, lazy SpecStepResult) awaiting commit while the GPU runs the
+        # next step. None when no spec step is in flight.
+        self._pending_spec = None
 
     # ------------------------------------------------------------------
     # Submission
@@ -582,33 +586,71 @@ class GenerationScheduler:
         return progressed
 
     def _spec_decode_step(self) -> bool:
-        """Run one spec macro-step over the active running sequences."""
+        """Run one spec macro-step, overlapped depth-1.
+
+        Launch the macro-step for the current running set *first* (async: the
+        decoder samples + commits on the GPU and returns a lazy
+        ``SpecStepResult`` whose token D2H is in flight), then commit the
+        *previous* macro-step -- whose D2H landed while this launch ran. The CPU
+        commit (token materialize + stage + finish) therefore overlaps GPU
+        compute.
+
+        Membership is an optimistic snapshot: a sequence finished by the previous
+        commit but already launched here rides as a zombie (``finalized`` with
+        ``inflight_refs > 0``) and is skipped + retired at its own commit next
+        tick -- the same zombie discipline the single-token pipeline uses.
+        """
         decoder = self.runtime.spec.decoder
+        pending = self._pending_spec
+        self._pending_spec = None
+
         active = [
             seq
             for seq in self.running
             if not seq.finished and seq.sequence_state is not None
         ]
-        if not active:
-            return False
+        if active:
+            with torch.inference_mode():
+                result = decoder.step([seq.state for seq in active])
+            for seq in active:
+                seq.inflight_refs += 1
+            self._pending_spec = (active, result)
 
-        states = [seq.state for seq in active]
-        with torch.inference_mode():
-            result = decoder.step(states)
+        if pending is not None:
+            self._commit_spec(decoder, pending)
 
-        for seq, new_token_ids in zip(active, result.tokens):
+        return bool(active) or pending is not None
+
+    def _commit_spec(self, decoder, pending) -> None:
+        """Commit one previously-launched spec macro-step (depth-1).
+
+        Resolving ``result.tokens`` blocks on the macro-step's deferred D2H, but
+        that transfer completed while the GPU ran the step launched after it, so
+        the wait is hidden. Mirrors ``commit_step``'s decode commit: decrement
+        ``inflight_refs``, skip + retire zombies, else stage the variable run of
+        committed tokens and finish/retire on EOS or length cap.
+        """
+        active, result = pending
+        tokens = result.tokens  # lazy: waits the (already-landed) deferred D2H
+        for seq, new_token_ids in zip(active, tokens):
+            seq.inflight_refs -= 1
+            if seq.finalized:
+                # Zombie: finished by an earlier commit while still in flight here.
+                if seq.inflight_refs == 0:
+                    decoder.retire(seq.state)
+                    self.runtime.active_sequences.pop(seq.state.batch_idx, None)
+                continue
             for token_id in new_token_ids:
-                # Advance KV length to mirror the committed token.
-                seq.state.advance()
+                seq.state.advance()  # KV length mirrors the committed token
                 token = TextToken(token_id=int(token_id))
                 seq.stage_token(self.runtime, token, logprob=None)
                 if self._mark_finished_if_needed(seq):
                     seq.finalized = True
                     self.running.remove(seq)
-                    decoder.retire(seq.state)
-                    self.runtime.active_sequences.pop(seq.state.batch_idx, None)
+                    if seq.inflight_refs == 0:
+                        decoder.retire(seq.state)
+                        self.runtime.active_sequences.pop(seq.state.batch_idx, None)
                     break
-        return True
 
     def pop_completed(self) -> List[SchedulerResult]:
         """Retrieve all completed results accumulated so far."""

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -588,7 +588,55 @@ class GenerationScheduler:
         # the same request (it stays in ``waiting``) while still letting other
         # waiting requests be considered for admission.
         deferred_ids: set[int] = set()
-        # Cap the live spec batch to the runtime's captured-graph batch size.
+        # Zero-length generation finalizes WITHOUT consuming a spec row.
+        #
+        # The non-spec path has a dedicated branch (see the ``max_new_tokens <=
+        # 0`` case in ``_launch_prefill_step``) that finalizes the request as
+        # ``"length"`` WITHOUT sampling/staging a first token. ``decoder.admit``
+        # has no prefill-only mode -- its contract is to prefill *and*
+        # sample/stage token0 -- so routing a 0-token request through it would
+        # stream/return one extra token and briefly consume a spec pool row.
+        # Match the non-spec contract: finalize with zero generated tokens, no
+        # admit, no row. The spec decoder's persistently-reserved pool gains
+        # nothing from a prefill it would immediately retire, so skipping
+        # admission entirely is both correct and leaves the row free for real
+        # work.
+        #
+        # Because such a request needs NO free pool row and NO running-batch
+        # slot, drain every launchable zero-token request in a pre-pass that is
+        # NOT gated by the capacity guard below. Otherwise a zero-token request
+        # queued behind a saturated spec batch (``decoder.free_slots == 0`` or
+        # ``len(self.running) >= max_batch_size``) would wait for an unrelated
+        # row to retire before completing -- diverging from this no-row
+        # contract -- even though it consumes none of the gated resources.
+        while True:
+            request = next(
+                (
+                    r
+                    for r in self.waiting
+                    if self._is_launchable_request(r)
+                    and r.request_id not in deferred_ids
+                    and r.max_new_tokens <= 0
+                ),
+                None,
+            )
+            if request is None:
+                break
+            lifecycle = request.lifecycle
+            self.waiting.remove(request)
+            # No spec row, so no ``sequence_state``; ``build_metrics`` then
+            # falls back to ``request.prompt_length`` exactly like the
+            # non-spec 0-length path (which also leaves ``sequence_state``
+            # unset). ``_finalize_sequence`` -> ``_release_sequence``
+            # early-returns for a spec runtime before touching the (absent)
+            # state, so this is safe with ``sequence_state is None``.
+            lifecycle.prefill_started_at = time.perf_counter()
+            lifecycle.prefill_completed_at = lifecycle.prefill_started_at
+            self._finalize_sequence(lifecycle, "length")
+            progressed = True
+
+        # Admit real (>=1 token) requests into free spec rows, capping the live
+        # spec batch to the runtime's captured-graph batch size.
         #
         # The decoder's pool can expose MORE free rows than ``max_batch_size``
         # (it is sized from ``max_batch_slots == max_batch_size + 2`` to keep
@@ -618,30 +666,12 @@ class GenerationScheduler:
             if request is None:
                 break
             lifecycle = request.lifecycle
-
-            # Zero-length generation: the non-spec path has a dedicated branch
-            # (see the ``max_new_tokens <= 0`` case in ``_launch_prefill_step``)
-            # that finalizes the request as ``"length"`` WITHOUT sampling/staging
-            # a first token. ``decoder.admit`` has no prefill-only mode -- its
-            # contract is to prefill *and* sample/stage token0 -- so routing a
-            # 0-token request through it would stream/return one extra token and
-            # briefly consume a spec pool row. Match the non-spec contract:
-            # finalize with zero generated tokens, no admit, no row. The spec
-            # decoder's persistently-reserved pool gains nothing from a prefill it
-            # would immediately retire, so skipping admission entirely is both
-            # correct and leaves the row free for real work.
+            # Zero-token requests were already finalized in the pre-pass above
+            # (no row, no batch slot); the launchable scan there shares this
+            # filter, so none can reach here. Guard defensively so a request can
+            # never fall through to ``decoder.admit`` (which would prefill +
+            # stage an unwanted token0) if invariants ever change.
             if request.max_new_tokens <= 0:
-                self.waiting.remove(request)
-                # No spec row, so no ``sequence_state``; ``build_metrics`` then
-                # falls back to ``request.prompt_length`` exactly like the
-                # non-spec 0-length path (which also leaves ``sequence_state``
-                # unset). ``_finalize_sequence`` -> ``_release_sequence``
-                # early-returns for a spec runtime before touching the (absent)
-                # state, so this is safe with ``sequence_state is None``.
-                lifecycle.prefill_started_at = time.perf_counter()
-                lifecycle.prefill_completed_at = lifecycle.prefill_started_at
-                self._finalize_sequence(lifecycle, "length")
-                progressed = True
                 continue
 
             # Acquire the LoRA slot before admission, mirroring the normal

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -375,6 +375,14 @@ class GenerationScheduler:
             len(self.waiting) > 0
             or len(self.running) > 0
             or not self._pipeline.is_empty()
+            # Depth-1 spec overlap: a launched-but-uncommitted macro-step keeps
+            # work pending even when ``running`` is already empty. The last
+            # running sequence can finish in ``_commit_spec`` while the
+            # follow-up (zombie) step it launched stays in ``_pending_spec``;
+            # without this term the executor stops calling ``advance`` and that
+            # step is never committed, so ``decoder.retire`` never runs and the
+            # spec row leaks.
+            or self._pending_spec is not None
         )
 
     def advance(self) -> bool:
@@ -535,13 +543,56 @@ class GenerationScheduler:
         if decoder is None:
             raise RuntimeError("runtime.spec set without a decoder")
         progressed = False
+        # Requests deferred this call because their adapter slot is currently
+        # unavailable. Tracking them stops the launchable scan from re-picking
+        # the same request (it stays in ``waiting``) while still letting other
+        # waiting requests be considered for admission.
+        deferred_ids: set[int] = set()
         while decoder.free_slots > 0:
             request = next(
-                (r for r in self.waiting if self._is_launchable_request(r)), None
+                (
+                    r
+                    for r in self.waiting
+                    if self._is_launchable_request(r)
+                    and r.request_id not in deferred_ids
+                ),
+                None,
             )
             if request is None:
                 break
             lifecycle = request.lifecycle
+
+            # Acquire the LoRA slot before admission, mirroring the normal
+            # prefill path. Without this, adapter requests admitted to the spec
+            # path keep ``request.lora_slot == 0`` and silently run on the
+            # base-model slot, ignoring the requested finetune. A genuine load
+            # failure fails just that request; transient slot exhaustion (all
+            # LoRA slots in use) keeps the request WAITING_RESOURCES so it
+            # retries once an adapter retires, instead of admitting it wrong.
+            if not lifecycle.lora_slot_ready:
+                try:
+                    request.lora_slot = self._acquire_adapter_slot(request.adapter)
+                    lifecycle.lora_slot_ready = True
+                except RuntimeError as exc:
+                    # Out of LoRA slots: recoverable. The request is genuinely
+                    # blocked on a LoRA resource, so put it back in
+                    # WAITING_RESOURCES (it stays in the waiting queue) and try
+                    # other waiting requests; it retries once a slot frees up.
+                    _LOGGER.debug(
+                        "Deferring spec admission for request %s: %s",
+                        request.request_id,
+                        exc,
+                    )
+                    lifecycle.transition(RequestPhase.WAITING_RESOURCES)
+                    deferred_ids.add(request.request_id)
+                    continue
+                except Exception as exc:
+                    # Unrecoverable adapter load/config error: fail this request.
+                    self.waiting.remove(request)
+                    self._fail_request_early(request, exc)
+                    progressed = True
+                    continue
+
             prompt_ids = [int(t.token_id) for t in request.prefill_tokens]
             # Admission capacity is the decoder's free rows: the spec decoder
             # owns a fixed, pre-reserved pool of page-table rows (its captured
@@ -563,6 +614,15 @@ class GenerationScheduler:
                 with torch.inference_mode():
                     first_token_id = decoder.admit(state, prompt_ids)
             except Exception as exc:
+                if lifecycle.lora_slot_ready and request.lora_slot:
+                    # Release the LoRA slot we acquired for this failed admission
+                    # so its refcount does not leak.
+                    try:
+                        self.runtime.release_adapter_slot(request.lora_slot)
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+                    request.lora_slot = 0
+                    lifecycle.lora_slot_ready = False
                 self._fail_request_early(request, exc)
                 progressed = True
                 continue
@@ -572,10 +632,31 @@ class GenerationScheduler:
             self.runtime.active_sequences[state.batch_idx] = state
             request.skill_state.on_prefill(self.runtime)
 
+            # TODO(spec-logprobs): the spec macro-step does not yet supply
+            # per-token logprobs (``admit`` returns only a token id and
+            # ``SpecStepResult`` carries none). Until the speculator branch
+            # populates them on the compute side, a ``return_logprobs`` request
+            # cannot be served on the spec path. Reject just that request here --
+            # cleanly retiring the row/slot ``admit`` allocated -- instead of
+            # letting ``stage_token`` raise a scheduler-wide exception on a None
+            # logprob. Once the macro-step provides logprobs, stage them through
+            # ``_spec_stage_token`` like the non-spec path.
+            if request.return_logprobs is True:
+                self._fail_admitted_spec_request(
+                    decoder,
+                    lifecycle,
+                    RuntimeError(
+                        "Speculative decoding does not yet support logprobs; "
+                        "disable speculation for return_logprobs requests."
+                    ),
+                )
+                progressed = True
+                continue
+
             # Stage the first (prefill/bonus) token exactly like the non-spec
             # prefill path: consume_step + streaming + finish check.
             token = TextToken(token_id=int(first_token_id))
-            lifecycle.stage_token(self.runtime, token, logprob=None)
+            self._spec_stage_token(lifecycle, token, logprob=None)
             progressed = True
             if self._mark_finished_if_needed(lifecycle):
                 lifecycle.finalized = True
@@ -584,6 +665,72 @@ class GenerationScheduler:
                 continue
             self.running.push(lifecycle)
         return progressed
+
+    def _spec_stage_token(
+        self,
+        seq: RequestLifecycle,
+        token: Token,
+        *,
+        logprob: float | None,
+    ) -> None:
+        """Stage one spec-committed token onto ``seq``.
+
+        Mirrors ``RequestLifecycle.stage_token`` but is the single spec-path
+        staging point. ``return_logprobs`` requests are rejected at admission
+        (the spec macro-step cannot supply logprobs yet, see the
+        ``# TODO(spec-logprobs)`` above), so any sequence reaching here either
+        does not want logprobs or carries a real one. The non-None ``logprob``
+        branch is wired so that the day the macro-step supplies logprobs they
+        flow through unchanged.
+        """
+        seq.stage_token(self.runtime, token, logprob=logprob)
+
+    def _fail_admitted_spec_request(
+        self,
+        decoder,
+        seq: RequestLifecycle,
+        exc: Exception,
+    ) -> None:
+        """Fail one already-admitted spec sequence cleanly (no scheduler abort).
+
+        ``admit`` has already allocated a pool row (and the caller a LoRA slot),
+        so retire the row, drop it from ``active_sequences``, release any LoRA
+        slot, and emit an error result for just this request. The request was
+        not yet pushed onto ``running``.
+        """
+        _LOGGER.warning(
+            "Failing spec request %s: %s", seq.request.request_id, exc
+        )
+        state = seq.sequence_state
+        if state is not None:
+            try:
+                decoder.retire(state)
+            except Exception:  # pragma: no cover - defensive
+                pass
+            self.runtime.active_sequences.pop(state.batch_idx, None)
+        request = seq.request
+        if seq.lora_slot_ready and request.lora_slot:
+            try:
+                self.runtime.release_adapter_slot(request.lora_slot)
+            except Exception:  # pragma: no cover - defensive
+                pass
+            request.lora_slot = 0
+            seq.lora_slot_ready = False
+        seq.finish_reason = "error"
+        seq.error = exc
+        seq.finished = True
+        seq.finalized = True
+        seq.transition(RequestPhase.COMPLETED)
+        metrics = seq.build_metrics(decode_tokens=0)
+        self._completed.append(
+            SchedulerResult(
+                request_id=request.request_id,
+                tokens=[],
+                finish_reason="error",
+                metrics=metrics,
+                output={"error": str(exc)},
+            )
+        )
 
     def _spec_decode_step(self) -> bool:
         """Run one spec macro-step, overlapped depth-1.
@@ -643,7 +790,12 @@ class GenerationScheduler:
             for token_id in new_token_ids:
                 seq.state.advance()  # KV length mirrors the committed token
                 token = TextToken(token_id=int(token_id))
-                seq.stage_token(self.runtime, token, logprob=None)
+                # TODO(spec-logprobs): pass the macro-step's per-token logprob
+                # here once ``SpecStepResult`` carries them. ``return_logprobs``
+                # requests are rejected at spec admission today, so every
+                # sequence reaching this commit has ``return_logprobs`` unset and
+                # ``stage_token`` does not require a logprob.
+                self._spec_stage_token(seq, token, logprob=None)
                 if self._mark_finished_if_needed(seq):
                     seq.finalized = True
                     self.running.remove(seq)

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1162,10 +1162,13 @@ class GenerationScheduler:
 
         * ``side_values`` set -> route through the dedicated
           ``materialize_spec_tokens`` hook (the spec analog that decodes coord/size
-          from the packed hidden). If the runtime exposes no such hook (text-only,
-          or a runtime that does not type spatial tokens on the spec path),
-          *guard* by materialising plain ``TextToken``s rather than misusing the
-          non-spec hook.
+          from the packed hidden). If the runtime emits spatial side-values but
+          exposes no such hook, *fail fast* (``RuntimeError``) -- never silently
+          materialise the committed ids as plain ``TextToken``s (that would DROP
+          the decoded coordinates/sizes and corrupt spatial-skill results), and
+          never misuse the non-spec hook (whose handle shape ``SpecSideValues``
+          does not match). A text-only runtime leaves ``side_values`` ``None`` and
+          takes the branch below, so it never reaches this guard.
         * ``side_values is None`` -> a text-only macro-step; use the normal
           ``materialize_tokens`` path with a ``None`` handle (its plain-text
           branch), matching the non-spec single-token commit.
@@ -1186,18 +1189,28 @@ class GenerationScheduler:
         batch_idx = torch.tensor(batch_indices, dtype=torch.long)
         if side_values is not None:
             spec_hook = self._hooks.materialize_spec_tokens
-            if spec_hook is not None:
-                flat_tokens = spec_hook(
-                    token_ids_cpu, active, batch_idx, side_values
+            if spec_hook is None:
+                # Fail fast (no silent fallback). ``side_values`` is produced ONLY
+                # when the runtime decoded spatial values that MUST be typed into
+                # ``CoordToken`` / ``SizeToken`` from the target's per-position
+                # final hidden (the spatial-skill spec path: detect/point). The
+                # non-spec ``materialize_tokens`` hook cannot consume a
+                # ``SpecSideValues`` (its handle is the ``post_sample``
+                # ``(slot, batch_size)`` aux value), and materialising the
+                # committed ids as plain ``TextToken``s would silently DROP the
+                # decoded coordinates/sizes and corrupt the result. A runtime that
+                # emits spatial side-values must expose ``materialize_spec_tokens``
+                # (see ``MoondreamRuntime.sampling_hooks``); a text-only runtime
+                # leaves ``side_values`` ``None`` and never reaches here.
+                raise RuntimeError(
+                    "Speculative macro-step returned spatial SpecSideValues but "
+                    "the runtime's SamplingHooks expose no materialize_spec_tokens "
+                    "hook; refusing to silently drop decoded coord/size values to "
+                    "TextToken. Implement materialize_spec_tokens on the runtime "
+                    "(mirror its non-spec materialize_tokens spatial decode) to "
+                    "enable spec for spatial skills."
                 )
-            else:
-                # Guard: a runtime that does not type spatial tokens on the spec
-                # path still returned side-values; never pass them to the
-                # non-spec hook -- materialise plain text ids.
-                flat_tokens = [
-                    TextToken(token_id=int(t))
-                    for t in token_ids_cpu.view(-1).tolist()
-                ]
+            flat_tokens = spec_hook(token_ids_cpu, active, batch_idx, side_values)
         else:
             # Text-only macro-step: the non-spec hook's ``step_handle is None``
             # branch (plain text) applies.

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -69,6 +69,22 @@ def _is_out_of_lora_slots(exc: BaseException) -> bool:
     return isinstance(exc, RuntimeError) and _OUT_OF_LORA_SLOTS_MARKER in str(exc)
 
 
+def _min_cap(a: Optional[int], b: Optional[int]) -> Optional[int]:
+    """Combine two spec ``commit_caps`` (per-row token bounds).
+
+    Each cap is an upper bound on tokens a spec macro-step may commit for a row,
+    with ``None`` meaning "no bound" (+inf). The combined cap is the tighter of
+    the two: ``min`` when both are present, the present one when only one is, and
+    ``None`` when neither bounds the row. Used to fold the stateful-mask cap and
+    the remaining-output-budget cap into a single per-row ``commit_caps`` entry.
+    """
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if a <= b else b
+
+
 @dataclass(slots=True)
 class _MaskPlan:
     """Constrained-decode mask for one decode sampling step.
@@ -940,39 +956,61 @@ class GenerationScheduler:
         for seq in active:
             seq.inflight_refs += 1
 
-        if pending is not None:
-            self._commit_spec(pending)
+        # The commit + launch below can raise (e.g. ``decoder.step`` on a CUDA
+        # error). Until ``_pending_spec`` is installed those reserved refs are
+        # owned by nothing -- no future ``_commit_spec`` will decrement them -- so
+        # a finishing row would stay stuck in ``FINALIZING`` and its pool row /
+        # adapter slot would leak. Mirror the non-spec launch path
+        # (``launch_decode_step``): on any failure before the pending step is
+        # installed, roll back exactly the reservation added above, then re-raise.
+        try:
+            if pending is not None:
+                self._commit_spec(pending)
 
-        if active:
-            # Recompute each row's skill mask from the now-current skill state
-            # (post-commit), so stateful skills constrain the drafter + verify
-            # with the up-to-date allowed/suppressed set this step -- not the
-            # admit-time snapshot. Finalized zombies come back unconstrained.
-            # ``commit_caps`` caps a STATEFUL-masked row (one whose allowed/
-            # suppressed set changes per committed token) to a single committed
-            # token this step: the single per-step mask is only exact for one
-            # constraint transition per run, so a row that would otherwise commit
-            # a multi-token run under a stale 1st-position mask is held to one
-            # token and re-masked from the now-current skill state next step (see
-            # ``_build_spec_step_masks`` / ``decoder.step``).
-            (
-                allowed_token_ids,
-                suppressed_token_ids,
-                commit_caps,
-            ) = self._build_spec_step_masks(active)
-            with torch.inference_mode():
-                result = decoder.step(
-                    [seq.state for seq in active],
-                    allowed_token_ids=allowed_token_ids,
-                    suppressed_token_ids=suppressed_token_ids,
-                    commit_caps=commit_caps,
-                )
-            self._pending_spec = (active, result)
-        else:
-            # No launch this tick: roll back the refs reserved above so the
-            # count stays balanced (no-op when ``active`` is empty).
-            for seq in active:
-                seq.inflight_refs -= 1
+            if active:
+                # Recompute each row's skill mask from the now-current skill
+                # state (post-commit), so stateful skills constrain the drafter +
+                # verify with the up-to-date allowed/suppressed set this step --
+                # not the admit-time snapshot. Finalized zombies come back
+                # unconstrained. ``commit_caps`` is the per-row min of two
+                # accept-truncations: the STATEFUL-mask cap (a row whose allowed/
+                # suppressed set changes per committed token is held to one token
+                # this step, since the single per-step mask is only exact for one
+                # constraint transition per run -- then re-masked from the
+                # now-current skill state next step), and the REMAINING-BUDGET cap
+                # (``max_new_tokens - token_count``) so the decoder's KV/proposer
+                # state never advances past the request's output limit (the
+                # optimistic depth-1 zombie step would otherwise run off a row
+                # already past its target length). See ``_build_spec_step_masks``
+                # / ``decoder.step``.
+                (
+                    allowed_token_ids,
+                    suppressed_token_ids,
+                    commit_caps,
+                ) = self._build_spec_step_masks(active)
+                with torch.inference_mode():
+                    result = decoder.step(
+                        [seq.state for seq in active],
+                        allowed_token_ids=allowed_token_ids,
+                        suppressed_token_ids=suppressed_token_ids,
+                        commit_caps=commit_caps,
+                    )
+                self._pending_spec = (active, result)
+            else:
+                # No launch this tick: roll back the refs reserved above so the
+                # count stays balanced (no-op when ``active`` is empty).
+                for seq in active:
+                    seq.inflight_refs -= 1
+        except Exception:
+            # Failure before ``_pending_spec`` was installed: undo this launch's
+            # reservation so the count stays balanced and no row is left with a
+            # phantom ref (mirrors ``launch_decode_step``'s rollback). ``active``
+            # is the only set whose refs this method added; ``_commit_spec``
+            # already decremented whatever it committed before raising.
+            if self._pending_spec is None:
+                for seq in active:
+                    seq.inflight_refs -= 1
+            raise
 
         return bool(active) or pending is not None
 
@@ -2046,19 +2084,39 @@ class GenerationScheduler:
         window.
 
         The third return is the per-row ``commit_caps`` (parallel to
-        ``sequences``): ``1`` for a row whose skill mask is STATEFUL (its
-        allowed/suppressed set changes per committed token), else ``None``
-        (uncapped). The single per-step mask is exact only for one constraint
-        transition per committed run -- a macro-step commits a *variable* run of
-        ``a_i + 1`` tokens under ONE mask, so a stateful row's 2nd..Nth positions
-        would be verified under the stale 1st-position mask (e.g. a detect run
-        could suppress the required ``size_id`` or accept a ``coord`` where
-        ``size`` is required). Capping such a row to one committed token forces
-        exactly one transition per run -- the regime where the per-step mask IS
-        exact, identical to the non-spec one-token-per-step path -- and the next
-        step re-queries the mask from the now-current skill state. A non-stateful
-        (unconstrained, or constant-mask) row stays uncapped so it keeps the full
-        multi-token speculative accept. Returns
+        ``sequences``): the per-row upper bound on tokens this macro-step may
+        commit, the ``min`` of two independent accept-truncation caps (``None``
+        in either slot means that cap is absent / +inf):
+
+        * the STATEFUL-mask cap -- ``1`` for a row whose skill mask changes per
+          committed token, else absent. The single per-step mask is exact only
+          for one constraint transition per committed run: a macro-step commits a
+          *variable* run of ``a_i + 1`` tokens under ONE mask, so a stateful
+          row's 2nd..Nth positions would be verified under the stale
+          1st-position mask (e.g. a detect run could suppress the required
+          ``size_id`` or accept a ``coord`` where ``size`` is required). Capping
+          such a row to one committed token forces exactly one transition per run
+          -- the regime where the per-step mask IS exact, identical to the
+          non-spec one-token-per-step path -- and the next step re-queries the
+          mask from the now-current skill state.
+
+        * the REMAINING-BUDGET cap -- ``max_new_tokens - token_count``, the
+          number of output tokens the request may still emit. ``_commit_spec``
+          already stops *staging* once ``max_new_tokens`` is reached, but the
+          decoder advances its KV / proposer state through the *whole* committed
+          run regardless, so without this cap the row's pool state (and the
+          optimistic depth-1 zombie step launched off it) runs past the request's
+          target length even though the extra tokens are never emitted. Capping
+          the committed run to the remaining budget makes the decoder finish the
+          row at exactly ``max_new_tokens`` -- the same hard stop the non-spec
+          path hits -- so this step's commit lands the final token and
+          ``_commit_spec`` marks it ``length``-finished. A continuing (not
+          finalized) row always has ``token_count < max_new_tokens`` here (else a
+          prior commit would have finished it), so the budget is ``>= 1``.
+
+        A non-stateful row with budget to spare stays uncapped (``None``) so it
+        keeps the full multi-token speculative accept. Finalized/zombie rows come
+        back ``None`` (their tokens are dropped at commit). Returns
         ``(allowed_per_row, suppressed_per_row, commit_caps_per_row)``.
         """
         allowed_tokens: list[Optional[Sequence[int]]] = []
@@ -2074,10 +2132,30 @@ class GenerationScheduler:
             suppressed = seq.skill_state.suppressed_token_ids(self.runtime)
             allowed_tokens.append(allowed)
             suppressed_tokens.append(suppressed)
-            commit_caps.append(
+            stateful_cap = (
                 1 if self._mask_is_stateful(seq, allowed, suppressed) else None
             )
+            budget_cap = self._remaining_commit_budget(seq)
+            commit_caps.append(_min_cap(stateful_cap, budget_cap))
         return allowed_tokens, suppressed_tokens, commit_caps
+
+    def _remaining_commit_budget(self, seq: RequestLifecycle) -> Optional[int]:
+        """Tokens ``seq`` may still emit this macro-step before ``max_new_tokens``.
+
+        The committed run must not advance the decoder past the request's output
+        budget (the non-spec path stops sampling exactly at ``max_new_tokens``).
+        ``skill_state.token_count`` already reflects every token committed through
+        the prior macro-step (this runs post-commit), so the remaining budget is
+        ``max_new_tokens - token_count``. Returns ``None`` (uncapped) only when
+        ``max_new_tokens`` is unset; otherwise the live remaining count, which is
+        ``>= 1`` for any not-yet-finalized row (a row that had already reached the
+        limit would have been finished + retired at the prior commit and is not in
+        this step's ``active`` set).
+        """
+        max_new = seq.request.max_new_tokens
+        if max_new is None:
+            return None
+        return max(0, max_new - seq.skill_state.token_count)
 
     def _mask_is_stateful(
         self,

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -937,17 +937,28 @@ class GenerationScheduler:
             # runtime leaves it ``None`` and the id materialises as a plain
             # ``TextToken`` (unchanged).
             admit_side_values = getattr(state, "admit_side_values", None)
-            (typed_first,) = self._materialize_spec_tokens(
-                [lifecycle], [[int(first_token_id)]], admit_side_values
-            )
-            token = typed_first[0]
             # ``admit`` returns the real first-token logprob for a
             # ``return_logprobs`` request (the sampler's selected-token logprob,
             # matching the non-spec prefill path's transferred ``sampled_logprobs``
-            # for token0) and ``None`` otherwise. Stage it through unchanged --
+            # for token0) and ``None`` otherwise. Thread it through the hook so a
+            # spatial admit token (``coord_id`` / ``size_id`` -- point/detect apply
+            # the skill mask before this first sample) gets its coord/size head
+            # logprob folded in, exactly as the non-spec prefill ``post_sample``
+            # path does. ``None`` (no logprobs requested) stays ``None``.
+            admit_logprobs = None if first_logprob is None else [[first_logprob]]
+            (typed_first,), typed_first_logprobs = self._materialize_spec_tokens(
+                [lifecycle], [[int(first_token_id)]], admit_side_values, admit_logprobs
+            )
+            token = typed_first[0]
+            staged_first_logprob = (
+                typed_first_logprobs[0][0]
+                if typed_first_logprobs is not None
+                else first_logprob
+            )
+            # Stage the (spatial-augmented) first-token logprob through unchanged --
             # no 0.0 greedy-approximation placeholder. The macro-step supplies
             # real per-token logprobs for every subsequently committed token.
-            self._spec_stage_token(lifecycle, token, logprob=first_logprob)
+            self._spec_stage_token(lifecycle, token, logprob=staged_first_logprob)
             progressed = True
             if self._mark_finished_if_needed(lifecycle):
                 lifecycle.finalized = True
@@ -1147,10 +1158,23 @@ class GenerationScheduler:
         active: List[RequestLifecycle],
         runs: Sequence[Sequence[int]],
         side_values: object | None,
-    ) -> list[list[Token]]:
+        logprobs: Sequence[Sequence[float]] | None = None,
+    ) -> tuple[list[list[Token]], list[list[float]] | None]:
         """Type each sequence's committed run via the runtime hook.
 
         ``runs[i]`` is the committed id list for ``active[i]``.
+
+        ``logprobs`` (optional) is the per-committed-token vocab logprob, parallel
+        to ``runs`` (``logprobs[i][j]`` for ``runs[i][j]``). It is the spec
+        decoder's verify-logit logprob -- the vocab head only. A spatial runtime
+        also has a coord/size head whose logprob the non-spec ``post_sample`` path
+        folds into the token logprob in-place; the spec ``materialize_spec_tokens``
+        hook mirrors that, mutating the flat logprob list to add each spatial
+        position's head logprob. We flatten ``logprobs`` into that hook (sequences-
+        major, parallel to the flat ids), then re-group the (now-augmented) values
+        so the caller stages the combined vocab + coord/size logprob for spatial
+        tokens, matching the non-spec convention. ``None`` (no request wanted
+        logprobs) skips this and returns ``None`` for the regrouped logprobs.
 
         Dispatch is on ``side_values`` (the macro-step's :class:`SpecSideValues`),
         which carries the target's per-committed-position final hidden + sampling
@@ -1173,11 +1197,29 @@ class GenerationScheduler:
           ``materialize_tokens`` path with a ``None`` handle (its plain-text
           branch), matching the non-spec single-token commit.
 
-        Returns the typed tokens re-grouped per sequence (parallel to ``runs``).
+        Returns the typed tokens re-grouped per sequence (parallel to ``runs``)
+        plus the per-sequence logprobs (augmented with the spatial head logprob
+        when a spatial hook ran), or ``None`` for the logprobs when ``logprobs``
+        was ``None``.
         """
         flat_ids: list[int] = [int(t) for run in runs for t in run]
         if not flat_ids:
-            return [[] for _ in runs]
+            empty_lp: list[list[float]] | None = (
+                [[] for _ in runs] if logprobs is not None else None
+            )
+            return [[] for _ in runs], empty_lp
+        # Flatten the per-sequence logprobs parallel to the flat ids. The spec hook
+        # may mutate this list in place to fold in each spatial position's
+        # coord/size head logprob (mirroring the non-spec ``post_sample`` path).
+        flat_logprobs: list[float] | None = None
+        if logprobs is not None:
+            flat_logprobs = [float(lp) for run in logprobs for lp in run]
+            if len(flat_logprobs) != len(flat_ids):
+                raise ValueError(
+                    "_materialize_spec_tokens: logprobs length "
+                    f"{len(flat_logprobs)} != committed token count "
+                    f"{len(flat_ids)}"
+                )
         token_ids_cpu = torch.tensor(flat_ids, dtype=torch.long)
         # ``batch_idx`` parallel to the flattened ids (the spec batch row each
         # committed token belongs to); a spatial hook indexes side-values by the
@@ -1210,24 +1252,36 @@ class GenerationScheduler:
                     "(mirror its non-spec materialize_tokens spatial decode) to "
                     "enable spec for spatial skills."
                 )
-            flat_tokens = spec_hook(token_ids_cpu, active, batch_idx, side_values)
+            # The spatial hook folds each coord/size position's head logprob into
+            # ``flat_logprobs`` in place (no-op when ``flat_logprobs`` is ``None``).
+            flat_tokens = spec_hook(
+                token_ids_cpu, active, batch_idx, side_values, flat_logprobs
+            )
         else:
             # Text-only macro-step: the non-spec hook's ``step_handle is None``
-            # branch (plain text) applies.
+            # branch (plain text) applies. No spatial head, so the vocab logprobs
+            # pass through unchanged.
             flat_tokens = self._materialize_tokens(
                 token_ids_cpu,
                 active,
                 batch_idx,
                 None,
             )
-        # Re-group the flat typed tokens back into per-sequence runs.
+        # Re-group the flat typed tokens (and augmented logprobs) into per-sequence
+        # runs parallel to ``runs``.
         grouped: list[list[Token]] = []
+        grouped_logprobs: list[list[float]] | None = (
+            [] if flat_logprobs is not None else None
+        )
         cursor = 0
         for run in runs:
             n = len(run)
             grouped.append(list(flat_tokens[cursor:cursor + n]))
+            if grouped_logprobs is not None:
+                assert flat_logprobs is not None
+                grouped_logprobs.append(list(flat_logprobs[cursor:cursor + n]))
             cursor += n
-        return grouped
+        return grouped, grouped_logprobs
 
     def _commit_spec(self, pending) -> None:
         """Commit one previously-launched spec macro-step (depth-1).
@@ -1248,7 +1302,16 @@ class GenerationScheduler:
         # Type the whole step's committed ids up front (coord/size via the
         # runtime hook using ``side_values``), then stage each typed token below
         # so a mid-run EOS still drops the trailing typed tokens correctly.
-        typed = self._materialize_spec_tokens(active, tokens, side_values)
+        # Passing ``logprobs`` lets the spatial hook fold each coord/size head
+        # logprob into the staged value (mirroring the non-spec ``post_sample``
+        # path); ``typed_logprobs`` is the augmented per-sequence logprobs (or
+        # ``None`` when no request wanted logprobs), which we stage instead of the
+        # raw vocab-only ``logprobs``.
+        typed, typed_logprobs = self._materialize_spec_tokens(
+            active, tokens, side_values, logprobs
+        )
+        if typed_logprobs is not None:
+            logprobs = typed_logprobs
         for i, (seq, typed_run) in enumerate(zip(active, typed)):
             seq.inflight_refs -= 1
             if seq.finalized:

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -856,17 +856,34 @@ class GenerationScheduler:
     def _spec_decode_step(self) -> bool:
         """Run one spec macro-step, overlapped depth-1.
 
-        Launch the macro-step for the current running set *first* (async: the
-        decoder samples + commits on the GPU and returns a lazy
-        ``SpecStepResult`` whose token D2H is in flight), then commit the
-        *previous* macro-step -- whose D2H landed while this launch ran. The CPU
-        commit (token materialize + stage + finish) therefore overlaps GPU
-        compute.
+        Ordering per tick: snapshot membership -> reserve in-flight refs ->
+        commit the previous macro-step -> build this step's masks -> launch.
 
-        Membership is an optimistic snapshot: a sequence finished by the previous
-        commit but already launched here rides as a zombie (``finalized`` with
-        ``inflight_refs > 0``) and is skipped + retired at its own commit next
-        tick -- the same zombie discipline the single-token pipeline uses.
+        Membership is an *optimistic* snapshot taken BEFORE the commit, so a
+        sequence the upcoming commit finishes still rides this tick's launch as
+        a zombie (``finalized`` with ``inflight_refs > 0``) and is skipped +
+        retired at its own commit next tick -- the same zombie discipline the
+        single-token pipeline uses, and the property the depth-1
+        ``has_pending_work`` leak-guard relies on (a finishing sequence's
+        optimistic follow-up step stays pending until committed).
+
+        Why the commit happens before the launch (and before the mask build):
+        ``_commit_spec`` advances each committed sequence's skill state via
+        ``consume_step``, and STATEFUL constrained skills evolve their allowed-
+        token set per committed token (e.g. point toggles ``[coord,eos]`` <->
+        ``[coord]`` every coordinate; detect cycles x->y->size). The mask handed
+        to ``decoder.step`` must therefore be recomputed from the skill state
+        *after* the prior run is committed -- exactly the non-spec
+        commit-before-finalize invariant (``advance`` docstring), where
+        ``_build_mask`` re-queries ``allowed_token_ids`` post-commit.
+        Snapshotting once at ``admit`` and reusing it (as the spec path did)
+        left stateful skills with a stale mask for every later position.
+
+        ``inflight_refs`` is reserved for this launch BEFORE the commit so a
+        sequence present in both the previous step and this one (the common
+        continuing case) never drops to zero refs mid-commit and is not retired
+        out from under the relaunch; its ref is decremented again when this
+        launch is itself committed next tick, keeping the count balanced.
         """
         decoder = self.runtime.spec.decoder
         pending = self._pending_spec
@@ -877,15 +894,35 @@ class GenerationScheduler:
             for seq in self.running
             if not seq.finished and seq.sequence_state is not None
         ]
-        if active:
-            with torch.inference_mode():
-                result = decoder.step([seq.state for seq in active])
-            for seq in active:
-                seq.inflight_refs += 1
-            self._pending_spec = (active, result)
+        # Reserve this launch's ref before the commit (see docstring): protects
+        # continuing sequences from a premature retire when the commit drops
+        # their previous-step ref.
+        for seq in active:
+            seq.inflight_refs += 1
 
         if pending is not None:
             self._commit_spec(pending)
+
+        if active:
+            # Recompute each row's skill mask from the now-current skill state
+            # (post-commit), so stateful skills constrain the drafter + verify
+            # with the up-to-date allowed/suppressed set this step -- not the
+            # admit-time snapshot. Finalized zombies come back unconstrained.
+            allowed_token_ids, suppressed_token_ids = self._build_spec_step_masks(
+                active
+            )
+            with torch.inference_mode():
+                result = decoder.step(
+                    [seq.state for seq in active],
+                    allowed_token_ids=allowed_token_ids,
+                    suppressed_token_ids=suppressed_token_ids,
+                )
+            self._pending_spec = (active, result)
+        else:
+            # No launch this tick: roll back the refs reserved above so the
+            # count stays balanced (no-op when ``active`` is empty).
+            for seq in active:
+                seq.inflight_refs -= 1
 
         return bool(active) or pending is not None
 
@@ -1008,7 +1045,14 @@ class GenerationScheduler:
             seq.inflight_refs -= 1
             if seq.finalized:
                 # Zombie: finished by an earlier commit while still in flight here.
+                # When its last in-flight ref drops, mark the lifecycle COMPLETED
+                # *before* retiring the row, mirroring the non-spec zombie path in
+                # ``commit_step`` (``seq.transition(COMPLETED)`` then release). The
+                # finishing commit left it FINALIZING because ``inflight_refs > 0``;
+                # without this transition a normally-completed spec request stays
+                # stuck in FINALIZING forever after its row is retired.
                 if seq.inflight_refs == 0:
+                    seq.transition(RequestPhase.COMPLETED)
                     self._retire_spec_row(seq.state)
                 continue
             seq_logprobs = logprobs[i] if logprobs is not None else None
@@ -1921,6 +1965,45 @@ class GenerationScheduler:
             all_greedy,
             any_return_logprobs,
         )
+
+    def _build_spec_step_masks(
+        self, sequences: List[RequestLifecycle]
+    ) -> tuple[list[Optional[Sequence[int]]], list[Optional[Sequence[int]]]]:
+        """Per-row skill masks for a spec macro-step, re-queried per step.
+
+        The spec-decode analog of ``_build_mask_spec``'s allowed/suppressed
+        re-query. ``_spec_decode_step`` calls this AFTER committing the previous
+        macro-step (so ``skill_state`` reflects every token committed through the
+        prior run), then threads the result into ``decoder.step`` so the drafter
+        + verify constrain to the *current* allowed/suppressed set instead of the
+        snapshot taken once at ``admit``. This is what keeps STATEFUL skills
+        correct on the spec path (point toggles ``[coord,eos]`` <-> ``[coord]``
+        every coordinate; detect cycles x->y->size), mirroring how the non-spec
+        ``_build_mask`` refreshes the mask each step.
+
+        Finalized/zombie rows come back unconstrained (``None``), exactly like
+        ``_build_mask_spec`` -- their tokens are dropped at commit, so masking
+        them is moot.
+
+        Deliberately does NOT re-apply the request-level one-shot
+        ``suppress_next_token_ids``: that suppression targets a request's *first*
+        generated token only and is applied once, at ``admit`` (which samples
+        that token); re-applying it here would wrongly suppress past the one-shot
+        window. Returns ``(allowed_per_row, suppressed_per_row)`` parallel to
+        ``sequences``.
+        """
+        allowed_tokens: list[Optional[Sequence[int]]] = []
+        suppressed_tokens: list[Optional[Sequence[int]]] = []
+        for seq in sequences:
+            if seq.finalized:
+                allowed_tokens.append(None)
+                suppressed_tokens.append(None)
+                continue
+            allowed_tokens.append(seq.skill_state.allowed_token_ids(self.runtime))
+            suppressed_tokens.append(
+                seq.skill_state.suppressed_token_ids(self.runtime)
+            )
+        return allowed_tokens, suppressed_tokens
 
     def _build_mask(
         self, sequences: List[RequestLifecycle], slot

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -624,12 +624,34 @@ class GenerationScheduler:
                 break
             lifecycle = request.lifecycle
             self.waiting.remove(request)
-            # No spec row, so no ``sequence_state``; ``build_metrics`` then
-            # falls back to ``request.prompt_length`` exactly like the
-            # non-spec 0-length path (which also leaves ``sequence_state``
-            # unset). ``_finalize_sequence`` -> ``_release_sequence``
-            # early-returns for a spec runtime before touching the (absent)
-            # state, so this is safe with ``sequence_state is None``.
+            # No spec row is consumed (``decoder.admit`` is never called), but
+            # this request still carried a (possibly image-bearing) prompt, so
+            # record a minimal ``SequenceState`` purely to carry the KV prompt
+            # length for metrics -- mirroring BOTH the regular spec admit path
+            # (which sets ``prompt_length = len(prompt_tokens) + image_length``)
+            # and the non-spec 0-length path (which sets ``sequence_state`` from
+            # ``prepare_sequence``, whose ``prompt_length`` includes the image
+            # KV prefix). Without it ``build_metrics`` would fall back to the
+            # text-only ``request.prompt_length`` and under-report
+            # ``prompt_tokens`` by ``request.image_length`` for a zero-token
+            # IMAGE request. The KV prompt length is the full prompt --
+            # ``request.prompt_length + request.image_length`` (the same
+            # convention as ``request.target_length``); a zero-token request can
+            # carry no generated prefix, so the typed prefill length equals
+            # ``request.prompt_length`` here. ``batch_idx == -1`` because no pool
+            # row backs this state; it is never dereferenced --
+            # ``_finalize_sequence`` -> ``_release_sequence`` early-returns for a
+            # spec runtime before touching ``batch_idx``, and a zero-token
+            # request never enters the running/active decode paths that read it.
+            kv_prompt_length = request.prompt_length + request.image_length
+            lifecycle.sequence_state = SequenceState(
+                batch_idx=-1,
+                length=kv_prompt_length,
+                max_length=request.target_length,
+                prompt_length=kv_prompt_length,
+                image_length=request.image_length,
+                lora_slot=request.lora_slot,
+            )
             lifecycle.prefill_started_at = time.perf_counter()
             lifecycle.prefill_completed_at = lifecycle.prefill_started_at
             self._finalize_sequence(lifecycle, "length")

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1230,11 +1230,31 @@ class GenerationScheduler:
         the runtime does not speculate (``_pending_spec`` stays ``None``).
         """
         while self._pending_spec is not None:
+            # Snapshot the in-flight step but KEEP ``self._pending_spec`` pointing
+            # at it until ``_commit_spec`` has actually consumed its in-flight refs.
+            # Mirror the keep-until-success guard in ``_spec_decode_step``:
+            # ``_commit_spec`` decrements each pending sequence's ``inflight_refs``
+            # only in its final per-sequence loop, AFTER resolving the lazy
+            # ``result.tokens`` and running ``_materialize_spec_tokens`` -- either
+            # of which can raise (a fail-fast hook, a deferred D2H error). If we
+            # cleared ``_pending_spec`` up front and the commit raised before that
+            # loop, the OLD pending refs would be left on the sequences with no
+            # ``_pending_spec`` record left to ever commit them: a finishing row
+            # would stay stuck in ``FINALIZING`` and leak its decoder row / LoRA
+            # slot, and a later launch from device state would never be staged.
+            # Leaving the record installed keeps those refs owned by
+            # ``_pending_spec`` so the next drain / retry can consume them; we clear
+            # it only once the commit SUCCEEDS (below).
             pending = self._pending_spec
-            self._pending_spec = None
             with stream_context(self._compute_stream):
                 with torch.inference_mode():
                     self._commit_spec(pending)
+            # Commit consumed the in-flight step's refs; only now is it safe to drop
+            # the record. A raise above skips this, leaving ``_pending_spec``
+            # installed so those refs are never orphaned (committed by a later
+            # drain / retry). ``has_pending_work`` still reports True via the
+            # ``_pending_spec is not None`` term, so the executor keeps driving it.
+            self._pending_spec = None
 
     def _materialize_spec_tokens(
         self,

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -770,6 +770,38 @@ class GenerationScheduler:
                         top_p=float(request.top_p),
                     )
             except Exception as exc:
+                # ``admit`` prefills into a free spec pool row and assigns
+                # ``state.batch_idx`` before the prefill's image/CUDA work
+                # runs, so a mid-admit failure can leave the row reserved
+                # (and ``batch_idx`` set) even though no token was staged.
+                # This request has already left ``waiting`` and
+                # ``lifecycle.sequence_state`` is not set yet, so no later
+                # finish/zombie path will ever call ``decoder.retire`` for
+                # it -- the row would leak permanently and repeated failures
+                # would drain ``decoder.free_slots`` and stall unrelated spec
+                # requests. Retire the row here when ``admit`` got far enough
+                # to reserve one (``batch_idx`` left at its ``-1`` sentinel
+                # means it never did, so there is nothing to retire).
+                #
+                # This is NOT ``_retire_spec_row``: that also calls
+                # ``release_adapter_slot(state.lora_slot)``, which would
+                # double-release the LoRA slot the block below already frees
+                # via ``request.lora_slot`` (the same slot). Each resource is
+                # released exactly once -- pool row via ``decoder.retire``,
+                # adapter slot via the ``release_adapter_slot`` below --
+                # mirroring the per-resource cleanup the non-spec
+                # admit-failure path performs.
+                if state.batch_idx >= 0:
+                    try:
+                        decoder.retire(state)
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+                    # ``active_sequences[batch_idx]`` is only populated AFTER
+                    # the ``try`` (on the success path), so on this failure
+                    # path it is normally absent; pop defensively in case a
+                    # future reorder registers it earlier, leaving no dangling
+                    # entry.
+                    self.runtime.active_sequences.pop(state.batch_idx, None)
                 if lifecycle.lora_slot_ready and request.lora_slot:
                     # Release the LoRA slot we acquired for this failed admission
                     # so its refcount does not leak.

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -744,17 +744,25 @@ class GenerationScheduler:
                 suppress_next_token_ids = request.suppress_next_token_ids
             try:
                 with torch.inference_mode():
-                    # Pass the request's image (image prefill: vision block + KV
-                    # prefix), skill mask, one-shot suppression, and sampling
-                    # params (temperature/top_p) through to ``admit`` so image +
-                    # constrained + non-greedy requests run on the spec path with
-                    # no fallback. ``admit`` returns ``(first_token_id,
+                    # Pass the request's image AND its multi-crop tiles
+                    # (``image_crops``) -- exactly what the non-spec
+                    # ``prepare_sequence`` forwards (it hands both to the vision
+                    # encoder, which reads ``image_crops`` as the ``overlap`` so
+                    # the high-res crop tiles are encoded, not just the
+                    # global/thumbnail image). Forwarding ``image`` alone would
+                    # give a multi-crop request an incomplete image prefill on
+                    # the spec path and diverge from the non-spec output. Skill
+                    # mask, one-shot suppression, and sampling params
+                    # (temperature/top_p) likewise go through ``admit`` so image
+                    # + constrained + non-greedy requests run on the spec path
+                    # with no fallback. ``admit`` returns ``(first_token_id,
                     # first_logprob)``: the real selected-token logprob for a
                     # ``return_logprobs`` request, or ``None`` otherwise.
                     first_token_id, first_logprob = decoder.admit(
                         state,
                         prompt_tokens,
                         image=request.image,
+                        image_crops=request.image_crops,
                         allowed_token_ids=allowed_token_ids,
                         suppressed_token_ids=suppressed_token_ids,
                         suppress_next_token_ids=suppress_next_token_ids,

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -616,7 +616,18 @@ class GenerationScheduler:
                     progressed = True
                     continue
 
-            prompt_ids = [int(t.token_id) for t in request.prefill_tokens]
+            # Hand ``admit`` the request's *typed* prefill tokens -- exactly the
+            # ``prompt_tokens`` the non-spec ``prepare_sequence`` path receives --
+            # not a text-only ``int(t.token_id)`` projection. A launchable prefill
+            # can contain non-text tokens: multi-image chat prompts carry
+            # ``ImageMarker`` tokens, and a generated prefix (resumed request) can
+            # carry ``CoordToken`` / ``SizeToken``; none of those expose
+            # ``token_id``, so stripping every token to its id would raise
+            # ``AttributeError`` here -- *before* the per-request ``try`` below --
+            # and abort the whole scheduler instead of admitting or failing just
+            # this request. ``admit`` (like ``prepare_sequence``) expands
+            # ``ImageMarker``s with the image KV prefix and reads the typed ids.
+            prompt_tokens = list(request.prefill_tokens)
             # Admission capacity is the decoder's free rows: the spec decoder
             # owns a fixed, pre-reserved pool of page-table rows (its captured
             # graphs depend on them), so ``runtime.can_reserve`` -- which gates on
@@ -626,11 +637,13 @@ class GenerationScheduler:
             lifecycle.prefill_started_at = time.perf_counter()
             lifecycle.transition(RequestPhase.PREFILLING)
             # batch_idx is assigned by ``admit`` (it picks the spec pool row).
+            # ``length`` / ``prompt_length`` are the token *count* (markers count
+            # as one each; ``admit`` expands them and owns the real KV length).
             state = SequenceState(
                 batch_idx=-1,
-                length=len(prompt_ids),
+                length=len(prompt_tokens),
                 max_length=request.target_length,
-                prompt_length=len(prompt_ids),
+                prompt_length=len(prompt_tokens),
                 lora_slot=request.lora_slot,
             )
             # The spec decoder reads ``return_logprobs`` off the state to decide
@@ -685,7 +698,7 @@ class GenerationScheduler:
                     # ``return_logprobs`` request, or ``None`` otherwise.
                     first_token_id, first_logprob = decoder.admit(
                         state,
-                        prompt_ids,
+                        prompt_tokens,
                         image=request.image,
                         allowed_token_ids=allowed_token_ids,
                         suppressed_token_ids=suppressed_token_ids,
@@ -714,17 +727,20 @@ class GenerationScheduler:
             # Stage the first (prefill/bonus) token exactly like the non-spec
             # prefill path: consume_step + streaming + finish check.
             #
-            # Type the admit token through the runtime ``materialize_tokens``
-            # hook -- not a hard-coded ``TextToken``. On a spatial runtime the
-            # first generated id can be ``coord_id`` / ``size_id`` (point/detect
-            # apply the skill mask before this first sample), so it must become a
-            # ``CoordToken`` / ``SizeToken`` the way the non-spec prefill path
-            # does via ``post_sample`` -> ``materialize_tokens``; otherwise the
-            # first coordinate/box component is dropped. ``admit`` surfaces the
+            # Type the admit token through the runtime hook -- not a hard-coded
+            # ``TextToken``. On a spatial runtime the first generated id can be
+            # ``coord_id`` / ``size_id`` (point/detect apply the skill mask before
+            # this first sample), so it must become a ``CoordToken`` /
+            # ``SizeToken`` the way the non-spec prefill path does via
+            # ``post_sample`` -> ``materialize_tokens``; otherwise the first
+            # coordinate/box component is dropped. ``admit`` surfaces the
             # admit-position side-values (the target's last hidden + sampling
             # knobs the spatial hook needs to decode the coord/size value) on
-            # ``state.admit_side_values``; a text-only runtime leaves it ``None``
-            # and the id materialises as a plain ``TextToken`` (unchanged).
+            # ``state.admit_side_values`` -- a :class:`SpecSideValues`, so
+            # ``_materialize_spec_tokens`` routes it through the spec-aware
+            # ``materialize_spec_tokens`` hook (not the non-spec one). A text-only
+            # runtime leaves it ``None`` and the id materialises as a plain
+            # ``TextToken`` (unchanged).
             admit_side_values = getattr(state, "admit_side_values", None)
             (typed_first,) = self._materialize_spec_tokens(
                 [lifecycle], [[int(first_token_id)]], admit_side_values
@@ -740,8 +756,7 @@ class GenerationScheduler:
             progressed = True
             if self._mark_finished_if_needed(lifecycle):
                 lifecycle.finalized = True
-                decoder.retire(state)
-                self.runtime.active_sequences.pop(state.batch_idx, None)
+                self._retire_spec_row(state)
                 continue
             self.running.push(lifecycle)
         return progressed
@@ -762,6 +777,26 @@ class GenerationScheduler:
         to ``stage_token`` exactly like the non-spec single-token path.
         """
         seq.stage_token(self.runtime, token, logprob=logprob)
+
+    def _retire_spec_row(self, state: SequenceState) -> None:
+        """Release every resource a finished spec row holds.
+
+        The single spec-path retire point. The spec decoder owns the pool's
+        page-table rows, so ``decoder.retire`` (not ``runtime.release_sequence``)
+        reclaims the row; ``_release_sequence`` deliberately early-returns for a
+        spec runtime to avoid erasing those persistently-reserved pages. But the
+        adapter slot is *not* part of that pool -- ``_spec_admit`` acquires it via
+        ``_acquire_adapter_slot`` exactly like the non-spec prefill path, which
+        releases it in ``runtime.release_sequence`` -> ``release_adapter_slot``.
+        Since the spec path skips ``release_sequence``, release the slot here too;
+        otherwise every completed adapter spec request leaks its LoRA slot until
+        the adapter pool starves. ``release_adapter_slot`` is a no-op for
+        ``lora_slot == 0`` (a base-model request), so this is unconditional.
+        """
+        decoder = self.runtime.spec.decoder
+        decoder.retire(state)
+        self.runtime.active_sequences.pop(state.batch_idx, None)
+        self.runtime.release_adapter_slot(state.lora_slot)
 
     def _spec_decode_step(self) -> bool:
         """Run one spec macro-step, overlapped depth-1.
@@ -795,7 +830,7 @@ class GenerationScheduler:
             self._pending_spec = (active, result)
 
         if pending is not None:
-            self._commit_spec(decoder, pending)
+            self._commit_spec(pending)
 
         return bool(active) or pending is not None
 
@@ -807,15 +842,27 @@ class GenerationScheduler:
     ) -> list[list[Token]]:
         """Type each sequence's committed run via the runtime hook.
 
-        ``runs[i]`` is the committed id list for ``active[i]``. Routes the whole
-        step's ids through the runtime ``materialize_tokens`` hook, threading
-        ``side_values`` (the macro-step's :class:`SpecSideValues`) as the opaque
-        runtime step-handle so a spatial runtime (Moondream) types coord/size ids
-        into ``CoordToken`` / ``SizeToken`` from the per-position hidden it
-        carries -- the spec analog of the non-spec ``post_sample`` ->
-        ``materialize_tokens`` path. A text-only runtime (``side_values is None``,
-        or no hook) materialises plain ``TextToken``s. Returns the typed tokens
-        re-grouped per sequence (parallel to ``runs``).
+        ``runs[i]`` is the committed id list for ``active[i]``.
+
+        Dispatch is on ``side_values`` (the macro-step's :class:`SpecSideValues`),
+        which carries the target's per-committed-position final hidden + sampling
+        knobs a spatial runtime decodes coord/size ids from. It must NOT be handed
+        to the non-spec ``materialize_tokens`` hook: that hook's step-handle is the
+        ``post_sample`` aux handle (Moondream unpacks it as ``(slot, batch_size)``
+        and synchronises slot-local staging), so feeding it a ``SpecSideValues``
+        raises (cannot unpack) or reads the wrong layout. So:
+
+        * ``side_values`` set -> route through the dedicated
+          ``materialize_spec_tokens`` hook (the spec analog that decodes coord/size
+          from the packed hidden). If the runtime exposes no such hook (text-only,
+          or a runtime that does not type spatial tokens on the spec path),
+          *guard* by materialising plain ``TextToken``s rather than misusing the
+          non-spec hook.
+        * ``side_values is None`` -> a text-only macro-step; use the normal
+          ``materialize_tokens`` path with a ``None`` handle (its plain-text
+          branch), matching the non-spec single-token commit.
+
+        Returns the typed tokens re-grouped per sequence (parallel to ``runs``).
         """
         flat_ids: list[int] = [int(t) for run in runs for t in run]
         if not flat_ids:
@@ -829,12 +876,29 @@ class GenerationScheduler:
             seq.state.batch_idx for seq, run in zip(active, runs) for _ in run
         ]
         batch_idx = torch.tensor(batch_indices, dtype=torch.long)
-        flat_tokens = self._materialize_tokens(
-            token_ids_cpu,
-            active,
-            batch_idx,
-            side_values,
-        )
+        if side_values is not None:
+            spec_hook = self._hooks.materialize_spec_tokens
+            if spec_hook is not None:
+                flat_tokens = spec_hook(
+                    token_ids_cpu, active, batch_idx, side_values
+                )
+            else:
+                # Guard: a runtime that does not type spatial tokens on the spec
+                # path still returned side-values; never pass them to the
+                # non-spec hook -- materialise plain text ids.
+                flat_tokens = [
+                    TextToken(token_id=int(t))
+                    for t in token_ids_cpu.view(-1).tolist()
+                ]
+        else:
+            # Text-only macro-step: the non-spec hook's ``step_handle is None``
+            # branch (plain text) applies.
+            flat_tokens = self._materialize_tokens(
+                token_ids_cpu,
+                active,
+                batch_idx,
+                None,
+            )
         # Re-group the flat typed tokens back into per-sequence runs.
         grouped: list[list[Token]] = []
         cursor = 0
@@ -844,7 +908,7 @@ class GenerationScheduler:
             cursor += n
         return grouped
 
-    def _commit_spec(self, decoder, pending) -> None:
+    def _commit_spec(self, pending) -> None:
         """Commit one previously-launched spec macro-step (depth-1).
 
         Resolving ``result.tokens`` blocks on the macro-step's deferred D2H, but
@@ -869,8 +933,7 @@ class GenerationScheduler:
             if seq.finalized:
                 # Zombie: finished by an earlier commit while still in flight here.
                 if seq.inflight_refs == 0:
-                    decoder.retire(seq.state)
-                    self.runtime.active_sequences.pop(seq.state.batch_idx, None)
+                    self._retire_spec_row(seq.state)
                 continue
             seq_logprobs = logprobs[i] if logprobs is not None else None
             for j, token in enumerate(typed_run):
@@ -881,8 +944,7 @@ class GenerationScheduler:
                     seq.finalized = True
                     self.running.remove(seq)
                     if seq.inflight_refs == 0:
-                        decoder.retire(seq.state)
-                        self.runtime.active_sequences.pop(seq.state.batch_idx, None)
+                        self._retire_spec_row(seq.state)
                     break
 
     def pop_completed(self) -> List[SchedulerResult]:

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -610,9 +610,46 @@ class GenerationScheduler:
                 prompt_length=len(prompt_ids),
                 lora_slot=request.lora_slot,
             )
+            # The spec decoder reads ``return_logprobs`` off the state to decide
+            # whether ``step`` computes per-committed-token logprobs for this row
+            # (matching the non-spec sampler, which gates the logprob gather on
+            # the request). ``SequenceState`` is a plain dataclass, so attach it
+            # as an extra attribute the decoder picks up via ``getattr``.
+            state.return_logprobs = request.return_logprobs is True
+
+            # Run the skill's prefill hook BEFORE building the mask + admitting:
+            # ``admit`` prefills *and* samples the first (bonus) token in one
+            # call, so the row's skill mask has to be installed before that
+            # sample -- and some skills (e.g. query) initialise the ids their
+            # ``allowed_token_ids`` depends on inside ``on_prefill``. The hook
+            # only reads ``runtime.prompt_template`` (no dependency on the
+            # forward having run), so running it here is safe.
+            request.skill_state.on_prefill(self.runtime)
+
+            # Per-sequence constrained-decode mask (skill whitelist/blacklist),
+            # forwarded into ``admit`` so the spec path constrains the drafter +
+            # verify exactly like the non-spec sampler's whitelist-then-blacklist
+            # -- no gating to a text-only/unconstrained fallback. ``None`` leaves
+            # the row unmasked.
+            allowed_token_ids = request.skill_state.allowed_token_ids(self.runtime)
+            suppressed_token_ids = request.skill_state.suppressed_token_ids(
+                self.runtime
+            )
             try:
                 with torch.inference_mode():
-                    first_token_id = decoder.admit(state, prompt_ids)
+                    # Pass the request's image (image prefill: vision block + KV
+                    # prefix), skill mask, and sampling params (temperature/top_p)
+                    # through to ``admit`` so image + constrained + non-greedy
+                    # requests run on the spec path with no fallback.
+                    first_token_id = decoder.admit(
+                        state,
+                        prompt_ids,
+                        image=request.image,
+                        allowed_token_ids=allowed_token_ids,
+                        suppressed_token_ids=suppressed_token_ids,
+                        temperature=float(request.temperature),
+                        top_p=float(request.top_p),
+                    )
             except Exception as exc:
                 if lifecycle.lora_slot_ready and request.lora_slot:
                     # Release the LoRA slot we acquired for this failed admission
@@ -630,33 +667,18 @@ class GenerationScheduler:
             lifecycle.sequence_state = state
             lifecycle.prefill_completed_at = time.perf_counter()
             self.runtime.active_sequences[state.batch_idx] = state
-            request.skill_state.on_prefill(self.runtime)
-
-            # TODO(spec-logprobs): the spec macro-step does not yet supply
-            # per-token logprobs (``admit`` returns only a token id and
-            # ``SpecStepResult`` carries none). Until the speculator branch
-            # populates them on the compute side, a ``return_logprobs`` request
-            # cannot be served on the spec path. Reject just that request here --
-            # cleanly retiring the row/slot ``admit`` allocated -- instead of
-            # letting ``stage_token`` raise a scheduler-wide exception on a None
-            # logprob. Once the macro-step provides logprobs, stage them through
-            # ``_spec_stage_token`` like the non-spec path.
-            if request.return_logprobs is True:
-                self._fail_admitted_spec_request(
-                    decoder,
-                    lifecycle,
-                    RuntimeError(
-                        "Speculative decoding does not yet support logprobs; "
-                        "disable speculation for return_logprobs requests."
-                    ),
-                )
-                progressed = True
-                continue
 
             # Stage the first (prefill/bonus) token exactly like the non-spec
-            # prefill path: consume_step + streaming + finish check.
+            # prefill path: consume_step + streaming + finish check. ``admit``
+            # returns the greedy/bonus token id (it does not type the token or
+            # return a logprob), so the first token is a ``TextToken`` and, for a
+            # ``return_logprobs`` request, carries the greedy-bonus logprob (0.0
+            # under the non-spec sampler's greedy convention -- the bonus token
+            # is the argmax of the prefill logits). The macro-step supplies real
+            # per-token logprobs for every subsequently committed token.
             token = TextToken(token_id=int(first_token_id))
-            self._spec_stage_token(lifecycle, token, logprob=None)
+            first_logprob = 0.0 if request.return_logprobs is True else None
+            self._spec_stage_token(lifecycle, token, logprob=first_logprob)
             progressed = True
             if self._mark_finished_if_needed(lifecycle):
                 lifecycle.finalized = True
@@ -676,61 +698,12 @@ class GenerationScheduler:
         """Stage one spec-committed token onto ``seq``.
 
         Mirrors ``RequestLifecycle.stage_token`` but is the single spec-path
-        staging point. ``return_logprobs`` requests are rejected at admission
-        (the spec macro-step cannot supply logprobs yet, see the
-        ``# TODO(spec-logprobs)`` above), so any sequence reaching here either
-        does not want logprobs or carries a real one. The non-None ``logprob``
-        branch is wired so that the day the macro-step supplies logprobs they
-        flow through unchanged.
+        staging point. ``logprob`` is the macro-step's per-committed-token
+        logprob (``SpecStepResult.logprobs``) for a ``return_logprobs`` request,
+        or ``None`` when the request did not ask for logprobs; it flows through
+        to ``stage_token`` exactly like the non-spec single-token path.
         """
         seq.stage_token(self.runtime, token, logprob=logprob)
-
-    def _fail_admitted_spec_request(
-        self,
-        decoder,
-        seq: RequestLifecycle,
-        exc: Exception,
-    ) -> None:
-        """Fail one already-admitted spec sequence cleanly (no scheduler abort).
-
-        ``admit`` has already allocated a pool row (and the caller a LoRA slot),
-        so retire the row, drop it from ``active_sequences``, release any LoRA
-        slot, and emit an error result for just this request. The request was
-        not yet pushed onto ``running``.
-        """
-        _LOGGER.warning(
-            "Failing spec request %s: %s", seq.request.request_id, exc
-        )
-        state = seq.sequence_state
-        if state is not None:
-            try:
-                decoder.retire(state)
-            except Exception:  # pragma: no cover - defensive
-                pass
-            self.runtime.active_sequences.pop(state.batch_idx, None)
-        request = seq.request
-        if seq.lora_slot_ready and request.lora_slot:
-            try:
-                self.runtime.release_adapter_slot(request.lora_slot)
-            except Exception:  # pragma: no cover - defensive
-                pass
-            request.lora_slot = 0
-            seq.lora_slot_ready = False
-        seq.finish_reason = "error"
-        seq.error = exc
-        seq.finished = True
-        seq.finalized = True
-        seq.transition(RequestPhase.COMPLETED)
-        metrics = seq.build_metrics(decode_tokens=0)
-        self._completed.append(
-            SchedulerResult(
-                request_id=request.request_id,
-                tokens=[],
-                finish_reason="error",
-                metrics=metrics,
-                output={"error": str(exc)},
-            )
-        )
 
     def _spec_decode_step(self) -> bool:
         """Run one spec macro-step, overlapped depth-1.
@@ -768,6 +741,51 @@ class GenerationScheduler:
 
         return bool(active) or pending is not None
 
+    def _materialize_spec_tokens(
+        self,
+        active: List[RequestLifecycle],
+        runs: Sequence[Sequence[int]],
+        side_values: object | None,
+    ) -> list[list[Token]]:
+        """Type each sequence's committed run via the runtime hook.
+
+        ``runs[i]`` is the committed id list for ``active[i]``. Routes the whole
+        step's ids through the runtime ``materialize_tokens`` hook, threading
+        ``side_values`` (the macro-step's :class:`SpecSideValues`) as the opaque
+        runtime step-handle so a spatial runtime (Moondream) types coord/size ids
+        into ``CoordToken`` / ``SizeToken`` from the per-position hidden it
+        carries -- the spec analog of the non-spec ``post_sample`` ->
+        ``materialize_tokens`` path. A text-only runtime (``side_values is None``,
+        or no hook) materialises plain ``TextToken``s. Returns the typed tokens
+        re-grouped per sequence (parallel to ``runs``).
+        """
+        flat_ids: list[int] = [int(t) for run in runs for t in run]
+        if not flat_ids:
+            return [[] for _ in runs]
+        token_ids_cpu = torch.tensor(flat_ids, dtype=torch.long)
+        # ``batch_idx`` parallel to the flattened ids (the spec batch row each
+        # committed token belongs to); a spatial hook indexes side-values by the
+        # active-sequence order, but keep the row ids aligned for hooks that key
+        # off them.
+        batch_indices: list[int] = [
+            seq.state.batch_idx for seq, run in zip(active, runs) for _ in run
+        ]
+        batch_idx = torch.tensor(batch_indices, dtype=torch.long)
+        flat_tokens = self._materialize_tokens(
+            token_ids_cpu,
+            active,
+            batch_idx,
+            side_values,
+        )
+        # Re-group the flat typed tokens back into per-sequence runs.
+        grouped: list[list[Token]] = []
+        cursor = 0
+        for run in runs:
+            n = len(run)
+            grouped.append(list(flat_tokens[cursor:cursor + n]))
+            cursor += n
+        return grouped
+
     def _commit_spec(self, decoder, pending) -> None:
         """Commit one previously-launched spec macro-step (depth-1).
 
@@ -775,11 +793,20 @@ class GenerationScheduler:
         that transfer completed while the GPU ran the step launched after it, so
         the wait is hidden. Mirrors ``commit_step``'s decode commit: decrement
         ``inflight_refs``, skip + retire zombies, else stage the variable run of
-        committed tokens and finish/retire on EOS or length cap.
+        committed tokens (typed via the runtime hook, each with its macro-step
+        logprob) and finish/retire on EOS or length cap.
         """
         active, result = pending
-        tokens = result.tokens  # lazy: waits the (already-landed) deferred D2H
-        for seq, new_token_ids in zip(active, tokens):
+        # ``tokens``/``logprobs`` resolve lazily off the (already-landed) D2H;
+        # ``side_values`` holds device tensors read at ``step`` time.
+        tokens = result.tokens
+        logprobs = result.logprobs  # None when nobody requested logprobs
+        side_values = result.side_values
+        # Type the whole step's committed ids up front (coord/size via the
+        # runtime hook using ``side_values``), then stage each typed token below
+        # so a mid-run EOS still drops the trailing typed tokens correctly.
+        typed = self._materialize_spec_tokens(active, tokens, side_values)
+        for i, (seq, typed_run) in enumerate(zip(active, typed)):
             seq.inflight_refs -= 1
             if seq.finalized:
                 # Zombie: finished by an earlier commit while still in flight here.
@@ -787,15 +814,11 @@ class GenerationScheduler:
                     decoder.retire(seq.state)
                     self.runtime.active_sequences.pop(seq.state.batch_idx, None)
                 continue
-            for token_id in new_token_ids:
+            seq_logprobs = logprobs[i] if logprobs is not None else None
+            for j, token in enumerate(typed_run):
                 seq.state.advance()  # KV length mirrors the committed token
-                token = TextToken(token_id=int(token_id))
-                # TODO(spec-logprobs): pass the macro-step's per-token logprob
-                # here once ``SpecStepResult`` carries them. ``return_logprobs``
-                # requests are rejected at spec admission today, so every
-                # sequence reaching this commit has ``return_logprobs`` unset and
-                # ``stage_token`` does not require a logprob.
-                self._spec_stage_token(seq, token, logprob=None)
+                logprob = seq_logprobs[j] if seq_logprobs is not None else None
+                self._spec_stage_token(seq, token, logprob=logprob)
                 if self._mark_finished_if_needed(seq):
                     seq.finalized = True
                     self.running.remove(seq)

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -2281,17 +2281,35 @@ class GenerationScheduler:
         first-position mask. This decides that cap from the live skill state,
         model-agnostically (the scheduler never imports a model's skills).
 
-        A skill may declare its mask precisely via an optional
-        ``mask_is_stateful`` attribute / property on its ``SkillState`` (``True``
-        => evolving, ``False`` => provably constant); when present that wins. In
-        its absence the conservative behavioural rule is: any ACTIVE constraint
-        (a non-empty ``allowed`` whitelist or ``suppressed`` blacklist this step)
-        is treated as potentially stateful and capped, because the scheduler
-        cannot prove the set is position-independent without model knowledge.
-        Correctness-first: over-capping a constant-mask skill only costs that
-        row's intra-step speculation (it still advances one token per step), while
-        under-capping a stateful one corrupts constrained output. A row with no
-        active constraint is never stateful and keeps the full multi-token accept.
+        A skill MUST declare its mask precisely via the ``mask_is_stateful``
+        attribute / property on its ``SkillState`` (``True`` => evolving,
+        ``False`` => provably constant) whenever its mask is anything other than
+        a single constant set held for the whole generation; when present that
+        declaration wins. The behavioural fallback below is only a safety net for
+        states that never declare, and it is NOT sufficient on its own for an
+        important class of stateful masks: it inspects the constraint at the run's
+        FIRST position, so it cannot see a mask that is INACTIVE at step start but
+        transitions to ACTIVE within the committed run. Reasoning skills do
+        exactly this -- ``QuerySkillState`` / ``ChatSkillState`` hold no
+        constraint while collecting reasoning (for non-moondream2 query, and for
+        chat, both ``allowed`` and ``suppressed`` are ``None``), then force a
+        ``post_reasoning_prefix`` AFTER the model emits ``answer_id``; if a run
+        committed ``answer_id`` plus following tokens under that None-at-start
+        mask, the post-boundary tokens would be accepted WITHOUT the required
+        prefix constraint. Those states therefore declare ``mask_is_stateful =
+        True`` so they are always capped (see their class comments); the fallback
+        alone would wrongly return ``False`` for them.
+
+        In the absence of a declaration the conservative behavioural rule is: any
+        ACTIVE constraint (a non-empty ``allowed`` whitelist or ``suppressed``
+        blacklist this step) is treated as potentially stateful and capped,
+        because the scheduler cannot prove the set is position-independent without
+        model knowledge. Correctness-first: over-capping a constant-mask skill
+        only costs that row's intra-step speculation (it still advances one token
+        per step), while under-capping a stateful one corrupts constrained
+        output. A row with no active constraint AND no stateful declaration is
+        treated as non-stateful and keeps the full multi-token accept -- which is
+        why a transitions-from-None mask must not rely on the fallback.
         """
         declared = getattr(seq.skill_state, "mask_is_stateful", None)
         if declared is not None:

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -915,13 +915,19 @@ class GenerationScheduler:
         Ordering per tick: snapshot membership -> reserve in-flight refs ->
         commit the previous macro-step -> build this step's masks -> launch.
 
-        Membership is an *optimistic* snapshot taken BEFORE the commit, so a
-        sequence the upcoming commit finishes still rides this tick's launch as
-        a zombie (``finalized`` with ``inflight_refs > 0``) and is skipped +
-        retired at its own commit next tick -- the same zombie discipline the
-        single-token pipeline uses, and the property the depth-1
-        ``has_pending_work`` leak-guard relies on (a finishing sequence's
-        optimistic follow-up step stays pending until committed).
+        Membership is an *optimistic* snapshot taken BEFORE the commit. The
+        commit can FINALIZE a sequence (it hit ``max_new_tokens`` / EOS); because
+        the snapshot predates the commit, such a row is still in ``active`` but
+        must NOT be launched into another macro-step -- its ``state.length`` can
+        already equal ``max_length`` and a real decoder that reserves only the
+        request budget would advance/write past the row. So after the commit the
+        snapshot is filtered: rows the commit finalized are dropped from this
+        launch and retired SYNCHRONOUSLY (their reserved ref is released and the
+        row retired here, mirroring ``_commit_spec``'s zombie branch), exactly
+        like the non-spec launch set, which excludes finalized rows via
+        ``_can_dispatch``. Only continuing rows are launched. The depth-1
+        ``has_pending_work`` leak-guard (``_pending_spec is not None``) still
+        covers a launched-but-uncommitted step for those continuing rows.
 
         Why the commit happens before the launch (and before the mask build):
         ``_commit_spec`` advances each committed sequence's skill state via
@@ -967,22 +973,44 @@ class GenerationScheduler:
             if pending is not None:
                 self._commit_spec(pending)
 
+            # The commit above can FINALIZE a row (its last allowed token was
+            # ``length``-committed), which sets ``finalized`` and removes it from
+            # ``running`` but cannot retire it yet because the ref reserved above
+            # keeps ``inflight_refs > 0``. That row is still in ``active`` (the
+            # snapshot predates the commit), so it must NOT be launched into
+            # another macro-step: its ``SequenceState.length`` can already equal
+            # ``max_length``, and ``_build_spec_step_masks`` returns ``None`` caps
+            # for a finalized row, so the decoder would be asked to advance/write
+            # past a row that has no budget left (the non-spec launch set excludes
+            # finalized rows via ``_can_dispatch``). Drop those rows from the
+            # launch and turn each one's reserved ref into an immediate retire
+            # (mirrors ``_commit_spec``'s zombie branch: COMPLETED then retire when
+            # the last ref clears).
+            launchable = []
+            for seq in active:
+                if seq.finalized:
+                    seq.inflight_refs -= 1
+                    if seq.inflight_refs == 0:
+                        seq.transition(RequestPhase.COMPLETED)
+                        self._retire_spec_row(seq.state)
+                else:
+                    launchable.append(seq)
+            active = launchable
+
             if active:
                 # Recompute each row's skill mask from the now-current skill
                 # state (post-commit), so stateful skills constrain the drafter +
                 # verify with the up-to-date allowed/suppressed set this step --
-                # not the admit-time snapshot. Finalized zombies come back
-                # unconstrained. ``commit_caps`` is the per-row min of two
-                # accept-truncations: the STATEFUL-mask cap (a row whose allowed/
-                # suppressed set changes per committed token is held to one token
-                # this step, since the single per-step mask is only exact for one
-                # constraint transition per run -- then re-masked from the
+                # not the admit-time snapshot. ``commit_caps`` is the per-row min
+                # of two accept-truncations: the STATEFUL-mask cap (a row whose
+                # allowed/suppressed set changes per committed token is held to one
+                # token this step, since the single per-step mask is only exact for
+                # one constraint transition per run -- then re-masked from the
                 # now-current skill state next step), and the REMAINING-BUDGET cap
                 # (``max_new_tokens - token_count``) so the decoder's KV/proposer
-                # state never advances past the request's output limit (the
-                # optimistic depth-1 zombie step would otherwise run off a row
-                # already past its target length). See ``_build_spec_step_masks``
-                # / ``decoder.step``.
+                # state never advances past the request's output limit. Rows
+                # finalized by the commit above were already dropped from
+                # ``active``. See ``_build_spec_step_masks`` / ``decoder.step``.
                 (
                     allowed_token_ids,
                     suppressed_token_ids,
@@ -996,11 +1024,6 @@ class GenerationScheduler:
                         commit_caps=commit_caps,
                     )
                 self._pending_spec = (active, result)
-            else:
-                # No launch this tick: roll back the refs reserved above so the
-                # count stays balanced (no-op when ``active`` is empty).
-                for seq in active:
-                    seq.inflight_refs -= 1
         except Exception:
             # Failure before ``_pending_spec`` was installed: undo this launch's
             # reservation so the count stays balanced and no row is left with a

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -56,6 +56,17 @@ _SAMPLING_EPS = 1e-6
 # Prefer seeding miss-frontier work only when launch capacity is large enough to
 # absorb the short-term hit latency tradeoff.
 _MISS_FRONTIER_MIN_CAPACITY = 32
+# Marker the LoRA slot manager raises when every adapter slot is in use (see
+# ``LoRASlotManager.acquire`` -> "Out of LoRA slots: all N slots are in use").
+# Only this RuntimeError is a recoverable, retry-once-a-slot-frees deferral;
+# every other RuntimeError from adapter acquisition (e.g. a CUDA load/copy
+# failure) is unrecoverable and must fail the request, not loop forever.
+_OUT_OF_LORA_SLOTS_MARKER = "Out of LoRA slots"
+
+
+def _is_out_of_lora_slots(exc: BaseException) -> bool:
+    """True only for the recoverable out-of-LoRA-slots signal."""
+    return isinstance(exc, RuntimeError) and _OUT_OF_LORA_SLOTS_MARKER in str(exc)
 
 
 @dataclass(slots=True)
@@ -574,6 +585,16 @@ class GenerationScheduler:
                     request.lora_slot = self._acquire_adapter_slot(request.adapter)
                     lifecycle.lora_slot_ready = True
                 except RuntimeError as exc:
+                    if not _is_out_of_lora_slots(exc):
+                        # Not the recoverable out-of-slots case: a genuine
+                        # adapter load/copy failure (e.g. a CUDA error while
+                        # loading a new slot) also surfaces as a RuntimeError.
+                        # Retrying it would loop forever, so fail this request
+                        # cleanly instead of deferring it.
+                        self.waiting.remove(request)
+                        self._fail_request_early(request, exc)
+                        progressed = True
+                        continue
                     # Out of LoRA slots: recoverable. The request is genuinely
                     # blocked on a LoRA resource, so put it back in
                     # WAITING_RESOURCES (it stays in the waiting queue) and try
@@ -587,7 +608,9 @@ class GenerationScheduler:
                     deferred_ids.add(request.request_id)
                     continue
                 except Exception as exc:
-                    # Unrecoverable adapter load/config error: fail this request.
+                    # Unrecoverable adapter load/config error (NotImplementedError
+                    # for an unconfigured provider, ValueError for a rank/device
+                    # mismatch, etc.): fail this request rather than retry it.
                     self.waiting.remove(request)
                     self._fail_request_early(request, exc)
                     progressed = True
@@ -635,18 +658,38 @@ class GenerationScheduler:
             suppressed_token_ids = request.skill_state.suppressed_token_ids(
                 self.runtime
             )
+            # Request-level *one-shot* suppression. The non-spec path applies
+            # ``suppress_next_token_ids`` to a request's first generated token
+            # only (``_build_mask_spec`` gates it on
+            # ``token_count == generated_prefix_length``). ``admit`` samples that
+            # exact first token, so forward the suppression here -- otherwise a
+            # suppressed id can be sampled at admit, staged, and the one-shot
+            # window closes (``token_count`` advances) before ``step`` could ever
+            # apply it. ``None`` when the request set no one-shot suppression or
+            # already generated past its prefix (resumed request).
+            suppress_next_token_ids = None
+            if (
+                request.suppress_next_token_ids
+                and request.skill_state.token_count
+                == request.generated_prefix_length
+            ):
+                suppress_next_token_ids = request.suppress_next_token_ids
             try:
                 with torch.inference_mode():
                     # Pass the request's image (image prefill: vision block + KV
-                    # prefix), skill mask, and sampling params (temperature/top_p)
-                    # through to ``admit`` so image + constrained + non-greedy
-                    # requests run on the spec path with no fallback.
-                    first_token_id = decoder.admit(
+                    # prefix), skill mask, one-shot suppression, and sampling
+                    # params (temperature/top_p) through to ``admit`` so image +
+                    # constrained + non-greedy requests run on the spec path with
+                    # no fallback. ``admit`` returns ``(first_token_id,
+                    # first_logprob)``: the real selected-token logprob for a
+                    # ``return_logprobs`` request, or ``None`` otherwise.
+                    first_token_id, first_logprob = decoder.admit(
                         state,
                         prompt_ids,
                         image=request.image,
                         allowed_token_ids=allowed_token_ids,
                         suppressed_token_ids=suppressed_token_ids,
+                        suppress_next_token_ids=suppress_next_token_ids,
                         temperature=float(request.temperature),
                         top_p=float(request.top_p),
                     )
@@ -669,15 +712,30 @@ class GenerationScheduler:
             self.runtime.active_sequences[state.batch_idx] = state
 
             # Stage the first (prefill/bonus) token exactly like the non-spec
-            # prefill path: consume_step + streaming + finish check. ``admit``
-            # returns the greedy/bonus token id (it does not type the token or
-            # return a logprob), so the first token is a ``TextToken`` and, for a
-            # ``return_logprobs`` request, carries the greedy-bonus logprob (0.0
-            # under the non-spec sampler's greedy convention -- the bonus token
-            # is the argmax of the prefill logits). The macro-step supplies real
-            # per-token logprobs for every subsequently committed token.
-            token = TextToken(token_id=int(first_token_id))
-            first_logprob = 0.0 if request.return_logprobs is True else None
+            # prefill path: consume_step + streaming + finish check.
+            #
+            # Type the admit token through the runtime ``materialize_tokens``
+            # hook -- not a hard-coded ``TextToken``. On a spatial runtime the
+            # first generated id can be ``coord_id`` / ``size_id`` (point/detect
+            # apply the skill mask before this first sample), so it must become a
+            # ``CoordToken`` / ``SizeToken`` the way the non-spec prefill path
+            # does via ``post_sample`` -> ``materialize_tokens``; otherwise the
+            # first coordinate/box component is dropped. ``admit`` surfaces the
+            # admit-position side-values (the target's last hidden + sampling
+            # knobs the spatial hook needs to decode the coord/size value) on
+            # ``state.admit_side_values``; a text-only runtime leaves it ``None``
+            # and the id materialises as a plain ``TextToken`` (unchanged).
+            admit_side_values = getattr(state, "admit_side_values", None)
+            (typed_first,) = self._materialize_spec_tokens(
+                [lifecycle], [[int(first_token_id)]], admit_side_values
+            )
+            token = typed_first[0]
+            # ``admit`` returns the real first-token logprob for a
+            # ``return_logprobs`` request (the sampler's selected-token logprob,
+            # matching the non-spec prefill path's transferred ``sampled_logprobs``
+            # for token0) and ``None`` otherwise. Stage it through unchanged --
+            # no 0.0 greedy-approximation placeholder. The macro-step supplies
+            # real per-token logprobs for every subsequently committed token.
             self._spec_stage_token(lifecycle, token, logprob=first_logprob)
             progressed = True
             if self._mark_finished_if_needed(lifecycle):

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1096,8 +1096,20 @@ class GenerationScheduler:
         launch is itself committed next tick, keeping the count balanced.
         """
         decoder = self.runtime.spec.decoder
+        # Snapshot the previous macro-step but KEEP ``self._pending_spec``
+        # pointing at it until ``_commit_spec`` has actually consumed its
+        # in-flight refs. ``_commit_spec`` decrements each pending sequence's
+        # ``inflight_refs`` only in its final per-sequence loop, AFTER resolving
+        # the lazy ``result.tokens`` and running ``_materialize_spec_tokens`` --
+        # either of which can raise (a fail-fast hook, a deferred D2H error). If
+        # we cleared ``_pending_spec`` up front and the commit raised before that
+        # loop, the OLD pending refs would be left on the sequences with no
+        # ``_pending_spec`` record left to ever commit them: a finishing row would
+        # stay stuck in ``FINALIZING`` and leak its decoder row / LoRA slot. By
+        # leaving the record installed, a failed commit's pending refs stay owned
+        # by ``_pending_spec`` for a later ``_drain_spec`` / retry to consume; we
+        # clear it only once the commit SUCCEEDS (below).
         pending = self._pending_spec
-        self._pending_spec = None
 
         active = [
             seq
@@ -1109,17 +1121,28 @@ class GenerationScheduler:
         # their previous-step ref.
         for seq in active:
             seq.inflight_refs += 1
+        # Tracks whether this launch's reservation has been handed to a freshly
+        # installed ``_pending_spec`` (the next step). Until it is, the ``except``
+        # path owns the rollback of exactly that reservation.
+        launch_committed = False
 
         # The commit + launch below can raise (e.g. ``decoder.step`` on a CUDA
-        # error). Until ``_pending_spec`` is installed those reserved refs are
-        # owned by nothing -- no future ``_commit_spec`` will decrement them -- so
-        # a finishing row would stay stuck in ``FINALIZING`` and its pool row /
-        # adapter slot would leak. Mirror the non-spec launch path
-        # (``launch_decode_step``): on any failure before the pending step is
-        # installed, roll back exactly the reservation added above, then re-raise.
+        # error). Until this launch's reservation is handed to a new
+        # ``_pending_spec`` those reserved refs are owned by nothing -- no future
+        # ``_commit_spec`` will decrement them -- so a finishing row would stay
+        # stuck in ``FINALIZING`` and its pool row / adapter slot would leak.
+        # Mirror the non-spec launch path (``launch_decode_step``): on any failure
+        # before the new pending step is installed, roll back exactly the
+        # reservation added above, then re-raise. The OLD pending step's refs are
+        # NOT this method's to roll back -- they stay owned by ``_pending_spec``
+        # (still installed on a commit failure) for a later drain/retry.
         try:
             if pending is not None:
                 self._commit_spec(pending)
+                # Commit consumed the old pending step's refs; only now is it safe
+                # to drop the record. A raise above skips this, leaving
+                # ``_pending_spec`` installed so those refs are never orphaned.
+                self._pending_spec = None
 
             # The commit above can FINALIZE a row (its last allowed token was
             # ``length``-committed), which sets ``finalized`` and removes it from
@@ -1172,13 +1195,20 @@ class GenerationScheduler:
                         commit_caps=commit_caps,
                     )
                 self._pending_spec = (active, result)
+                launch_committed = True
         except Exception:
-            # Failure before ``_pending_spec`` was installed: undo this launch's
-            # reservation so the count stays balanced and no row is left with a
-            # phantom ref (mirrors ``launch_decode_step``'s rollback). ``active``
-            # is the only set whose refs this method added; ``_commit_spec``
-            # already decremented whatever it committed before raising.
-            if self._pending_spec is None:
+            # Failure before this launch's reservation was handed to a new
+            # ``_pending_spec``: undo exactly that reservation so the count stays
+            # balanced and no row is left with a phantom ref (mirrors
+            # ``launch_decode_step``'s rollback). ``active`` is the only set whose
+            # refs this method added; ``_commit_spec`` already decremented whatever
+            # it committed before raising, and a commit that did NOT reach its
+            # decrement loop leaves the OLD pending refs owned by the still-
+            # installed ``_pending_spec`` (committed later by drain/retry) -- not
+            # this method's to touch. ``launch_committed`` (not ``_pending_spec``
+            # being unset) gates the rollback, because on a commit failure
+            # ``_pending_spec`` is deliberately left set to the OLD step.
+            if not launch_committed:
                 for seq in active:
                     seq.inflight_refs -= 1
             raise

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -879,39 +879,10 @@ class GenerationScheduler:
                 # finish/zombie path will ever call ``decoder.retire`` for
                 # it -- the row would leak permanently and repeated failures
                 # would drain ``decoder.free_slots`` and stall unrelated spec
-                # requests. Retire the row here when ``admit`` got far enough
-                # to reserve one (``batch_idx`` left at its ``-1`` sentinel
-                # means it never did, so there is nothing to retire).
-                #
-                # This is NOT ``_retire_spec_row``: that also calls
-                # ``release_adapter_slot(state.lora_slot)``, which would
-                # double-release the LoRA slot the block below already frees
-                # via ``request.lora_slot`` (the same slot). Each resource is
-                # released exactly once -- pool row via ``decoder.retire``,
-                # adapter slot via the ``release_adapter_slot`` below --
-                # mirroring the per-resource cleanup the non-spec
-                # admit-failure path performs.
-                if state.batch_idx >= 0:
-                    try:
-                        decoder.retire(state)
-                    except Exception:  # pragma: no cover - defensive
-                        pass
-                    # ``active_sequences[batch_idx]`` is only populated AFTER
-                    # the ``try`` (on the success path), so on this failure
-                    # path it is normally absent; pop defensively in case a
-                    # future reorder registers it earlier, leaving no dangling
-                    # entry.
-                    self.runtime.active_sequences.pop(state.batch_idx, None)
-                if lifecycle.lora_slot_ready and request.lora_slot:
-                    # Release the LoRA slot we acquired for this failed admission
-                    # so its refcount does not leak.
-                    try:
-                        self.runtime.release_adapter_slot(request.lora_slot)
-                    except Exception:  # pragma: no cover - defensive
-                        pass
-                    request.lora_slot = 0
-                    lifecycle.lora_slot_ready = False
-                self._fail_request_early(request, exc)
+                # requests. ``_fail_admitted_spec_request`` retires the row
+                # (when ``admit`` got far enough to reserve one) and releases
+                # the LoRA slot before failing the request cleanly.
+                self._fail_admitted_spec_request(request, state, exc)
                 progressed = True
                 continue
 
@@ -945,20 +916,46 @@ class GenerationScheduler:
             # the skill mask before this first sample) gets its coord/size head
             # logprob folded in, exactly as the non-spec prefill ``post_sample``
             # path does. ``None`` (no logprobs requested) stays ``None``.
-            admit_logprobs = None if first_logprob is None else [[first_logprob]]
-            (typed_first,), typed_first_logprobs = self._materialize_spec_tokens(
-                [lifecycle], [[int(first_token_id)]], admit_side_values, admit_logprobs
-            )
-            token = typed_first[0]
-            staged_first_logprob = (
-                typed_first_logprobs[0][0]
-                if typed_first_logprobs is not None
-                else first_logprob
-            )
-            # Stage the (spatial-augmented) first-token logprob through unchanged --
-            # no 0.0 greedy-approximation placeholder. The macro-step supplies
-            # real per-token logprobs for every subsequently committed token.
-            self._spec_stage_token(lifecycle, token, logprob=staged_first_logprob)
+            #
+            # Materialising/staging the admit token must share the SAME
+            # admit-failure cleanup as ``decoder.admit`` above. ``admit`` has
+            # already succeeded -- the row is reserved, ``sequence_state`` is
+            # set, and the state is registered in ``active_sequences`` -- but the
+            # request is not yet ``running`` and has no finish/zombie path. If
+            # ``_materialize_spec_tokens`` raises here (a spatial admit token
+            # whose runtime emits ``admit_side_values`` but exposes no
+            # ``materialize_spec_tokens`` hook, or a hook that rejects the side
+            # values), an unguarded raise would propagate out of ``_spec_admit``
+            # and leak the spec pool row + LoRA slot + ``active_sequences`` entry,
+            # leaving the request stuck with no scheduler path to finish. Wrap the
+            # materialize/stage path in the same ``_fail_admitted_spec_request``
+            # cleanup so a single bad spatial admit retires the row, releases the
+            # slot, and fails the request cleanly instead.
+            try:
+                admit_logprobs = None if first_logprob is None else [[first_logprob]]
+                (typed_first,), typed_first_logprobs = self._materialize_spec_tokens(
+                    [lifecycle],
+                    [[int(first_token_id)]],
+                    admit_side_values,
+                    admit_logprobs,
+                )
+                token = typed_first[0]
+                staged_first_logprob = (
+                    typed_first_logprobs[0][0]
+                    if typed_first_logprobs is not None
+                    else first_logprob
+                )
+                # Stage the (spatial-augmented) first-token logprob through
+                # unchanged -- no 0.0 greedy-approximation placeholder. The
+                # macro-step supplies real per-token logprobs for every
+                # subsequently committed token.
+                self._spec_stage_token(
+                    lifecycle, token, logprob=staged_first_logprob
+                )
+            except Exception as exc:
+                self._fail_admitted_spec_request(request, state, exc)
+                progressed = True
+                continue
             progressed = True
             if self._mark_finished_if_needed(lifecycle):
                 lifecycle.finalized = True
@@ -983,6 +980,62 @@ class GenerationScheduler:
         to ``stage_token`` exactly like the non-spec single-token path.
         """
         seq.stage_token(self.runtime, token, logprob=logprob)
+
+    def _fail_admitted_spec_request(
+        self,
+        request: GenerationRequest,
+        state: SequenceState,
+        exc: Exception,
+    ) -> None:
+        """Clean up after a spec admission that failed *after* reserving a row.
+
+        The single cleanup point for an admission that has already run far
+        enough through ``_spec_admit`` to claim resources -- ``decoder.admit``
+        reserving a pool row, and/or the post-admit admit-token
+        materialization/staging registering the state in ``active_sequences``.
+        Both failure sites (a raising ``decoder.admit`` and a raising
+        ``_materialize_spec_tokens`` for the admit token) route here so a partly
+        admitted request never leaks the spec pool row, the
+        ``active_sequences`` entry, or the LoRA slot, and is always failed
+        cleanly (it has already left ``waiting`` and is not yet ``running``, so
+        no finish/zombie path would otherwise retire it).
+
+        Each resource is released exactly once and per-resource (mirroring the
+        non-spec admit-failure path): the pool row via ``decoder.retire`` and
+        the adapter slot via ``release_adapter_slot``. This is deliberately NOT
+        ``_retire_spec_row`` -- that also releases ``state.lora_slot`` (the same
+        slot freed here via ``request.lora_slot``), which would double-release
+        it.
+        """
+        decoder = self.runtime.spec.decoder
+        # ``admit`` reserves a free pool row and assigns ``state.batch_idx``
+        # before its prefill image/CUDA work runs, so the row can be reserved
+        # even though no token was staged. ``batch_idx`` left at its ``-1``
+        # sentinel means ``admit`` never reserved one, so there is nothing to
+        # retire.
+        if state.batch_idx >= 0:
+            if decoder is not None:
+                try:
+                    decoder.retire(state)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+            # ``active_sequences[batch_idx]`` is populated only once the admit
+            # token has been materialized/staged. On the ``decoder.admit``
+            # failure path it is absent; on the admit-token materialization
+            # failure path it was registered just before -- pop it
+            # unconditionally so neither leaves a dangling entry.
+            self.runtime.active_sequences.pop(state.batch_idx, None)
+        lifecycle = request.lifecycle
+        if lifecycle.lora_slot_ready and request.lora_slot:
+            # Release the LoRA slot we acquired for this failed admission so its
+            # refcount does not leak.
+            try:
+                self.runtime.release_adapter_slot(request.lora_slot)
+            except Exception:  # pragma: no cover - defensive
+                pass
+            request.lora_slot = 0
+            lifecycle.lora_slot_ready = False
+        self._fail_request_early(request, exc)
 
     def _retire_spec_row(self, state: SequenceState) -> None:
         """Release every resource a finished spec row holds.

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -588,7 +588,24 @@ class GenerationScheduler:
         # the same request (it stays in ``waiting``) while still letting other
         # waiting requests be considered for admission.
         deferred_ids: set[int] = set()
-        while decoder.free_slots > 0:
+        # Cap the live spec batch to the runtime's captured-graph batch size.
+        #
+        # The decoder's pool can expose MORE free rows than ``max_batch_size``
+        # (it is sized from ``max_batch_slots == max_batch_size + 2`` to keep
+        # headroom for transient prefill, see ``runtime.max_batch_slots``), so
+        # admitting ``while decoder.free_slots > 0`` alone would queue up to
+        # ``max_batch_slots`` running rows. ``_spec_decode_step`` then snapshots
+        # EVERY running row into ``active`` and hands the whole set to one
+        # ``decoder.step`` call -- but the verify/draft CUDA graphs and staging
+        # buffers are captured for ``max_batch_size`` states, so an oversized
+        # batch overruns them. The non-spec path enforces the same bound via its
+        # ``max_batch_size`` dispatch cap (``_cap_decode_dispatch``); bound the
+        # spec batch at admission so the running set -- and thus every
+        # ``decoder.step`` -- never exceeds it. Excess launchable requests stay
+        # WAITING and are admitted as running rows retire (same deferral the
+        # non-spec path applies when more rows are dispatchable than fit).
+        max_running = self.runtime.max_batch_size
+        while decoder.free_slots > 0 and len(self.running) < max_running:
             request = next(
                 (
                     r

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -948,14 +948,24 @@ class GenerationScheduler:
             # (post-commit), so stateful skills constrain the drafter + verify
             # with the up-to-date allowed/suppressed set this step -- not the
             # admit-time snapshot. Finalized zombies come back unconstrained.
-            allowed_token_ids, suppressed_token_ids = self._build_spec_step_masks(
-                active
-            )
+            # ``commit_caps`` caps a STATEFUL-masked row (one whose allowed/
+            # suppressed set changes per committed token) to a single committed
+            # token this step: the single per-step mask is only exact for one
+            # constraint transition per run, so a row that would otherwise commit
+            # a multi-token run under a stale 1st-position mask is held to one
+            # token and re-masked from the now-current skill state next step (see
+            # ``_build_spec_step_masks`` / ``decoder.step``).
+            (
+                allowed_token_ids,
+                suppressed_token_ids,
+                commit_caps,
+            ) = self._build_spec_step_masks(active)
             with torch.inference_mode():
                 result = decoder.step(
                     [seq.state for seq in active],
                     allowed_token_ids=allowed_token_ids,
                     suppressed_token_ids=suppressed_token_ids,
+                    commit_caps=commit_caps,
                 )
             self._pending_spec = (active, result)
         else:
@@ -2008,8 +2018,12 @@ class GenerationScheduler:
 
     def _build_spec_step_masks(
         self, sequences: List[RequestLifecycle]
-    ) -> tuple[list[Optional[Sequence[int]]], list[Optional[Sequence[int]]]]:
-        """Per-row skill masks for a spec macro-step, re-queried per step.
+    ) -> tuple[
+        list[Optional[Sequence[int]]],
+        list[Optional[Sequence[int]]],
+        list[Optional[int]],
+    ]:
+        """Per-row skill masks (+ commit caps) for a spec macro-step.
 
         The spec-decode analog of ``_build_mask_spec``'s allowed/suppressed
         re-query. ``_spec_decode_step`` calls this AFTER committing the previous
@@ -2029,21 +2043,75 @@ class GenerationScheduler:
         ``suppress_next_token_ids``: that suppression targets a request's *first*
         generated token only and is applied once, at ``admit`` (which samples
         that token); re-applying it here would wrongly suppress past the one-shot
-        window. Returns ``(allowed_per_row, suppressed_per_row)`` parallel to
-        ``sequences``.
+        window.
+
+        The third return is the per-row ``commit_caps`` (parallel to
+        ``sequences``): ``1`` for a row whose skill mask is STATEFUL (its
+        allowed/suppressed set changes per committed token), else ``None``
+        (uncapped). The single per-step mask is exact only for one constraint
+        transition per committed run -- a macro-step commits a *variable* run of
+        ``a_i + 1`` tokens under ONE mask, so a stateful row's 2nd..Nth positions
+        would be verified under the stale 1st-position mask (e.g. a detect run
+        could suppress the required ``size_id`` or accept a ``coord`` where
+        ``size`` is required). Capping such a row to one committed token forces
+        exactly one transition per run -- the regime where the per-step mask IS
+        exact, identical to the non-spec one-token-per-step path -- and the next
+        step re-queries the mask from the now-current skill state. A non-stateful
+        (unconstrained, or constant-mask) row stays uncapped so it keeps the full
+        multi-token speculative accept. Returns
+        ``(allowed_per_row, suppressed_per_row, commit_caps_per_row)``.
         """
         allowed_tokens: list[Optional[Sequence[int]]] = []
         suppressed_tokens: list[Optional[Sequence[int]]] = []
+        commit_caps: list[Optional[int]] = []
         for seq in sequences:
             if seq.finalized:
                 allowed_tokens.append(None)
                 suppressed_tokens.append(None)
+                commit_caps.append(None)
                 continue
-            allowed_tokens.append(seq.skill_state.allowed_token_ids(self.runtime))
-            suppressed_tokens.append(
-                seq.skill_state.suppressed_token_ids(self.runtime)
+            allowed = seq.skill_state.allowed_token_ids(self.runtime)
+            suppressed = seq.skill_state.suppressed_token_ids(self.runtime)
+            allowed_tokens.append(allowed)
+            suppressed_tokens.append(suppressed)
+            commit_caps.append(
+                1 if self._mask_is_stateful(seq, allowed, suppressed) else None
             )
-        return allowed_tokens, suppressed_tokens
+        return allowed_tokens, suppressed_tokens, commit_caps
+
+    def _mask_is_stateful(
+        self,
+        seq: RequestLifecycle,
+        allowed: Optional[Sequence[int]],
+        suppressed: Optional[Sequence[int]],
+    ) -> bool:
+        """Whether ``seq``'s skill mask can change WITHIN one committed run.
+
+        A spec macro-step commits a variable run of tokens under a single
+        per-step mask, so a row whose allowed/suppressed set evolves per
+        committed token (point cycles coord/eos; detect cycles x->y->size; query
+        injects a fixed post-reasoning prefix one id at a time, and toggles its
+        suppression as it leaves reasoning) must be capped to one committed token
+        per step -- otherwise the run's later positions verify under the stale
+        first-position mask. This decides that cap from the live skill state,
+        model-agnostically (the scheduler never imports a model's skills).
+
+        A skill may declare its mask precisely via an optional
+        ``mask_is_stateful`` attribute / property on its ``SkillState`` (``True``
+        => evolving, ``False`` => provably constant); when present that wins. In
+        its absence the conservative behavioural rule is: any ACTIVE constraint
+        (a non-empty ``allowed`` whitelist or ``suppressed`` blacklist this step)
+        is treated as potentially stateful and capped, because the scheduler
+        cannot prove the set is position-independent without model knowledge.
+        Correctness-first: over-capping a constant-mask skill only costs that
+        row's intra-step speculation (it still advances one token per step), while
+        under-capping a stateful one corrupts constrained output. A row with no
+        active constraint is never stateful and keeps the full multi-token accept.
+        """
+        declared = getattr(seq.skill_state, "mask_is_stateful", None)
+        if declared is not None:
+            return bool(declared)
+        return bool(allowed) or bool(suppressed)
 
     def _build_mask(
         self, sequences: List[RequestLifecycle], slot

--- a/kestrel/skills/chat.py
+++ b/kestrel/skills/chat.py
@@ -268,6 +268,28 @@ class ChatSkill(SkillSpec):
 class ChatSkillState(SkillState):
     """Buffers an assistant turn (optional thinking block) into a chat message."""
 
+    # The chat mask is genuinely stateful: it transitions INACTIVE -> ACTIVE
+    # mid-run. While collecting reasoning, ``allowed_token_ids`` is ``None`` and
+    # this state overrides no ``suppressed_token_ids`` (base returns ``None``) --
+    # no active constraint. Once the model emits ``answer_id``, the state flips
+    # to forcing ``post_reasoning_prefix`` one id at a time via
+    # ``allowed_token_ids``. A single spec macro-step commits a variable run
+    # under ONE mask, so a run that begins in reasoning (mask = None) and crosses
+    # ``answer_id`` would verify the post-boundary tokens under the stale,
+    # unconstrained first-position mask -- accepting them WITHOUT the required
+    # prefix constraint and corrupting the output. The scheduler's behavioural
+    # fallback ("any ACTIVE constraint is stateful") cannot see this transition
+    # because the mask is ``None`` at the run's first position, so declare the
+    # mask stateful explicitly: the scheduler then caps such a row to one
+    # committed token per macro-step, forcing exactly one constraint transition
+    # per run (the regime where the per-step mask is exact). Always-cap is the
+    # correctness-first verdict; a transition-only cap is not expressible here
+    # because the boundary (when the model emits ``answer_id``) is model-decided
+    # and unknowable before the run commits. Tradeoff (follow-up): this also caps
+    # the long unconstrained answer/reasoning phases, costing intra-step
+    # speculation on those rows.
+    mask_is_stateful = True
+
     def __init__(
         self,
         spec: SkillSpec,

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -8,6 +8,7 @@ non-spec path stays untouched when ``runtime.spec`` is ``None``.
 
 from __future__ import annotations
 
+from concurrent.futures import Future
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -963,6 +964,125 @@ def test_spec_admit_forwards_image_crops_for_multicrop_request() -> None:
     # request.
     assert kw["image"] is img
     assert kw["image_crops"] is crops
+
+
+def test_spec_admit_materializes_crops_for_prefix_cache_image_hit() -> None:
+    """A prefix-cache image hit never reaches ``admit`` with ``image_crops=None``.
+
+    Regression for the codex P1 @ scheduler.py:865. The admission coordinator
+    (``engine/executor.py``) short-circuits a single-image request whose prompt
+    HITS the prefix cache: ``_AdmissionCoordinator.submit`` returns
+    ``prefix_cache_hit=True`` WITHOUT running image preprocessing, so
+    ``_admit_ready`` marks the request launchable (``crops_ready=True``) with
+    ``image_crops`` still ``None``. The non-spec ``prepare_sequence`` path is safe
+    (it reuses the cached KV prefix and never re-encodes the image), but the spec
+    ``decoder.admit`` has no cache-reuse path -- it re-prefills the image by
+    running the vision encoder, which needs the overlap crop tiles. So
+    ``_spec_admit`` must materialize the crops (the preprocessing the coordinator
+    skipped) BEFORE ``admit`` -- otherwise a multi-crop image gets an incomplete
+    prefill (only the global image) or a decoder that requires the tiles fails.
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+
+    # Stand-in for the OverlapCropOutput the runtime's overlap-crop preprocessing
+    # produces; assert exactly THIS object reaches ``admit`` so we know the
+    # scheduler ran the preprocessing rather than forwarding the bare image.
+    materialized_crops = object()
+    preprocess_calls: list[object] = []
+
+    def _fake_preprocess(image: object) -> Future:
+        preprocess_calls.append(image)
+        fut: Future = Future()
+        fut.set_result(materialized_crops)
+        return fut
+
+    rt.preprocess_image_async = _fake_preprocess  # type: ignore[method-assign]
+    sched = _make_scheduler(rt)
+
+    img = object()
+    # Model the prefix-cache image hit exactly as the coordinator leaves it:
+    # a single image, launchable (crops_ready), but image_crops still None.
+    req = _enqueue(sched, 0, prompt_len=3, max_new=8, image=img)
+    assert req.image_crops is None  # coordinator skipped preprocessing on the hit
+    req.lifecycle.prefix_cache_hit = True
+
+    assert sched._spec_admit() is True
+
+    # The scheduler ran the overlap-crop preprocessing the coordinator skipped...
+    assert preprocess_calls == [img]
+    # ...and forwarded the materialized crops (NOT None) into admit alongside the
+    # image, so the decoder prefills the full multi-crop image.
+    kw = dec.admit_kwargs[0]
+    assert kw["image"] is img
+    assert kw["image_crops"] is materialized_crops
+    assert kw["image_crops"] is not None
+    # The request now carries the crops for any later re-prefill too.
+    assert req.image_crops is materialized_crops
+
+
+def test_spec_admit_does_not_preprocess_when_crops_already_present() -> None:
+    """A single-image request that already has crops is NOT re-preprocessed.
+
+    The non-cache-hit single-image path already had its overlap crops
+    materialized by the admission coordinator before the request became
+    launchable, so ``_spec_admit`` must forward the existing
+    ``request.image_crops`` unchanged and not run preprocessing a second time.
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    preprocess_calls: list[object] = []
+
+    def _fake_preprocess(image: object) -> Future:
+        preprocess_calls.append(image)
+        fut: Future = Future()
+        fut.set_result(object())
+        return fut
+
+    rt.preprocess_image_async = _fake_preprocess  # type: ignore[method-assign]
+    sched = _make_scheduler(rt)
+
+    img = object()
+    crops = object()  # the coordinator already tiled this image
+    _enqueue(sched, 0, prompt_len=3, max_new=8, image=img, image_crops=crops)
+
+    assert sched._spec_admit() is True
+    # No re-preprocessing, and the original crops reach admit unchanged.
+    assert preprocess_calls == []
+    kw = dec.admit_kwargs[0]
+    assert kw["image"] is img
+    assert kw["image_crops"] is crops
+
+
+def test_spec_admit_skips_crop_materialization_for_multi_image_request() -> None:
+    """A multi-image (list) request is left untouched -- crops happen inline.
+
+    Multi-image chat is never a single-image prefix-cache hit and the encoder
+    crops each image inline (no precomputed overlap), so ``_spec_admit`` must NOT
+    run single-image overlap preprocessing on it: ``image_crops`` stays ``None``
+    and the image list reaches ``admit`` unchanged.
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    preprocess_calls: list[object] = []
+
+    def _fake_preprocess(image: object) -> Future:
+        preprocess_calls.append(image)
+        fut: Future = Future()
+        fut.set_result(object())
+        return fut
+
+    rt.preprocess_image_async = _fake_preprocess  # type: ignore[method-assign]
+    sched = _make_scheduler(rt)
+
+    images = [object(), object()]  # multi-image chat payload
+    _enqueue(sched, 0, prompt_len=3, max_new=8, image=images)
+
+    assert sched._spec_admit() is True
+    assert preprocess_calls == []  # single-image preprocessing must not run
+    kw = dec.admit_kwargs[0]
+    assert kw["image"] is images
+    assert kw["image_crops"] is None
 
 
 def test_spec_commit_routes_committed_ids_through_materialize_hook() -> None:

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -1217,6 +1217,91 @@ def test_spec_admit_failure_releases_lora_slot_and_retires_row() -> None:
     assert rt.active_sequences == {}
 
 
+def test_spec_pre_admit_hook_failure_releases_lora_slot_and_fails_cleanly() -> None:
+    """P2 codex finding @ scheduler.py:781: a pre-admit hook failure stays on the
+    admit-failure cleanup path (LoRA slot released, request failed cleanly).
+
+    The skill ``on_prefill`` hook (and the ``allowed_token_ids`` /
+    ``suppressed_token_ids`` mask queries) run AFTER the request has left
+    ``waiting``, transitioned to ``PREFILLING``, and acquired its LoRA slot, but
+    BEFORE ``decoder.admit``. If that hook raises while it sits outside the
+    ``try``/cleanup block, the request is dropped from ``waiting`` stuck in
+    ``PREFILLING`` with its LoRA slot leaked (``sequence_state`` is never set, so
+    no finish/zombie path ever releases it) and the scheduler later crashes on
+    it. With the hook inside the same ``try`` as ``admit``, the existing
+    admit-failure cleanup releases the slot and fails the request cleanly.
+    ``decoder.admit`` never runs, so no pool row is reserved (``batch_idx`` stays
+    at its ``-1`` sentinel) and nothing is retired. Asserts the slot is released
+    exactly once, ``admit``/``retire`` are never called (no row leak), and the
+    request ends as a clean error -- not stuck PREFILLING.
+    """
+
+    class _RaisingOnPrefillState(_RecordingState):
+        def on_prefill(self, runtime: object) -> None:  # type: ignore[override]
+            raise RuntimeError("skill on_prefill failed before admit")
+
+    class _FakeAdapterProvider:
+        def config(self) -> dict:
+            return {"max_lora_rank": 16}
+
+        def get(self, adapter: str) -> object:
+            return object()
+
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    assert dec.free_slots == 1  # baseline: one row free
+    sched = GenerationScheduler(
+        rt,
+        compute_stream=None,
+        skill_registry=__import__(
+            "kestrel.skills", fromlist=["SkillRegistry"]
+        ).SkillRegistry([]),
+        adapter_provider=_FakeAdapterProvider(),
+    )
+    req = GenerationRequest(
+        request_id=0,
+        prompt="p",
+        prompt_tokens=[TextToken(1)] * 3,
+        max_new_tokens=8,
+        skill=_SpecSkillSpec(),  # type: ignore[arg-type]
+        request_context=object(),
+        adapter="ft-1",
+    )
+    lc = RequestLifecycle(request=req, skill_state=_RaisingOnPrefillState(req))
+    lc.lora_slot_ready = False
+    lc.transition(RequestPhase.READY_FOR_PREFILL)
+    req.lifecycle = lc
+    sched.enqueue_request(req, lc.skill_state)
+
+    assert sched._spec_admit() is True
+    # ``admit`` was never reached (the hook raised first) -> no pool row was ever
+    # reserved, so none was admitted and none retired, and ``free_slots`` is
+    # untouched (no leak).
+    assert dec.admitted == []
+    assert dec.retired == []
+    assert dec.free_slots == 1
+    # The LoRA slot acquired before the hook ran is released exactly once on the
+    # cleanup path (not leaked, not double-released).
+    assert len(rt.acquired_adapter_slots) == 1
+    acquired_slot = len(rt.acquired_adapter_slots)  # FakeRuntime numbers from 1
+    assert rt.released_adapter_slots == [acquired_slot]
+    assert rt.released_adapter_slots.count(acquired_slot) == 1
+    # request.lora_slot was zeroed so no later path can re-release it.
+    assert req.lora_slot == 0
+    assert req.lifecycle.lora_slot_ready is False
+    # The request failed cleanly -- it is NOT left stuck in PREFILLING, and no
+    # sequence_state / active row was registered for it.
+    assert req.lifecycle.finished is True
+    assert req.lifecycle.finish_reason == "error"
+    assert req.lifecycle.phase == RequestPhase.COMPLETED
+    assert req.lifecycle.sequence_state is None
+    assert rt.active_sequences == {}
+    # It was removed from the waiting queue (the scheduler removes it before the
+    # hook runs) and never entered the running set.
+    assert req not in sched.waiting
+    assert len(sched.running) == 0
+
+
 def test_spec_side_values_guarded_when_no_spec_hook() -> None:
     """Round-2 codex finding @ L836: SpecSideValues never hits the non-spec hook.
 

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -43,34 +43,68 @@ class _RecordingState(SkillState):
 class _FakeDecoder:
     """Scriptable ``SpecDecoder`` for the scheduler test (no GPU).
 
-    ``admit`` hands back a fixed first token and assigns the next free pool row.
-    ``step`` pops a scripted ``(tokens, accept)`` plan per call from each row's
-    queue (rows advance by *different* amounts to exercise ragged advance).
+    ``admit`` hands back a fixed first token and assigns the next free pool row,
+    recording the image / skill-mask / sampling kwargs the scheduler forwards so
+    tests can assert the spec path passes a request's full context through (no
+    text-only/unconstrained fallback). ``step`` pops a scripted ``tokens`` plan
+    per call from each row's queue (rows advance by *different* amounts to
+    exercise ragged advance) and, when ``emit_logprobs`` is set, returns a
+    parallel per-committed-token logprob list.
     """
 
     num_speculative_tokens = 3
 
-    def __init__(self, *, n_rows: int, plans: dict, first_tokens: dict) -> None:
+    def __init__(
+        self,
+        *,
+        n_rows: int,
+        plans: dict,
+        first_tokens: dict,
+        emit_logprobs: bool = False,
+        side_values: object | None = None,
+    ) -> None:
         self._free = list(range(n_rows))
         self._row_of: dict[int, int] = {}
         self._plans = plans            # row -> list[list[int]] per step
         self._first = first_tokens     # row -> first token id
+        self._emit_logprobs = emit_logprobs
+        self._side_values = side_values
         self.admitted: list[int] = []
         self.retired: list[int] = []
+        # admit kwargs recorded per row.
+        self.admit_kwargs: dict[int, dict] = {}
 
     @property
     def free_slots(self) -> int:
         return len(self._free)
 
-    def admit(self, state, prompt_token_ids):
+    def admit(
+        self,
+        state,
+        prompt_token_ids,
+        *,
+        image=None,
+        allowed_token_ids=None,
+        suppressed_token_ids=None,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+    ):
         row = self._free.pop(0)
         self._row_of[id(state)] = row
         state.batch_idx = 100 + row
         self.admitted.append(row)
+        self.admit_kwargs[row] = {
+            "image": image,
+            "allowed_token_ids": allowed_token_ids,
+            "suppressed_token_ids": suppressed_token_ids,
+            "temperature": temperature,
+            "top_p": top_p,
+            "return_logprobs": getattr(state, "return_logprobs", None),
+        }
         return self._first[row]
 
     def step(self, states):
-        tokens, accepts = [], []
+        tokens, accepts, logprobs = [], [], []
         for s in states:
             row = self._row_of[id(s)]
             plan = self._plans[row]
@@ -81,7 +115,15 @@ class _FakeDecoder:
             nxt = plan.pop(0) if plan else [0]
             tokens.append(list(nxt))
             accepts.append(len(nxt) - 1)
-        return SpecStepResult(tokens=tokens, accept_counts=accepts)
+            # Scripted logprob per committed token: -(token_id) keeps it
+            # deterministic and easy to assert.
+            logprobs.append([-float(t) for t in nxt])
+        return SpecStepResult(
+            tokens=tokens,
+            accept_counts=accepts,
+            logprobs=logprobs if self._emit_logprobs else None,
+            side_values=self._side_values,
+        )
 
     def retire(self, state) -> None:
         self.retired.append(self._row_of.pop(id(state)))
@@ -106,6 +148,10 @@ def _enqueue(
     adapter: str | None = None,
     lora_slot_ready: bool = True,
     return_logprobs: bool | None = None,
+    temperature: float = 0.0,
+    top_p: float = 1.0,
+    image: object | None = None,
+    skill_state: SkillState | None = None,
 ):
     req = GenerationRequest(
         request_id=rid,
@@ -116,8 +162,14 @@ def _enqueue(
         request_context=object(),
         adapter=adapter,
         return_logprobs=return_logprobs,
+        temperature=temperature,
+        top_p=top_p,
+        image=image,
     )
-    lc = RequestLifecycle(request=req, skill_state=_RecordingState(req))
+    lc = RequestLifecycle(
+        request=req, skill_state=skill_state or _RecordingState(req)
+    )
+    lc.has_image = image is not None
     lc.crops_ready = True
     lc.lora_slot_ready = lora_slot_ready
     lc.transition(RequestPhase.READY_FOR_PREFILL)
@@ -379,31 +431,128 @@ def test_spec_admit_defers_when_lora_slots_exhausted() -> None:
     assert sched.pop_completed() == []
 
 
-def test_spec_admit_rejects_logprobs_request_cleanly() -> None:
-    """Regression for the spec+logprobs crash (codex finding @ L578).
+def test_spec_admit_and_step_stage_logprobs() -> None:
+    """``return_logprobs`` is served on the spec path (no clean-reject fallback).
 
-    A ``return_logprobs=True`` request on the spec path must fail just that
-    request (clean error result + row retired) instead of raising a
-    scheduler-wide exception when ``stage_token`` sees a None logprob.
+    The spec macro-step now supplies per-committed-token logprobs
+    (``SpecStepResult.logprobs``), so a ``return_logprobs=True`` request is
+    admitted and its logprobs are staged through ``stage_token`` like the
+    non-spec single-token path -- not rejected. ``admit`` also learns the request
+    wants logprobs (via ``state.return_logprobs``) so ``step`` knows to gather
+    them.
     """
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12, 13]]},  # admit(1) + 2 == max_new=3 -> finishes here
+        emit_logprobs=True,
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=3, return_logprobs=True)
+
+    # Admission succeeds (not rejected) and tells the decoder logprobs are wanted.
+    assert sched._spec_admit() is True
+    assert dec.admitted == [0]
+    assert dec.admit_kwargs[0]["return_logprobs"] is True
+    assert req.lifecycle.finished is False
+    assert len(sched.running) == 1
+
+    # Drive the depth-1 pipeline to quiescence; the scripted step commits
+    # tokens 12, 13 with logprobs -12.0, -13.0.
+    while sched._spec_decode_step():
+        pass
+
+    assert [int(t.token_id) for t in req.lifecycle.skill_state.tokens] == [11, 12, 13]
+    # First (bonus) token from admit carries the greedy-bonus logprob (0.0);
+    # the macro-step supplies the real logprobs for the committed tokens.
+    assert req.lifecycle.logprobs == [0.0, -12.0, -13.0]
+    completed = sched.pop_completed()
+    assert completed[0].logprobs == [0.0, -12.0, -13.0]
+
+
+def test_spec_admit_forwards_image_mask_and_sampling_params() -> None:
+    """The spec path passes a request's full context into ``admit`` (no fallback).
+
+    Regression for the three newer codex findings (image @ L615, masks/sampling
+    @ L761): image requests must prefill *with the image*, skill masks must
+    constrain the drafter+verify, and temperature/top_p must reach the decoder --
+    not be silently dropped to a text-only / unconstrained / greedy path.
+    """
+
+    class _MaskedState(_RecordingState):
+        def allowed_token_ids(self, runtime: object):
+            return [12, 13]
+
+        def suppressed_token_ids(self, runtime: object):
+            return [99]
+
     dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
     rt = _spec_runtime(dec)
     sched = _make_scheduler(rt)
-    req = _enqueue(sched, 0, prompt_len=3, max_new=8, return_logprobs=True)
+    img = object()
+    # Build the request, then bind a masked skill-state to it (the state needs
+    # the real request so its mask methods see the right context).
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=8, temperature=0.7, top_p=0.9, image=img
+    )
+    masked_state = _MaskedState(req)
+    req.lifecycle.skill_state = masked_state
+    req.skill_state = masked_state
 
-    # Must not raise.
     assert sched._spec_admit() is True
-    # Request failed cleanly: errored result, not pushed to running, row retired.
-    assert req.lifecycle.finished is True
-    assert req.lifecycle.finish_reason == "error"
-    assert len(sched.running) == 0
-    assert dec.retired == [0]
-    assert rt.active_sequences == {}
-    completed = sched.pop_completed()
-    assert [c.request_id for c in completed] == [0]
-    assert completed[0].finish_reason == "error"
-    assert "error" in completed[0].output
+    kw = dec.admit_kwargs[0]
+    assert kw["image"] is img
+    assert list(kw["allowed_token_ids"]) == [12, 13]
+    assert list(kw["suppressed_token_ids"]) == [99]
+    assert kw["temperature"] == 0.7
+    assert kw["top_p"] == 0.9
 
-    # And the spec decode loop stays healthy afterward (no leaked pending step).
-    assert sched._spec_decode_step() is False
-    assert sched.has_pending_work() is False
+
+def test_spec_commit_routes_committed_ids_through_materialize_hook() -> None:
+    """Committed ids are typed via the runtime ``materialize_tokens`` hook.
+
+    Regression for typed-token finding @ L792: the spec commit must route the
+    committed ids (+ ``SpecStepResult.side_values``) through the runtime hook so a
+    spatial runtime types coord/size ids -- not hardcode ``TextToken``. Stubs the
+    hook to wrap every committed id and asserts the macro-step's ``side_values``
+    reached it.
+    """
+    sentinel_side_values = object()
+    calls: list[dict] = []
+
+    @dataclass
+    class _TypedToken:
+        token_id: int
+
+    def materialize_tokens(token_ids_cpu, sequences, batch_idx, step_handle):
+        ids = [int(t) for t in token_ids_cpu.view(-1).tolist()]
+        calls.append({"step_handle": step_handle, "ids": ids})
+        return [_TypedToken(token_id=int(t)) for t in ids]
+
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12, 13]]},  # admit(1) + 2 == max_new=3 -> finishes here
+        side_values=sentinel_side_values,
+    )
+    rt = _spec_runtime(dec)
+    from kestrel.runtime.sampling import SamplingHooks
+
+    # Hooks are read at scheduler construction, so install before _make_scheduler.
+    rt.sampling_hooks = SamplingHooks(materialize_tokens=materialize_tokens)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=3)
+    sched._spec_admit()
+    while sched._spec_decode_step():
+        pass
+
+    # The runtime hook typed the committed ids (12, 13) and was handed the
+    # macro-step's side_values as its opaque step-handle.
+    real = next(c for c in calls if c["ids"] == [12, 13])
+    assert real["step_handle"] is sentinel_side_values
+    staged = req.lifecycle.skill_state.tokens
+    # token 11 is the admit bonus (TextToken); 12/13 come from the typed hook.
+    assert isinstance(staged[1], _TypedToken)
+    assert isinstance(staged[2], _TypedToken)
+    assert [int(t.token_id) for t in staged] == [11, 12, 13]

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -3003,3 +3003,172 @@ def test_spec_inactive_to_active_reasoning_mask_is_capped() -> None:
     assert commit_caps[0] == 1
     assert commit_caps[1] == 1
     assert commit_caps[2] == 1000
+
+
+class _CommitSideValuesDecoder(_FakeDecoder):
+    """``SpecDecoder`` whose macro-step ``step`` attaches spatial ``side_values``
+    so the COMMIT routes the committed ids through ``materialize_spec_tokens``
+    (the spatial typing hook), and whose ``retire`` returns the row to the free
+    pool so a test can prove a commit-time failure leaked no pool row.
+
+    The admit token is deliberately left text-only (``admit_side_values`` unset),
+    so admission types it through the default ``materialize_tokens`` path and
+    never touches the spec hook -- the ONLY ``materialize_spec_tokens`` call is in
+    ``_commit_spec``. That isolates the fail-fast hook to the commit step, which
+    is exactly the path the P2 guards: ``_commit_spec`` resolves the lazy result
+    and runs ``materialize_spec_tokens`` BEFORE its per-sequence ``inflight_refs``
+    decrement, so a hook raise there must not orphan the pending step's refs.
+    """
+
+    def retire(self, state) -> None:
+        row = self._row_of.pop(id(state))
+        self.retired.append(row)
+        # Return the row to the free pool so the test can prove no leak.
+        self._free.append(row)
+
+
+def test_spec_commit_failure_keeps_pending_refs_until_committed() -> None:
+    """P2 codex finding @ scheduler.py:1100: keep the pending spec record until
+    ``_commit_spec`` SUCCEEDS, so a commit-time failure orphans no in-flight refs.
+
+    Depth-1 overlap launches step N+1 while committing step N. The previous
+    implementation cleared ``_pending_spec`` BEFORE ``_commit_spec(pending)`` ran;
+    ``_commit_spec`` decrements each pending sequence's ``inflight_refs`` only in
+    its FINAL per-sequence loop, after resolving the lazy ``result.tokens`` and
+    running ``materialize_spec_tokens`` -- either of which can raise (a fail-fast
+    hook, a deferred-D2H error). On such a raise the OLD pending refs stayed on
+    the sequences with no ``_pending_spec`` record left to ever commit them, and
+    the ``except`` rolled back only the NEWLY reserved launch refs -- so a
+    finishing row was stranded in ``FINALIZING`` and leaked its decoder row +
+    LoRA slot.
+
+    This drives an adapter row to the point where a macro-step is in flight in
+    ``_pending_spec`` (its ref held on the sequence), makes the NEXT
+    ``_commit_spec`` raise inside ``materialize_spec_tokens`` (before its
+    decrement loop), and asserts that:
+
+    * the commit-time raise propagates but ``_pending_spec`` is STILL installed
+      (the pending step is not lost), the row keeps exactly its one in-flight ref,
+      and nothing was retired / released / finalized -- the refs are not orphaned;
+      and
+    * once the hook stops failing, draining the pipeline commits that same pending
+      step, the row finishes, retires EXACTLY once, ends ``COMPLETED`` with
+      ``inflight_refs`` back at 0, its LoRA slot released exactly once, no
+      ``active_sequences`` entry, and the pool row back at baseline -- i.e. the
+      pending refs were committed, never leaked.
+    """
+    from kestrel.runtime.sampling import SamplingHooks
+
+    @dataclass
+    class _TypedToken:
+        token_id: int
+
+    # Arm the spec typing hook to raise on its FIRST commit call (emulating a
+    # fail-fast materialize / lazy-result error), then succeed on every later
+    # call so the retry/drain can complete the pending step.
+    hook_calls = {"n": 0}
+
+    def materialize_spec_tokens(
+        token_ids_cpu, sequences, batch_idx, side_values, token_logprobs=None
+    ):
+        hook_calls["n"] += 1
+        if hook_calls["n"] == 1:
+            raise RuntimeError("materialize_spec_tokens failed mid-commit")
+        return [
+            _TypedToken(token_id=int(t)) for t in token_ids_cpu.view(-1).tolist()
+        ]
+
+    class _FakeAdapterProvider:
+        def config(self) -> dict:
+            return {"max_lora_rank": 16}
+
+        def get(self, adapter: str) -> object:
+            return object()
+
+    # admit(1) + a 1-token macro-step == max_new=2 -> the committed step finishes
+    # the row, so a botched commit would strand a FINALIZING row (the exact leak).
+    dec = _CommitSideValuesDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12]]},
+        side_values=object(),  # macro-step emits side-values -> commit uses the hook
+        # admit_side_values left None: the admit token stays text-only.
+    )
+    rt = _spec_runtime(dec)
+    rt.sampling_hooks = SamplingHooks(
+        materialize_spec_tokens=materialize_spec_tokens
+    )
+    sched = GenerationScheduler(
+        rt,
+        compute_stream=None,
+        skill_registry=__import__(
+            "kestrel.skills", fromlist=["SkillRegistry"]
+        ).SkillRegistry([]),
+        adapter_provider=_FakeAdapterProvider(),
+    )
+    assert dec.free_slots == 1  # baseline: one row free
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=2, adapter="ft-1", lora_slot_ready=False
+    )
+
+    sched._spec_admit()
+    seq = req.lifecycle
+    acquired_slot = req.lora_slot
+    assert acquired_slot >= 1  # a real adapter slot was acquired
+    assert dec.free_slots == 0  # the row is in use
+
+    # Tick 1 launches the macro-step (no commit yet); it now lives in
+    # ``_pending_spec`` with its in-flight ref held on the sequence.
+    assert sched._spec_decode_step() is True
+    assert sched._pending_spec is not None
+    refs_with_pending = seq.inflight_refs
+    assert refs_with_pending >= 1  # the pending step's ref is held
+
+    # Tick 2 commits the pending step -> the hook raises inside ``_commit_spec``
+    # BEFORE its per-sequence decrement. The raise propagates.
+    with pytest.raises(RuntimeError, match="materialize_spec_tokens failed"):
+        sched._spec_decode_step()
+
+    # ---- The core regression invariant: the pending refs are NOT orphaned. ----
+    # The pending record is STILL installed (old code cleared it up front, losing
+    # the only handle that could ever commit those refs).
+    assert sched._pending_spec is not None
+    # The newly reserved launch ref was rolled back; the row keeps EXACTLY the
+    # pending step's ref (no phantom ref, no dropped ref).
+    assert seq.inflight_refs == refs_with_pending
+    # Nothing was retired / released / finalized by the failed commit: the row is
+    # not stranded in FINALIZING and holds all its resources.
+    assert dec.retired == []
+    assert rt.released_adapter_slots == []
+    assert seq.finalized is False
+    assert seq.finished is False
+    assert seq in sched.running
+    assert seq.phase != RequestPhase.FINALIZING
+    assert req.lora_slot == acquired_slot  # slot still held, not released
+    assert seq.state.batch_idx in rt.active_sequences
+    assert dec.free_slots == 0  # row still in use, not leaked-then-lost
+    # ``has_pending_work`` stays True so the executor keeps driving the commit.
+    assert sched.has_pending_work() is True
+
+    # The hook now succeeds; draining the pipeline commits that SAME pending step
+    # (its refs are consumed, not orphaned), finishing the row.
+    sched._drain_pipeline()
+
+    # The pending step was committed and the row finished cleanly.
+    assert sched._pending_spec is None
+    assert seq.finished is True
+    # Retired EXACTLY once (the committed pending refs drove the retire), back to
+    # a balanced ref count -- the leak the P2 fixes would have left this nonzero
+    # with the row never retired.
+    assert dec.retired == [0]
+    assert dec.retired.count(0) == 1
+    assert seq.inflight_refs == 0
+    assert seq.phase == RequestPhase.COMPLETED
+    # LoRA slot released exactly once (no leak, no double-release).
+    assert rt.released_adapter_slots == [acquired_slot]
+    assert rt.released_adapter_slots.count(acquired_slot) == 1
+    # No dangling active-sequence entry and the pool row is back at baseline.
+    assert seq.state.batch_idx not in rt.active_sequences
+    assert rt.active_sequences == {}
+    assert dec.free_slots == 1
+    assert [c.finish_reason for c in sched.pop_completed()] == ["length"]

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -2296,3 +2296,129 @@ def test_spec_admit_zero_token_request_bypasses_saturated_batch() -> None:
     assert 77 in completed2
     assert completed2[77].finish_reason == "length"
     assert completed2[77].tokens == []
+
+
+def test_spec_inactive_to_active_reasoning_mask_is_capped() -> None:
+    """A reasoning mask that is None at step start but forces a prefix mid-run is capped.
+
+    Regression for the codex P1 @ scheduler ``_mask_is_stateful``: the
+    behavioural fallback inspects the constraint at the committed run's FIRST
+    position only, so it cannot see a mask that is INACTIVE at step start but
+    transitions to ACTIVE within the run. Reasoning skills do exactly that --
+    while collecting reasoning, ``QuerySkillState`` (non-moondream2) and
+    ``ChatSkillState`` expose NO constraint (both ``allowed_token_ids`` and
+    ``suppressed_token_ids`` return ``None``); once the model emits ``answer_id``
+    they force ``post_reasoning_prefix`` one id at a time. If a spec macro-step
+    committed ``answer_id`` plus following tokens under that None-at-start mask,
+    the post-boundary tokens would be accepted WITHOUT the required prefix
+    constraint. So both states declare ``mask_is_stateful = True`` and the
+    scheduler must cap them to one committed token per step EVEN THOUGH both
+    masks read ``None`` this step -- the verdict the bare fallback would miss.
+
+    The contrast row is caption: under the same non-moondream2 runtime its mask
+    is also unconstrained (no allowed/suppressed), and it declares
+    ``mask_is_stateful = False``, so it must STAY uncapped. Same None/None
+    step-start signature, opposite cap verdict -- proving the declaration (not
+    the fallback) decides.
+    """
+    from kestrel.models.moondream.skills.caption import (
+        CaptionRequest,
+        CaptionSkill,
+        CaptionSkillState,
+    )
+    from kestrel.models.moondream.skills.query import (
+        QueryRequest,
+        QuerySkill,
+        QuerySkillState,
+    )
+    from kestrel.skills.chat import (
+        ChatMessage,
+        ChatContentPart,
+        ChatRequest,
+        ChatSkill,
+        ChatSkillState,
+    )
+
+    # A NON-moondream2 runtime: this is the case the bug lived in -- query's
+    # ``suppressed_token_ids`` returns ``None`` off-model, so a reasoning row's
+    # mask is fully None at step start. ``answer_id`` is only read once a step is
+    # consumed (not on the bare mask query this test drives), but provide it for
+    # completeness.
+    ANSWER = 7
+    runtime = SimpleNamespace(
+        model_name="qwen3",
+        prompt_template=SimpleNamespace(answer_id=ANSWER),
+    )
+
+    dec = _FakeDecoder(
+        n_rows=3,
+        first_tokens={0: 10, 1: 20, 2: 30},
+        plans={0: [[]], 1: [[]], 2: [[]]},
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    # Query the REAL skills against the stub ``runtime`` above.
+    sched.runtime = runtime
+
+    # Generous budget so the remaining-budget cap never bites: the only cap that
+    # can appear is the STATEFUL cap (``1``).
+    r_query = _enqueue(sched, 0, prompt_len=3, max_new=1000)
+    r_chat = _enqueue(sched, 1, prompt_len=3, max_new=1000)
+    r_cap = _enqueue(sched, 2, prompt_len=3, max_new=1000)
+
+    # Reasoning ON for query + chat: collecting reasoning, no constraint yet, but
+    # the mask WILL force a prefix after ``answer_id`` -- the transition the
+    # fallback can't see.
+    query_state = QuerySkillState(
+        QuerySkill(),
+        r_query,
+        QueryRequest(
+            question="q", image=None, reasoning=True, stream=False, spatial_refs=None
+        ),
+    )
+    chat_state = ChatSkillState(
+        ChatSkill(),
+        r_chat,
+        ChatRequest(
+            messages=(
+                ChatMessage(role="user", parts=(ChatContentPart(text="hi"),)),
+            ),
+            images=(),
+            reasoning=True,
+            stream=False,
+        ),
+        post_reasoning_prefix=[ANSWER],
+        turn_end_ids=[],
+    )
+    cap_state = CaptionSkillState(
+        CaptionSkill(),
+        r_cap,
+        CaptionRequest(length="normal", image=None, stream=False),
+    )
+    r_query.lifecycle.skill_state = query_state
+    r_chat.lifecycle.skill_state = chat_state
+    r_cap.lifecycle.skill_state = cap_state
+
+    seqs = [r_query.lifecycle, r_chat.lifecycle, r_cap.lifecycle]
+
+    # The exact bug precondition: every row's mask reads None/None THIS step.
+    assert query_state.allowed_token_ids(runtime) is None
+    assert query_state.suppressed_token_ids(runtime) is None
+    assert chat_state.allowed_token_ids(runtime) is None
+    assert chat_state.suppressed_token_ids(runtime) is None
+    assert cap_state.suppressed_token_ids(runtime) is None
+    # The bare behavioural fallback would call all three non-stateful (both masks
+    # empty); the declarations override that for the reasoning rows only.
+    assert (bool(None) or bool(None)) is False  # what the fallback alone returns
+    assert sched._mask_is_stateful(r_query.lifecycle, None, None) is True
+    assert sched._mask_is_stateful(r_chat.lifecycle, None, None) is True
+    assert sched._mask_is_stateful(r_cap.lifecycle, None, None) is False
+
+    _allowed, _suppressed, commit_caps = sched._build_spec_step_masks(seqs)
+
+    # Reasoning rows capped to one committed token per macro-step despite the
+    # None-at-start mask; caption keeps the full multi-token accept (its only cap
+    # is the loose remaining budget).
+    assert commit_caps[0] == 1
+    assert commit_caps[1] == 1
+    assert commit_caps[2] == 1000

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -12,7 +12,8 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 
 from kestrel.runtime import TextToken
-from kestrel.runtime.spec import SpecDecodeCaps, SpecStepResult
+from kestrel.runtime.tokens import CoordToken, ImageMarker, SizeToken
+from kestrel.runtime.spec import SpecDecodeCaps, SpecSideValues, SpecStepResult
 from kestrel.scheduler.scheduler import GenerationScheduler
 from kestrel.scheduler.types import (
     GenerationRequest,
@@ -106,6 +107,11 @@ class _FakeDecoder:
         self.admitted.append(row)
         want_logprobs = getattr(state, "return_logprobs", None) is True
         self.admit_kwargs[row] = {
+            # The *typed* prompt tokens the scheduler forwards (the non-spec
+            # ``prepare_sequence`` contract): asserted to survive admission whole,
+            # not be stripped to ``int(t.token_id)`` (which would raise on
+            # ImageMarker/Coord/Size tokens that lack ``token_id``).
+            "prompt_tokens": list(prompt_token_ids),
             "image": image,
             "allowed_token_ids": allowed_token_ids,
             "suppressed_token_ids": suppressed_token_ids,
@@ -582,26 +588,35 @@ def test_spec_admit_no_one_shot_suppression_past_prefix() -> None:
 
 
 def test_spec_admit_types_admit_token_via_materialize_hook() -> None:
-    """Regression for codex finding: type the admit token through the hook.
+    """Regression for codex finding: type the admit token through the spec hook.
 
     On a spatial runtime the first generated id can be coord/size, so the admit
-    (first) token must be typed through the runtime ``materialize_tokens`` hook
-    using ``admit``'s side-values -- not hard-coded to ``TextToken``. Stubs the
-    hook to wrap the admit id and asserts (a) it ran for the admit token, (b) it
-    received ``admit``'s side-values as the opaque step-handle, (c) the staged
-    first token is the typed token.
+    (first) token must be typed through the runtime ``materialize_spec_tokens``
+    hook using ``admit``'s :class:`SpecSideValues` -- not hard-coded to
+    ``TextToken``, and not via the non-spec ``materialize_tokens`` hook (whose
+    ``(slot, batch_size)`` handle shape ``SpecSideValues`` does not match). Stubs
+    the spec hook to wrap the admit id and asserts (a) it ran for the admit
+    token, (b) it received ``admit``'s side-values, (c) the staged first token is
+    the typed token, (d) the non-spec hook was never invoked with the
+    side-values.
     """
     admit_side_values = object()
     calls: list[dict] = []
+    nonspec_calls: list[object] = []
 
     @dataclass
     class _TypedToken:
         token_id: int
 
-    def materialize_tokens(token_ids_cpu, sequences, batch_idx, step_handle):
+    def materialize_spec_tokens(token_ids_cpu, sequences, batch_idx, side_values):
         ids = [int(t) for t in token_ids_cpu.view(-1).tolist()]
-        calls.append({"step_handle": step_handle, "ids": ids})
+        calls.append({"side_values": side_values, "ids": ids})
         return [_TypedToken(token_id=int(t)) for t in ids]
+
+    def materialize_tokens(token_ids_cpu, sequences, batch_idx, step_handle):
+        # The spec side-values must never reach the non-spec hook.
+        nonspec_calls.append(step_handle)
+        return [_TypedToken(token_id=int(t)) for t in token_ids_cpu.view(-1).tolist()]
 
     dec = _FakeDecoder(
         n_rows=1,
@@ -613,14 +628,19 @@ def test_spec_admit_types_admit_token_via_materialize_hook() -> None:
     from kestrel.runtime.sampling import SamplingHooks
 
     # Hooks are read at scheduler construction, so install before _make_scheduler.
-    rt.sampling_hooks = SamplingHooks(materialize_tokens=materialize_tokens)
+    rt.sampling_hooks = SamplingHooks(
+        materialize_tokens=materialize_tokens,
+        materialize_spec_tokens=materialize_spec_tokens,
+    )
     sched = _make_scheduler(rt)
     req = _enqueue(sched, 0, prompt_len=3, max_new=8)
 
     assert sched._spec_admit() is True
-    # The hook typed the admit id (11) and was handed admit's side-values.
+    # The spec hook typed the admit id (11) and was handed admit's side-values.
     admit_call = next(c for c in calls if c["ids"] == [11])
-    assert admit_call["step_handle"] is admit_side_values
+    assert admit_call["side_values"] is admit_side_values
+    # The non-spec hook was never called with the SpecSideValues.
+    assert admit_side_values not in nonspec_calls
     staged = req.lifecycle.skill_state.tokens
     assert isinstance(staged[0], _TypedToken)
     assert int(staged[0].token_id) == 11
@@ -714,25 +734,33 @@ def test_spec_admit_forwards_image_mask_and_sampling_params() -> None:
 
 
 def test_spec_commit_routes_committed_ids_through_materialize_hook() -> None:
-    """Committed ids are typed via the runtime ``materialize_tokens`` hook.
+    """Committed ids are typed via the runtime ``materialize_spec_tokens`` hook.
 
-    Regression for typed-token finding @ L792: the spec commit must route the
-    committed ids (+ ``SpecStepResult.side_values``) through the runtime hook so a
-    spatial runtime types coord/size ids -- not hardcode ``TextToken``. Stubs the
-    hook to wrap every committed id and asserts the macro-step's ``side_values``
-    reached it.
+    Regression for typed-token finding @ L792 + SpecSideValues finding @ L836:
+    the spec commit must route the committed ids (+ ``SpecStepResult.side_values``)
+    through the *spec-aware* runtime hook so a spatial runtime types coord/size
+    ids -- not hardcode ``TextToken``, and not via the non-spec
+    ``materialize_tokens`` hook (whose ``(slot, batch_size)`` handle shape a
+    ``SpecSideValues`` does not match). Stubs the spec hook to wrap every
+    committed id and asserts the macro-step's ``side_values`` reached it and the
+    non-spec hook was never handed the side-values.
     """
     sentinel_side_values = object()
     calls: list[dict] = []
+    nonspec_calls: list[object] = []
 
     @dataclass
     class _TypedToken:
         token_id: int
 
-    def materialize_tokens(token_ids_cpu, sequences, batch_idx, step_handle):
+    def materialize_spec_tokens(token_ids_cpu, sequences, batch_idx, side_values):
         ids = [int(t) for t in token_ids_cpu.view(-1).tolist()]
-        calls.append({"step_handle": step_handle, "ids": ids})
+        calls.append({"side_values": side_values, "ids": ids})
         return [_TypedToken(token_id=int(t)) for t in ids]
+
+    def materialize_tokens(token_ids_cpu, sequences, batch_idx, step_handle):
+        nonspec_calls.append(step_handle)
+        return [_TypedToken(token_id=int(t)) for t in token_ids_cpu.view(-1).tolist()]
 
     dec = _FakeDecoder(
         n_rows=1,
@@ -744,19 +772,211 @@ def test_spec_commit_routes_committed_ids_through_materialize_hook() -> None:
     from kestrel.runtime.sampling import SamplingHooks
 
     # Hooks are read at scheduler construction, so install before _make_scheduler.
-    rt.sampling_hooks = SamplingHooks(materialize_tokens=materialize_tokens)
+    rt.sampling_hooks = SamplingHooks(
+        materialize_tokens=materialize_tokens,
+        materialize_spec_tokens=materialize_spec_tokens,
+    )
     sched = _make_scheduler(rt)
     req = _enqueue(sched, 0, prompt_len=3, max_new=3)
     sched._spec_admit()
     while sched._spec_decode_step():
         pass
 
-    # The runtime hook typed the committed ids (12, 13) and was handed the
-    # macro-step's side_values as its opaque step-handle.
+    # The spec hook typed the committed ids (12, 13) and was handed the
+    # macro-step's side_values.
     real = next(c for c in calls if c["ids"] == [12, 13])
-    assert real["step_handle"] is sentinel_side_values
+    assert real["side_values"] is sentinel_side_values
+    # The SpecSideValues was never passed into the non-spec hook.
+    assert sentinel_side_values not in nonspec_calls
     staged = req.lifecycle.skill_state.tokens
-    # token 11 is the admit bonus (TextToken); 12/13 come from the typed hook.
+    # token 11 is the admit bonus (TextToken); 12/13 come from the typed spec hook.
     assert isinstance(staged[1], _TypedToken)
     assert isinstance(staged[2], _TypedToken)
     assert [int(t.token_id) for t in staged] == [11, 12, 13]
+
+
+def test_spec_admit_preserves_typed_prefill_tokens() -> None:
+    """Round-2 codex finding @ L619: typed prefill tokens survive admission.
+
+    A launchable prefill can contain non-text tokens -- multi-image chat prompts
+    carry ``ImageMarker`` tokens, and a resumed request's generated prefix can
+    carry ``CoordToken`` / ``SizeToken`` -- none of which expose ``token_id``.
+    The old ``prompt_ids = [int(t.token_id) for t in prefill_tokens]`` ran
+    *before* the per-request ``try`` and raised ``AttributeError``, aborting the
+    whole scheduler. The fix forwards the full typed list (like the non-spec
+    ``prepare_sequence`` path). Asserts admission succeeds and the decoder
+    receives the typed tokens whole (not stripped / dropped).
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    img = object()
+    req = _enqueue(sched, 0, prompt_len=1, max_new=8, image=img)
+    # Inject a mixed typed prefill: BOS text + image marker + a generated-prefix
+    # spatial pair. The base ``_enqueue`` already added one TextToken; replace
+    # the prompt with the multimodal layout.
+    typed_prompt = [
+        TextToken(1),
+        ImageMarker(index=0),
+        CoordToken(pos=0.25),
+        SizeToken(width=0.1, height=0.2),
+        TextToken(2),
+    ]
+    req.prompt_tokens = typed_prompt
+
+    # Must NOT raise (the bug raised AttributeError here, aborting the scheduler).
+    assert sched._spec_admit() is True
+    assert dec.admitted == [0]
+    # The decoder got the *typed* tokens, unstripped and in order.
+    forwarded = dec.admit_kwargs[0]["prompt_tokens"]
+    assert forwarded == typed_prompt
+    # Non-text tokens survived (the regression dropped them via int(t.token_id)).
+    assert any(isinstance(t, ImageMarker) for t in forwarded)
+    assert any(isinstance(t, CoordToken) for t in forwarded)
+    assert any(isinstance(t, SizeToken) for t in forwarded)
+    # The state's token count reflects the typed list length (markers count 1).
+    assert req.lifecycle.state.prompt_length == len(typed_prompt)
+
+
+def test_spec_adapter_request_releases_lora_slot_on_retire() -> None:
+    """Round-2 codex finding @ L1725: a retiring spec row frees its LoRA slot.
+
+    ``_spec_admit`` acquires a runtime LoRA slot for an adapter request, but the
+    spec completion path retires the pool row via ``decoder.retire`` and skips
+    ``runtime.release_sequence`` (which is where the non-spec path drops the
+    adapter ref). Without an explicit release the slot leaks until the adapter
+    pool starves. Asserts every acquired slot is released after the row retires
+    (slot count returns to baseline -- no leak).
+    """
+
+    class _FakeAdapterProvider:
+        def config(self) -> dict:
+            return {"max_lora_rank": 16}
+
+        def get(self, adapter: str) -> object:
+            return object()
+
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12, 13]]},  # admit(1) + 2 == max_new=3 -> finishes + retires
+    )
+    rt = _spec_runtime(dec)
+    sched = GenerationScheduler(
+        rt,
+        compute_stream=None,
+        skill_registry=__import__(
+            "kestrel.skills", fromlist=["SkillRegistry"]
+        ).SkillRegistry([]),
+        adapter_provider=_FakeAdapterProvider(),
+    )
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=3, adapter="ft-1", lora_slot_ready=False
+    )
+    sched._spec_admit()
+    acquired_slot = req.lora_slot
+    assert acquired_slot >= 1  # a real adapter slot was acquired
+    assert rt.released_adapter_slots == []  # not yet released
+
+    # Drive the row to completion (it finishes at max_new=3 and retires).
+    while sched._spec_decode_step():
+        pass
+
+    assert req.lifecycle.finished is True
+    assert dec.retired == [0]
+    # The acquired slot was released exactly once -> count back to baseline.
+    assert rt.released_adapter_slots == [acquired_slot]
+    assert rt.released_adapter_slots.count(acquired_slot) == 1
+    assert req.lifecycle.state.batch_idx not in rt.active_sequences
+
+
+def test_spec_admit_finish_releases_lora_slot() -> None:
+    """LoRA slot is released even when the request finishes at admit time.
+
+    If the admit bonus token already finishes the request (e.g. immediate EOS),
+    ``_spec_admit`` retires the row inline. That path must also release the
+    adapter slot (it goes through the same ``_retire_spec_row`` helper).
+    """
+
+    class _FakeAdapterProvider:
+        def config(self) -> dict:
+            return {"max_lora_rank": 16}
+
+        def get(self, adapter: str) -> object:
+            return object()
+
+    # First token is EOS -> request finishes right after admit.
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 999}, plans={0: [[0]]})
+    rt = _spec_runtime(dec, eos_id=999)
+    sched = GenerationScheduler(
+        rt,
+        compute_stream=None,
+        skill_registry=__import__(
+            "kestrel.skills", fromlist=["SkillRegistry"]
+        ).SkillRegistry([]),
+        adapter_provider=_FakeAdapterProvider(),
+    )
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=8, adapter="ft-1", lora_slot_ready=False
+    )
+
+    assert sched._spec_admit() is True
+    acquired_slot = req.lora_slot
+    assert acquired_slot >= 1
+    assert req.lifecycle.finished is True
+    assert dec.retired == [0]
+    # Slot released on the admit-finish path too (no leak).
+    assert rt.released_adapter_slots == [acquired_slot]
+    assert req.lifecycle.state.batch_idx not in rt.active_sequences
+
+
+def test_spec_side_values_guarded_when_no_spec_hook() -> None:
+    """Round-2 codex finding @ L836: SpecSideValues never hits the non-spec hook.
+
+    When a macro-step returns spatial ``SpecSideValues`` but the runtime exposes
+    only the non-spec ``materialize_tokens`` hook (whose handle is the
+    ``post_sample`` ``(slot, batch_size)`` aux value), the scheduler must NOT feed
+    the side-values into it -- doing so raises ``cannot unpack SpecSideValues`` or
+    reads the wrong layout. The guard materialises plain ``TextToken``s instead.
+    Asserts (a) no crash, (b) the non-spec hook is never handed the side-values,
+    (c) the committed ids still materialise (as text) and stage correctly.
+    """
+    real_side_values = SpecSideValues(
+        hidden=__import__("torch").zeros(1, 3, 4),
+        temperatures=__import__("torch").zeros(1),
+        top_ps=__import__("torch").ones(1),
+    )
+    nonspec_handles: list[object] = []
+
+    def materialize_tokens(token_ids_cpu, sequences, batch_idx, step_handle):
+        # Emulate the Moondream hook's unpack so a SpecSideValues would blow up
+        # here if the scheduler ever routed it through this non-spec hook.
+        nonspec_handles.append(step_handle)
+        if step_handle is not None:
+            _slot, _batch_size = step_handle  # would raise on SpecSideValues
+        return [TextToken(token_id=int(t)) for t in token_ids_cpu.view(-1).tolist()]
+
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12, 13]]},  # admit(1) + 2 == max_new=3 -> finishes here
+        side_values=real_side_values,
+    )
+    rt = _spec_runtime(dec)
+    from kestrel.runtime.sampling import SamplingHooks
+
+    # Only the NON-spec hook is installed; no materialize_spec_tokens.
+    rt.sampling_hooks = SamplingHooks(materialize_tokens=materialize_tokens)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=3)
+    sched._spec_admit()
+    # Must not raise (the bug fed SpecSideValues into the non-spec hook -> unpack
+    # TypeError, aborting the scheduler).
+    while sched._spec_decode_step():
+        pass
+
+    # The non-spec hook was never handed the SpecSideValues (guard held).
+    assert real_side_values not in nonspec_handles
+    # Committed ids still staged (materialised as plain text via the guard).
+    assert [int(t.token_id) for t in req.lifecycle.skill_state.tokens] == [11, 12, 13]
+    assert req.lifecycle.finished is True

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -1384,6 +1384,122 @@ def test_spec_pre_admit_hook_failure_releases_lora_slot_and_fails_cleanly() -> N
     assert len(sched.running) == 0
 
 
+class _AdmitSideValuesDecoder(_FakeDecoder):
+    """``SpecDecoder`` whose ``admit`` SUCCEEDS -- reserving a pool row, assigning
+    ``batch_idx``, and attaching spatial ``admit_side_values`` to the state -- but
+    whose row is returned to the free pool by ``retire`` so a test can prove the
+    post-admit cleanup did not leak the row.
+
+    This drives the failure site that the base ``_RaisingAdmitDecoder`` does NOT:
+    ``decoder.admit`` returns cleanly, the request is registered in
+    ``active_sequences`` and ``sequence_state`` is set, and the failure happens
+    LATER when the scheduler types the admit token via ``_materialize_spec_tokens``
+    (a spatial ``admit_side_values`` with no ``materialize_spec_tokens`` hook fails
+    fast). That materialization runs OUTSIDE the original admit ``try``/cleanup, so
+    without the fix it leaks the spec row + LoRA slot + ``active_sequences`` entry
+    and strands the request.
+    """
+
+    def retire(self, state) -> None:
+        row = self._row_of.pop(id(state))
+        self.retired.append(row)
+        # Return the row to the free pool so the test can prove no leak.
+        self._free.append(row)
+
+
+def test_spec_admit_token_materialize_failure_retires_row_no_leak() -> None:
+    """P2 codex finding @ scheduler.py:950: a raising admit-token
+    materialization retires the spec row and frees the LoRA slot, no leak.
+
+    The admit-token typing/staging path runs AFTER ``decoder.admit`` has reserved
+    the pool row, set ``sequence_state``, and registered the state in
+    ``active_sequences`` -- but BEFORE the request is pushed to ``running`` and
+    while it has no finish/zombie path. It also sits OUTSIDE the admit ``try`` that
+    retires the row + releases the LoRA slot. If ``_materialize_spec_tokens``
+    raises here (a spatial admit token whose runtime emits ``admit_side_values``
+    but exposes no ``materialize_spec_tokens`` hook -> fail-fast ``RuntimeError``),
+    an unguarded raise would leak the spec pool row + adapter slot +
+    ``active_sequences`` entry and strand the request with no scheduler path to
+    finish. Asserts the bad spatial admit (a) retires the reserved row, (b)
+    releases the LoRA slot exactly once, (c) fails the request cleanly (error
+    result, COMPLETED -- not stuck PREFILLING), (d) leaves no ``active_sequences``
+    leak and ``free_slots`` back at baseline, and (e) lets a SUBSEQUENT request
+    admit into the reclaimed row.
+    """
+
+    class _FakeAdapterProvider:
+        def config(self) -> dict:
+            return {"max_lora_rank": 16}
+
+        def get(self, adapter: str) -> object:
+            return object()
+
+    # ``admit`` succeeds and attaches spatial side-values; the runtime exposes NO
+    # ``materialize_spec_tokens`` hook (the default ``_spec_runtime`` SamplingHooks
+    # are empty), so typing the admit token fails fast inside ``_spec_admit``.
+    admit_side_values = object()
+    dec = _AdmitSideValuesDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12]]},
+        admit_side_values=admit_side_values,
+    )
+    rt = _spec_runtime(dec)
+    assert dec.free_slots == 1  # baseline: one row free
+    sched = GenerationScheduler(
+        rt,
+        compute_stream=None,
+        skill_registry=__import__(
+            "kestrel.skills", fromlist=["SkillRegistry"]
+        ).SkillRegistry([]),
+        adapter_provider=_FakeAdapterProvider(),
+    )
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=8, adapter="ft-1", lora_slot_ready=False
+    )
+
+    # The scheduler does not crash out -- it cleans up and reports progress.
+    assert sched._spec_admit() is True
+    # ``admit`` reserved the row; the admit-token materialization then failed and
+    # the row was retired -> no leak (free pool back at baseline).
+    assert dec.admitted == [0]
+    assert dec.retired == [0]
+    assert dec.free_slots == 1
+    # The LoRA slot acquired for the adapter request was released exactly once
+    # (not leaked, not double-released) and zeroed so no later path re-releases it.
+    assert len(rt.acquired_adapter_slots) == 1
+    acquired_slot = len(rt.acquired_adapter_slots)  # FakeRuntime numbers from 1
+    assert rt.released_adapter_slots == [acquired_slot]
+    assert rt.released_adapter_slots.count(acquired_slot) == 1
+    assert req.lora_slot == 0
+    assert req.lifecycle.lora_slot_ready is False
+    # The request failed cleanly -- COMPLETED, error result, not stuck PREFILLING,
+    # never pushed to running, and no token staged.
+    assert req.lifecycle.finished is True
+    assert req.lifecycle.finish_reason == "error"
+    assert req.lifecycle.phase == RequestPhase.COMPLETED
+    assert len(req.lifecycle.skill_state.tokens) == 0
+    assert len(sched.running) == 0
+    assert len(sched.waiting) == 0
+    # No dangling active row: the state registered just before the failed
+    # materialization was popped on cleanup.
+    assert rt.active_sequences == {}
+    completed = sched.pop_completed()
+    assert [c.request_id for c in completed] == [0]
+    assert completed[0].finish_reason == "error"
+
+    # The reclaimed row is genuinely reusable: a fresh (non-spatial) request admits
+    # into it rather than starving on a permanently-drained pool. Clear the admit
+    # side-values so the next admit token types as a plain TextToken (no hook
+    # needed) and succeeds.
+    dec._admit_side_values = None
+    req2 = _enqueue(sched, 1, prompt_len=2, max_new=8)
+    assert sched._spec_admit() is True
+    assert req2.lifecycle.finished is False
+    assert req2.lifecycle.state.batch_idx in rt.active_sequences
+    assert dec.free_slots == 0  # the single row is now in use by req2
+
+
 def test_spec_side_values_fails_fast_when_no_spec_hook() -> None:
     """Spatial ``SpecSideValues`` without a spec hook must FAIL FAST, not degrade.
 

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -1,0 +1,229 @@
+"""CPU tests for the scheduler's speculative-decoding path.
+
+Drives ``GenerationScheduler`` with a fake ``SpecDecoder`` (no GPU): proves spec
+admission (prefill -> first token), the per-macro-step variable advance, finish
+handling within an accepted run, continuous-batching retire, and that the
+non-spec path stays untouched when ``runtime.spec`` is ``None``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+from kestrel.runtime import TextToken
+from kestrel.runtime.spec import SpecDecodeCaps, SpecStepResult
+from kestrel.scheduler.scheduler import GenerationScheduler
+from kestrel.scheduler.types import (
+    GenerationRequest,
+    RequestLifecycle,
+    RequestPhase,
+)
+from kestrel.skills import DecodeStep, SkillFinalizeResult, SkillState
+
+from tests.scheduler._fake_runtime import FakeRuntime
+
+
+@dataclass(frozen=True)
+class _SpecSkillSpec:
+    name: str = "spec"
+
+
+class _RecordingState(SkillState):
+    def __init__(self, request: GenerationRequest) -> None:
+        super().__init__(_SpecSkillSpec(), request)  # type: ignore[arg-type]
+
+    def consume_step(self, runtime: object, step: DecodeStep) -> None:
+        self.append_token(step.token)
+
+    def finalize(self, runtime: object, *, reason: str) -> SkillFinalizeResult:
+        return SkillFinalizeResult(text="", tokens=list(self.tokens), output={})
+
+
+class _FakeDecoder:
+    """Scriptable ``SpecDecoder`` for the scheduler test (no GPU).
+
+    ``admit`` hands back a fixed first token and assigns the next free pool row.
+    ``step`` pops a scripted ``(tokens, accept)`` plan per call from each row's
+    queue (rows advance by *different* amounts to exercise ragged advance).
+    """
+
+    num_speculative_tokens = 3
+
+    def __init__(self, *, n_rows: int, plans: dict, first_tokens: dict) -> None:
+        self._free = list(range(n_rows))
+        self._row_of: dict[int, int] = {}
+        self._plans = plans            # row -> list[list[int]] per step
+        self._first = first_tokens     # row -> first token id
+        self.admitted: list[int] = []
+        self.retired: list[int] = []
+
+    @property
+    def free_slots(self) -> int:
+        return len(self._free)
+
+    def admit(self, state, prompt_token_ids):
+        row = self._free.pop(0)
+        self._row_of[id(state)] = row
+        state.batch_idx = 100 + row
+        self.admitted.append(row)
+        return self._first[row]
+
+    def step(self, states):
+        tokens, accepts = [], []
+        for s in states:
+            row = self._row_of[id(s)]
+            nxt = self._plans[row].pop(0)
+            tokens.append(list(nxt))
+            accepts.append(len(nxt) - 1)
+        return SpecStepResult(tokens=tokens, accept_counts=accepts)
+
+    def retire(self, state) -> None:
+        self.retired.append(self._row_of.pop(id(state)))
+        # row not returned to free list in this test (fixed admission set)
+
+
+def _spec_runtime(decoder: _FakeDecoder, *, eos_id: int = 999) -> FakeRuntime:
+    rt = FakeRuntime(max_batch_size=4, max_batch_slots=8)
+    rt.spec = SpecDecodeCaps(proposer=SimpleNamespace(num_speculative_tokens=3,
+                                                      num_lookahead_tokens=4),
+                             decoder=decoder)
+    rt.prompt_template = SimpleNamespace(eos_id=eos_id)
+    return rt
+
+
+def _enqueue(sched: GenerationScheduler, rid: int, prompt_len: int, max_new: int):
+    req = GenerationRequest(
+        request_id=rid,
+        prompt="p",
+        prompt_tokens=[TextToken(1)] * prompt_len,
+        max_new_tokens=max_new,
+        skill=_SpecSkillSpec(),  # type: ignore[arg-type]
+        request_context=object(),
+    )
+    lc = RequestLifecycle(request=req, skill_state=_RecordingState(req))
+    lc.crops_ready = True
+    lc.lora_slot_ready = True
+    lc.transition(RequestPhase.READY_FOR_PREFILL)
+    req.lifecycle = lc
+    sched.enqueue_request(req, lc.skill_state)
+    return req
+
+
+def _make_scheduler(rt: FakeRuntime) -> GenerationScheduler:
+    from kestrel.skills import SkillRegistry
+
+    return GenerationScheduler(rt, compute_stream=None, skill_registry=SkillRegistry([]))
+
+
+def test_spec_admit_stages_first_token_and_queues() -> None:
+    dec = _FakeDecoder(
+        n_rows=2,
+        first_tokens={0: 11, 1: 22},
+        plans={0: [[12, 13]], 1: [[23]]},  # one step each
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    r0 = _enqueue(sched, 0, prompt_len=3, max_new=8)
+    r1 = _enqueue(sched, 1, prompt_len=2, max_new=8)
+
+    assert sched._spec_admit() is True
+    # Both admitted, first tokens staged, queued into running.
+    assert dec.admitted == [0, 1]
+    assert [int(t.token_id) for t in r0.lifecycle.skill_state.tokens] == [11]
+    assert [int(t.token_id) for t in r1.lifecycle.skill_state.tokens] == [22]
+    assert len(sched.running) == 2
+    # admit assigned the decoder's pool batch index onto the state.
+    assert r0.lifecycle.state.batch_idx == 100
+    assert r1.lifecycle.state.batch_idx == 101
+    assert r0.lifecycle.state.batch_idx in rt.active_sequences
+
+
+def test_spec_step_variable_advance_and_state_length() -> None:
+    dec = _FakeDecoder(
+        n_rows=2,
+        first_tokens={0: 11, 1: 22},
+        # row 0 advances 2 tokens, row 1 advances 1 token in the same step.
+        plans={0: [[12, 13]], 1: [[23]]},
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    r0 = _enqueue(sched, 0, prompt_len=3, max_new=8)
+    r1 = _enqueue(sched, 1, prompt_len=2, max_new=8)
+    sched._spec_admit()
+
+    len0_before = r0.lifecycle.state.length
+    len1_before = r1.lifecycle.state.length
+    assert sched._spec_decode_step() is True
+
+    # Variable advance: row 0 committed 2, row 1 committed 1.
+    assert [int(t.token_id) for t in r0.lifecycle.skill_state.tokens] == [11, 12, 13]
+    assert [int(t.token_id) for t in r1.lifecycle.skill_state.tokens] == [22, 23]
+    # KV length advanced by the committed count per sequence.
+    assert r0.lifecycle.state.length - len0_before == 2
+    assert r1.lifecycle.state.length - len1_before == 1
+
+
+def test_spec_finish_on_eos_within_run_retires_and_completes() -> None:
+    # row 0 emits eos as its 2nd new token -> finishes mid-run, retires.
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12, 999, 13]]},  # 999 == eos; 13 should not be staged
+    )
+    rt = _spec_runtime(dec, eos_id=999)
+    sched = _make_scheduler(rt)
+    r0 = _enqueue(sched, 0, prompt_len=3, max_new=20)
+    sched._spec_admit()
+    sched._spec_decode_step()
+
+    toks = [int(t.token_id) for t in r0.lifecycle.skill_state.tokens]
+    # Staged up to and including eos, then stopped (13 dropped).
+    assert toks == [11, 12, 999]
+    assert r0.lifecycle.finished is True
+    assert dec.retired == [0]
+    assert r0.lifecycle.state.batch_idx not in rt.active_sequences
+    completed = sched.pop_completed()
+    assert [c.request_id for c in completed] == [0]
+    assert completed[0].finish_reason == "stop"
+
+
+def test_spec_finish_on_max_new_tokens() -> None:
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12, 13]]},  # admit(1) + 2 -> 3 tokens == max_new
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    r0 = _enqueue(sched, 0, prompt_len=3, max_new=3)
+    sched._spec_admit()
+    # admit already staged 1; one step stages 2 more -> hits max_new=3.
+    sched._spec_decode_step()
+    assert r0.lifecycle.finished is True
+    assert dec.retired == [0]
+    assert [c.finish_reason for c in sched.pop_completed()] == ["length"]
+
+
+def test_spec_admit_respects_free_slots() -> None:
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    _enqueue(sched, 0, prompt_len=3, max_new=8)
+    _enqueue(sched, 1, prompt_len=3, max_new=8)
+    sched._spec_admit()
+    # Only one row free -> only one admitted; the other stays waiting.
+    assert dec.admitted == [0]
+    assert len(sched.waiting) == 1
+    assert len(sched.running) == 1
+
+
+def test_advance_routes_to_spec_when_capability_present() -> None:
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12], [13]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    _enqueue(sched, 0, prompt_len=3, max_new=8)
+    # advance() must take the spec branch (admits + steps) without touching the
+    # single-token decode pipeline.
+    assert sched.advance() is True
+    assert dec.admitted == [0]

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -176,6 +176,7 @@ def _enqueue(
     temperature: float = 0.0,
     top_p: float = 1.0,
     image: object | None = None,
+    image_length: int = 0,
     skill_state: SkillState | None = None,
 ):
     req = GenerationRequest(
@@ -190,6 +191,7 @@ def _enqueue(
         temperature=temperature,
         top_p=top_p,
         image=image,
+        image_length=image_length,
     )
     lc = RequestLifecycle(
         request=req, skill_state=skill_state or _RecordingState(req)
@@ -980,3 +982,151 @@ def test_spec_side_values_guarded_when_no_spec_hook() -> None:
     # Committed ids still staged (materialised as plain text via the guard).
     assert [int(t.token_id) for t in req.lifecycle.skill_state.tokens] == [11, 12, 13]
     assert req.lifecycle.finished is True
+
+
+def test_spec_admit_image_sequence_state_includes_image_kv_length() -> None:
+    """Regression for the image-prompt length under-report (codex finding @ L646).
+
+    For an image request the spec ``SequenceState`` must record the *KV* prompt
+    length -- the typed-token count PLUS the image KV prefix -- exactly like the
+    non-spec ``prepare_sequence`` (which expands a single-image prefix /
+    ``ImageMarker``s into the KV prompt length). Initializing ``length`` /
+    ``prompt_length`` from the typed token count alone (leaving ``image_length``
+    at 0) made ``build_metrics`` under-report prompt tokens by the image prefix
+    and skewed ``output_length`` (``length - prompt_length``). Assert the state
+    carries ``len(prompt_tokens) + request.image_length`` and ``image_length``.
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    prompt_len = 3
+    image_kv = 729  # a single-image prefix (image_prefix_length) worth of KV
+    req = _enqueue(
+        sched, 0, prompt_len=prompt_len, max_new=8, image=object(),
+        image_length=image_kv,
+    )
+
+    assert sched._spec_admit() is True
+    state = req.lifecycle.state
+    # KV prompt length = typed token count + image KV prefix (matches the
+    # non-spec prepare_sequence single-image layout: len(tokens) + image_kv).
+    assert state.length == prompt_len + image_kv
+    assert state.prompt_length == prompt_len + image_kv
+    assert state.image_length == image_kv
+    # build_metrics reports the full (image-inclusive) prompt length, not the
+    # bare typed-token count.
+    metrics = req.lifecycle.build_metrics(decode_tokens=0)
+    assert metrics.prompt_tokens == prompt_len + image_kv
+
+
+def test_spec_admit_text_sequence_state_length_unchanged() -> None:
+    """Text-only spec admission is unaffected by the image-KV length fix.
+
+    With ``image_length == 0`` the state length must remain the bare typed-token
+    count (no regression to the non-image path).
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=4, max_new=8)
+
+    assert sched._spec_admit() is True
+    state = req.lifecycle.state
+    assert state.length == 4
+    assert state.prompt_length == 4
+    assert state.image_length == 0
+
+
+def test_spec_admit_zero_token_request_admits_and_samples_nothing() -> None:
+    """Regression for the 0-token spec admit (codex finding @ L699).
+
+    ``decoder.admit`` prefills *and* samples/stages token0, but a request with
+    ``max_new_tokens == 0`` must not sample/stream any token (the non-spec path
+    has a dedicated zero-length branch that finalizes as ``"length"`` without
+    sampling). A 0-token request routed through the spec runtime must therefore
+    admit nothing, consume no spec pool row, stage no token, and complete
+    immediately with finish_reason ``"length"`` and zero output tokens.
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=0)
+
+    progressed = sched._spec_admit()
+
+    assert progressed is True
+    # No spec row consumed (admit never called), nothing retired, no active row.
+    assert dec.admitted == []
+    assert dec.retired == []
+    assert rt.active_sequences == {}
+    # Not queued into running; no sequence_state attached.
+    assert len(sched.running) == 0
+    assert len(sched.waiting) == 0
+    assert req.lifecycle.sequence_state is None
+    # No token sampled/staged.
+    assert list(req.lifecycle.skill_state.tokens) == []
+    # Completed immediately as a length-capped (0-token) result.
+    completed = sched.pop_completed()
+    assert [c.request_id for c in completed] == [0]
+    assert completed[0].finish_reason == "length"
+    assert list(completed[0].tokens) == []
+    # build_metrics falls back to request.prompt_length (no sequence_state),
+    # mirroring the non-spec zero-length path.
+    assert completed[0].metrics.prompt_tokens == req.prompt_length
+
+
+def test_spec_drain_pipeline_commits_pending_spec_before_pause() -> None:
+    """Regression for the pause/drain leak of in-flight spec work (finding @ L548).
+
+    The engine PAUSE path calls ``Executor.drain`` -> ``_drain_pipeline`` before
+    mutating runtime/graph state. ``_spec_decode_step`` launches a macro-step
+    (stored in ``_pending_spec``) one tick before committing it, so a pause can
+    land with a spec result still uncommitted. ``_drain_pipeline`` must drain that
+    pending spec work (commit + retire) before returning -- otherwise the runtime
+    is mutated under an active, uncommitted spec row and the completion/retire is
+    deferred to resume. Launch a macro-step, leave it pending, then assert
+    ``_drain_pipeline`` flushes it.
+    """
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12, 13]]},  # admit(1) + 2 == max_new=3 -> finishes in the run
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=3)
+    sched._spec_admit()
+
+    # One macro-step: depth-1 means this LAUNCHES the step and leaves it pending
+    # (uncommitted) -- exactly the window a pause can land in.
+    assert sched._spec_decode_step() is True
+    assert sched._pending_spec is not None
+    assert req.lifecycle.finished is False  # not yet committed
+
+    # The pause path's drain entry point must flush the pending spec step.
+    sched._drain_pipeline()
+
+    assert sched._pending_spec is None
+    assert req.lifecycle.finished is True
+    assert dec.retired == [0]
+    assert rt.active_sequences == {}
+    # Drained work surfaced its completion (committed tokens 11,12,13).
+    assert [int(t.token_id) for t in req.lifecycle.skill_state.tokens] == [11, 12, 13]
+    completed = sched.pop_completed()
+    assert [c.request_id for c in completed] == [0]
+    assert completed[0].finish_reason == "length"
+
+
+def test_spec_drain_pipeline_noop_when_no_pending_spec() -> None:
+    """``_drain_pipeline`` is a safe no-op when no spec step is outstanding."""
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    _enqueue(sched, 0, prompt_len=3, max_new=8)
+    sched._spec_admit()
+    assert sched._pending_spec is None
+
+    # No launched-but-uncommitted step: drain must not raise or launch new work.
+    sched._drain_pipeline()
+    assert sched._pending_spec is None
+    assert dec.retired == []

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -93,6 +93,10 @@ class _FakeDecoder:
         # each parallel to that call's ``states``). Lets a test assert the
         # scheduler caps a STATEFUL-masked row to a single committed token.
         self.step_commit_caps: list = []
+        # Per-``step`` row ids the scheduler launches (one entry per call, the
+        # decoder rows backing that call's ``states``). Lets a test assert a row
+        # finalized by the prior commit is NOT launched into another macro-step.
+        self.step_rows: list = []
 
     @property
     def free_slots(self) -> int:
@@ -162,6 +166,7 @@ class _FakeDecoder:
         self.step_commit_caps.append(
             list(commit_caps) if commit_caps is not None else None
         )
+        self.step_rows.append([self._row_of[id(s)] for s in states])
         tokens, accepts, logprobs = [], [], []
         for idx, s in enumerate(states):
             row = self._row_of[id(s)]
@@ -378,45 +383,65 @@ def test_advance_routes_to_spec_when_capability_present() -> None:
 def test_has_pending_work_tracks_pending_spec_until_drained() -> None:
     """Regression for the depth-1 drain leak (codex finding @ L617).
 
-    A finishing sequence launches one optimistic follow-up macro-step before its
-    own commit removes it from ``running``. That follow-up lives in
-    ``_pending_spec`` as a zombie. ``has_pending_work()`` must stay True while it
-    is outstanding, otherwise the executor stops calling ``advance`` and the
-    zombie step is never committed -> ``decoder.retire`` never runs -> the spec
-    row leaks. Drive the loop until ``running`` empties with a pending step still
-    outstanding and assert (a) the row is retired exactly once, (b)
-    ``has_pending_work`` only goes False after the pending step is committed.
+    A launched-but-uncommitted macro-step lives in ``_pending_spec`` (depth-1
+    overlap launches step N+1 while committing step N). ``has_pending_work()``
+    must stay True while such a step is outstanding, otherwise the executor stops
+    calling ``advance`` and the pending step is never committed -> the spec row
+    leaks. The ``_pending_spec is not None`` term in ``has_pending_work`` is the
+    guard for exactly that.
+
+    NOTE on the L997 fix: a row finalized by the commit (it hit ``max_new_tokens``)
+    is now dropped from the next launch and retired SYNCHRONOUSLY -- its reserved
+    ref is decremented and the row retired inside the same ``_spec_decode_step``
+    -- rather than launched into one more optimistic ``decoder.step`` and retired
+    a tick later. So a *finishing* row no longer produces a ``running``-empty /
+    ``_pending_spec``-set window (that window only existed because the finished
+    row was launched into a throwaway step -- the exact unsafe relaunch L997
+    fixes). This drives a CONTINUING (multi-step) sequence -- whose follow-up step
+    is genuinely in flight across ticks -- to assert the live invariant
+    (``_pending_spec`` set => ``has_pending_work`` True), then lets it finish and
+    asserts the finishing row retires exactly once, ends ``COMPLETED``, and leaves
+    ``has_pending_work`` False, with no leak.
     """
     dec = _FakeDecoder(
         n_rows=1,
         first_tokens={0: 11},
-        plans={0: [[12, 13]]},  # admit(1) + 2 == max_new=3 -> finishes here
+        # A continuing run: one token per step across several steps, then EOS, so a
+        # real follow-up step sits in ``_pending_spec`` while the row keeps running.
+        plans={0: [[12], [13], [14], [999]]},  # 999 == eos -> finishes
     )
-    rt = _spec_runtime(dec)
+    rt = _spec_runtime(dec, eos_id=999)
     sched = _make_scheduler(rt)
-    _enqueue(sched, 0, prompt_len=3, max_new=3)
+    r0 = _enqueue(sched, 0, prompt_len=3, max_new=20)
     sched._spec_admit()
 
-    # Drive macro-steps manually so we can observe the tick where ``running``
-    # is already empty but a pending (zombie) spec step is still outstanding.
-    saw_pending_after_running_empty = False
-    for _ in range(10):
+    # While the row is running with a launched-but-uncommitted step in flight,
+    # ``has_pending_work`` must report True via the ``_pending_spec`` term.
+    saw_pending_while_running = False
+    for _ in range(20):
         if not sched._spec_decode_step():
             break
-        if len(sched.running) == 0 and sched._pending_spec is not None:
-            saw_pending_after_running_empty = True
-            # This is exactly the window the bug regressed: the old
-            # has_pending_work() (waiting/running/pipeline only) returned False
-            # here and the executor would stop driving advance().
+        if sched._pending_spec is not None:
+            # The live L617 invariant: an outstanding pending step keeps work
+            # pending so the executor keeps driving ``advance`` until it commits.
             assert sched.has_pending_work() is True
+            if len(sched.running) > 0:
+                saw_pending_while_running = True
+        # L997: a finishing row retires synchronously, so a ``running``-empty tick
+        # never leaves an optimistic follow-up step dangling in ``_pending_spec``.
+        if len(sched.running) == 0:
+            assert sched._pending_spec is None
 
-    assert saw_pending_after_running_empty is True
-    # Pending step committed, row retired exactly once, nothing leaked.
+    # The pending-while-running window (the one the L617 guard protects) occurred.
+    assert saw_pending_while_running is True
+    # Drained: pending committed, row retired exactly once, COMPLETED, no leak.
     assert sched._pending_spec is None
     assert dec.retired == [0]
+    assert dec.retired.count(0) == 1
+    assert r0.lifecycle.phase == RequestPhase.COMPLETED
     assert rt.active_sequences == {}
     assert sched.has_pending_work() is False
-    assert [c.finish_reason for c in sched.pop_completed()] == ["length"]
+    assert [c.finish_reason for c in sched.pop_completed()] == ["stop"]
 
 
 def test_spec_admit_acquires_lora_slot_for_adapter_request() -> None:
@@ -1568,17 +1593,23 @@ def test_spec_step_does_not_cap_unconstrained_or_constant_mask_row() -> None:
 
 
 def test_spec_zombie_lifecycle_marked_completed_before_retire() -> None:
-    """Regression for codex P2 @ L1012: zombie -> COMPLETED before row retire.
+    """Regression for codex P2 @ L1012: a finished spec row ends COMPLETED, retired once.
 
-    When a spec request finishes while its depth-1 follow-up macro-step is still
-    in flight, ``_finalize_sequence`` leaves it FINALIZING (``inflight_refs >
-    0``). The zombie branch in ``_commit_spec`` is where that last ref reaches
-    zero; it used to ONLY retire the decoder row and never transition the
-    lifecycle to COMPLETED, so a normally-completed spec request could stay stuck
-    in FINALIZING forever after its row was retired. This drives a sequence that
-    finishes with an optimistic follow-up step outstanding and asserts the
-    lifecycle ends COMPLETED (not FINALIZING) and its row is retired exactly
-    once -- matching the non-spec zombie ordering in ``commit_step``.
+    A finishing spec request must end ``COMPLETED`` (not stuck ``FINALIZING``)
+    with its decoder row retired exactly once -- the invariant this guards (the
+    bug left a completed request in ``FINALIZING`` forever after its row was
+    retired, because the zombie commit retired the row but never transitioned the
+    lifecycle).
+
+    L997 fix changes only the *timing*, not this invariant: a row finalized by the
+    commit (it hit ``max_new_tokens``) is now dropped from the next launch and
+    retired SYNCHRONOUSLY inside the finishing ``_spec_decode_step`` -- the
+    ``transition(COMPLETED)`` + ``_retire_spec_row`` happen in the filter right
+    after the commit, NOT a tick later via an optimistic follow-up (zombie)
+    commit. So there is no longer a FINALIZING-with-pending window: the request
+    goes ``FINALIZING -> COMPLETED -> retired`` within one step. This asserts the
+    end state (COMPLETED, retired exactly once, no leak) and that the row was
+    never left FINALIZING after its retire.
     """
     dec = _FakeDecoder(
         n_rows=1,
@@ -1590,27 +1621,19 @@ def test_spec_zombie_lifecycle_marked_completed_before_retire() -> None:
     req = _enqueue(sched, 0, prompt_len=3, max_new=3)
     sched._spec_admit()
 
-    # Drive to quiescence. The finishing commit lands while a follow-up
-    # (zombie) step is in flight; the zombie's own commit retires the row and
-    # must mark the lifecycle COMPLETED.
-    saw_finalizing_with_pending = False
+    # Drive to quiescence, asserting the row is never left FINALIZING while still
+    # holding the decoder row (the bug's stuck state). Under L997 the finishing
+    # step transitions COMPLETED + retires in one go, so a retired row is never
+    # observed in FINALIZING.
     for _ in range(10):
         if not sched._spec_decode_step():
             break
-        if (
-            req.lifecycle.finished
-            and sched._pending_spec is not None
-            and req.lifecycle.phase == RequestPhase.FINALIZING
-        ):
-            # The exact window: finished + an in-flight zombie step still holds a
-            # ref, so the lifecycle is (correctly) FINALIZING, not yet COMPLETED.
-            saw_finalizing_with_pending = True
+        if req.lifecycle.phase == RequestPhase.FINALIZING:
+            # If ever FINALIZING, its row must still be live (not yet retired) --
+            # i.e. the lifecycle is never stuck FINALIZING after a retire.
+            assert req.lifecycle.state.batch_idx in rt.active_sequences
 
-    # The FINALIZING-with-zombie window actually occurred (otherwise the test
-    # would not be exercising the zombie completion path at all).
-    assert saw_finalizing_with_pending is True
-    # After the zombie's commit: row retired exactly once, lifecycle COMPLETED
-    # (the bug left it stuck in FINALIZING), nothing leaked.
+    # End state: lifecycle COMPLETED, row retired exactly once, nothing leaked.
     assert dec.retired == [0]
     assert dec.retired.count(0) == 1
     assert req.lifecycle.phase == RequestPhase.COMPLETED
@@ -1742,3 +1765,138 @@ def test_spec_step_rolls_back_refs_when_launch_raises() -> None:
     assert r0.lifecycle.finalized is False
     assert r0.lifecycle in sched.running
     assert r0.lifecycle.state.batch_idx in rt.active_sequences
+
+
+def test_spec_step_does_not_launch_row_finalized_by_commit() -> None:
+    """Regression for codex P1 @ L997: a row finalized by the commit is not relaunched.
+
+    ``_spec_decode_step`` snapshots ``active`` (the launch membership) BEFORE
+    committing the previous macro-step. That commit can FINALIZE a row -- the row
+    hit ``max_new_tokens`` so its last allowed token was ``length``-committed --
+    which sets ``finalized`` and drops it from ``running`` but cannot retire it
+    yet because this tick reserved an ``inflight_refs`` for the (about-to-launch)
+    step. Because the snapshot predates the commit, that now-finalized row was
+    still in ``active``; ``_build_spec_step_masks`` then returns a ``None`` commit
+    cap for it (finalized rows come back unconstrained), so the scheduler asked
+    ``decoder.step`` to run ANOTHER macro-step on a row whose
+    ``SequenceState.length`` already equals ``max_length`` -- a real spec decoder
+    that reserves only the request budget can advance/write past the row or raise.
+    The non-spec launch set never includes a finalized row (``_can_dispatch``
+    returns False for it); the spec path must match that by filtering the rows the
+    commit just finalized out of the launch (and immediately retiring their
+    reserved ref).
+
+    This scripts a single row that finishes by ``max_new_tokens`` and asserts the
+    decoder is launched EXACTLY ONCE (the legitimate macro-step that lands the
+    final token) -- never a second time on the finalized row -- that the row's
+    ``length`` never exceeds ``max_length``, and that the row retires cleanly with
+    the ref count balanced (no phantom ref / pool leak).
+    """
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        # admit stages 1; this single macro-step commits 2 more == max_new=3, so
+        # the row FINALIZES at the commit that runs on the NEXT tick (depth-1).
+        plans={0: [[12, 13]]},
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    r0 = _enqueue(sched, 0, prompt_len=3, max_new=3)
+    sched._spec_admit()  # stages token 11 -> token_count == 1
+
+    max_len = r0.lifecycle.state.max_length
+    # Drive the depth-1 pipeline to quiescence, asserting on every tick that the
+    # row's KV length never runs past its absolute limit (the bug would launch a
+    # macro-step off a row already at ``max_length``).
+    while sched._spec_decode_step():
+        assert r0.lifecycle.state.length <= max_len
+
+    # The decoder.step was invoked exactly ONCE -- the one launch that commits the
+    # final token. The pre-fix code launched a SECOND macro-step on the now-
+    # finalized row (its tick-2 ``active`` snapshot still held the row the commit
+    # had just finished), which this asserts never happens: row 0 appears in
+    # exactly one launch and there is no extra launch after it finalized.
+    assert dec.step_rows == [[0]]
+    assert sum(1 for rows in dec.step_rows if 0 in rows) == 1
+
+    # The request finished at exactly max_new_tokens (length), the row retired
+    # exactly once, the ref count is balanced (no phantom ref), and nothing leaks.
+    assert [int(t.token_id) for t in r0.lifecycle.skill_state.tokens] == [11, 12, 13]
+    assert r0.lifecycle.finished is True
+    assert r0.lifecycle.phase == RequestPhase.COMPLETED
+    assert r0.lifecycle.inflight_refs == 0
+    assert dec.retired == [0]
+    assert dec.retired.count(0) == 1
+    assert r0.lifecycle.state.batch_idx not in rt.active_sequences
+    assert sched._pending_spec is None
+    assert [c.finish_reason for c in sched.pop_completed()] == ["length"]
+
+
+def test_spec_step_excludes_finalized_row_but_launches_continuing_row() -> None:
+    """L997, multi-row: drop the finalized row from the launch, keep the continuer.
+
+    The interesting case the single-row test cannot show: in one macro-step row A
+    is committed to its ``max_new_tokens`` (finalizes) while row B keeps running.
+    ``active`` is snapshotted before the commit, so BOTH rows are in it; after the
+    commit finalizes A, the next ``decoder.step`` must launch ONLY B -- never A
+    (A's ``state.length`` already equals ``max_length``; relaunching it is the
+    unsafe over-advance L997 fixes) -- and A must retire synchronously while B's
+    refs/launch continue undisturbed. Asserts (a) A appears in exactly the launch
+    that lands its final token and never after it finalizes, (b) B is launched on
+    every step it runs, (c) both rows retire exactly once with no leak and end
+    COMPLETED.
+    """
+    dec = _FakeDecoder(
+        n_rows=2,
+        first_tokens={0: 11, 1: 22},
+        plans={
+            0: [[12, 13]],          # admit(1) + 2 == max_new=3 -> A finalizes
+            1: [[23], [24], [999]],  # B keeps running, then EOS
+        },
+    )
+    rt = _spec_runtime(dec, eos_id=999)
+    sched = _make_scheduler(rt)
+    rA = _enqueue(sched, 0, prompt_len=3, max_new=3)
+    rB = _enqueue(sched, 1, prompt_len=2, max_new=20)
+    sched._spec_admit()
+
+    rowA = rA.lifecycle.state.batch_idx
+    rowB = rB.lifecycle.state.batch_idx
+    maxlenA = rA.lifecycle.state.max_length
+    # Drive to quiescence, asserting on every tick that A's KV length never runs
+    # past its limit (the bug would relaunch A off a row already at max_length).
+    finalized_tick = None
+    for tick in range(20):
+        if not sched._spec_decode_step():
+            break
+        assert rA.lifecycle.state.length <= maxlenA
+        if rA.lifecycle.finished and finalized_tick is None:
+            finalized_tick = len(dec.step_rows)
+
+    # A finalized; from the launch AT/AFTER its finalizing commit it is excluded.
+    assert finalized_tick is not None
+    # A was launched exactly once (the macro-step that lands its final token) and
+    # never appears in a launch again -- the L997 fix dropped it from ``active``.
+    a_launches = [rows for rows in dec.step_rows if 0 in rows]
+    assert len(a_launches) == 1
+    assert a_launches[0] == [0, 1]  # the single shared launch, with B alongside
+    # Every launch after A finalized contains ONLY B (never A).
+    assert all(rows == [1] for rows in dec.step_rows if rows != [0, 1])
+
+    # B was launched on each of its running steps (1 shared + its solo steps).
+    assert sum(1 for rows in dec.step_rows if 1 in rows) >= 3
+
+    # Both rows finished cleanly: retired exactly once, COMPLETED, no leak.
+    assert sorted(dec.retired) == [0, 1]
+    assert dec.retired.count(0) == 1
+    assert dec.retired.count(1) == 1
+    assert rA.lifecycle.phase == RequestPhase.COMPLETED
+    assert rB.lifecycle.phase == RequestPhase.COMPLETED
+    assert rA.lifecycle.inflight_refs == 0
+    assert rB.lifecycle.inflight_refs == 0
+    assert rowA not in rt.active_sequences
+    assert rowB not in rt.active_sequences
+    assert sched._pending_spec is None
+    assert sched.has_pending_work() is False
+    reasons = sorted(c.finish_reason for c in sched.pop_completed())
+    assert reasons == ["length", "stop"]  # A by length (max_new), B by eos

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -97,7 +97,16 @@ def _spec_runtime(decoder: _FakeDecoder, *, eos_id: int = 999) -> FakeRuntime:
     return rt
 
 
-def _enqueue(sched: GenerationScheduler, rid: int, prompt_len: int, max_new: int):
+def _enqueue(
+    sched: GenerationScheduler,
+    rid: int,
+    prompt_len: int,
+    max_new: int,
+    *,
+    adapter: str | None = None,
+    lora_slot_ready: bool = True,
+    return_logprobs: bool | None = None,
+):
     req = GenerationRequest(
         request_id=rid,
         prompt="p",
@@ -105,10 +114,12 @@ def _enqueue(sched: GenerationScheduler, rid: int, prompt_len: int, max_new: int
         max_new_tokens=max_new,
         skill=_SpecSkillSpec(),  # type: ignore[arg-type]
         request_context=object(),
+        adapter=adapter,
+        return_logprobs=return_logprobs,
     )
     lc = RequestLifecycle(request=req, skill_state=_RecordingState(req))
     lc.crops_ready = True
-    lc.lora_slot_ready = True
+    lc.lora_slot_ready = lora_slot_ready
     lc.transition(RequestPhase.READY_FOR_PREFILL)
     req.lifecycle = lc
     sched.enqueue_request(req, lc.skill_state)
@@ -239,3 +250,160 @@ def test_advance_routes_to_spec_when_capability_present() -> None:
     # single-token decode pipeline.
     assert sched.advance() is True
     assert dec.admitted == [0]
+
+
+def test_has_pending_work_tracks_pending_spec_until_drained() -> None:
+    """Regression for the depth-1 drain leak (codex finding @ L617).
+
+    A finishing sequence launches one optimistic follow-up macro-step before its
+    own commit removes it from ``running``. That follow-up lives in
+    ``_pending_spec`` as a zombie. ``has_pending_work()`` must stay True while it
+    is outstanding, otherwise the executor stops calling ``advance`` and the
+    zombie step is never committed -> ``decoder.retire`` never runs -> the spec
+    row leaks. Drive the loop until ``running`` empties with a pending step still
+    outstanding and assert (a) the row is retired exactly once, (b)
+    ``has_pending_work`` only goes False after the pending step is committed.
+    """
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12, 13]]},  # admit(1) + 2 == max_new=3 -> finishes here
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    _enqueue(sched, 0, prompt_len=3, max_new=3)
+    sched._spec_admit()
+
+    # Drive macro-steps manually so we can observe the tick where ``running``
+    # is already empty but a pending (zombie) spec step is still outstanding.
+    saw_pending_after_running_empty = False
+    for _ in range(10):
+        if not sched._spec_decode_step():
+            break
+        if len(sched.running) == 0 and sched._pending_spec is not None:
+            saw_pending_after_running_empty = True
+            # This is exactly the window the bug regressed: the old
+            # has_pending_work() (waiting/running/pipeline only) returned False
+            # here and the executor would stop driving advance().
+            assert sched.has_pending_work() is True
+
+    assert saw_pending_after_running_empty is True
+    # Pending step committed, row retired exactly once, nothing leaked.
+    assert sched._pending_spec is None
+    assert dec.retired == [0]
+    assert rt.active_sequences == {}
+    assert sched.has_pending_work() is False
+    assert [c.finish_reason for c in sched.pop_completed()] == ["length"]
+
+
+def test_spec_admit_acquires_lora_slot_for_adapter_request() -> None:
+    """Regression for the LoRA wrong-slot bug (codex finding @ L560).
+
+    Adapter requests admitted to the spec path must acquire a LoRA slot the way
+    the normal prefill path does; otherwise ``request.lora_slot`` stays 0 and the
+    finetune is silently ignored (base-model slot).
+    """
+
+    class _FakeAdapterProvider:
+        def config(self) -> dict:
+            return {"max_lora_rank": 16}
+
+        def get(self, adapter: str) -> object:
+            return object()
+
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = GenerationScheduler(
+        rt,
+        compute_stream=None,
+        skill_registry=__import__(
+            "kestrel.skills", fromlist=["SkillRegistry"]
+        ).SkillRegistry([]),
+        adapter_provider=_FakeAdapterProvider(),
+    )
+    # Adapter request enters WAITING_RESOURCES with no slot yet.
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=8, adapter="ft-1", lora_slot_ready=False
+    )
+
+    assert sched._spec_admit() is True
+    # Slot was acquired (FakeRuntime returns slot index >= 1) and threaded onto
+    # both the request and the admitted SequenceState.
+    assert rt.acquired_adapter_slots == [("ft-1", rt.acquired_adapter_slots[0][1])]
+    assert req.lifecycle.lora_slot_ready is True
+    assert req.lora_slot >= 1
+    assert req.lifecycle.state.lora_slot == req.lora_slot
+
+
+def test_spec_admit_defers_when_lora_slots_exhausted() -> None:
+    """Out-of-slots is recoverable: keep the request WAITING_RESOURCES.
+
+    When ``acquire_adapter_slot`` raises ``RuntimeError`` (all LoRA slots in
+    use), the adapter request must stay in the waiting queue (not be admitted
+    with the wrong slot, nor failed) so it retries once a slot frees up.
+    """
+
+    class _ExhaustedAdapterProvider:
+        def config(self) -> dict:
+            return {"max_lora_rank": 16}
+
+        def get(self, adapter: str) -> object:
+            return object()
+
+    dec = _FakeDecoder(n_rows=2, first_tokens={0: 11, 1: 22}, plans={0: [[12]], 1: [[23]]})
+    rt = _spec_runtime(dec)
+
+    def _raise_out_of_slots(adapter_id: str, adapter: object) -> int:
+        raise RuntimeError("Out of LoRA slots: all slots are in use.")
+
+    rt.acquire_adapter_slot = _raise_out_of_slots  # type: ignore[method-assign]
+
+    sched = GenerationScheduler(
+        rt,
+        compute_stream=None,
+        skill_registry=__import__(
+            "kestrel.skills", fromlist=["SkillRegistry"]
+        ).SkillRegistry([]),
+        adapter_provider=_ExhaustedAdapterProvider(),
+    )
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=8, adapter="ft-1", lora_slot_ready=False
+    )
+
+    # No row admitted, request stays waiting (WAITING_RESOURCES), no error result.
+    assert sched._spec_admit() is False
+    assert dec.admitted == []
+    assert len(sched.waiting) == 1
+    assert len(sched.running) == 0
+    assert req.lifecycle.phase == RequestPhase.WAITING_RESOURCES
+    assert sched.pop_completed() == []
+
+
+def test_spec_admit_rejects_logprobs_request_cleanly() -> None:
+    """Regression for the spec+logprobs crash (codex finding @ L578).
+
+    A ``return_logprobs=True`` request on the spec path must fail just that
+    request (clean error result + row retired) instead of raising a
+    scheduler-wide exception when ``stage_token`` sees a None logprob.
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=8, return_logprobs=True)
+
+    # Must not raise.
+    assert sched._spec_admit() is True
+    # Request failed cleanly: errored result, not pushed to running, row retired.
+    assert req.lifecycle.finished is True
+    assert req.lifecycle.finish_reason == "error"
+    assert len(sched.running) == 0
+    assert dec.retired == [0]
+    assert rt.active_sequences == {}
+    completed = sched.pop_completed()
+    assert [c.request_id for c in completed] == [0]
+    assert completed[0].finish_reason == "error"
+    assert "error" in completed[0].output
+
+    # And the spec decode loop stays healthy afterward (no leaked pending step).
+    assert sched._spec_decode_step() is False
+    assert sched.has_pending_work() is False

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -979,6 +979,141 @@ def test_spec_admit_finish_releases_lora_slot() -> None:
     assert req.lifecycle.state.batch_idx not in rt.active_sequences
 
 
+class _RaisingAdmitDecoder(_FakeDecoder):
+    """``SpecDecoder`` whose ``admit`` reserves a pool row, sets ``batch_idx``,
+    then RAISES -- emulating a prefill that fails mid-flight (e.g. an image
+    preprocessing / CUDA error) *after* the decoder has already claimed a free
+    row for the sequence. Unlike the base ``_FakeDecoder``, ``retire`` returns
+    the row to the free pool so a test can assert the failed admission did not
+    leak a slot (``free_slots`` returns to baseline).
+    """
+
+    def admit(self, state, prompt_token_ids, **kwargs):
+        # Reserve a row + assign batch_idx exactly like a real admit does before
+        # its prefill work runs, so the failure path has a row to leak.
+        row = self._free.pop(0)
+        self._row_of[id(state)] = row
+        state.batch_idx = 100 + row
+        self.admitted.append(row)
+        raise RuntimeError("CUDA error: image prefill failed mid-admit")
+
+    def retire(self, state) -> None:
+        row = self._row_of.pop(id(state))
+        self.retired.append(row)
+        # Return the row to the free pool so the test can prove no leak.
+        self._free.append(row)
+
+
+def test_spec_admit_failure_retires_row_no_leak() -> None:
+    """P2 codex finding @ scheduler.py:776: a failed ``decoder.admit`` retires
+    the reserved spec row so ``free_slots`` does not leak.
+
+    ``admit`` reserves a free pool row and assigns ``state.batch_idx`` BEFORE its
+    prefill image/CUDA work, so a mid-admit failure leaves the row reserved even
+    though no token was staged. The request has already left ``waiting`` and
+    ``lifecycle.sequence_state`` is never set, so no finish/zombie path retires
+    it -- the row would leak permanently and repeated failures would drain
+    ``decoder.free_slots`` and stall unrelated spec requests. Asserts the failed
+    admission (a) fails the request cleanly, (b) retires the reserved row, and
+    (c) leaves ``free_slots`` back at baseline (no leak), and that a SUBSEQUENT
+    request can still be admitted into the reclaimed row.
+    """
+    dec = _RaisingAdmitDecoder(
+        n_rows=1, first_tokens={0: 11}, plans={0: [[12]]}
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    assert dec.free_slots == 1  # baseline: one row free
+
+    req = _enqueue(sched, 0, prompt_len=3, max_new=8)
+
+    assert sched._spec_admit() is True
+    # The row was reserved (admit started) then retired on failure.
+    assert dec.admitted == [0]
+    assert dec.retired == [0]
+    # No leak: the reserved row was returned to the pool.
+    assert dec.free_slots == 1
+    # The request failed cleanly (error result), not deferred/queued.
+    assert req.lifecycle.finished is True
+    assert req.lifecycle.finish_reason == "error"
+    assert len(sched.waiting) == 0
+    assert len(sched.running) == 0
+    completed = sched.pop_completed()
+    assert [c.request_id for c in completed] == [0]
+    assert completed[0].finish_reason == "error"
+    # ``sequence_state`` is intentionally never set on the admit-failure path
+    # (it is only assigned AFTER a successful admit) -- which is exactly why no
+    # finish/zombie path would have retired the row without this fix. The
+    # reserved row left no dangling ``active_sequences`` entry.
+    assert req.lifecycle.sequence_state is None
+    assert rt.active_sequences == {}
+
+    # The reclaimed row is genuinely reusable: a fresh request admits into it
+    # rather than starving on a permanently-drained pool.
+    dec.admit = _FakeDecoder.admit.__get__(dec, _RaisingAdmitDecoder)  # stop raising
+    req2 = _enqueue(sched, 1, prompt_len=2, max_new=8)
+    assert sched._spec_admit() is True
+    assert req2.lifecycle.finished is False
+    assert req2.lifecycle.state.batch_idx in rt.active_sequences
+    assert dec.free_slots == 0  # the single row is now in use by req2
+
+
+def test_spec_admit_failure_releases_lora_slot_and_retires_row() -> None:
+    """P2 codex finding @ scheduler.py:776 (adapter variant): a failed
+    ``decoder.admit`` releases BOTH the reserved spec row and the LoRA slot.
+
+    For an adapter request, ``_spec_admit`` acquires a LoRA slot *and* (via
+    ``admit``) reserves a pool row before the prefill can fail. On failure both
+    must be released exactly once -- the row via ``decoder.retire`` and the
+    adapter slot via ``release_adapter_slot`` -- without double-releasing the
+    slot (the cleanup is deliberately NOT ``_retire_spec_row``, which would
+    release the slot a second time). Asserts the row is retired, the acquired
+    slot is released exactly once, and the request fails cleanly.
+    """
+
+    class _FakeAdapterProvider:
+        def config(self) -> dict:
+            return {"max_lora_rank": 16}
+
+        def get(self, adapter: str) -> object:
+            return object()
+
+    dec = _RaisingAdmitDecoder(
+        n_rows=1, first_tokens={0: 11}, plans={0: [[12]]}
+    )
+    rt = _spec_runtime(dec)
+    sched = GenerationScheduler(
+        rt,
+        compute_stream=None,
+        skill_registry=__import__(
+            "kestrel.skills", fromlist=["SkillRegistry"]
+        ).SkillRegistry([]),
+        adapter_provider=_FakeAdapterProvider(),
+    )
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=8, adapter="ft-1", lora_slot_ready=False
+    )
+
+    assert sched._spec_admit() is True
+    # The slot was acquired for the adapter, then released on the failure path.
+    assert len(rt.acquired_adapter_slots) == 1
+    acquired_slot = len(rt.acquired_adapter_slots)  # FakeRuntime numbers from 1
+    assert rt.released_adapter_slots == [acquired_slot]
+    assert rt.released_adapter_slots.count(acquired_slot) == 1  # not double-released
+    # The reserved row was retired -> no leak.
+    assert dec.admitted == [0]
+    assert dec.retired == [0]
+    assert dec.free_slots == 1
+    # request.lora_slot was zeroed so a later path cannot re-release it.
+    assert req.lora_slot == 0
+    assert req.lifecycle.lora_slot_ready is False
+    # The request failed cleanly.
+    assert req.lifecycle.finished is True
+    assert req.lifecycle.finish_reason == "error"
+    assert req.lifecycle.sequence_state is None
+    assert rt.active_sequences == {}
+
+
 def test_spec_side_values_guarded_when_no_spec_hook() -> None:
     """Round-2 codex finding @ L836: SpecSideValues never hits the non-spec hook.
 

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -1507,12 +1507,15 @@ def test_spec_step_caps_stateful_mask_to_one_committed_token_per_step() -> None:
 def test_spec_step_does_not_cap_unconstrained_or_constant_mask_row() -> None:
     """A non-stateful row keeps the full multi-token speculative accept.
 
-    The L958 cap is *only* for rows whose mask can change within a run. An
-    unconstrained row (no allowed/suppressed set) and a row that declares its
-    mask constant via ``mask_is_stateful = False`` must stay uncapped, so they
-    still commit their whole accepted run in one macro-step (the throughput win
-    spec decode exists for). Asserts the scheduler forwards ``commit_caps`` of
-    ``None`` for both and the full 3-token run commits in a single step.
+    The STATEFUL-mask cap is *only* for rows whose mask can change within a run.
+    An unconstrained row (no allowed/suppressed set) and a row that declares its
+    mask constant via ``mask_is_stateful = False`` must not be throttled to one
+    token per step, so they still commit their whole accepted run in a single
+    macro-step (the throughput win spec decode exists for). With a generous
+    ``max_new_tokens`` the only ``commit_caps`` entry is the remaining-budget cap
+    (well above the run length, so it does not truncate) -- never the stateful
+    ``1``. Asserts the scheduler forwards the loose budget cap (NOT the stateful
+    cap) for both rows and the full 3-token run commits in a single step.
     """
 
     class _ConstantMaskState(_RecordingState):
@@ -1532,6 +1535,8 @@ def test_spec_step_does_not_cap_unconstrained_or_constant_mask_row() -> None:
     )
     rt = _spec_runtime(dec)
     sched = _make_scheduler(rt)
+    # max_new far above the run length so the remaining-budget cap never bites
+    # (isolating the stateful-cap behaviour this test is about).
     r0 = _enqueue(sched, 0, prompt_len=3, max_new=20)
     r1 = _enqueue(sched, 1, prompt_len=3, max_new=20)
     constant = _ConstantMaskState(r1)
@@ -1542,8 +1547,10 @@ def test_spec_step_does_not_cap_unconstrained_or_constant_mask_row() -> None:
     sched._spec_decode_step()  # launch macro-step over both rows
     sched._spec_decode_step()  # commit it
 
-    # No row was capped: the scheduler forwarded ``None`` for both.
-    assert dec.step_commit_caps[0] == [None, None]
+    # Neither row was capped by the STATEFUL cap (which would be ``1``): the only
+    # cap is the loose remaining budget (max_new 20 - 1 staged at admit == 19),
+    # far above the 3-token run, so the full run still commits this step.
+    assert dec.step_commit_caps[0] == [19, 19]
     # Each row committed its WHOLE 3-token run in the single macro-step (the
     # admit token plus the full accepted run -- not throttled to one/step).
     assert [int(t.token_id) for t in r0.lifecycle.skill_state.tokens] == [
@@ -1611,3 +1618,127 @@ def test_spec_zombie_lifecycle_marked_completed_before_retire() -> None:
     assert rt.active_sequences == {}
     assert sched._pending_spec is None
     assert [c.finish_reason for c in sched.pop_completed()] == ["length"]
+
+
+def test_spec_step_caps_commit_to_remaining_max_new_tokens() -> None:
+    """Regression for codex P1 @ L2079: cap the committed run to the budget.
+
+    For an unconstrained row the stateful-mask cap is ``None``, so before the fix
+    ``commit_caps[i]`` stayed ``None`` even when the request had fewer than the
+    decoder's offered run left. ``_commit_spec`` stops *staging* at
+    ``max_new_tokens``, but the decoder advances its KV / proposer state through
+    the WHOLE accepted run, so the row (and the optimistic depth-1 zombie step
+    launched off it) runs past the request's target length while the surplus
+    tokens are silently dropped -- over-generation the non-spec path never does
+    (it stops sampling exactly at the limit).
+
+    The scheduler now folds the remaining output budget
+    (``max_new_tokens - token_count``) into ``commit_caps``. This scripts a
+    decoder that WOULD commit a 3-token run in the final macro-step of a request
+    with only 2 new tokens left, and asserts the cap holds the committed run to
+    exactly the remaining budget: the request finishes at exactly
+    ``max_new_tokens`` (``length``), no surplus token is ever staged, and the
+    decoder advance stays in lockstep with the (truncated) committed run.
+    """
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        # The decoder OFFERS a 3-token run, but admit already staged 1 of the 3
+        # allowed tokens, so only 2 remain. Without the budget cap all 3 would
+        # advance the decoder; the cap must hold the committed run to 2.
+        plans={0: [[12, 13, 14]]},
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    r0 = _enqueue(sched, 0, prompt_len=3, max_new=3)
+    sched._spec_admit()  # stages token 11 -> token_count == 1, budget == 2
+
+    len_before = r0.lifecycle.state.length
+    while sched._spec_decode_step():
+        pass
+
+    # The first launch saw budget == 2 (max_new 3 - 1 staged) and, with no skill
+    # mask, forwarded that budget as the row's commit cap (NOT None).
+    assert dec.step_commit_caps[0] == [2]
+    # Exactly the remaining budget was staged: token 14 was NEVER committed, so
+    # the request stops at exactly max_new_tokens with no over-generation.
+    assert [int(t.token_id) for t in r0.lifecycle.skill_state.tokens] == [11, 12, 13]
+    # The decoder's KV length advanced by the committed (truncated) run only -- it
+    # did not run past the target length through the dropped token.
+    assert r0.lifecycle.state.length - len_before == 2
+    # Finished at the limit, length-finished, row retired exactly once.
+    assert r0.lifecycle.finished is True
+    assert dec.retired == [0]
+    assert r0.lifecycle.state.batch_idx not in rt.active_sequences
+    assert sched._pending_spec is None
+    assert [c.finish_reason for c in sched.pop_completed()] == ["length"]
+
+
+def test_spec_step_rolls_back_refs_when_launch_raises() -> None:
+    """Regression for codex P2 @ L941: roll back reserved refs on launch failure.
+
+    ``_spec_decode_step`` reserves an ``inflight_refs`` for every active row
+    BEFORE committing the previous macro-step and launching this one. If the
+    commit or ``decoder.step`` raises before ``_pending_spec`` is installed, those
+    reserved refs were owned by nothing -- no future ``_commit_spec`` decrements
+    them -- so a later finish stays stuck in ``FINALIZING`` and the spec row /
+    adapter slot leaks. The non-spec launch path (``launch_decode_step``) rolls
+    back its reservation for exactly this reason; the spec path now does too. This
+    scripts a decoder whose SECOND ``step`` raises and asserts the reservation is
+    undone (no phantom ref), ``_pending_spec`` stays clear, and the row is left in
+    a clean, still-running state rather than wedged.
+    """
+
+    class _RaisingDecoder(_FakeDecoder):
+        def __init__(self, *, raise_on_step: int, **kwargs) -> None:
+            super().__init__(**kwargs)
+            self._raise_on_step = raise_on_step
+            self._step_calls = 0
+
+        def step(self, states, **kwargs):
+            self._step_calls += 1
+            if self._step_calls == self._raise_on_step:
+                raise RuntimeError("simulated decoder.step CUDA failure")
+            return super().step(states, **kwargs)
+
+    dec = _RaisingDecoder(
+        raise_on_step=2,
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12], [13]]},  # max_new large -> row keeps running across steps
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    r0 = _enqueue(sched, 0, prompt_len=3, max_new=20)
+    sched._spec_admit()  # stages token 11
+
+    # Step 1 launches cleanly: reserves a ref and installs the pending step.
+    assert sched._spec_decode_step() is True
+    assert sched._pending_spec is not None
+    assert r0.lifecycle.inflight_refs == 1
+
+    # Step 2 reserves a SECOND ref for this launch, commits step 1 (which
+    # consumes step 1's ref and stages token 12), and then raises inside
+    # ``decoder.step`` -- after step 2's ref was reserved but before
+    # ``_pending_spec`` is reinstalled.
+    try:
+        sched._spec_decode_step()
+        raise AssertionError("expected decoder.step to raise")
+    except RuntimeError as exc:
+        assert "simulated decoder.step CUDA failure" in str(exc)
+
+    # Step 2's reservation was rolled back and step 1's was consumed by its
+    # commit, so the row is left with ZERO in-flight refs -- no phantom ref. (The
+    # bug would leave it at 1: step 2's reservation orphaned, since no future
+    # ``_commit_spec`` would ever decrement it, wedging a later finish in
+    # ``FINALIZING`` and leaking the pool/adapter slot.) No pending step dangles.
+    assert r0.lifecycle.inflight_refs == 0
+    assert sched._pending_spec is None
+    # The commit that ran before the raise still took effect (token 12 staged),
+    # and the row is left running -- not finished/finalized -- so a clean retry
+    # could proceed without a wedged FINALIZING row or leaked pool slot.
+    assert [int(t.token_id) for t in r0.lifecycle.skill_state.tokens] == [11, 12]
+    assert r0.lifecycle.finished is False
+    assert r0.lifecycle.finalized is False
+    assert r0.lifecycle in sched.running
+    assert r0.lifecycle.state.batch_idx in rt.active_sequences

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -1730,6 +1730,111 @@ def test_spec_step_does_not_cap_unconstrained_or_constant_mask_row() -> None:
     ]
 
 
+def test_spec_real_caption_skill_not_capped_while_stateful_skills_are() -> None:
+    """The REAL moondream skills carry the right ``mask_is_stateful`` verdict.
+
+    Regression for codex P2 @ scheduler ``_mask_is_stateful``: caption's
+    ``suppressed_token_ids`` returns a CONSTANT set (``[answer_id]`` on
+    moondream2) at every position, so its per-step mask is already exact for a
+    whole committed run -- it must NOT be capped to one token per macro-step.
+    The behavioural fallback ("any active constraint is stateful") would wrongly
+    cap it, so ``CaptionSkillState`` declares ``mask_is_stateful = False``; this
+    pins that declaration on the real class (the generic ``_ConstantMaskState``
+    test above would still pass even if the real skill forgot it).
+
+    Conversely the genuinely stateful skills -- detect (cycles x->y->size) and
+    point (toggles coord/eos) -- whose allowed set changes per committed token
+    must STAY capped (``commit_caps = 1``), so this asserts the scheduler keeps
+    throttling them. Drives the scheduler's ``_build_spec_step_masks`` directly
+    over real skill states attached to enqueued rows.
+    """
+    from kestrel.models.moondream.skills.caption import (
+        CaptionRequest,
+        CaptionSkill,
+        CaptionSkillState,
+    )
+    from kestrel.models.moondream.skills.detect import (
+        DetectRequest,
+        DetectSkill,
+        DetectSkillState,
+    )
+    from kestrel.models.moondream.skills.point import (
+        PointRequest,
+        PointSkill,
+        PointSkillState,
+    )
+
+    # Minimal runtime/template the real mask queries read: caption needs
+    # ``model_name`` + ``answer_id``; detect needs coord/eos/size; point needs
+    # coord/eos. The ids are arbitrary-but-distinct.
+    COORD, EOS, SIZE, ANSWER = 3, 4, 5, 6
+    runtime = SimpleNamespace(
+        model_name="moondream2",
+        prompt_template=SimpleNamespace(
+            answer_id=ANSWER, coord_id=COORD, eos_id=EOS, size_id=SIZE
+        ),
+    )
+
+    dec = _FakeDecoder(
+        n_rows=3,
+        first_tokens={0: 10, 1: 20, 2: 30},
+        plans={0: [[]], 1: [[]], 2: [[]]},
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    # The scheduler queries the REAL skills against the stub ``runtime`` above,
+    # not the bare ``_spec_runtime`` fake -- point ``_build_spec_step_masks`` at it.
+    sched.runtime = runtime
+
+    # Generous budget so the remaining-budget cap never bites: the only cap that
+    # can appear is the STATEFUL cap (``1``). caption => no stateful cap; detect
+    # / point => stateful cap of ``1``.
+    r_cap = _enqueue(sched, 0, prompt_len=3, max_new=1000)
+    r_det = _enqueue(sched, 1, prompt_len=3, max_new=1000)
+    r_pt = _enqueue(sched, 2, prompt_len=3, max_new=1000)
+
+    cap_state = CaptionSkillState(
+        CaptionSkill(),
+        r_cap,
+        CaptionRequest(length="normal", image=None, stream=False),
+    )
+    det_state = DetectSkillState(
+        DetectSkill(),
+        r_det,
+        DetectRequest(object="cat", image=None, stream=False, max_objects=10),
+    )
+    pt_state = PointSkillState(
+        PointSkill(),
+        r_pt,
+        PointRequest(object="cat", image=None, stream=False),
+    )
+    r_cap.lifecycle.skill_state = cap_state
+    r_det.lifecycle.skill_state = det_state
+    r_pt.lifecycle.skill_state = pt_state
+
+    seqs = [r_cap.lifecycle, r_det.lifecycle, r_pt.lifecycle]
+
+    # Caption: constant ``[answer_id]`` suppression, declared non-stateful.
+    assert cap_state.suppressed_token_ids(runtime) == [ANSWER]
+    assert sched._mask_is_stateful(r_cap.lifecycle, None, [ANSWER]) is False
+    # Detect / point: their allowed set evolves per committed token -> stateful.
+    assert det_state.allowed_token_ids(runtime) == [COORD, EOS]
+    assert pt_state.allowed_token_ids(runtime) == [COORD, EOS]
+    assert sched._mask_is_stateful(r_det.lifecycle, [COORD, EOS], None) is True
+    assert sched._mask_is_stateful(r_pt.lifecycle, [COORD, EOS], None) is True
+
+    _allowed, _suppressed, commit_caps = sched._build_spec_step_masks(seqs)
+
+    # Caption row is NOT capped to one token: its only cap is the loose remaining
+    # budget (1000 - 0 staged == 1000), never the stateful ``1``. The constant
+    # suppression is still forwarded so masking stays correct.
+    assert commit_caps[0] == 1000
+    assert list(_suppressed[0]) == [ANSWER]
+    # Detect and point rows stay capped at one committed token per macro-step.
+    assert commit_caps[1] == 1
+    assert commit_caps[2] == 1
+
+
 def test_spec_zombie_lifecycle_marked_completed_before_retire() -> None:
     """Regression for codex P2 @ L1012: a finished spec row ends COMPLETED, retired once.
 

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -99,6 +99,7 @@ class _FakeDecoder:
         prompt_token_ids,
         *,
         image=None,
+        image_crops=None,
         allowed_token_ids=None,
         suppressed_token_ids=None,
         suppress_next_token_ids=None,
@@ -119,6 +120,7 @@ class _FakeDecoder:
             # ImageMarker/Coord/Size tokens that lack ``token_id``).
             "prompt_tokens": list(prompt_token_ids),
             "image": image,
+            "image_crops": image_crops,
             "allowed_token_ids": allowed_token_ids,
             "suppressed_token_ids": suppressed_token_ids,
             "suppress_next_token_ids": suppress_next_token_ids,
@@ -191,6 +193,7 @@ def _enqueue(
     temperature: float = 0.0,
     top_p: float = 1.0,
     image: object | None = None,
+    image_crops: object | None = None,
     image_length: int = 0,
     skill_state: SkillState | None = None,
 ):
@@ -206,12 +209,13 @@ def _enqueue(
         temperature=temperature,
         top_p=top_p,
         image=image,
+        image_crops=image_crops,
         image_length=image_length,
     )
     lc = RequestLifecycle(
         request=req, skill_state=skill_state or _RecordingState(req)
     )
-    lc.has_image = image is not None
+    lc.has_image = image is not None or image_crops is not None
     lc.crops_ready = True
     lc.lora_slot_ready = lora_slot_ready
     lc.transition(RequestPhase.READY_FOR_PREFILL)
@@ -748,6 +752,34 @@ def test_spec_admit_forwards_image_mask_and_sampling_params() -> None:
     assert list(kw["suppressed_token_ids"]) == [99]
     assert kw["temperature"] == 0.7
     assert kw["top_p"] == 0.9
+
+
+def test_spec_admit_forwards_image_crops_for_multicrop_request() -> None:
+    """The spec path forwards a request's multi-crop tiles into ``admit``.
+
+    Regression for the codex finding @ scheduler.py:757: ``_spec_admit`` forwarded
+    ``request.image`` but NOT ``request.image_crops`` -- the high-res overlap crop
+    tiles Moondream tiles a large image into. The non-spec ``prepare_sequence``
+    path forwards BOTH (the vision encoder reads ``image_crops`` as its ``overlap``
+    so the crop tiles -- not just the global/thumbnail image -- are encoded into
+    the KV prefix). Dropping ``image_crops`` on the spec path gives a multi-crop
+    request an incomplete image prefill and diverges from the non-spec output.
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    img = object()
+    crops = object()  # stand-in for the OverlapCropOutput the runtime tiles
+    _enqueue(sched, 0, prompt_len=3, max_new=8, image=img, image_crops=crops)
+
+    assert sched._spec_admit() is True
+    kw = dec.admit_kwargs[0]
+    # Both the image AND its crop tiles must reach ``admit`` -- exactly what the
+    # non-spec ``prepare_sequence`` forwards. Forwarding ``image`` alone (the
+    # pre-fix behaviour) would prefill only the global image for a multi-crop
+    # request.
+    assert kw["image"] is img
+    assert kw["image_crops"] is crops
 
 
 def test_spec_commit_routes_committed_ids_through_materialize_hook() -> None:

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -1953,3 +1953,98 @@ def test_spec_step_excludes_finalized_row_but_launches_continuing_row() -> None:
     assert sched.has_pending_work() is False
     reasons = sorted(c.finish_reason for c in sched.pop_completed())
     assert reasons == ["length", "stop"]  # A by length (max_new), B by eos
+
+
+def test_spec_admit_zero_token_request_bypasses_saturated_batch() -> None:
+    """Regression for the codex finding @ scheduler.py:608.
+
+    A ``max_new_tokens <= 0`` request finalizes as ``"length"`` WITHOUT calling
+    ``decoder.admit`` and WITHOUT consuming a spec pool row -- mirroring the
+    non-spec ``_launch_prefill_step`` zero-length branch. That finalize therefore
+    needs neither a free pool row nor a free running-batch slot.
+
+    Before the fix, the zero-token branch lived INSIDE the admission loop whose
+    guard is ``while decoder.free_slots > 0 and len(self.running) < max_running``.
+    So a zero-token request queued behind a saturated spec batch -- either the
+    pool is full (``decoder.free_slots == 0``) or the running set is already at
+    ``max_batch_size`` -- never reached the branch and stalled until an unrelated
+    row retired, diverging from its documented no-row contract. The fix drains
+    launchable zero-token requests in a pre-pass that is NOT gated by that
+    capacity guard. This covers BOTH saturating conditions.
+    """
+    # --- Condition A: running already at max_batch_size (pool still has rows) ---
+    # ``_spec_runtime`` is max_batch_size=4 / max_batch_slots=8 over an 8-row
+    # pool, so the batch cap stops real admissions at 4 while 4 pool rows stay
+    # free. A zero-token request must still finalize despite ``running`` being
+    # saturated -- this is exactly the ``len(self.running) < max_running`` clause
+    # added in 6d27414 that the finding flags.
+    n = 8
+    dec = _FakeDecoder(
+        n_rows=n,
+        first_tokens={r: 10 + r for r in range(n)},
+        plans={r: [[100 + r]] for r in range(n)},
+    )
+    rt = _spec_runtime(dec)
+    assert rt.max_batch_size == 4 and dec.free_slots == 8
+    sched = _make_scheduler(rt)
+    # 4 real requests saturate the running batch at max_batch_size.
+    for rid in range(4):
+        _enqueue(sched, rid, prompt_len=3, max_new=8)
+    # A zero-token request queued BEHIND the saturating batch.
+    rz = _enqueue(sched, 99, prompt_len=5, max_new=0)
+
+    assert sched._spec_admit() is True
+    # Running saturated at the cap; pool NOT full (4 rows still free).
+    assert len(dec.admitted) == rt.max_batch_size
+    assert len(sched.running) == rt.max_batch_size
+    assert dec.free_slots == n - rt.max_batch_size
+    # The zero-token request finalized WITHOUT admit and WITHOUT a pool row:
+    # it is no longer waiting, never entered ``running``, and ``decoder.admit``
+    # was never called for it (row 99's id is not among the admitted pool rows;
+    # admitted rows are the 4 real ones [0..3]).
+    assert 99 not in dec.admitted
+    # No spec row / sequence_state assigned (the ``.state`` property would raise
+    # if ``sequence_state`` were unset, so assert the underlying field directly).
+    assert rz.lifecycle.sequence_state is None
+    assert all(r.request_id != 99 for r in sched.waiting)
+    assert all(lc.request.request_id != 99 for lc in sched.running)
+    completed = {c.request_id: c for c in sched.pop_completed()}
+    assert 99 in completed
+    assert completed[99].finish_reason == "length"
+    assert completed[99].tokens == []
+
+    # --- Condition B: pool fully drained (decoder.free_slots == 0) ---
+    # Size the runtime so the batch cap does NOT block draining the pool: a
+    # 2-row pool with max_batch_size=4 lets both rows admit, leaving
+    # ``free_slots == 0``. A zero-token request behind the full pool must still
+    # finalize immediately.
+    dec2 = _FakeDecoder(
+        n_rows=2,
+        first_tokens={0: 11, 1: 22},
+        plans={0: [[12]], 1: [[23]]},
+    )
+    rt2 = FakeRuntime(max_batch_size=4, max_batch_slots=6)
+    rt2.spec = SpecDecodeCaps(
+        proposer=SimpleNamespace(num_speculative_tokens=3, num_lookahead_tokens=4),
+        decoder=dec2,
+    )
+    rt2.prompt_template = SimpleNamespace(eos_id=999)
+    sched2 = _make_scheduler(rt2)
+    _enqueue(sched2, 0, prompt_len=3, max_new=8)
+    _enqueue(sched2, 1, prompt_len=3, max_new=8)
+    rz2 = _enqueue(sched2, 77, prompt_len=4, max_new=0)
+
+    assert sched2._spec_admit() is True
+    # Pool fully consumed by the two real admissions.
+    assert dec2.free_slots == 0
+    assert dec2.admitted == [0, 1]
+    assert len(sched2.running) == 2
+    # The zero-token request finalized despite the empty pool: not waiting, not
+    # running, never admitted.
+    assert 77 not in dec2.admitted
+    assert rz2.lifecycle.sequence_state is None
+    assert all(r.request_id != 77 for r in sched2.waiting)
+    completed2 = {c.request_id: c for c in sched2.pop_completed()}
+    assert 77 in completed2
+    assert completed2[77].finish_reason == "length"
+    assert completed2[77].tokens == []

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -62,6 +62,8 @@ class _FakeDecoder:
         first_tokens: dict,
         emit_logprobs: bool = False,
         side_values: object | None = None,
+        first_logprobs: dict | None = None,
+        admit_side_values: object | None = None,
     ) -> None:
         self._free = list(range(n_rows))
         self._row_of: dict[int, int] = {}
@@ -69,6 +71,12 @@ class _FakeDecoder:
         self._first = first_tokens     # row -> first token id
         self._emit_logprobs = emit_logprobs
         self._side_values = side_values
+        # row -> first-token logprob ``admit`` returns when the request wants
+        # logprobs (defaults to the non-spec greedy-bonus convention 0.0).
+        self._first_logprobs = first_logprobs or {}
+        # Optional per-admit side-values the decoder attaches to the state so
+        # the scheduler types the admit token via the runtime hook.
+        self._admit_side_values = admit_side_values
         self.admitted: list[int] = []
         self.retired: list[int] = []
         # admit kwargs recorded per row.
@@ -86,22 +94,33 @@ class _FakeDecoder:
         image=None,
         allowed_token_ids=None,
         suppressed_token_ids=None,
+        suppress_next_token_ids=None,
         temperature: float = 0.0,
         top_p: float = 1.0,
     ):
         row = self._free.pop(0)
         self._row_of[id(state)] = row
         state.batch_idx = 100 + row
+        if self._admit_side_values is not None:
+            state.admit_side_values = self._admit_side_values
         self.admitted.append(row)
+        want_logprobs = getattr(state, "return_logprobs", None) is True
         self.admit_kwargs[row] = {
             "image": image,
             "allowed_token_ids": allowed_token_ids,
             "suppressed_token_ids": suppressed_token_ids,
+            "suppress_next_token_ids": suppress_next_token_ids,
             "temperature": temperature,
             "top_p": top_p,
             "return_logprobs": getattr(state, "return_logprobs", None),
         }
-        return self._first[row]
+        # New contract: ``admit`` returns ``(first_token_id, first_logprob)``.
+        # ``first_logprob`` is the real selected-token logprob when the request
+        # wants logprobs, else ``None``.
+        first_logprob = (
+            self._first_logprobs.get(row, 0.0) if want_logprobs else None
+        )
+        return self._first[row], first_logprob
 
     def step(self, states):
         tokens, accepts, logprobs = [], [], []
@@ -446,6 +465,9 @@ def test_spec_admit_and_step_stage_logprobs() -> None:
         first_tokens={0: 11},
         plans={0: [[12, 13]]},  # admit(1) + 2 == max_new=3 -> finishes here
         emit_logprobs=True,
+        # admit returns the REAL first-token logprob (not the 0.0 greedy
+        # placeholder) for a return_logprobs request.
+        first_logprobs={0: -0.5},
     )
     rt = _spec_runtime(dec)
     sched = _make_scheduler(rt)
@@ -464,11 +486,193 @@ def test_spec_admit_and_step_stage_logprobs() -> None:
         pass
 
     assert [int(t.token_id) for t in req.lifecycle.skill_state.tokens] == [11, 12, 13]
-    # First (bonus) token from admit carries the greedy-bonus logprob (0.0);
-    # the macro-step supplies the real logprobs for the committed tokens.
-    assert req.lifecycle.logprobs == [0.0, -12.0, -13.0]
+    # First (bonus) token carries the REAL admit logprob (-0.5), and the
+    # macro-step supplies the real logprobs for the committed tokens.
+    assert req.lifecycle.logprobs == [-0.5, -12.0, -13.0]
     completed = sched.pop_completed()
-    assert completed[0].logprobs == [0.0, -12.0, -13.0]
+    assert completed[0].logprobs == [-0.5, -12.0, -13.0]
+
+
+def test_spec_admit_returns_real_first_token_logprob() -> None:
+    """Regression for codex finding: real admit logprob, not a 0.0 placeholder.
+
+    For a non-greedy ``return_logprobs`` request the first (bonus) token sampled
+    by ``decoder.admit`` must be staged with the sampler's selected-token logprob
+    (the value ``admit`` now returns), not the 0.0 greedy approximation. Asserts
+    the staged first logprob is exactly the real value the decoder returned.
+    """
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12]]},
+        emit_logprobs=True,
+        first_logprobs={0: -1.25},  # real selected-token logprob from admit
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    # temperature > 0: the case where 0.0 would be wrong (non-greedy default).
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=8, return_logprobs=True, temperature=0.7
+    )
+
+    assert sched._spec_admit() is True
+    # The first staged logprob is the real value, not the 0.0 placeholder.
+    assert req.lifecycle.logprobs == [-1.25]
+
+
+def test_spec_admit_no_logprob_when_not_requested() -> None:
+    """``admit`` returns ``None`` logprob (and none is staged) without a request."""
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=8)  # return_logprobs unset
+
+    assert sched._spec_admit() is True
+    # No logprobs requested -> none collected (staging would raise if a stray
+    # 0.0 were threaded for a non-logprobs request).
+    assert req.lifecycle.logprobs == []
+
+
+def test_spec_admit_applies_one_shot_suppression() -> None:
+    """Regression for codex finding: one-shot suppression reaches the admit sample.
+
+    ``GenerationRequest.suppress_next_token_ids`` is a one-shot blacklist the
+    non-spec path applies to a request's *first* generated token. ``admit``
+    samples that exact token, so the scheduler must forward the suppression as
+    ``suppress_next_token_ids`` -- otherwise a suppressed id can be emitted at
+    admit and the one-shot window closes before ``step`` could apply it.
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=8)
+    req.suppress_next_token_ids = (7, 8, 9)
+
+    assert sched._spec_admit() is True
+    # The one-shot suppression was forwarded into admit (the first sample).
+    assert tuple(dec.admit_kwargs[0]["suppress_next_token_ids"]) == (7, 8, 9)
+
+
+def test_spec_admit_no_one_shot_suppression_past_prefix() -> None:
+    """One-shot suppression is *not* forwarded once past a request's prefix.
+
+    Mirrors the non-spec gate (``token_count == generated_prefix_length``): a
+    resumed request that already generated its prefix is not on its first
+    generated token, so the one-shot suppression must not re-fire at admit.
+    """
+
+    class _PrefixState(_RecordingState):
+        # Pretend the request already generated one prefix token.
+        @property
+        def token_count(self) -> int:  # type: ignore[override]
+            return 1
+
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=8)
+    req.suppress_next_token_ids = (7, 8, 9)
+    prefix_state = _PrefixState(req)
+    req.lifecycle.skill_state = prefix_state
+    req.skill_state = prefix_state
+
+    assert sched._spec_admit() is True
+    # token_count (1) != generated_prefix_length (0) -> suppression not applied.
+    assert dec.admit_kwargs[0]["suppress_next_token_ids"] is None
+
+
+def test_spec_admit_types_admit_token_via_materialize_hook() -> None:
+    """Regression for codex finding: type the admit token through the hook.
+
+    On a spatial runtime the first generated id can be coord/size, so the admit
+    (first) token must be typed through the runtime ``materialize_tokens`` hook
+    using ``admit``'s side-values -- not hard-coded to ``TextToken``. Stubs the
+    hook to wrap the admit id and asserts (a) it ran for the admit token, (b) it
+    received ``admit``'s side-values as the opaque step-handle, (c) the staged
+    first token is the typed token.
+    """
+    admit_side_values = object()
+    calls: list[dict] = []
+
+    @dataclass
+    class _TypedToken:
+        token_id: int
+
+    def materialize_tokens(token_ids_cpu, sequences, batch_idx, step_handle):
+        ids = [int(t) for t in token_ids_cpu.view(-1).tolist()]
+        calls.append({"step_handle": step_handle, "ids": ids})
+        return [_TypedToken(token_id=int(t)) for t in ids]
+
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12]]},
+        admit_side_values=admit_side_values,
+    )
+    rt = _spec_runtime(dec)
+    from kestrel.runtime.sampling import SamplingHooks
+
+    # Hooks are read at scheduler construction, so install before _make_scheduler.
+    rt.sampling_hooks = SamplingHooks(materialize_tokens=materialize_tokens)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=8)
+
+    assert sched._spec_admit() is True
+    # The hook typed the admit id (11) and was handed admit's side-values.
+    admit_call = next(c for c in calls if c["ids"] == [11])
+    assert admit_call["step_handle"] is admit_side_values
+    staged = req.lifecycle.skill_state.tokens
+    assert isinstance(staged[0], _TypedToken)
+    assert int(staged[0].token_id) == 11
+
+
+def test_spec_admit_fails_on_non_slot_adapter_error() -> None:
+    """Regression for codex finding: a non-slot adapter error fails, not defers.
+
+    Only the recoverable out-of-LoRA-slots ``RuntimeError`` should defer the
+    request back to WAITING_RESOURCES. A different ``RuntimeError`` (e.g. a CUDA
+    load/copy failure) is unrecoverable: the request must FAIL cleanly rather
+    than loop forever in the waiting queue.
+    """
+
+    class _BrokenAdapterProvider:
+        def config(self) -> dict:
+            return {"max_lora_rank": 16}
+
+        def get(self, adapter: str) -> object:
+            return object()
+
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+
+    def _raise_load_failure(adapter_id: str, adapter: object) -> int:
+        # A genuine load/copy failure, NOT the out-of-slots signal.
+        raise RuntimeError("CUDA error: out of memory while loading adapter slot")
+
+    rt.acquire_adapter_slot = _raise_load_failure  # type: ignore[method-assign]
+
+    sched = GenerationScheduler(
+        rt,
+        compute_stream=None,
+        skill_registry=__import__(
+            "kestrel.skills", fromlist=["SkillRegistry"]
+        ).SkillRegistry([]),
+        adapter_provider=_BrokenAdapterProvider(),
+    )
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=8, adapter="ft-1", lora_slot_ready=False
+    )
+
+    # The request is removed from waiting and failed (error result), not deferred.
+    assert sched._spec_admit() is True
+    assert dec.admitted == []
+    assert len(sched.waiting) == 0
+    assert len(sched.running) == 0
+    assert req.lifecycle.finished is True
+    assert req.lifecycle.finish_reason == "error"
+    completed = sched.pop_completed()
+    assert [c.request_id for c in completed] == [0]
+    assert completed[0].finish_reason == "error"
 
 
 def test_spec_admit_forwards_image_mask_and_sampling_params() -> None:

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -82,6 +82,12 @@ class _FakeDecoder:
         self.retired: list[int] = []
         # admit kwargs recorded per row.
         self.admit_kwargs: dict[int, dict] = {}
+        # Per-``step`` skill masks the scheduler forwards (one entry per call,
+        # each parallel to that call's ``states``). Lets a test assert the
+        # stateful skill mask is RECOMPUTED per macro-step rather than reusing
+        # the stale admit-time snapshot.
+        self.step_allowed: list = []
+        self.step_suppressed: list = []
 
     @property
     def free_slots(self) -> int:
@@ -128,7 +134,16 @@ class _FakeDecoder:
         )
         return self._first[row], first_logprob
 
-    def step(self, states):
+    def step(self, states, *, allowed_token_ids=None, suppressed_token_ids=None):
+        # Record the per-step masks the scheduler recomputes + forwards.
+        self.step_allowed.append(
+            list(allowed_token_ids) if allowed_token_ids is not None else None
+        )
+        self.step_suppressed.append(
+            list(suppressed_token_ids)
+            if suppressed_token_ids is not None
+            else None
+        )
         tokens, accepts, logprobs = [], [], []
         for s in states:
             row = self._row_of[id(s)]
@@ -1130,3 +1145,127 @@ def test_spec_drain_pipeline_noop_when_no_pending_spec() -> None:
     sched._drain_pipeline()
     assert sched._pending_spec is None
     assert dec.retired == []
+def test_spec_step_recomputes_stateful_skill_mask_per_step() -> None:
+    """Regression for codex P1 @ L727: stateful skill masks refresh per step.
+
+    For a STATEFUL constrained skill the allowed-token set evolves per committed
+    token (point toggles ``[coord, eos]`` <-> ``[coord]`` after each coordinate;
+    detect cycles x->y->size). The spec path used to snapshot the mask ONCE at
+    ``admit`` and reuse it for every later position, so ``decoder.step`` -- which
+    only saw ``SequenceState`` -- could never see the mask change after a
+    ``consume_step``, allowing e.g. EOS where ``y`` is required.
+
+    This drives a toggling skill state (mirroring point: allowed set flips every
+    committed token) through several macro-steps with ONE token committed per
+    step (so at most one stateful transition happens per committed run -- the
+    regime where a single per-step mask is exact, matching the non-spec
+    one-token-per-step refresh) and asserts the mask the scheduler hands to each
+    ``decoder.step`` is RECOMPUTED from the live skill state -- it alternates
+    with the state instead of being frozen at the admit-time value.
+    """
+    COORD, EOS = 7, 8
+
+    class _TogglingState(_RecordingState):
+        def __init__(self, request: GenerationRequest) -> None:
+            super().__init__(request)
+            self._awaiting_y = False
+
+        def consume_step(self, runtime: object, step: DecodeStep) -> None:
+            # Mirror PointSkillState: every committed token flips the stage.
+            self.append_token(step.token)
+            self._awaiting_y = not self._awaiting_y
+
+        def allowed_token_ids(self, runtime: object):
+            # awaiting y -> only a coordinate may follow; else coord or EOS.
+            return [COORD] if self._awaiting_y else [COORD, EOS]
+
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 19},
+        # One token committed per macro-step -> one stateful transition per run.
+        plans={0: [[20], [21], [22], [23]]},
+        # EOS exists in the skill mask but is never the scripted token, so the
+        # request runs long enough to observe several mask refreshes.
+    )
+    rt = _spec_runtime(dec, eos_id=EOS)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=20)
+    toggling = _TogglingState(req)
+    req.lifecycle.skill_state = toggling
+    req.skill_state = toggling
+
+    assert sched._spec_admit() is True
+    # At admit the state was ``_awaiting_y=False`` -> the admit-time (stale)
+    # snapshot allows [COORD, EOS]. The bug reused exactly this for all later
+    # positions. ``admit`` staged token 19, flipping the state to awaiting_y.
+    assert list(dec.admit_kwargs[0]["allowed_token_ids"]) == [COORD, EOS]
+
+    # Drive four macro-steps so each commits one scripted token and flips state.
+    for _ in range(4):
+        sched._spec_decode_step()
+
+    # Each ``step`` got a single-row mask (the one active sequence). Pull the
+    # per-call allowed set for that row.
+    per_step = [call[0] for call in dec.step_allowed]
+
+    # The mask handed to step 0 reflects the POST-admit state (awaiting_y=True)
+    # -> [COORD] -- already DIFFERENT from the admit-time [COORD, EOS], proving
+    # it is recomputed, not the frozen admit snapshot.
+    assert per_step[0] == [COORD]
+    assert per_step[0] != list(dec.admit_kwargs[0]["allowed_token_ids"])
+    # ... and it tracks the toggling skill state across subsequent steps: each
+    # committed token flips the allowed set, so it alternates per macro-step.
+    assert per_step[:4] == [[COORD], [COORD, EOS], [COORD], [COORD, EOS]]
+
+
+def test_spec_zombie_lifecycle_marked_completed_before_retire() -> None:
+    """Regression for codex P2 @ L1012: zombie -> COMPLETED before row retire.
+
+    When a spec request finishes while its depth-1 follow-up macro-step is still
+    in flight, ``_finalize_sequence`` leaves it FINALIZING (``inflight_refs >
+    0``). The zombie branch in ``_commit_spec`` is where that last ref reaches
+    zero; it used to ONLY retire the decoder row and never transition the
+    lifecycle to COMPLETED, so a normally-completed spec request could stay stuck
+    in FINALIZING forever after its row was retired. This drives a sequence that
+    finishes with an optimistic follow-up step outstanding and asserts the
+    lifecycle ends COMPLETED (not FINALIZING) and its row is retired exactly
+    once -- matching the non-spec zombie ordering in ``commit_step``.
+    """
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12, 13]]},  # admit(1) + 2 == max_new=3 -> finishes mid-pipeline
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=3)
+    sched._spec_admit()
+
+    # Drive to quiescence. The finishing commit lands while a follow-up
+    # (zombie) step is in flight; the zombie's own commit retires the row and
+    # must mark the lifecycle COMPLETED.
+    saw_finalizing_with_pending = False
+    for _ in range(10):
+        if not sched._spec_decode_step():
+            break
+        if (
+            req.lifecycle.finished
+            and sched._pending_spec is not None
+            and req.lifecycle.phase == RequestPhase.FINALIZING
+        ):
+            # The exact window: finished + an in-flight zombie step still holds a
+            # ref, so the lifecycle is (correctly) FINALIZING, not yet COMPLETED.
+            saw_finalizing_with_pending = True
+
+    # The FINALIZING-with-zombie window actually occurred (otherwise the test
+    # would not be exercising the zombie completion path at all).
+    assert saw_finalizing_with_pending is True
+    # After the zombie's commit: row retired exactly once, lifecycle COMPLETED
+    # (the bug left it stuck in FINALIZING), nothing leaked.
+    assert dec.retired == [0]
+    assert dec.retired.count(0) == 1
+    assert req.lifecycle.phase == RequestPhase.COMPLETED
+    assert req.lifecycle.finished is True
+    assert rt.active_sequences == {}
+    assert sched._pending_spec is None
+    assert [c.finish_reason for c in sched.pop_completed()] == ["length"]

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -665,6 +665,82 @@ def test_spec_admit_no_logprob_when_not_requested() -> None:
     assert req.lifecycle.logprobs == []
 
 
+def test_spec_spatial_logprob_folds_head_logprob_into_staged() -> None:
+    """P2 regression: the scheduler stages the spatial-head-augmented logprob.
+
+    When a macro-step emits ``SpecSideValues`` (spatial runtime) and the request
+    wants logprobs, the scheduler must hand the spec decoder's *vocab* logprobs to
+    ``materialize_spec_tokens`` and stage the value the hook returns -- which a
+    spatial runtime augments with the coord/size head logprob in place. This is
+    the wiring the P2 fixed: previously the hook got ``token_logprobs=None`` and
+    the scheduler staged only the vocab logprob (under-reporting spatial tokens,
+    including the admit token, which routes through the same hook).
+
+    A fake spatial hook here adds a fixed ``-0.5`` head delta to every position
+    (standing in for the real coord/size head logprob) and records the vocab
+    logprobs it received. We assert: (a) the hook was handed the spec decoder's
+    vocab logprobs (parallel to the committed ids), and (b) every staged logprob
+    -- the admit token AND each committed token -- is the vocab value PLUS the
+    head delta (not the bare vocab value).
+    """
+    from kestrel.runtime.sampling import SamplingHooks
+
+    HEAD_DELTA = -0.5
+    side_values = object()
+    received: list[list[float]] = []
+
+    @dataclass
+    class _TypedToken:
+        token_id: int
+
+    def materialize_spec_tokens(
+        token_ids_cpu, sequences, batch_idx, sv, token_logprobs=None
+    ):
+        ids = [int(t) for t in token_ids_cpu.view(-1).tolist()]
+        if token_logprobs is not None:
+            received.append(list(token_logprobs))
+            # Fold a per-position "spatial head" logprob in place, exactly as the
+            # real Moondream hook folds the coord/size head logprob.
+            for k in range(len(token_logprobs)):
+                token_logprobs[k] += HEAD_DELTA
+        return [_TypedToken(token_id=t) for t in ids]
+
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12, 13]]},  # admit(1) + 2 == max_new=3 -> finishes here
+        emit_logprobs=True,
+        first_logprobs={0: -0.5},  # real admit vocab logprob
+        side_values=side_values,
+        admit_side_values=side_values,  # route the admit token through the hook
+    )
+    rt = _spec_runtime(dec)
+    rt.sampling_hooks = SamplingHooks(
+        materialize_spec_tokens=materialize_spec_tokens
+    )
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=3, return_logprobs=True)
+
+    assert sched._spec_admit() is True
+    while sched._spec_decode_step():
+        pass
+
+    # The hook was handed the spec decoder's vocab logprobs: the admit token
+    # (-0.5) on its own, then the macro-step's committed-token vocab logprobs
+    # (-12.0, -13.0 == -(token_id)).
+    assert [-0.5] in received
+    assert [-12.0, -13.0] in received
+    # Every staged logprob is vocab + head delta (folded by the hook), not the
+    # bare vocab value the spec decoder gathered.
+    assert req.lifecycle.logprobs == pytest.approx(
+        [-0.5 + HEAD_DELTA, -12.0 + HEAD_DELTA, -13.0 + HEAD_DELTA]
+    )
+    completed = sched.pop_completed()
+    assert completed[0].logprobs == pytest.approx(
+        [-0.5 + HEAD_DELTA, -12.0 + HEAD_DELTA, -13.0 + HEAD_DELTA]
+    )
+
+
 def test_spec_admit_applies_one_shot_suppression() -> None:
     """Regression for codex finding: one-shot suppression reaches the admit sample.
 
@@ -734,7 +810,9 @@ def test_spec_admit_types_admit_token_via_materialize_hook() -> None:
     class _TypedToken:
         token_id: int
 
-    def materialize_spec_tokens(token_ids_cpu, sequences, batch_idx, side_values):
+    def materialize_spec_tokens(
+        token_ids_cpu, sequences, batch_idx, side_values, token_logprobs=None
+    ):
         ids = [int(t) for t in token_ids_cpu.view(-1).tolist()]
         calls.append({"side_values": side_values, "ids": ids})
         return [_TypedToken(token_id=int(t)) for t in ids]
@@ -907,7 +985,9 @@ def test_spec_commit_routes_committed_ids_through_materialize_hook() -> None:
     class _TypedToken:
         token_id: int
 
-    def materialize_spec_tokens(token_ids_cpu, sequences, batch_idx, side_values):
+    def materialize_spec_tokens(
+        token_ids_cpu, sequences, batch_idx, side_values, token_logprobs=None
+    ):
         ids = [int(t) for t in token_ids_cpu.view(-1).tolist()]
         calls.append({"side_values": side_values, "ids": ids})
         return [_TypedToken(token_id=int(t)) for t in ids]
@@ -1535,6 +1615,144 @@ def test_moondream_materialize_spec_tokens_types_coord_size() -> None:
     # Seq B: its coord uses seq B's OWN hidden row (0.3), not seq A's (0.7).
     assert isinstance(tokens[3], CoordToken)
     assert tokens[3].pos == pytest.approx(b_coord_bin / (coord_bins - 1))
+
+
+def test_moondream_materialize_spec_tokens_folds_spatial_head_logprob(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """P2 regression: a spatial spec token requesting logprobs reports the
+    coord/size head logprob *added* to the vocab logprob, not the vocab logprob
+    alone -- matching the non-spec ``post_sample`` convention.
+
+    The spec decoder only gathers the vocab-token logprob (it never runs the
+    spatial head), so the scheduler hands ``materialize_spec_tokens`` the flat
+    per-committed-position vocab logprobs and the hook must fold each spatial
+    position's coord/size head logprob into them in place (exactly as the non-spec
+    path's ``compute_spatial_values`` does). We patch ``sample_step_from_logits``
+    (the spatial sampler) to emit scripted per-head logprobs -- the same hermetic
+    technique ``tests/scheduler/test_logprobs.py`` uses for the non-spec path -- so
+    the expected combined value is exact and CPU-deterministic. We assert:
+
+    * a ``coord_id`` position: ``vocab + coord_head`` logprob,
+    * a ``size_id`` position: ``vocab + width_head + height_head`` logprob,
+    * a plain text position: vocab logprob unchanged (no spatial head),
+    * the hook returns the same per-token combined values to the scheduler.
+    """
+    import torch
+
+    from kestrel.models.moondream.runtime import (
+        CoordToken,
+        MoondreamRuntime,
+        SizeToken,
+        TextToken,
+    )
+    from kestrel.runtime.spec import SpecSideValues
+
+    coord_bins, size_bins = 11, 8
+    tables, hidden_dim = _synthetic_spatial_tables(coord_bins, size_bins)
+    coord_id, size_id = 5000, 5001
+
+    stub = SimpleNamespace(
+        config=SimpleNamespace(
+            tokenizer=SimpleNamespace(coord_id=coord_id, size_id=size_id)
+        ),
+        spatial_tables=tables,
+        _pending_coord_values=torch.zeros(8, 1),
+        _pending_size_values=torch.zeros(8, 2),
+        _copy_stream=None,
+        _spatial_rng=None,
+    )
+    hooks = MoondreamRuntime.sampling_hooks.func(stub)
+
+    # One sequence committing 3 tokens: [coord, size, text]. Greedy (temp 0), but
+    # ``token_logprobs`` is set so ``compute_spatial_values`` still runs the
+    # sampler (and thus the spatial-head logprob fold) rather than the pure-argmax
+    # branch -- which is exactly the path that was passing ``token_logprobs=None``.
+    seq = SimpleNamespace(
+        request=SimpleNamespace(temperature=0.0, top_p=1.0),
+        state=SimpleNamespace(batch_idx=300),
+    )
+    text_id = 42
+    flat_ids = [coord_id, size_id, text_id]
+    token_ids_cpu = torch.tensor(flat_ids, dtype=torch.long)
+    batch_idx = torch.tensor([300, 300, 300], dtype=torch.long)
+    total = len(flat_ids)
+
+    coord_bin, w_bin, h_bin = 7, 2, 5
+    hidden = torch.zeros(1, total, hidden_dim, dtype=torch.float32)
+    hidden[0, 0] = _encode_spatial_hidden(
+        coord_bins, size_bins, hidden_dim, coord=coord_bin, width=0, height=0
+    )
+    hidden[0, 1] = _encode_spatial_hidden(
+        coord_bins, size_bins, hidden_dim, coord=0, width=w_bin, height=h_bin
+    )
+    # Text position: hidden would decode to a valid bin, but the head logprob must
+    # NOT be added (it is not a coord/size id).
+    hidden[0, 2] = _encode_spatial_hidden(
+        coord_bins, size_bins, hidden_dim, coord=9, width=7, height=7
+    )
+
+    side_values = SpecSideValues(
+        hidden=hidden,
+        temperatures=torch.zeros(1, dtype=torch.float32),
+        top_ps=torch.ones(1, dtype=torch.float32),
+        counts=None,
+    )
+
+    # Scripted spatial-head logprobs. ``compute_spatial_values`` calls the sampler
+    # twice: first coord (batch == total), then size (batch == total*2, the
+    # width rows then the height rows stacked). Return the argmax bins (so decoded
+    # values stay consistent with the one-hot hidden) and write known logprobs.
+    coord_head = [-0.10, -0.20, -0.30]               # per position
+    width_head = [-0.40, -0.50, -0.60]               # per position
+    height_head = [-0.70, -0.80, -0.90]              # per position
+
+    def fake_sample_step_from_logits(
+        logits, temperatures, top_p, *, generator=None, logprobs_out=None
+    ):
+        bins = torch.argmax(logits, dim=-1)
+        if logits.shape[0] == total:  # coord head
+            if logprobs_out is not None:
+                logprobs_out.copy_(torch.tensor(coord_head, dtype=torch.float32))
+        else:  # size head: [width(total) | height(total)]
+            if logprobs_out is not None:
+                logprobs_out.copy_(
+                    torch.tensor(width_head + height_head, dtype=torch.float32)
+                )
+        return bins
+
+    monkeypatch.setattr(
+        "kestrel.scheduler.spatial.sample_step_from_logits",
+        fake_sample_step_from_logits,
+    )
+
+    # Vocab logprobs the spec decoder staged (parallel to ``flat_ids``). The hook
+    # mutates this list in place to fold in the spatial head logprobs.
+    vocab_logprobs = [-1.0, -2.0, -3.0]
+    token_logprobs = list(vocab_logprobs)
+
+    tokens = hooks.materialize_spec_tokens(
+        token_ids_cpu, [seq], batch_idx, side_values, token_logprobs
+    )
+
+    # Token typing is unaffected by the logprob threading.
+    assert isinstance(tokens[0], CoordToken)
+    assert isinstance(tokens[1], SizeToken)
+    assert isinstance(tokens[2], TextToken)
+    assert tokens[2].token_id == text_id
+
+    # coord: vocab + coord_head; size: vocab + width_head + height_head; text: vocab.
+    expected = [
+        vocab_logprobs[0] + coord_head[0],
+        vocab_logprobs[1] + width_head[1] + height_head[1],
+        vocab_logprobs[2],  # text id -- no spatial head added
+    ]
+    assert token_logprobs == pytest.approx(expected)
+    # The spatial positions are strictly more negative than the vocab-only value
+    # (under-reporting would have left them at the vocab logprob).
+    assert token_logprobs[0] < vocab_logprobs[0]
+    assert token_logprobs[1] < vocab_logprobs[1]
+    assert token_logprobs[2] == pytest.approx(vocab_logprobs[2])
 
 
 def test_moondream_materialize_spec_tokens_honors_explicit_counts() -> None:

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -369,6 +369,59 @@ def test_spec_admit_respects_free_slots() -> None:
     assert len(sched.running) == 1
 
 
+def test_spec_admit_caps_running_batch_to_max_batch_size() -> None:
+    """Regression: cap the live spec batch to ``runtime.max_batch_size``.
+
+    The decoder's pool can expose MORE free rows than ``max_batch_size`` -- it
+    is sized from ``max_batch_slots == max_batch_size + 2`` for transient-prefill
+    headroom (here ``_spec_runtime`` uses ``max_batch_size=4`` /
+    ``max_batch_slots=8``, and the decoder pool has 8 rows). If ``_spec_admit``
+    admitted ``while decoder.free_slots > 0`` with no batch bound, it would queue
+    all 8 running rows, and ``_spec_decode_step`` would then snapshot every one
+    into a single ``decoder.step`` call -- overrunning the verify/draft graphs
+    and staging buffers captured for ``max_batch_size`` states (the non-spec path
+    caps the same way via ``_cap_decode_dispatch``).
+
+    Enqueue 6 launchable requests against an 8-row pool and assert:
+
+    * admission stops at ``max_batch_size`` (4) even though 8 rows are free and 6
+      requests are launchable -- the surplus stays WAITING; and
+    * across the whole depth-1 run, NO ``decoder.step`` call is ever handed more
+      than ``max_batch_size`` states (``_FakeDecoder.step_rows`` records each
+      call's launched rows).
+    """
+    n = 8  # pool rows -- intentionally > max_batch_size (4)
+    dec = _FakeDecoder(
+        n_rows=n,
+        first_tokens={r: 10 + r for r in range(n)},
+        # One token per step for a few steps so ``decoder.step`` actually fires
+        # with the full admitted batch before any row finishes.
+        plans={r: [[100 + r], [200 + r], [300 + r]] for r in range(n)},
+    )
+    rt = _spec_runtime(dec)
+    assert rt.max_batch_size == 4 and dec.free_slots == 8
+    sched = _make_scheduler(rt)
+    for rid in range(6):  # more launchable requests than the batch cap
+        _enqueue(sched, rid, prompt_len=3, max_new=8)
+
+    sched._spec_admit()
+    # Capped at max_batch_size: only 4 rows admitted, the other 2 stay waiting,
+    # and free pool rows remain (admission was bound by the batch, not the pool).
+    assert len(dec.admitted) == rt.max_batch_size
+    assert dec.admitted == [0, 1, 2, 3]
+    assert len(sched.running) == rt.max_batch_size
+    assert len(sched.waiting) == 2
+    assert dec.free_slots == n - rt.max_batch_size  # pool not over-subscribed
+
+    # Drive the depth-1 pipeline; every ``decoder.step`` must stay within the
+    # captured batch size for the whole run.
+    for _ in range(8):
+        if not sched._spec_decode_step():
+            break
+    assert dec.step_rows  # at least one macro-step actually launched
+    assert all(len(rows) <= rt.max_batch_size for rows in dec.step_rows)
+
+
 def test_advance_routes_to_spec_when_capability_present() -> None:
     dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12], [13]]})
     rt = _spec_runtime(dec)

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -73,7 +73,12 @@ class _FakeDecoder:
         tokens, accepts = [], []
         for s in states:
             row = self._row_of[id(s)]
-            nxt = self._plans[row].pop(0)
+            plan = self._plans[row]
+            # Depth-1 overlap launches one macro-step ahead, so a finishing row
+            # gets one extra optimistic launch whose result is discarded as a
+            # zombie at commit. Hand back a throwaway token when the script is
+            # exhausted.
+            nxt = plan.pop(0) if plan else [0]
             tokens.append(list(nxt))
             accepts.append(len(nxt) - 1)
         return SpecStepResult(tokens=tokens, accept_counts=accepts)
@@ -148,13 +153,17 @@ def test_spec_step_variable_advance_and_state_length() -> None:
     )
     rt = _spec_runtime(dec)
     sched = _make_scheduler(rt)
-    r0 = _enqueue(sched, 0, prompt_len=3, max_new=8)
-    r1 = _enqueue(sched, 1, prompt_len=2, max_new=8)
+    # max_new sized so each row finishes exactly at its scripted step (the
+    # depth-1 pipeline commits a step one tick after it launches).
+    r0 = _enqueue(sched, 0, prompt_len=3, max_new=3)
+    r1 = _enqueue(sched, 1, prompt_len=2, max_new=2)
     sched._spec_admit()
 
     len0_before = r0.lifecycle.state.length
     len1_before = r1.lifecycle.state.length
-    assert sched._spec_decode_step() is True
+    # Drive the depth-1 pipeline to quiescence (launch N / commit N-1 / drain).
+    while sched._spec_decode_step():
+        pass
 
     # Variable advance: row 0 committed 2, row 1 committed 1.
     assert [int(t.token_id) for t in r0.lifecycle.skill_state.tokens] == [11, 12, 13]
@@ -175,7 +184,8 @@ def test_spec_finish_on_eos_within_run_retires_and_completes() -> None:
     sched = _make_scheduler(rt)
     r0 = _enqueue(sched, 0, prompt_len=3, max_new=20)
     sched._spec_admit()
-    sched._spec_decode_step()
+    while sched._spec_decode_step():  # depth-1: commit lands a tick after launch
+        pass
 
     toks = [int(t.token_id) for t in r0.lifecycle.skill_state.tokens]
     # Staged up to and including eos, then stopped (13 dropped).
@@ -198,8 +208,10 @@ def test_spec_finish_on_max_new_tokens() -> None:
     sched = _make_scheduler(rt)
     r0 = _enqueue(sched, 0, prompt_len=3, max_new=3)
     sched._spec_admit()
-    # admit already staged 1; one step stages 2 more -> hits max_new=3.
-    sched._spec_decode_step()
+    # admit staged 1; the scripted step stages 2 more -> hits max_new=3. Drive
+    # the depth-1 pipeline to quiescence (commit lands a tick after launch).
+    while sched._spec_decode_step():
+        pass
     assert r0.lifecycle.finished is True
     assert dec.retired == [0]
     assert [c.finish_reason for c in sched.pop_completed()] == ["length"]

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -86,8 +86,13 @@ class _FakeDecoder:
         # each parallel to that call's ``states``). Lets a test assert the
         # stateful skill mask is RECOMPUTED per macro-step rather than reusing
         # the stale admit-time snapshot.
+
         self.step_allowed: list = []
         self.step_suppressed: list = []
+        # Per-``step`` commit caps the scheduler forwards (one entry per call,
+        # each parallel to that call's ``states``). Lets a test assert the
+        # scheduler caps a STATEFUL-masked row to a single committed token.
+        self.step_commit_caps: list = []
 
     @property
     def free_slots(self) -> int:
@@ -136,7 +141,15 @@ class _FakeDecoder:
         )
         return self._first[row], first_logprob
 
-    def step(self, states, *, allowed_token_ids=None, suppressed_token_ids=None):
+
+    def step(
+        self,
+        states,
+        *,
+        allowed_token_ids=None,
+        suppressed_token_ids=None,
+        commit_caps=None,
+    ):
         # Record the per-step masks the scheduler recomputes + forwards.
         self.step_allowed.append(
             list(allowed_token_ids) if allowed_token_ids is not None else None
@@ -146,8 +159,11 @@ class _FakeDecoder:
             if suppressed_token_ids is not None
             else None
         )
+        self.step_commit_caps.append(
+            list(commit_caps) if commit_caps is not None else None
+        )
         tokens, accepts, logprobs = [], [], []
-        for s in states:
+        for idx, s in enumerate(states):
             row = self._row_of[id(s)]
             plan = self._plans[row]
             # Depth-1 overlap launches one macro-step ahead, so a finishing row
@@ -155,6 +171,15 @@ class _FakeDecoder:
             # zombie at commit. Hand back a throwaway token when the script is
             # exhausted.
             nxt = plan.pop(0) if plan else [0]
+            # Honor the scheduler's per-row commit cap exactly as the real
+            # decoder must: truncate the accepted run to ``commit_caps[idx]``
+            # tokens (a stateful-masked row is capped to 1) and push the dropped
+            # tail back onto the script so it is committed on later steps -- the
+            # KV/pool advance stays consistent with the (truncated) committed run.
+            cap = None if commit_caps is None else commit_caps[idx]
+            if cap is not None and len(nxt) > cap:
+                plan.insert(0, nxt[cap:])
+                nxt = nxt[:cap]
             tokens.append(list(nxt))
             accepts.append(len(nxt) - 1)
             # Scripted logprob per committed token: -(token_id) keeps it
@@ -1382,7 +1407,157 @@ def test_spec_step_recomputes_stateful_skill_mask_per_step() -> None:
     assert per_step[0] != list(dec.admit_kwargs[0]["allowed_token_ids"])
     # ... and it tracks the toggling skill state across subsequent steps: each
     # committed token flips the allowed set, so it alternates per macro-step.
+
     assert per_step[:4] == [[COORD], [COORD, EOS], [COORD], [COORD, EOS]]
+
+
+def test_spec_step_caps_stateful_mask_to_one_committed_token_per_step() -> None:
+    """Regression for codex P1 @ L958: cap stateful masks within a macro-step.
+
+    The L727 fix re-queries the per-row skill mask each macro-step, but a single
+    ``decoder.step`` mask still covers a *variable* committed run: ``_commit_spec``
+    can stage MULTIPLE accepted tokens before the next ``consume_step`` refreshes
+    the mask. For a per-token-STATEFUL skill (detect cycles x->y->size; point
+    toggles coord/eos) a >1-token run would verify its 2nd..Nth positions under
+    the stale 1st-position mask -- e.g. a detect run could accept a ``coord``
+    where ``size`` is required, or suppress the required ``size_id``.
+
+    The scheduler now sends ``commit_caps[i] = 1`` for a stateful-masked row, so
+    that row commits exactly one token per macro-step (one constraint transition
+    per run -- the regime where the single per-step mask IS exact) and is
+    re-masked from the now-current skill state on the next step. This scripts a
+    decoder that WOULD commit the whole x/y/size run in one step and asserts the
+    cap holds it to one token per step, with the mask the scheduler hands each
+    step advancing in lockstep with the single committed token -- so every
+    committed position is constrained by ITS OWN stage, never the whole run under
+    the first-position mask.
+    """
+    COORD, SIZE, EOS = 7, 8, 9
+
+    class _DetectLikeState(_RecordingState):
+        # Mirror DetectSkillState: allowed set cycles x -> y -> size per token.
+        def __init__(self, request: GenerationRequest) -> None:
+            super().__init__(request)
+            self._stage = "x"
+
+        def consume_step(self, runtime: object, step: DecodeStep) -> None:
+            self.append_token(step.token)
+            if self._stage == "x":
+                self._stage = "y"
+            elif self._stage == "y":
+                self._stage = "size"
+            else:
+                self._stage = "x"
+
+        def allowed_token_ids(self, runtime: object):
+            if self._stage == "x":
+                return [COORD, EOS]
+            if self._stage == "y":
+                return [COORD]
+            return [SIZE]
+
+    dec = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 19},
+        # The decoder OFFERS a 3-token run (x, y, size) in a single macro-step.
+        # Without the cap this whole run would commit under the first-position
+        # mask; the cap must split it to one token per step.
+        plans={0: [[20, 21, 22]]},
+    )
+    rt = _spec_runtime(dec, eos_id=EOS)
+    sched = _make_scheduler(rt)
+    req = _enqueue(sched, 0, prompt_len=3, max_new=20)
+    detect = _DetectLikeState(req)
+    req.lifecycle.skill_state = detect
+    req.skill_state = detect
+
+    assert sched._spec_admit() is True
+    # ``admit`` sampled token 19 and advanced the stage x -> y, so the first
+    # ``step`` is launched under the y mask. The admit-time snapshot was the x
+    # mask -- which the bug would have reused for the whole run.
+    assert list(dec.admit_kwargs[0]["allowed_token_ids"]) == [COORD, EOS]
+
+    # Four macro-steps drive the depth-1 pipeline so the 3-token run commits ONE
+    # token per step (commit lands one tick after launch): step1 launches /
+    # step2..4 each commit one of 20, 21, 22.
+    for _ in range(4):
+        sched._spec_decode_step()
+
+    # The scheduler signalled a one-token cap for this stateful row every step.
+    assert dec.step_commit_caps[:4] == [[1], [1], [1], [1]]
+
+    # Exactly one token committed per macro-step -- the run was NOT swallowed
+    # under a single mask: tokens 20, 21, 22 staged across the steps, in order,
+    # after the admit token 19.
+    assert [int(t.token_id) for t in req.lifecycle.skill_state.tokens] == [
+        19,
+        20,
+        21,
+        22,
+    ]
+
+    # ...and the mask the scheduler hands each launch advances with the single
+    # committed token (y -> size -> x -> y), so the token committed by each
+    # step's commit was drafted/verified under ITS OWN stage's mask -- not all
+    # three positions under the first (x) mask.
+    per_step = [call[0] for call in dec.step_allowed]
+    assert per_step[:4] == [[COORD], [SIZE], [COORD, EOS], [COORD]]
+
+
+def test_spec_step_does_not_cap_unconstrained_or_constant_mask_row() -> None:
+    """A non-stateful row keeps the full multi-token speculative accept.
+
+    The L958 cap is *only* for rows whose mask can change within a run. An
+    unconstrained row (no allowed/suppressed set) and a row that declares its
+    mask constant via ``mask_is_stateful = False`` must stay uncapped, so they
+    still commit their whole accepted run in one macro-step (the throughput win
+    spec decode exists for). Asserts the scheduler forwards ``commit_caps`` of
+    ``None`` for both and the full 3-token run commits in a single step.
+    """
+
+    class _ConstantMaskState(_RecordingState):
+        # A constant suppression set (like caption's ``[answer_id]``): present
+        # every step but never transitions, so the per-step mask is already exact
+        # for a multi-token run. Declares itself non-stateful so it is uncapped.
+        mask_is_stateful = False
+
+        def suppressed_token_ids(self, runtime: object):
+            return [42]
+
+    # Row 0: unconstrained (no mask). Row 1: constant-mask, declared not stateful.
+    dec = _FakeDecoder(
+        n_rows=2,
+        first_tokens={0: 11, 1: 21},
+        plans={0: [[12, 13, 14]], 1: [[22, 23, 24]]},
+    )
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    r0 = _enqueue(sched, 0, prompt_len=3, max_new=20)
+    r1 = _enqueue(sched, 1, prompt_len=3, max_new=20)
+    constant = _ConstantMaskState(r1)
+    r1.lifecycle.skill_state = constant
+    r1.skill_state = constant
+
+    assert sched._spec_admit() is True
+    sched._spec_decode_step()  # launch macro-step over both rows
+    sched._spec_decode_step()  # commit it
+
+    # No row was capped: the scheduler forwarded ``None`` for both.
+    assert dec.step_commit_caps[0] == [None, None]
+    # Each row committed its WHOLE 3-token run in the single macro-step (the
+    # admit token plus the full accepted run -- not throttled to one/step).
+    assert [int(t.token_id) for t in r0.lifecycle.skill_state.tokens] == [
+        11,
+        12,
+        13,
+        14,
+    ]
+    assert [int(t.token_id) for t in r1.lifecycle.skill_state.tokens] == [
+        21,
+        22,
+        23,
+        24,
+    ]
 
 
 def test_spec_zombie_lifecycle_marked_completed_before_retire() -> None:

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -1429,10 +1429,13 @@ def test_spec_admit_zero_token_request_admits_and_samples_nothing() -> None:
     assert dec.admitted == []
     assert dec.retired == []
     assert rt.active_sequences == {}
-    # Not queued into running; no sequence_state attached.
+    # Not queued into running. A metrics-only ``SequenceState`` is attached so
+    # ``build_metrics`` reports the KV prompt length (no spec pool row backs it:
+    # ``batch_idx == -1`` and ``_release_sequence`` early-returns for spec).
     assert len(sched.running) == 0
     assert len(sched.waiting) == 0
-    assert req.lifecycle.sequence_state is None
+    assert req.lifecycle.sequence_state is not None
+    assert req.lifecycle.sequence_state.batch_idx == -1
     # No token sampled/staged.
     assert list(req.lifecycle.skill_state.tokens) == []
     # Completed immediately as a length-capped (0-token) result.
@@ -1440,9 +1443,59 @@ def test_spec_admit_zero_token_request_admits_and_samples_nothing() -> None:
     assert [c.request_id for c in completed] == [0]
     assert completed[0].finish_reason == "length"
     assert list(completed[0].tokens) == []
-    # build_metrics falls back to request.prompt_length (no sequence_state),
-    # mirroring the non-spec zero-length path.
+    # Text-only zero-token request (image_length == 0): the recorded KV prompt
+    # length equals request.prompt_length, so prompt_tokens is unchanged.
     assert completed[0].metrics.prompt_tokens == req.prompt_length
+
+
+def test_spec_admit_zero_token_image_request_reports_image_prompt_tokens() -> None:
+    """Regression for the 0-token spec image-prompt metrics under-report (P3).
+
+    The ``max_new_tokens <= 0`` spec fast-path finalizes WITHOUT calling
+    ``decoder.admit`` (no pool row), so it does not go through the regular spec
+    admit path that records ``prompt_length = len(prompt_tokens) + image_length``.
+    Earlier it left ``sequence_state`` unset, so ``build_metrics`` fell back to
+    the TEXT-ONLY ``request.prompt_length`` and under-reported ``prompt_tokens``
+    by the image KV prefix -- even though the request carried image context. The
+    fast-path now attaches a metrics-only ``SequenceState`` whose KV prompt
+    length includes ``image_length`` (matching the regular spec path and the
+    non-spec 0-length path, whose ``prepare_sequence`` state also includes the
+    image prefix). Assert a zero-token IMAGE request reports
+    ``prompt_tokens == prompt_len + image_length``.
+    """
+    dec = _FakeDecoder(n_rows=1, first_tokens={0: 11}, plans={0: [[12]]})
+    rt = _spec_runtime(dec)
+    sched = _make_scheduler(rt)
+    prompt_len = 3
+    image_kv = 729  # a single-image prefix (image_prefix_length) worth of KV
+    req = _enqueue(
+        sched, 0, prompt_len=prompt_len, max_new=0, image=object(),
+        image_length=image_kv,
+    )
+
+    assert sched._spec_admit() is True
+    # No spec row consumed (admit never called), nothing retired, no active row.
+    assert dec.admitted == []
+    assert dec.retired == []
+    assert rt.active_sequences == {}
+    assert len(sched.running) == 0
+    assert len(sched.waiting) == 0
+    # Metrics-only state carries the image-inclusive KV prompt length; no pool
+    # row backs it (batch_idx == -1).
+    state = req.lifecycle.sequence_state
+    assert state is not None
+    assert state.batch_idx == -1
+    assert state.prompt_length == prompt_len + image_kv
+    assert state.image_length == image_kv
+    # Completed immediately as a length-capped (0-token) result.
+    completed = sched.pop_completed()
+    assert [c.request_id for c in completed] == [0]
+    assert completed[0].finish_reason == "length"
+    assert list(completed[0].tokens) == []
+    # build_metrics reports the FULL (image-inclusive) prompt length, matching
+    # the regular prefill path -- not the bare text-only request.prompt_length.
+    assert completed[0].metrics.prompt_tokens == prompt_len + image_kv
+    assert completed[0].metrics.prompt_tokens != req.prompt_length
 
 
 def test_spec_drain_pipeline_commits_pending_spec_before_pause() -> None:
@@ -2193,9 +2246,12 @@ def test_spec_admit_zero_token_request_bypasses_saturated_batch() -> None:
     # was never called for it (row 99's id is not among the admitted pool rows;
     # admitted rows are the 4 real ones [0..3]).
     assert 99 not in dec.admitted
-    # No spec row / sequence_state assigned (the ``.state`` property would raise
-    # if ``sequence_state`` were unset, so assert the underlying field directly).
-    assert rz.lifecycle.sequence_state is None
+    # No spec POOL ROW is assigned (``decoder.admit`` never ran), but a
+    # metrics-only ``SequenceState`` is attached so ``build_metrics`` reports the
+    # KV prompt length; it is unbacked (``batch_idx == -1``).
+    assert rz.lifecycle.sequence_state is not None
+    assert rz.lifecycle.sequence_state.batch_idx == -1
+    assert rz.lifecycle.sequence_state.prompt_length == rz.prompt_length
     assert all(r.request_id != 99 for r in sched.waiting)
     assert all(lc.request.request_id != 99 for lc in sched.running)
     completed = {c.request_id: c for c in sched.pop_completed()}
@@ -2232,7 +2288,9 @@ def test_spec_admit_zero_token_request_bypasses_saturated_batch() -> None:
     # The zero-token request finalized despite the empty pool: not waiting, not
     # running, never admitted.
     assert 77 not in dec2.admitted
-    assert rz2.lifecycle.sequence_state is None
+    assert rz2.lifecycle.sequence_state is not None
+    assert rz2.lifecycle.sequence_state.batch_idx == -1
+    assert rz2.lifecycle.sequence_state.prompt_length == rz2.prompt_length
     assert all(r.request_id != 77 for r in sched2.waiting)
     completed2 = {c.request_id: c for c in sched2.pop_completed()}
     assert 77 in completed2

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -3172,3 +3172,154 @@ def test_spec_commit_failure_keeps_pending_refs_until_committed() -> None:
     assert rt.active_sequences == {}
     assert dec.free_slots == 1
     assert [c.finish_reason for c in sched.pop_completed()] == ["length"]
+
+
+def test_spec_drain_commit_failure_keeps_pending_refs_until_committed() -> None:
+    """P2 codex finding @ scheduler.py:1234 (``_drain_spec``): keep the pending
+    spec record installed until the DRAIN commit SUCCEEDS, so a commit-time
+    failure on the PAUSE/DRAIN path orphans no in-flight refs.
+
+    This is the follow-on of the ``_spec_decode_step`` keep-until-success fix: the
+    SAME clear-before-commit bug lived in the pause/drain path. ``_drain_pipeline``
+    (the engine PAUSE path, ``Executor.drain``) calls ``_drain_spec``, which used
+    to clear ``self._pending_spec`` BEFORE ``_commit_spec(pending)`` ran. But
+    ``_commit_spec`` decrements each pending sequence's ``inflight_refs`` only in
+    its FINAL per-sequence loop, after resolving the lazy ``result.tokens`` and
+    running ``materialize_spec_tokens`` -- either of which can raise (a fail-fast
+    hook, a deferred-D2H error: the same mode now guarded in ``_spec_decode_step``).
+    On such a raise the OLD pending refs stayed on the sequences with no
+    ``_pending_spec`` record left to ever commit them, so the scheduler lost the
+    only handle to retry that pending result -- stranding a finishing row in
+    ``FINALIZING`` and leaking its decoder row + LoRA slot, with subsequent
+    launches from device state never staged.
+
+    Unlike ``test_spec_commit_failure_keeps_pending_refs_until_committed`` (which
+    drives the failure through ``_spec_decode_step``'s overlap commit), this drives
+    the failure through ``_drain_pipeline`` -> ``_drain_spec`` -- the exact path
+    the P2 names -- and asserts that:
+
+    * the first drain's commit-time raise propagates but ``_pending_spec`` is STILL
+      installed (the pending step is not lost), the row keeps exactly its one
+      in-flight ref, and nothing was retired / released / finalized -- the refs are
+      not orphaned and the drain can retry; and
+    * once the hook stops failing, draining AGAIN commits that same pending step,
+      the row finishes, retires EXACTLY once, ends ``COMPLETED`` with
+      ``inflight_refs`` back at 0, its LoRA slot released exactly once, no
+      ``active_sequences`` entry, and the pool row back at baseline.
+    """
+    from kestrel.runtime.sampling import SamplingHooks
+
+    @dataclass
+    class _TypedToken:
+        token_id: int
+
+    # Arm the spec typing hook to raise on its FIRST commit call (emulating a
+    # fail-fast materialize / lazy-result error inside the drain), then succeed on
+    # every later call so the retry drain can complete the pending step.
+    hook_calls = {"n": 0}
+
+    def materialize_spec_tokens(
+        token_ids_cpu, sequences, batch_idx, side_values, token_logprobs=None
+    ):
+        hook_calls["n"] += 1
+        if hook_calls["n"] == 1:
+            raise RuntimeError("materialize_spec_tokens failed mid-drain")
+        return [
+            _TypedToken(token_id=int(t)) for t in token_ids_cpu.view(-1).tolist()
+        ]
+
+    class _FakeAdapterProvider:
+        def config(self) -> dict:
+            return {"max_lora_rank": 16}
+
+        def get(self, adapter: str) -> object:
+            return object()
+
+    # admit(1) + a 1-token macro-step == max_new=2 -> the committed step finishes
+    # the row, so a botched drain commit would strand a FINALIZING row (the leak).
+    dec = _CommitSideValuesDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12]]},
+        side_values=object(),  # macro-step emits side-values -> commit uses the hook
+        # admit_side_values left None: the admit token stays text-only.
+    )
+    rt = _spec_runtime(dec)
+    rt.sampling_hooks = SamplingHooks(
+        materialize_spec_tokens=materialize_spec_tokens
+    )
+    sched = GenerationScheduler(
+        rt,
+        compute_stream=None,
+        skill_registry=__import__(
+            "kestrel.skills", fromlist=["SkillRegistry"]
+        ).SkillRegistry([]),
+        adapter_provider=_FakeAdapterProvider(),
+    )
+    assert dec.free_slots == 1  # baseline: one row free
+    req = _enqueue(
+        sched, 0, prompt_len=3, max_new=2, adapter="ft-1", lora_slot_ready=False
+    )
+
+    sched._spec_admit()
+    seq = req.lifecycle
+    acquired_slot = req.lora_slot
+    assert acquired_slot >= 1  # a real adapter slot was acquired
+    assert dec.free_slots == 0  # the row is in use
+
+    # Tick 1 launches the macro-step (no commit yet); it now lives in
+    # ``_pending_spec`` with its in-flight ref held on the sequence.
+    assert sched._spec_decode_step() is True
+    assert sched._pending_spec is not None
+    refs_with_pending = seq.inflight_refs
+    assert refs_with_pending >= 1  # the pending step's ref is held
+
+    # A pause lands here: ``_drain_pipeline`` -> ``_drain_spec`` commits the
+    # in-flight step -> the hook raises inside ``_commit_spec`` BEFORE its
+    # per-sequence decrement. The raise propagates out of the drain.
+    with pytest.raises(RuntimeError, match="materialize_spec_tokens failed"):
+        sched._drain_pipeline()
+
+    # ---- The core regression invariant: the pending refs are NOT orphaned. ----
+    # The pending record is STILL installed (old code cleared it up front in
+    # ``_drain_spec``, losing the only handle that could ever commit those refs).
+    assert sched._pending_spec is not None
+    # The row keeps EXACTLY the pending step's ref (no phantom ref, no dropped
+    # ref); the drain reserves nothing of its own to roll back.
+    assert seq.inflight_refs == refs_with_pending
+    # Nothing was retired / released / finalized by the failed drain commit: the
+    # row is not stranded in FINALIZING and holds all its resources.
+    assert dec.retired == []
+    assert rt.released_adapter_slots == []
+    assert seq.finalized is False
+    assert seq.finished is False
+    assert seq in sched.running
+    assert seq.phase != RequestPhase.FINALIZING
+    assert req.lora_slot == acquired_slot  # slot still held, not released
+    assert seq.state.batch_idx in rt.active_sequences
+    assert dec.free_slots == 0  # row still in use, not leaked-then-lost
+    # ``has_pending_work`` stays True so the executor keeps driving the commit.
+    assert sched.has_pending_work() is True
+
+    # The hook now succeeds; draining AGAIN commits that SAME pending step (its
+    # refs are consumed, not orphaned), finishing the row.
+    sched._drain_pipeline()
+
+    # The pending step was committed and the row finished cleanly.
+    assert sched._pending_spec is None
+    assert seq.finished is True
+    # Retired EXACTLY once (the committed pending refs drove the retire), back to
+    # a balanced ref count -- the leak the P2 fixes would have left this nonzero
+    # with the row never retired.
+    assert dec.retired == [0]
+    assert dec.retired.count(0) == 1
+    assert seq.inflight_refs == 0
+    assert seq.phase == RequestPhase.COMPLETED
+    # LoRA slot released exactly once (no leak, no double-release).
+    assert rt.released_adapter_slots == [acquired_slot]
+    assert rt.released_adapter_slots.count(acquired_slot) == 1
+    # No dangling active-sequence entry and the pool row is back at baseline.
+    assert seq.state.batch_idx not in rt.active_sequences
+    assert rt.active_sequences == {}
+    assert dec.free_slots == 1
+    assert [c.finish_reason for c in sched.pop_completed()] == ["length"]

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from types import SimpleNamespace
 
+import pytest
+
 from kestrel.runtime import TextToken
 from kestrel.runtime.tokens import CoordToken, ImageMarker, SizeToken
 from kestrel.runtime.spec import SpecDecodeCaps, SpecSideValues, SpecStepResult
@@ -1302,21 +1304,28 @@ def test_spec_pre_admit_hook_failure_releases_lora_slot_and_fails_cleanly() -> N
     assert len(sched.running) == 0
 
 
-def test_spec_side_values_guarded_when_no_spec_hook() -> None:
-    """Round-2 codex finding @ L836: SpecSideValues never hits the non-spec hook.
+def test_spec_side_values_fails_fast_when_no_spec_hook() -> None:
+    """Spatial ``SpecSideValues`` without a spec hook must FAIL FAST, not degrade.
 
-    When a macro-step returns spatial ``SpecSideValues`` but the runtime exposes
+    P2: ``side_values`` is produced ONLY when the runtime decoded spatial values
+    that must be typed into ``CoordToken`` / ``SizeToken`` from the target's
+    per-position final hidden (the detect/point spec path). If the runtime exposes
     only the non-spec ``materialize_tokens`` hook (whose handle is the
-    ``post_sample`` ``(slot, batch_size)`` aux value), the scheduler must NOT feed
-    the side-values into it -- doing so raises ``cannot unpack SpecSideValues`` or
-    reads the wrong layout. The guard materialises plain ``TextToken``s instead.
-    Asserts (a) no crash, (b) the non-spec hook is never handed the side-values,
-    (c) the committed ids still materialise (as text) and stage correctly.
+    ``post_sample`` ``(slot, batch_size)`` aux value, which a ``SpecSideValues``
+    does not match), the scheduler must NOT (a) feed the side-values into that hook
+    (``cannot unpack`` / wrong layout) NOR (b) silently materialise the committed
+    ids as plain ``TextToken``s -- that would DROP the decoded coordinates/sizes
+    and corrupt the result. The project goal is full coverage / no silent
+    fallback, so the scheduler raises a clear ``RuntimeError`` instead. Asserts
+    (a) it raises, (b) the message names ``materialize_spec_tokens``, (c) the
+    non-spec hook was never handed the side-values.
     """
+    import torch
+
     real_side_values = SpecSideValues(
-        hidden=__import__("torch").zeros(1, 3, 4),
-        temperatures=__import__("torch").zeros(1),
-        top_ps=__import__("torch").ones(1),
+        hidden=torch.zeros(1, 3, 4),
+        temperatures=torch.zeros(1),
+        top_ps=torch.ones(1),
     )
     nonspec_handles: list[object] = []
 
@@ -1340,18 +1349,256 @@ def test_spec_side_values_guarded_when_no_spec_hook() -> None:
     # Only the NON-spec hook is installed; no materialize_spec_tokens.
     rt.sampling_hooks = SamplingHooks(materialize_tokens=materialize_tokens)
     sched = _make_scheduler(rt)
-    req = _enqueue(sched, 0, prompt_len=3, max_new=3)
+    _enqueue(sched, 0, prompt_len=3, max_new=3)
     sched._spec_admit()
-    # Must not raise (the bug fed SpecSideValues into the non-spec hook -> unpack
-    # TypeError, aborting the scheduler).
-    while sched._spec_decode_step():
-        pass
+    # The macro-step commit must fail fast rather than silently drop coord/size.
+    with pytest.raises(RuntimeError, match="materialize_spec_tokens"):
+        while sched._spec_decode_step():
+            pass
 
-    # The non-spec hook was never handed the SpecSideValues (guard held).
+    # The non-spec hook was never handed the SpecSideValues (no misuse).
     assert real_side_values not in nonspec_handles
-    # Committed ids still staged (materialised as plain text via the guard).
-    assert [int(t.token_id) for t in req.lifecycle.skill_state.tokens] == [11, 12, 13]
-    assert req.lifecycle.finished is True
+
+
+def _synthetic_spatial_tables(coord_bins: int, size_bins: int):
+    """An MLP ``SpatialDecodeTables`` whose argmax bins are read straight out of
+    the hidden state, with a pure-PyTorch decode (CPU-runnable, no custom kernels).
+
+    Lays the hidden out as ``[coord one-hot (coord_bins) | width one-hot (size_bins)
+    | height one-hot (size_bins)]``. The MLP path (``F.gelu`` + ``F.linear`` only,
+    unlike the linear path which calls a bf16-only LayerNorm CUDA kernel) is built
+    so ``argmax`` over each logit group recovers exactly the one-hot index set in
+    that group's hidden slice: ``fc1`` is a scaled identity (so gelu maps the hot
+    position to a large positive value and zeros to ~0), and ``fc2`` selects each
+    group's hidden dims. The greedy branch of ``compute_spatial_values`` uses
+    ``torch.argmax`` only, so the decoded coord/size values are deterministic and
+    the whole thing runs on CPU.
+    """
+    import torch
+    import torch.nn as nn
+
+    from kestrel.models.moondream.region import SpatialDecodeTables
+
+    hidden_dim = coord_bins + 2 * size_bins
+    inner = hidden_dim
+    scale = 50.0
+
+    def _decoder(select_rows: int, offset: int) -> nn.ModuleDict:
+        fc1 = nn.Linear(hidden_dim, inner)
+        with torch.no_grad():
+            fc1.weight.copy_(torch.eye(inner, hidden_dim) * scale)
+            fc1.bias.zero_()
+        fc2 = nn.Linear(inner, select_rows)
+        with torch.no_grad():
+            sel = torch.zeros(select_rows, inner)
+            for r in range(select_rows):
+                sel[r, offset + r] = 1.0
+            fc2.weight.copy_(sel)
+            fc2.bias.zero_()
+        return nn.ModuleDict({"fc1": fc1, "fc2": fc2})
+
+    coord_decoder = _decoder(coord_bins, offset=0)
+    size_decoder = _decoder(2 * size_bins, offset=coord_bins)
+
+    coord_value_lut = torch.linspace(0.0, 1.0, coord_bins, dtype=torch.float32)
+    size_exponents = torch.linspace(-10.0, 0.0, size_bins, dtype=torch.float32)
+    size_value_lut = torch.exp2(size_exponents)
+    tables = SpatialDecodeTables(
+        coord_value_lut=coord_value_lut,
+        size_value_lut=size_value_lut,
+        coord_logits_dim=coord_bins,
+        coord_decoder=coord_decoder,
+        size_decoder=size_decoder,
+    )
+    return tables, hidden_dim
+
+
+def _encode_spatial_hidden(coord_bins, size_bins, hidden_dim, *, coord, width, height):
+    """One-hot a (coord_bin, width_bin, height_bin) triple into a hidden vector that
+    ``_synthetic_spatial_tables`` decodes back to those bins."""
+    import torch
+
+    h = torch.zeros(hidden_dim, dtype=torch.float32)
+    h[coord] = 1.0
+    h[coord_bins + width] = 1.0
+    h[coord_bins + size_bins + height] = 1.0
+    return h
+
+
+def test_moondream_materialize_spec_tokens_types_coord_size() -> None:
+    """The REAL ``MoondreamRuntime.materialize_spec_tokens`` types a ragged spec
+    macro-step's committed ids into ``CoordToken`` / ``SizeToken`` (P2 full
+    coverage).
+
+    Exercises the actual production hook (not a stub) on CPU: builds the hook via
+    ``MoondreamRuntime.sampling_hooks`` over a minimal stand-in that supplies only
+    the attributes the property reads (``config.tokenizer.coord_id``/``size_id``,
+    ``spatial_tables``, the pending-pool buffers + copy stream + spatial RNG used by
+    the *other* closures), then drives it with the scheduler's exact
+    ``materialize_spec_tokens`` contract: a flat (sequences-major, contiguous-
+    per-sequence) committed-id batch + per-token ``batch_idx`` + a
+    :class:`SpecSideValues` whose ``hidden[i, j]`` is the committed-position final
+    hidden. Two ragged sequences mix ``coord_id`` / ``size_id`` / a plain text id,
+    and we assert each id is typed correctly with the value decoded from its OWN
+    hidden position (proving per-position routing, not a single shared value).
+    """
+    import torch
+
+    from kestrel.models.moondream.runtime import (
+        CoordToken,
+        MoondreamRuntime,
+        SizeToken,
+        TextToken,
+    )
+    from kestrel.runtime.spec import SpecSideValues
+
+    coord_bins, size_bins = 11, 8
+    tables, hidden_dim = _synthetic_spatial_tables(coord_bins, size_bins)
+    coord_id, size_id = 5000, 5001
+
+    # Minimal stand-in carrying exactly what ``sampling_hooks`` reads.
+    stub = SimpleNamespace(
+        config=SimpleNamespace(
+            tokenizer=SimpleNamespace(coord_id=coord_id, size_id=size_id)
+        ),
+        spatial_tables=tables,
+        _pending_coord_values=torch.zeros(8, 1),
+        _pending_size_values=torch.zeros(8, 2),
+        _copy_stream=None,
+        _spatial_rng=None,  # greedy path never samples, so the RNG is unused
+    )
+    hooks = MoondreamRuntime.sampling_hooks.func(stub)
+    assert hooks.materialize_spec_tokens is not None
+
+    # Two sequences (greedy: temperature 0). Seq A commits 3 tokens
+    # [coord, size, text]; seq B commits 1 token [coord]. Flat layout is
+    # sequences-major + contiguous per sequence (the scheduler's contract).
+    seq_a = SimpleNamespace(
+        request=SimpleNamespace(temperature=0.0, top_p=1.0),
+        state=SimpleNamespace(batch_idx=101),
+    )
+    seq_b = SimpleNamespace(
+        request=SimpleNamespace(temperature=0.0, top_p=1.0),
+        state=SimpleNamespace(batch_idx=102),
+    )
+    sequences = [seq_a, seq_b]
+
+    text_id = 42
+    flat_ids = [coord_id, size_id, text_id, coord_id]
+    batch_idx = torch.tensor([101, 101, 101, 102], dtype=torch.long)
+    token_ids_cpu = torch.tensor(flat_ids, dtype=torch.long)
+
+    # Per-committed-position target bins -> expected decoded values.
+    a_coord_bin = 7   # coord value 7/10 = 0.7
+    a_w_bin, a_h_bin = 2, 5
+    b_coord_bin = 3   # coord value 3/10 = 0.3
+    # K+1 hidden slots per sequence; only the committed leading positions matter.
+    K1 = 4
+    hidden = torch.zeros(2, K1, hidden_dim, dtype=torch.float32)
+    # Seq A committed positions 0,1,2 (coord, size, text); position 2 is text so
+    # its decoded coord/size are ignored -- still set a sentinel to prove text ids
+    # are NOT mis-typed even when their hidden would decode to a valid bin.
+    hidden[0, 0] = _encode_spatial_hidden(
+        coord_bins, size_bins, hidden_dim, coord=a_coord_bin, width=0, height=0
+    )
+    hidden[0, 1] = _encode_spatial_hidden(
+        coord_bins, size_bins, hidden_dim, coord=0, width=a_w_bin, height=a_h_bin
+    )
+    hidden[0, 2] = _encode_spatial_hidden(
+        coord_bins, size_bins, hidden_dim, coord=9, width=7, height=7
+    )
+    # Seq B committed position 0 (coord).
+    hidden[1, 0] = _encode_spatial_hidden(
+        coord_bins, size_bins, hidden_dim, coord=b_coord_bin, width=0, height=0
+    )
+
+    side_values = SpecSideValues(
+        hidden=hidden,
+        temperatures=torch.zeros(2, dtype=torch.float32),
+        top_ps=torch.ones(2, dtype=torch.float32),
+        counts=None,  # force the batch_idx-derived run-length path
+    )
+
+    tokens = hooks.materialize_spec_tokens(
+        token_ids_cpu, sequences, batch_idx, side_values
+    )
+
+    assert len(tokens) == 4
+    # Seq A: coord -> CoordToken(0.7); size -> SizeToken(2^(...)); text -> TextToken.
+    assert isinstance(tokens[0], CoordToken)
+    assert tokens[0].pos == pytest.approx(a_coord_bin / (coord_bins - 1))
+    assert isinstance(tokens[1], SizeToken)
+    assert tokens[1].width == pytest.approx(float(tables.size_value_lut[a_w_bin]))
+    assert tokens[1].height == pytest.approx(float(tables.size_value_lut[a_h_bin]))
+    assert isinstance(tokens[2], TextToken)
+    assert tokens[2].token_id == text_id
+    # Seq B: its coord uses seq B's OWN hidden row (0.3), not seq A's (0.7).
+    assert isinstance(tokens[3], CoordToken)
+    assert tokens[3].pos == pytest.approx(b_coord_bin / (coord_bins - 1))
+
+
+def test_moondream_materialize_spec_tokens_honors_explicit_counts() -> None:
+    """The hook uses ``SpecSideValues.counts`` when the producer supplies them.
+
+    Mirrors the explicit-``counts`` admit path (single position per sequence); the
+    decoded coord must come from each sequence's own ``hidden[i, 0]``.
+    """
+    import torch
+
+    from kestrel.models.moondream.runtime import (
+        CoordToken,
+        MoondreamRuntime,
+    )
+    from kestrel.runtime.spec import SpecSideValues
+
+    coord_bins, size_bins = 11, 8
+    tables, hidden_dim = _synthetic_spatial_tables(coord_bins, size_bins)
+    coord_id, size_id = 5000, 5001
+    stub = SimpleNamespace(
+        config=SimpleNamespace(
+            tokenizer=SimpleNamespace(coord_id=coord_id, size_id=size_id)
+        ),
+        spatial_tables=tables,
+        _pending_coord_values=torch.zeros(8, 1),
+        _pending_size_values=torch.zeros(8, 2),
+        _copy_stream=None,
+        _spatial_rng=None,
+    )
+    hooks = MoondreamRuntime.sampling_hooks.func(stub)
+
+    seqs = [
+        SimpleNamespace(
+            request=SimpleNamespace(temperature=0.0, top_p=1.0),
+            state=SimpleNamespace(batch_idx=200),
+        ),
+        SimpleNamespace(
+            request=SimpleNamespace(temperature=0.0, top_p=1.0),
+            state=SimpleNamespace(batch_idx=201),
+        ),
+    ]
+    hidden = torch.zeros(2, 1, hidden_dim, dtype=torch.float32)
+    hidden[0, 0] = _encode_spatial_hidden(
+        coord_bins, size_bins, hidden_dim, coord=4, width=0, height=0
+    )
+    hidden[1, 0] = _encode_spatial_hidden(
+        coord_bins, size_bins, hidden_dim, coord=8, width=0, height=0
+    )
+    side_values = SpecSideValues(
+        hidden=hidden,
+        temperatures=torch.zeros(2, dtype=torch.float32),
+        top_ps=torch.ones(2, dtype=torch.float32),
+        counts=[1, 1],
+    )
+    token_ids_cpu = torch.tensor([coord_id, coord_id], dtype=torch.long)
+    batch_idx = torch.tensor([200, 201], dtype=torch.long)
+
+    tokens = hooks.materialize_spec_tokens(
+        token_ids_cpu, seqs, batch_idx, side_values
+    )
+    assert isinstance(tokens[0], CoordToken)
+    assert tokens[0].pos == pytest.approx(4 / (coord_bins - 1))
+    assert isinstance(tokens[1], CoordToken)
+    assert tokens[1].pos == pytest.approx(8 / (coord_bins - 1))
 
 
 def test_spec_admit_image_sequence_state_includes_image_kv_length() -> None:

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -238,3 +238,81 @@ def test_shutdown_returns_requests_failed_during_fail_all() -> None:
     assert [c.request for c in completions] == [stuck]
     assert isinstance(completions[0].error, RuntimeError)
     assert ex._admission_failures == []
+
+
+def test_shutdown_retires_spec_rows_through_the_decoder() -> None:
+    """Regression: spec rows must be retired via ``decoder.retire`` on shutdown.
+
+    On a spec runtime the rows in ``active_sequences`` are decoder-owned: a
+    persistently-reserved pool backing captured CUDA graphs. The generic
+    cleanup must NOT call ``runtime.release_sequence`` for them (that erases the
+    reserved pages and skips the decoder), but route through the decoder's
+    retire the same way ``GenerationScheduler._retire_spec_row`` does -- freeing
+    the decoder-owned row (so it is reusable) and the admit-acquired adapter
+    slot. Mirrors the L836 admit site that registers the spec row here.
+    """
+    retired: list[Any] = []
+    released_slots: list[int] = []
+    released_via_release_sequence: list[Any] = []
+    free_rows: set[int] = set()
+
+    def _retire(state: Any) -> None:
+        retired.append(state)
+        # Model the decoder reclaiming its pool row: the freed row index
+        # becomes reusable for a future admit.
+        free_rows.add(state.batch_idx)
+
+    def _release_sequence(st: Any) -> None:
+        released_via_release_sequence.append(st)
+
+    decoder = SimpleNamespace(retire=_retire)
+    state = SimpleNamespace(batch_idx=7, lora_slot=3)
+
+    ex = _executor()
+    ex._runtime = SimpleNamespace(
+        max_batch_size=1,
+        active_sequences={state.batch_idx: state},
+        spec=SimpleNamespace(decoder=decoder),
+        release_adapter_slot=lambda slot: released_slots.append(slot),
+        # If the generic non-spec path is taken for a spec row this records it;
+        # the assertion below proves it never runs.
+        release_sequence=_release_sequence,
+    )
+
+    completions = ex.shutdown(RuntimeError("stop"))
+
+    assert completions == ()
+    # The decoder retired the row (not the generic release_sequence path).
+    assert retired == [state]
+    assert released_via_release_sequence == []
+    # Adapter slot the spec admit acquired was released.
+    assert released_slots == [state.lora_slot]
+    # The row is freed from the registry and reusable (decoder reclaimed it).
+    assert state.batch_idx not in ex._runtime.active_sequences
+    assert state.batch_idx in free_rows
+
+
+def test_shutdown_retires_base_model_spec_row_with_zero_slot() -> None:
+    """A base-model spec row (``lora_slot == 0``) still retires through the
+    decoder; ``release_adapter_slot(0)`` is the documented no-op."""
+    retired: list[Any] = []
+    released_slots: list[int] = []
+    state = SimpleNamespace(batch_idx=2, lora_slot=0)
+
+    def _must_not_run(st: Any) -> None:
+        raise AssertionError("release_sequence must not run for a spec row")
+
+    ex = _executor()
+    ex._runtime = SimpleNamespace(
+        max_batch_size=1,
+        active_sequences={state.batch_idx: state},
+        spec=SimpleNamespace(decoder=SimpleNamespace(retire=retired.append)),
+        release_adapter_slot=lambda slot: released_slots.append(slot),
+        release_sequence=_must_not_run,
+    )
+
+    ex.shutdown(RuntimeError("stop"))
+
+    assert retired == [state]
+    assert released_slots == [0]
+    assert state.batch_idx not in ex._runtime.active_sequences

--- a/tests/test_spec_interface.py
+++ b/tests/test_spec_interface.py
@@ -6,7 +6,13 @@ No model construction, no GPU.
 
 from __future__ import annotations
 
-from kestrel.runtime.spec import DraftResult, SpecDecodeCaps, SpecProposer
+from kestrel.runtime.spec import (
+    DraftResult,
+    SpecDecodeCaps,
+    SpecDecoder,
+    SpecProposer,
+    SpecStepResult,
+)
 
 
 def test_draft_result_probs_default_none() -> None:
@@ -36,6 +42,63 @@ def test_spec_decode_caps_defaults_to_no_hidden_layers() -> None:
     caps = SpecDecodeCaps(proposer=_StubProposer())
     assert caps.capture_hidden_layers == ()
     assert caps.proposer.num_lookahead_tokens == 17
+    # The spec-step decoder is optional on the scaffolding (CPU tests build caps
+    # that only advertise a proposer); it defaults to None.
+    assert caps.decoder is None
+
+
+class _StubState:
+    def __init__(self) -> None:
+        self.batch_idx = -1
+
+
+class _StubDecoder:
+    """Minimal structural implementation of the SpecDecoder contract."""
+
+    num_speculative_tokens = 15
+
+    @property
+    def free_slots(self) -> int:
+        return 4
+
+    def admit(self, state, prompt_token_ids):  # noqa: ANN001
+        state.batch_idx = 1
+        return 42
+
+    def step(self, states):  # noqa: ANN001
+        return SpecStepResult(
+            tokens=[[1, 2, 3] for _ in states],
+            accept_counts=[2 for _ in states],
+        )
+
+    def retire(self, state) -> None:  # noqa: ANN001
+        return None
+
+
+def test_spec_step_result_lengths_match_accept_plus_one() -> None:
+    res = SpecStepResult(tokens=[[7, 8]], accept_counts=[1])
+    assert len(res.tokens[0]) == res.accept_counts[0] + 1
+
+
+def test_stub_decoder_satisfies_protocol_and_sets_batch_idx() -> None:
+    dec = _StubDecoder()
+    assert isinstance(dec, SpecDecoder)
+    state = _StubState()
+    first = dec.admit(state, [1, 2, 3])
+    assert first == 42
+    assert state.batch_idx == 1  # admit assigns the pool row's batch index
+    out = dec.step([state, state])
+    assert len(out.tokens) == 2
+    assert all(len(t) == a + 1 for t, a in zip(out.tokens, out.accept_counts))
+
+
+def test_spec_decode_caps_carries_decoder() -> None:
+    dec = _StubDecoder()
+    caps = SpecDecodeCaps(
+        proposer=_StubProposer(), capture_hidden_layers=(1, 5, 9), decoder=dec
+    )
+    assert caps.decoder is dec
+    assert caps.capture_hidden_layers == (1, 5, 9)
 
 
 def test_autoregressive_runtime_declares_spec_attribute() -> None:

--- a/tests/test_spec_interface.py
+++ b/tests/test_spec_interface.py
@@ -67,7 +67,15 @@ class _StubDecoder:
         # not produce logprobs, so the logprob is None.
         return 42, None
 
-    def step(self, states):  # noqa: ANN001
+
+    def step(
+        self,
+        states,
+        *,
+        allowed_token_ids=None,
+        suppressed_token_ids=None,
+        commit_caps=None,
+    ):  # noqa: ANN001
         return SpecStepResult(
             tokens=[[1, 2, 3] for _ in states],
             accept_counts=[2 for _ in states],

--- a/tests/test_spec_interface.py
+++ b/tests/test_spec_interface.py
@@ -61,9 +61,11 @@ class _StubDecoder:
     def free_slots(self) -> int:
         return 4
 
-    def admit(self, state, prompt_token_ids):  # noqa: ANN001
+    def admit(self, state, prompt_token_ids, **kwargs):  # noqa: ANN001
         state.batch_idx = 1
-        return 42
+        # New contract: return (first_token_id, first_logprob). The stub does
+        # not produce logprobs, so the logprob is None.
+        return 42, None
 
     def step(self, states):  # noqa: ANN001
         return SpecStepResult(
@@ -84,8 +86,9 @@ def test_stub_decoder_satisfies_protocol_and_sets_batch_idx() -> None:
     dec = _StubDecoder()
     assert isinstance(dec, SpecDecoder)
     state = _StubState()
-    first = dec.admit(state, [1, 2, 3])
+    first, first_logprob = dec.admit(state, [1, 2, 3])
     assert first == 42
+    assert first_logprob is None  # stub produces no logprobs
     assert state.batch_idx == 1  # admit assigns the pool row's batch index
     out = dec.step([state, state])
     assert len(out.tokens) == 2


### PR DESCRIPTION
## Engine-side spec-decode scheduling

Wires speculative decoding into `GenerationScheduler`, behind the existing
spec-proposer interface. Two pieces:

- **Macro-step integration** (`scheduler.py`, `runtime/spec.py`): the scheduler
  drives a spec macro-step per `advance()` — the proposer drafts K tokens, the
  runtime verifies K+1 in one forward, and the scheduler commits the accepted
  prefix + bonus token, with optimistic-zombie membership for the ragged commit.
  No-op when `runtime.spec` is None (non-spec path unchanged).
- **Depth-1 overlap**: launches the next macro-step's GPU work while committing
  the previous step's accepted tokens on the host, hiding the per-tick host
  commit behind the GPU forward. Byte-identical to the synchronous path.

### Validation
- Bit-exact on GPU: `test_spec_decode_path.py` (scheduler logic / zombies /
  drain) + an engine e2e check (committed tokens == validated step backend).
  Exercised extensively in a perf A/B this week (hundreds of `advance()` calls).
- Non-spec path (`runtime.spec is None`) untouched.

### Perf
The depth-1 overlap is a measured **~1.2% throughput win at B=128 on H100** —
small because the speculator's GPU-resident accept/commit already takes most
host work off the critical path. Kept because it is free and correctness-
complete. (The dominant spec-decode lever is acceptance, which lives in the
model-specific speculator — landing separately.)
