### PR TITLE
Improve Photon CUDA diagnostics

### DIFF
--- a/kestrel/config.py
+++ b/kestrel/config.py
@@ -31,6 +31,42 @@ _MPS_PAGES_BY_TOTAL_GIB = (
 _SERVICE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
+def _format_cuda_version(version: int | str | None) -> str | None:
+    if version is None:
+        return None
+    if isinstance(version, str):
+        return version
+    try:
+        raw = int(version)
+    except (TypeError, ValueError):
+        return None
+    major = raw // 1000
+    minor = (raw % 1000) // 10
+    patch = raw % 10
+    if patch:
+        return f"{major}.{minor}.{patch}"
+    return f"{major}.{minor}"
+
+
+def _cuda_version_tuple(version: str | None) -> tuple[int, ...] | None:
+    if version is None:
+        return None
+    try:
+        return tuple(int(part) for part in version.split("."))
+    except ValueError:
+        return None
+
+
+def _torch_cuda_driver_version() -> str | None:
+    getter = getattr(torch._C, "_cuda_getDriverVersion", None)
+    if getter is None:
+        return None
+    try:
+        return _format_cuda_version(getter())
+    except Exception:
+        return None
+
+
 def _mps_total_memory_bytes() -> int | None:
     """Best-effort total unified memory on Apple Silicon.
 
@@ -176,6 +212,39 @@ class RuntimeConfig:
                 "install command. Verify the fix with: "
                 "`python -c 'import torch; print(torch.cuda.is_available())'`."
             )
+        torch_cuda = _format_cuda_version(getattr(torch.version, "cuda", None))
+        driver_cuda = _torch_cuda_driver_version()
+        torch_cuda_tuple = _cuda_version_tuple(torch_cuda)
+        driver_cuda_tuple = _cuda_version_tuple(driver_cuda)
+        details = [
+            "Photon needs CUDA, but PyTorch could not initialize CUDA.",
+        ]
+        if torch_cuda is not None:
+            details.append(f"Installed PyTorch is built for CUDA {torch_cuda}.")
+        if driver_cuda is not None:
+            details.append(f"The NVIDIA driver reports CUDA {driver_cuda} support.")
+        if (
+            torch_cuda_tuple is not None
+            and driver_cuda_tuple is not None
+            and torch_cuda_tuple > driver_cuda_tuple
+        ):
+            details.append(
+                "PyTorch's bundled CUDA runtime is newer than the installed "
+                "NVIDIA driver supports. Install a PyTorch build whose CUDA "
+                "runtime is supported by the driver (for example a CUDA 12.x "
+                "wheel on CUDA 12.x drivers), or update the NVIDIA driver."
+            )
+        else:
+            details.append(
+                "This usually means no NVIDIA GPU/driver is visible to this "
+                "process, or the installed NVIDIA driver is incompatible with "
+                "the PyTorch CUDA runtime."
+            )
+        details.append(
+            "Verify with: `python -c 'import torch; print(torch.version.cuda, "
+            "torch.cuda.is_available())'`."
+        )
+        raise RuntimeError(" ".join(details))
 
 
 __all__ = ["RuntimeConfig"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "a fast, efficient inference engine for moondream"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
-    "torch>=2.4",
+    "torch>=2.8",
     "tokenizers>=0.15",
     "safetensors>=0.4",
     "torch-c-dlpack-ext>=0.1.3",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from kestrel.config import RuntimeConfig
+import kestrel.config as config_mod
 
 
 def test_runtime_config_rejects_invalid_service_name_before_download(
@@ -26,3 +27,43 @@ def test_runtime_config_rejects_invalid_service_name_before_download(
         )
 
     assert calls == []
+
+
+def test_runtime_config_explains_torch_cuda_newer_than_driver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config_mod.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(config_mod.torch.backends.cuda, "is_built", lambda: True)
+    monkeypatch.setattr(config_mod.torch.version, "cuda", "13.0")
+    monkeypatch.setattr(config_mod, "_torch_cuda_driver_version", lambda: "12.8")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        RuntimeConfig(
+            model_path="/unused",
+            device="cuda",
+        )
+
+    msg = str(exc_info.value)
+    assert "PyTorch is built for CUDA 13.0" in msg
+    assert "driver reports CUDA 12.8 support" in msg
+    assert "newer than the installed NVIDIA driver supports" in msg
+
+
+def test_runtime_config_explains_cuda_initialization_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config_mod.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(config_mod.torch.backends.cuda, "is_built", lambda: True)
+    monkeypatch.setattr(config_mod.torch.version, "cuda", "12.8")
+    monkeypatch.setattr(config_mod, "_torch_cuda_driver_version", lambda: None)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        RuntimeConfig(
+            model_path="/unused",
+            device="cuda",
+        )
+
+    msg = str(exc_info.value)
+    assert "PyTorch could not initialize CUDA" in msg
+    assert "Installed PyTorch is built for CUDA 12.8" in msg
+    assert "Verify with:" in msg

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ requires-dist = [
     { name = "kestrel-native", specifier = "==0.1.5" },
     { name = "safetensors", specifier = ">=0.4" },
     { name = "tokenizers", specifier = ">=0.15" },
-    { name = "torch", specifier = ">=2.4" },
+    { name = "torch", specifier = ">=2.8" },
     { name = "torch-c-dlpack-ext", specifier = ">=0.1.3" },
 ]
 


### PR DESCRIPTION
## Summary

- Raise Kestrel's minimum supported PyTorch version to 2.8 so the default CUDA 12 PyTorch runtime has the CUDA Library API used by kestrel-kernels.
- Improve CUDA-device validation when PyTorch was built with CUDA but cannot initialize it.
- Include the PyTorch CUDA runtime and NVIDIA driver CUDA support in the error message, with a specific explanation when the PyTorch bundled runtime is newer than the installed driver supports.

## Why

Users installing Photon on L4s could get generic "CUDA unavailable" failures when pip selected a PyTorch CUDA runtime unsupported by the host driver. This makes that install/runtime mismatch actionable without adding any Photon-side CUDA-graph escape hatch.

## Validation

- `git diff --check`
- `uv run python -m py_compile kestrel/config.py tests/test_config.py`
- `uv run python -m pytest tests/test_config.py -q` was attempted, but local collection is blocked by the installed `kestrel-kernels` package lacking `attention.block_bidirectional_mask`, before these tests run.