### PR TITLE
Add local tokenizer path and Moondream 3.1 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Kestrel supports both Moondream 3 and Moondream 2:
 |-------|------------|-------|
 | Moondream 2 | [vikhyatk/moondream2](https://huggingface.co/vikhyatk/moondream2) | Public, no approval needed |
 | Moondream 3 | [moondream/moondream3-preview](https://huggingface.co/moondream/moondream3-preview) | Requires access approval |
+| Moondream 3.1 9B A2B | [moondream/moondream3.1-9B-A2B](https://huggingface.co/moondream/moondream3.1-9B-A2B) | Private repository |
 
 For Moondream 3, request access (automatically granted) then authenticate with `huggingface-cli login` or set `HF_TOKEN`.
 
@@ -58,7 +59,7 @@ from kestrel.engine import InferenceEngine
 
 async def main():
     # Weights are automatically downloaded from HuggingFace on first run.
-    # Use model="moondream2" or model="moondream3-preview".
+    # Use model="moondream2", "moondream3-preview", or "moondream3.1-9B-A2B".
     cfg = RuntimeConfig(model="moondream2")
 
     # Create the engine (loads model and warms up). No API key needed for
@@ -236,10 +237,30 @@ Adapters are automatically downloaded and cached on first use.
 
 ```python
 RuntimeConfig(
-    model="moondream3-preview",  # or "moondream2"
+    model="moondream3-preview",  # or "moondream2" / "moondream3.1-9B-A2B"
     max_batch_size=4,            # Max concurrent requests
 )
 ```
+
+To run from local files instead of the registered HuggingFace weights or
+tokenizer, keep `model` set to the matching registered architecture and pass
+local paths:
+
+```python
+RuntimeConfig(
+    model="moondream3.1-9B-A2B",
+    model_path="/models/moondream/model.safetensors",
+    tokenizer_path="/models/moondream/tokenizer.json",
+)
+```
+
+`model_path` points to the local checkpoint file and skips the automatic
+HuggingFace weight download. `tokenizer_path` is optional and only applies to
+models whose runtime uses a tokenizer; tokenizer-free models do not need one.
+When provided, it can point directly to a `tokenizer.json` file or to a
+directory containing `tokenizer.json`. When omitted, Kestrel uses the tokenizer
+declared by the registered model. Local files must match the selected model
+architecture and checkpoint format.
 
 ### Environment Variables
 

--- a/kestrel/config.py
+++ b/kestrel/config.py
@@ -168,6 +168,7 @@ class RuntimeConfig:
     # Model name registered in kestrel.models (see kestrel.models.known_models()).
     model: str = "moondream3-preview"
     service_name: str = "local"
+    tokenizer_path: str | Path | None = None
 
     def __post_init__(self):
         normalized_service_name = self.service_name.strip()

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -447,12 +447,12 @@ class InferenceEngine:
 
         The default model reuses ``runtime_cfg`` (already resolved for it).
         A co-hosted model gets a per-model config — its own ``model`` id, and
-        ``model_path`` reset so it resolves for that model (a single-pass
-        spec declares no weight file, so its path stays ``None`` and the
-        factory owns loading). Runtime factories receive common engine-owned
-        resources such as the compute stream and KV pool. ``max_lora_rank`` is
-        the default autoregressive model's concern, supplied by the adapter
-        provider only for that model.
+        ``model_path``/``tokenizer_path`` reset so it resolves for that model
+        (a single-pass spec declares no weight file, so its path stays
+        ``None`` and the factory owns loading). Runtime factories receive
+        common engine-owned resources such as the compute stream and KV pool.
+        ``max_lora_rank`` is the default autoregressive model's concern,
+        supplied by the adapter provider only for that model.
         """
         from kestrel.models import get_spec
 
@@ -467,7 +467,12 @@ class InferenceEngine:
                 max_lora_rank=max_lora_rank,
                 **kwargs,
             )
-        cfg = replace(self._runtime_cfg, model=model_id, model_path=None)
+        cfg = replace(
+            self._runtime_cfg,
+            model=model_id,
+            model_path=None,
+            tokenizer_path=None,
+        )
         return spec.runtime(cfg, **kwargs)
 
     def _shared_kv_pool(self):

--- a/kestrel/models/moondream/__init__.py
+++ b/kestrel/models/moondream/__init__.py
@@ -46,6 +46,18 @@ register(
         skills=build_skill_registry,
     )
 )
+register(
+    ModelSpec(
+        name="moondream3.1-9B-A2B",
+        repo_id="moondream/moondream3.1-9B-A2B",
+        filename="model.safetensors",
+        checkpoint_format="md3",
+        default_config=DEFAULT_MOONDREAM3_CONFIG,
+        tokenizer_id="moondream/starmie-v1",
+        runtime=MoondreamRuntime,
+        skills=build_skill_registry,
+    )
+)
 
 __all__ = [
     "DEFAULT_MOONDREAM2_CONFIG",

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -6,7 +6,6 @@ import functools
 import json
 from copy import deepcopy
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Optional, Sequence, cast
 
 import warnings
@@ -16,8 +15,6 @@ import numpy as np
 import torch
 from torch import Tensor
 
-
-from tokenizers import Tokenizer
 
 from kestrel_kernels import get_runtime
 from kestrel.config import RuntimeConfig
@@ -80,6 +77,7 @@ from .region import (
     encode_coordinate,
     encode_size,
 )
+from .tokenizer import load_tokenizer
 from ...seg_refiner import SegmentRefiner, _HAS_SEG_DEPS
 from ...dense_lora import DenseLoRATorchMLPScratch, create_mlp_scratch
 from .decode_slot import DecodeSlot, create_decode_slot
@@ -655,7 +653,10 @@ class MoondreamRuntime:
                     )
             self.kv_cache_dtype = self.dtype
 
-        self.tokenizer = Tokenizer.from_pretrained(self._spec.tokenizer_id)
+        self.tokenizer = load_tokenizer(
+            self._spec.tokenizer_id,
+            cfg.tokenizer_path,
+        )
         # TokenizerConfig satisfies the PromptTemplate protocol directly.
         self.prompt_template = self.config.tokenizer
 

--- a/kestrel/models/moondream/tokenizer.py
+++ b/kestrel/models/moondream/tokenizer.py
@@ -1,0 +1,19 @@
+"""Tokenizer loading helpers for Moondream runtimes."""
+
+from pathlib import Path
+
+from tokenizers import Tokenizer
+
+
+def load_tokenizer(
+    tokenizer_id: str | None,
+    tokenizer_path: str | Path | None,
+) -> Tokenizer:
+    if tokenizer_path is not None:
+        path = Path(tokenizer_path).expanduser()
+        if path.is_dir():
+            path = path / "tokenizer.json"
+        return Tokenizer.from_file(str(path))
+    if tokenizer_id is None:
+        raise ValueError("Moondream model spec must declare tokenizer_id")
+    return Tokenizer.from_pretrained(tokenizer_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "torch-c-dlpack-ext>=0.1.3",
     "httpx>=0.27",
     "kestrel-native==0.1.5",
-    "kestrel-kernels==0.4.6",
+    "kestrel-kernels==0.4.7",
     "huggingface-hub>=0.20",
 ]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,14 @@ def test_runtime_config_rejects_invalid_service_name_before_download(
     assert calls == []
 
 
+def test_runtime_config_preserves_model_path_device_positional_args() -> None:
+    cfg = RuntimeConfig("/weights/model.safetensors", "cpu")
+
+    assert cfg.model_path == "/weights/model.safetensors"
+    assert cfg.device == "cpu"
+    assert cfg.tokenizer_path is None
+
+
 def test_torch_cuda_driver_version_falls_back_to_libcuda(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -10,6 +10,12 @@ from __future__ import annotations
 
 import pytest
 
+from kestrel.models import get_spec, known_models
+from kestrel.models.moondream import (
+    DEFAULT_MOONDREAM3_CONFIG,
+    MoondreamRuntime,
+    build_skill_registry,
+)
 from kestrel.models.registry import ModelSpec
 from kestrel.skills import SkillRegistry
 
@@ -51,3 +57,16 @@ def test_modelspec_skills_factory_is_honored() -> None:
     sentinel = SkillRegistry([])
     spec = _spec(skills=lambda: sentinel)
     assert spec.skills() is sentinel
+
+
+def test_moondream31_a2b_uses_md3_runtime_metadata() -> None:
+    spec = get_spec("moondream3.1-9B-A2B")
+
+    assert "moondream3.1-9B-A2B" in known_models()
+    assert spec.repo_id == "moondream/moondream3.1-9B-A2B"
+    assert spec.filename == "model.safetensors"
+    assert spec.checkpoint_format == "md3"
+    assert spec.default_config == DEFAULT_MOONDREAM3_CONFIG
+    assert spec.tokenizer_id == "moondream/starmie-v1"
+    assert spec.runtime is MoondreamRuntime
+    assert spec.skills is build_skill_registry

--- a/tests/test_moondream_tokenizer.py
+++ b/tests/test_moondream_tokenizer.py
@@ -1,0 +1,26 @@
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+
+from kestrel.models.moondream.tokenizer import load_tokenizer
+
+
+def _save_test_tokenizer(path) -> None:
+    tokenizer = Tokenizer(WordLevel({"[UNK]": 0, "hello": 1}, unk_token="[UNK]"))
+    tokenizer.save(str(path))
+
+
+def test_load_tokenizer_from_local_json(tmp_path) -> None:
+    tokenizer_path = tmp_path / "tokenizer.json"
+    _save_test_tokenizer(tokenizer_path)
+
+    tokenizer = load_tokenizer("unused/repo", tokenizer_path)
+
+    assert tokenizer.encode("hello").ids == [1]
+
+
+def test_load_tokenizer_from_directory(tmp_path) -> None:
+    _save_test_tokenizer(tmp_path / "tokenizer.json")
+
+    tokenizer = load_tokenizer("unused/repo", tmp_path)
+
+    assert tokenizer.encode("hello").ids == [1]

--- a/tests/test_multi_model.py
+++ b/tests/test_multi_model.py
@@ -74,13 +74,16 @@ def test_build_configured_runtimes_builds_all_from_specs() -> None:
     tokenizer-free single-pass spec — with a per-model config, and
     max_lora_rank goes only to the default AR model."""
     built_kwargs: dict[str, dict[str, Any]] = {}
+    built_tokenizer_paths: dict[str, object] = {}
 
     def ar_factory(cfg: RuntimeConfig, **kwargs: Any) -> FakeRuntime:
         built_kwargs[cfg.model] = dict(kwargs)
+        built_tokenizer_paths[cfg.model] = cfg.tokenizer_path
         return FakeRuntime(model_name=cfg.model)
 
     def sp_factory(cfg: RuntimeConfig, **kwargs: Any) -> _SPStub:
         built_kwargs[cfg.model] = dict(kwargs)
+        built_tokenizer_paths[cfg.model] = cfg.tokenizer_path
         return _SPStub(cfg.model)
 
     # Tokenizer-free specs: no tokenizer_id / checkpoint_format / filename /
@@ -89,7 +92,11 @@ def test_build_configured_runtimes_builds_all_from_specs() -> None:
     register(ModelSpec(name="mm-sp", runtime=sp_factory))
     try:
         eng = object.__new__(InferenceEngine)
-        eng._runtime_cfg = RuntimeConfig(model="mm-ar", device="cpu")
+        eng._runtime_cfg = RuntimeConfig(
+            model="mm-ar",
+            device="cpu",
+            tokenizer_path="/tmp/tokenizer.json",
+        )
         eng._default_model = "mm-ar"
         eng._model_ids = ["mm-ar", "mm-sp"]
         eng._runtimes = {}
@@ -103,6 +110,10 @@ def test_build_configured_runtimes_builds_all_from_specs() -> None:
         assert eng._runtimes["mm-sp"].execution_shape is ExecutionShape.SINGLE_PASS
         # Each runtime is built with a per-model config carrying its own id.
         assert eng._runtimes["mm-sp"].model_name == "mm-sp"
+        assert built_tokenizer_paths == {
+            "mm-ar": "/tmp/tokenizer.json",
+            "mm-sp": None,
+        }
         # max_lora_rank → default AR only; compute_stream is supplied to
         # every runtime factory so both execution shapes share the engine
         # stream. The engine-owned kv_pool is also supplied via the common


### PR DESCRIPTION
## Summary

- register `moondream3.1-9B-A2B` with MD3 runtime metadata, `model.safetensors`, and the Starmie tokenizer
- add `RuntimeConfig.tokenizer_path` for Moondream runtimes
- load local tokenizer JSON files via `Tokenizer.from_file`, accepting either a direct `tokenizer.json` path or a directory containing it
- reset `tokenizer_path` when building co-hosted models so tokenizer-free specs do not inherit an unrelated tokenizer override
- document supported models plus local `model_path` and `tokenizer_path` usage in the README

## Validation

- `python -m py_compile kestrel/config.py kestrel/engine/core.py kestrel/models/moondream/__init__.py kestrel/models/moondream/runtime.py kestrel/models/moondream/tokenizer.py tests/test_model_registry.py tests/test_multi_model.py tests/test_moondream_tokenizer.py`
- static model spec check for `moondream3.1-9B-A2B`
- direct helper check for file and directory tokenizer paths
- `git diff --check`

Full pytest was not run locally because creating a fresh uv environment hit disk quota while copying `kestrel-kernels`.