### PR TITLE
Improve Photon CUDA diagnostics

### DIFF
--- a/kestrel/config.py
+++ b/kestrel/config.py
@@ -1,6 +1,7 @@
 """Runtime configuration objects for the Kestrel inference engine."""
 
 
+import ctypes
 from dataclasses import dataclass
 from pathlib import Path
 import re
@@ -59,12 +60,35 @@ def _cuda_version_tuple(version: str | None) -> tuple[int, ...] | None:
 
 def _torch_cuda_driver_version() -> str | None:
     getter = getattr(torch._C, "_cuda_getDriverVersion", None)
-    if getter is None:
+    if getter is not None:
+        try:
+            return _format_cuda_version(getter())
+        except Exception:
+            pass
+    return _libcuda_driver_version()
+
+
+def _libcuda_driver_version() -> str | None:
+    for soname in ("libcuda.so.1", "libcuda.so"):
+        try:
+            libcuda = ctypes.CDLL(soname)
+            break
+        except OSError:
+            continue
+    else:
         return None
+
     try:
-        return _format_cuda_version(getter())
+        get_version = libcuda.cuDriverGetVersion
+        get_version.argtypes = [ctypes.POINTER(ctypes.c_int)]
+        get_version.restype = ctypes.c_int
+        version = ctypes.c_int(0)
+        rc = get_version(ctypes.byref(version))
     except Exception:
         return None
+    if rc != 0 or version.value <= 0:
+        return None
+    return _format_cuda_version(version.value)
 
 
 def _mps_total_memory_bytes() -> int | None:

--- a/kestrel/config.py
+++ b/kestrel/config.py
@@ -62,7 +62,10 @@ def _torch_cuda_driver_version() -> str | None:
     getter = getattr(torch._C, "_cuda_getDriverVersion", None)
     if getter is not None:
         try:
-            return _format_cuda_version(getter())
+            version = getter()
+            if isinstance(version, int) and version <= 0:
+                return None
+            return _format_cuda_version(version)
         except Exception:
             pass
     return _libcuda_driver_version()

--- a/kestrel/config.py
+++ b/kestrel/config.py
@@ -31,6 +31,42 @@ _MPS_PAGES_BY_TOTAL_GIB = (
 _SERVICE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
+def _format_cuda_version(version: int | str | None) -> str | None:
+    if version is None:
+        return None
+    if isinstance(version, str):
+        return version
+    try:
+        raw = int(version)
+    except (TypeError, ValueError):
+        return None
+    major = raw // 1000
+    minor = (raw % 1000) // 10
+    patch = raw % 10
+    if patch:
+        return f"{major}.{minor}.{patch}"
+    return f"{major}.{minor}"
+
+
+def _cuda_version_tuple(version: str | None) -> tuple[int, ...] | None:
+    if version is None:
+        return None
+    try:
+        return tuple(int(part) for part in version.split("."))
+    except ValueError:
+        return None
+
+
+def _torch_cuda_driver_version() -> str | None:
+    getter = getattr(torch._C, "_cuda_getDriverVersion", None)
+    if getter is None:
+        return None
+    try:
+        return _format_cuda_version(getter())
+    except Exception:
+        return None
+
+
 def _mps_total_memory_bytes() -> int | None:
     """Best-effort total unified memory on Apple Silicon.
 
@@ -176,6 +212,39 @@ class RuntimeConfig:
                 "install command. Verify the fix with: "
                 "`python -c 'import torch; print(torch.cuda.is_available())'`."
             )
+        torch_cuda = _format_cuda_version(getattr(torch.version, "cuda", None))
+        driver_cuda = _torch_cuda_driver_version()
+        torch_cuda_tuple = _cuda_version_tuple(torch_cuda)
+        driver_cuda_tuple = _cuda_version_tuple(driver_cuda)
+        details = [
+            "Photon needs CUDA, but PyTorch could not initialize CUDA.",
+        ]
+        if torch_cuda is not None:
+            details.append(f"Installed PyTorch is built for CUDA {torch_cuda}.")
+        if driver_cuda is not None:
+            details.append(f"The NVIDIA driver reports CUDA {driver_cuda} support.")
+        if (
+            torch_cuda_tuple is not None
+            and driver_cuda_tuple is not None
+            and torch_cuda_tuple[:1] > driver_cuda_tuple[:1]
+        ):
+            details.append(
+                "PyTorch's bundled CUDA runtime is newer than the installed "
+                "NVIDIA driver supports. Install a PyTorch build whose CUDA "
+                "runtime is supported by the driver (for example a CUDA 12.x "
+                "wheel on CUDA 12.x drivers), or update the NVIDIA driver."
+            )
+        else:
+            details.append(
+                "This usually means no NVIDIA GPU/driver is visible to this "
+                "process, or the installed NVIDIA driver is incompatible with "
+                "the PyTorch CUDA runtime."
+            )
+        details.append(
+            "Verify with: `python -c 'import torch; print(torch.version.cuda, "
+            "torch.cuda.is_available())'`."
+        )
+        raise RuntimeError(" ".join(details))
 
 
 __all__ = ["RuntimeConfig"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ description = "a fast, efficient inference engine for moondream"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
-    "torch>=2.4",
+    "torch>=2.8; platform_machine != 'aarch64'",
+    "torch>=2.4; platform_machine == 'aarch64'",
     "tokenizers>=0.15",
     "safetensors>=0.4",
     "torch-c-dlpack-ext>=0.1.3",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from kestrel.config import RuntimeConfig
+import kestrel.config as config_mod
 
 
 def test_runtime_config_rejects_invalid_service_name_before_download(
@@ -26,3 +27,63 @@ def test_runtime_config_rejects_invalid_service_name_before_download(
         )
 
     assert calls == []
+
+
+def test_runtime_config_explains_torch_cuda_newer_than_driver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config_mod.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(config_mod.torch.backends.cuda, "is_built", lambda: True)
+    monkeypatch.setattr(config_mod.torch.version, "cuda", "13.0")
+    monkeypatch.setattr(config_mod, "_torch_cuda_driver_version", lambda: "12.8")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        RuntimeConfig(
+            model_path="/unused",
+            device="cuda",
+        )
+
+    msg = str(exc_info.value)
+    assert "PyTorch is built for CUDA 13.0" in msg
+    assert "driver reports CUDA 12.8 support" in msg
+    assert "newer than the installed NVIDIA driver supports" in msg
+
+
+def test_runtime_config_explains_cuda_initialization_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config_mod.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(config_mod.torch.backends.cuda, "is_built", lambda: True)
+    monkeypatch.setattr(config_mod.torch.version, "cuda", "12.8")
+    monkeypatch.setattr(config_mod, "_torch_cuda_driver_version", lambda: None)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        RuntimeConfig(
+            model_path="/unused",
+            device="cuda",
+        )
+
+    msg = str(exc_info.value)
+    assert "PyTorch could not initialize CUDA" in msg
+    assert "Installed PyTorch is built for CUDA 12.8" in msg
+    assert "Verify with:" in msg
+
+
+def test_runtime_config_allows_cuda_minor_compatibility_in_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config_mod.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(config_mod.torch.backends.cuda, "is_built", lambda: True)
+    monkeypatch.setattr(config_mod.torch.version, "cuda", "12.8")
+    monkeypatch.setattr(config_mod, "_torch_cuda_driver_version", lambda: "12.4")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        RuntimeConfig(
+            model_path="/unused",
+            device="cuda",
+        )
+
+    msg = str(exc_info.value)
+    assert "Installed PyTorch is built for CUDA 12.8" in msg
+    assert "driver reports CUDA 12.4 support" in msg
+    assert "newer than the installed NVIDIA driver supports" not in msg

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,29 @@ def test_runtime_config_rejects_invalid_service_name_before_download(
     assert calls == []
 
 
+def test_torch_cuda_driver_version_falls_back_to_libcuda(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class TorchCWithoutDriverVersion:
+        pass
+
+    class FakeCuDriverGetVersion:
+        argtypes = None
+        restype = None
+
+        def __call__(self, ptr) -> int:
+            ptr._obj.value = 12080
+            return 0
+
+    class FakeLibCuda:
+        cuDriverGetVersion = FakeCuDriverGetVersion()
+
+    monkeypatch.setattr(config_mod.torch, "_C", TorchCWithoutDriverVersion())
+    monkeypatch.setattr(config_mod.ctypes, "CDLL", lambda _soname: FakeLibCuda())
+
+    assert config_mod._torch_cuda_driver_version() == "12.8"
+
+
 def test_runtime_config_explains_torch_cuda_newer_than_driver(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,6 +52,24 @@ def test_torch_cuda_driver_version_falls_back_to_libcuda(
     assert config_mod._torch_cuda_driver_version() == "12.8"
 
 
+def test_torch_cuda_driver_version_treats_zero_as_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class TorchCWithNoDriver:
+        @staticmethod
+        def _cuda_getDriverVersion() -> int:
+            return 0
+
+    monkeypatch.setattr(config_mod.torch, "_C", TorchCWithNoDriver())
+    monkeypatch.setattr(
+        config_mod,
+        "_libcuda_driver_version",
+        lambda: pytest.fail("zero driver version should not fall back"),
+    )
+
+    assert config_mod._torch_cuda_driver_version() is None
+
+
 def test_runtime_config_explains_torch_cuda_newer_than_driver(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <3.15"
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
+    "python_full_version >= '3.12' and platform_machine != 'aarch64'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64'",
 ]
 
 [[package]]
@@ -587,7 +590,8 @@ requires-dist = [
     { name = "kestrel-native", specifier = "==0.1.5" },
     { name = "safetensors", specifier = ">=0.4" },
     { name = "tokenizers", specifier = ">=0.15" },
-    { name = "torch", specifier = ">=2.4" },
+    { name = "torch", marker = "platform_machine != 'aarch64'", specifier = ">=2.8" },
+    { name = "torch", marker = "platform_machine == 'aarch64'", specifier = ">=2.4" },
     { name = "torch-c-dlpack-ext", specifier = ">=0.1.3" },
 ]
 
@@ -913,7 +917,8 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -925,8 +930,10 @@ name = "networkx"
 version = "3.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and platform_machine != 'aarch64'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
@@ -1032,7 +1039,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -1043,7 +1050,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -1070,9 +1077,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'aarch64'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 'aarch64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -1083,7 +1090,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },


### PR DESCRIPTION
## Summary

- Raise Kestrel's minimum supported PyTorch version to 2.8 so the default CUDA 12 PyTorch runtime has the CUDA Library API used by kestrel-kernels.
- Improve CUDA-device validation when PyTorch was built with CUDA but cannot initialize it.
- Include the PyTorch CUDA runtime and NVIDIA driver CUDA support in the error message, with a specific explanation when the PyTorch bundled runtime is newer than the installed driver supports.

## Why

Users installing Photon on L4s could get generic "CUDA unavailable" failures when pip selected a PyTorch CUDA runtime unsupported by the host driver. This makes that install/runtime mismatch actionable without adding any Photon-side CUDA-graph escape hatch.

## Validation

- `git diff --check`
- `uv run python -m py_compile kestrel/config.py tests/test_config.py`
- `uv run python -m pytest tests/test_config.py -q` was attempted, but local collection is blocked by the installed `kestrel-kernels` package lacking `attention.block_bidirectional_mask`, before these tests run.