### PR TITLE
expose streaming for segment verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ result = await stream.result()
 print(f"\n\nGenerated {result.metrics.output_tokens} tokens")
 ```
 
-Streaming is supported for `query` and `caption` methods.
+Streaming is supported for `query`, `caption`, and `segment` methods.
 
 ## Response Format
 

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -752,19 +752,54 @@ class InferenceEngine:
             settings=settings,
         )
 
+    @overload
+    async def segment(
+        self,
+        image: Optional[np.ndarray | bytes],
+        object: str,
+        *,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = ...,
+        stream: Literal[True],
+        settings: Optional[Mapping[str, object]] = ...,
+    ) -> "EngineStream": ...
+
+    @overload
+    async def segment(
+        self,
+        image: Optional[np.ndarray | bytes],
+        object: str,
+        *,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = ...,
+        stream: Literal[False] = ...,
+        settings: Optional[Mapping[str, object]] = ...,
+    ) -> EngineResult: ...
+
+    @overload
+    async def segment(
+        self,
+        image: Optional[np.ndarray | bytes],
+        object: str,
+        *,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = ...,
+        stream: bool = ...,
+        settings: Optional[Mapping[str, object]] = ...,
+    ) -> Union[EngineResult, EngineStream]: ...
+
     async def segment(
         self,
         image: Optional[np.ndarray | bytes],
         object: str,
         *,
         spatial_refs: Optional[Sequence[Sequence[float]]] = None,
+        stream: bool = False,
         settings: Optional[Mapping[str, object]] = None,
-    ) -> EngineResult:
+    ) -> Union[EngineResult, EngineStream]:
         return await self._run_skill(
             "segment",
             image=image,
-            prompt={"object": object, "spatial_refs": spatial_refs},
+            prompt={"object": object, "spatial_refs": spatial_refs, "stream": stream},
             settings=settings,
+            stream=stream,
         )
 
     async def submit_streaming(

--- a/kestrel/models/moondream/skills/segment.py
+++ b/kestrel/models/moondream/skills/segment.py
@@ -67,7 +67,7 @@ class SegmentSkill(SkillSpec):
         request = SegmentRequest(
             object=obj,
             image=image,
-            stream=False,
+            stream=bool(prompt.get("stream", False)),
             spatial_refs=normalize_spatial_refs(prompt.get("spatial_refs")),
         )
         return BuiltRequest(


### PR DESCRIPTION
The `segment` skill supports streaming, but this is not exposed by the engine. This commit wires it up similar to other skills.