### PR TITLE
MD3 MoE up-projection: engine-owned interleaved slab (single copy for native + megakernel)

### DIFF
--- a/kestrel/models/moondream/_moe_layout.py
+++ b/kestrel/models/moondream/_moe_layout.py
@@ -86,6 +86,23 @@ def build_md3_moe_up_slab(
     return up_w_slab, up_scale_slab
 
 
+def _bind_md3_moe_up_view(
+    up_experts: nn.Module,
+    up_w_slab: torch.Tensor,
+    up_scale_slab: torch.Tensor,
+    layer_idx: int,
+) -> None:
+    """Point ``up_experts.weight``/``scale`` at the zero-copy ``layer_idx`` view of the slabs.
+
+    THE single source of truth for the slab-view aliasing (used by the initial load in
+    :func:`set_md3_moe_up_layer` and by the post-move rebind in
+    :func:`rebind_md3_moe_up_views`). After this the layer's up bytes live ONLY in the slab."""
+    up_experts.weight = nn.Parameter(up_w_slab[layer_idx], requires_grad=False)
+    # register_buffer overwrites an existing "scale" buffer in place; the view keeps the slab
+    # resident, so the engine co-owns it regardless of any later megakernel session lifetime.
+    up_experts.register_buffer("scale", up_scale_slab[layer_idx])
+
+
 def set_md3_moe_up_layer(
     fused: nn.Module,
     up_w_slab: torch.Tensor,
@@ -100,8 +117,53 @@ def set_md3_moe_up_layer(
     layer's up bytes live ONLY in the slab -- no private per-layer copy."""
     up_w_slab[layer_idx].copy_(_interleave_gate_up_rows8(up_weight_uint8, inter))
     up_scale_slab[layer_idx].copy_(_interleave_gate_up_rows8(up_scale, inter).float())
-    up_experts = fused.up_experts
-    up_experts.weight = nn.Parameter(up_w_slab[layer_idx], requires_grad=False)
-    # register_buffer overwrites an existing "scale" buffer in place; the view keeps the slab
-    # resident, so the engine co-owns it regardless of any later megakernel session lifetime.
-    up_experts.register_buffer("scale", up_scale_slab[layer_idx])
+    _bind_md3_moe_up_view(fused.up_experts, up_w_slab, up_scale_slab, layer_idx)
+
+
+def rebind_md3_moe_up_views(
+    text: nn.Module,
+    up_w_slab: torch.Tensor,
+    up_scale_slab: torch.Tensor,
+) -> None:
+    """Re-point every MoE layer's ``up_experts`` view at the (already-filled) slabs.
+
+    The slab data is untouched -- only the per-layer views are rebound, at their GLOBAL
+    ``layer_idx`` offset. Used after a module move (:class:`MoEUpSlabModuleDict._apply`) once the
+    slabs themselves have been moved, to restore the aliasing PyTorch tears apart when it moves the
+    per-layer views independently."""
+    for layer_idx, blk in enumerate(text.blocks):
+        # MoE blocks carry a router (dense pre-MoE layers do not) -- same probe the megakernel
+        # session uses to skip the zero-padded rows it never tiles.
+        if not hasattr(blk.mlp, "router"):
+            continue
+        _bind_md3_moe_up_view(
+            blk.mlp["mlp"].up_experts, up_w_slab, up_scale_slab, layer_idx)
+
+
+class MoEUpSlabModuleDict(nn.ModuleDict):
+    """``nn.ModuleDict`` that keeps the engine-owned MoE up-weight slab aliased through moves.
+
+    The slab (stashed as a plain attribute in :func:`build_md3_moe_up_slab`) is deliberately NOT a
+    parameter or buffer -- it must not double the state_dict. But that also means PyTorch's
+    ``Module._apply`` (the engine behind ``.to()`` / ``.cuda()`` / ``.float()`` / ``to_empty()``)
+    never visits it: it walks only registered params/buffers, moving each per-layer
+    ``up_experts.weight``/``scale`` view INDEPENDENTLY and never preserving cross-tensor storage
+    aliasing. So a post-load ``model.to(device)`` would leave the slab on the old device while the 20
+    views become 20 private copies -- silently losing the native dedup, and tripping the megakernel
+    session's alias assert. This override moves the slab with the SAME ``fn`` and re-points every MoE
+    layer's view back at it. Idempotent: a device/dtype-preserving ``fn`` returns the same tensors,
+    so the rebind is skipped (the normal no-move path is untouched)."""
+
+    def _apply(self, fn, *args, **kwargs):
+        super()._apply(fn, *args, **kwargs)
+        slab_w = getattr(self, "moe_up_w_slab", None)
+        slab_s = getattr(self, "moe_up_scale_slab", None)
+        if slab_w is None or slab_s is None:
+            return self  # dense / non-FP8 model: no slab to keep aliased
+        new_w, new_s = fn(slab_w), fn(slab_s)
+        if new_w is slab_w and new_s is slab_s:
+            return self  # no-op move: views already alias the resident slab
+        self.moe_up_w_slab = new_w
+        self.moe_up_scale_slab = new_s
+        rebind_md3_moe_up_views(self, new_w, new_s)
+        return self

--- a/kestrel/models/moondream/_moe_layout.py
+++ b/kestrel/models/moondream/_moe_layout.py
@@ -10,6 +10,7 @@ the whole-model cos/argmax gates catch any drift from the megakernel's layout.
 from __future__ import annotations
 
 import torch
+import torch.nn as nn
 
 
 def _interleave_gate_up_rows8(gate_up: torch.Tensor, inter: int) -> torch.Tensor:
@@ -43,3 +44,64 @@ def _interleave_up_b_rows8(up_b: torch.Tensor, inter: int) -> torch.Tensor:
     flat = up_b.reshape(-1, two_i, rank)
     out = _interleave_gate_up_rows8(flat, inter)
     return out.reshape(*lead, two_i, rank).contiguous()
+
+
+# THE ENGINE-OWNED MoE up-weight slab (kestrel#121 completion / kestrel-proprietary#384).
+#
+# The MD3 FP8 MoE up-projection is the largest duplicated tensor in the running model: the native
+# gated-GELU reads it per layer AND the whole-model megakernel reads it as one stacked
+# ``[NL, E, 2I, H]`` descriptor indexed by the GLOBAL layer field. To store it exactly once, the
+# engine allocates that stacked slab UP FRONT at weight load and points each MoE layer's
+# ``up_experts.weight``/``scale`` at a layer-view of it; the megakernel then consumes the same slab
+# byte-for-byte (see md3 session / bundle backend), no per-session stack + copy. ``NL`` is the FULL
+# text-block count (global layer indexing) -- the dense pre-MoE layers keep zero rows they never
+# read, which is the padding the megakernel's global ``FIELD_LAYER`` tile coordinate requires. Both
+# the loader (:mod:`.weights`) and the megakernel bench/test builders share these two helpers so the
+# slab-and-views contract is defined once.
+
+
+def build_md3_moe_up_slab(
+    text: nn.Module,
+    *,
+    num_experts: int,
+    two_inter: int,
+    hidden: int,
+    device: torch.device | str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Allocate the engine-owned ``[NL, E, 2I, H]`` uint8 up-weight slab (fp8 bits) and the
+    ``[NL, E, 2I]`` float32 up-scale slab, and stash them on ``text`` so the megakernel can consume
+    them directly. ``NL == len(text.blocks)`` (global layer indexing). Rows for dense pre-MoE layers
+    stay zero (the megakernel never tiles them). Returns ``(up_w_slab, up_scale_slab)``; the caller
+    fills each MoE layer's view via :func:`set_md3_moe_up_layer`."""
+    n_layers = len(text.blocks)
+    up_w_slab = torch.zeros(
+        n_layers, num_experts, two_inter, hidden, dtype=torch.uint8, device=device)
+    up_scale_slab = torch.zeros(
+        n_layers, num_experts, two_inter, dtype=torch.float32, device=device)
+    # Stash the slabs on the text module: THE contract the megakernel session asserts against (each
+    # MoE layer's up_experts view must alias these). Plain attributes -- not buffers -- so they do
+    # not appear twice in the state_dict (the per-layer views already round-trip the bytes).
+    text.moe_up_w_slab = up_w_slab
+    text.moe_up_scale_slab = up_scale_slab
+    return up_w_slab, up_scale_slab
+
+
+def set_md3_moe_up_layer(
+    fused: nn.Module,
+    up_w_slab: torch.Tensor,
+    up_scale_slab: torch.Tensor,
+    layer_idx: int,
+    up_weight_uint8: torch.Tensor,
+    up_scale: torch.Tensor,
+    inter: int,
+) -> None:
+    """Interleave-by-8 a single MoE layer's raw up weight/scale into slab row ``layer_idx`` and
+    re-point ``fused.up_experts.weight``/``scale`` at the (zero-copy) layer-view. After this the
+    layer's up bytes live ONLY in the slab -- no private per-layer copy."""
+    up_w_slab[layer_idx].copy_(_interleave_gate_up_rows8(up_weight_uint8, inter))
+    up_scale_slab[layer_idx].copy_(_interleave_gate_up_rows8(up_scale, inter).float())
+    up_experts = fused.up_experts
+    up_experts.weight = nn.Parameter(up_w_slab[layer_idx], requires_grad=False)
+    # register_buffer overwrites an existing "scale" buffer in place; the view keeps the slab
+    # resident, so the engine co-owns it regardless of any later megakernel session lifetime.
+    up_experts.register_buffer("scale", up_scale_slab[layer_idx])

--- a/kestrel/models/moondream/_moe_layout.py
+++ b/kestrel/models/moondream/_moe_layout.py
@@ -1,0 +1,45 @@
+"""8-row gate/up interleave for the MD3 FP8 MoE up-projection.
+
+Leaf module (torch only, no moondream imports) so both the weight loader
+(:mod:`.weights`) and the LoRA workspace (:mod:`.lora_workspace`) can share one
+definition of the permutation without an import cycle. It is a pure row shuffle
+of the ``2*inter`` gate/up axis -- ``gate[0:8], up[0:8], gate[8:16], ...`` -- and
+the whole-model cos/argmax gates catch any drift from the megakernel's layout.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def _interleave_gate_up_rows8(gate_up: torch.Tensor, inter: int) -> torch.Tensor:
+    """8-row gate/up row interleave: gate[0:8], up[0:8], gate[8:16], up[8:16], ...
+
+    Pure row permutation of the leading ``2*inter`` (gate/up output) axis of a
+    ``[rows, 2*inter, *tail]`` tensor; trailing axes (hidden columns) are carried
+    along untouched, so the per-neuron dot is bit-identical to the logical
+    ``[gate[0:inter], up[0:inter]]`` half-split. THE layout MD3's FP8 MoE stores
+    so the up weight is the same physical bytes the megakernel consumes.
+    """
+    if inter % 8 != 0:
+        raise ValueError(f"gate/up interleave requires inter divisible by 8, got {inter}")
+    if gate_up.shape[1] != 2 * inter:
+        raise ValueError(f"expected gate_up second dim {2 * inter}, got {gate_up.shape[1]}")
+    gate = gate_up[:, :inter, ...].reshape(gate_up.shape[0], inter // 8, 8, *gate_up.shape[2:])
+    up = gate_up[:, inter:, ...].reshape(gate_up.shape[0], inter // 8, 8, *gate_up.shape[2:])
+    return torch.stack((gate, up), dim=2).reshape(gate_up.shape).contiguous()
+
+
+def _interleave_up_b_rows8(up_b: torch.Tensor, inter: int) -> torch.Tensor:
+    """Interleave-by-8 the ``2*inter`` (up-proj row) axis of a LoRA up-B factor.
+
+    ``up_b`` is ``[*lead, 2*inter, rank]``; the rank axis is the per-neuron LoRA
+    column and is carried along, so the expand stays column-independent while the
+    rows are permuted to match the base up-weights' physical layout (see
+    :func:`_interleave_gate_up_rows8`).
+    """
+    two_i, rank = int(up_b.shape[-2]), int(up_b.shape[-1])
+    lead = up_b.shape[:-2]
+    flat = up_b.reshape(-1, two_i, rank)
+    out = _interleave_gate_up_rows8(flat, inter)
+    return out.reshape(*lead, two_i, rank).contiguous()

--- a/kestrel/models/moondream/lora_workspace.py
+++ b/kestrel/models/moondream/lora_workspace.py
@@ -28,6 +28,7 @@ from typing import Optional
 
 import torch
 
+from ._moe_layout import _interleave_up_b_rows8
 from .config import TextConfig
 from .lora import LoRA
 
@@ -296,9 +297,16 @@ class TextLoRAWorkspace:
                 layer.up_a[ws_idx, :adapter_rank_per_expert, :].copy_(
                     adapter_layer.up_a[expert_id]
                 )
-                layer.up_b[ws_idx, :, :adapter_rank_per_expert].copy_(
-                    adapter_layer.up_b[expert_id]
+                # The base up-projection weights are stored interleaved-by-8 on
+                # the 2*inter axis (THE layout for MD3's FP8 MoE). Column-
+                # interleave the up-B rows the SAME way so the expand's RMW into
+                # the interleaved base_up is an identity map -- no kernel change,
+                # the rank columns are carried along untouched. Down adapters are
+                # untouched (the GELU emits standard [0:inter] order).
+                up_b_src = _interleave_up_b_rows8(
+                    adapter_layer.up_b[expert_id], layer.up_b.shape[1] // 2
                 )
+                layer.up_b[ws_idx, :, :adapter_rank_per_expert].copy_(up_b_src)
                 layer.down_a[ws_idx, :adapter_rank_per_expert, :].copy_(
                     adapter_layer.down_a[expert_id]
                 )

--- a/kestrel/models/moondream/text.py
+++ b/kestrel/models/moondream/text.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ._moe_layout import MoEUpSlabModuleDict
 from .config import TextConfig
 from .layers import (
     build_dense_mlp,
@@ -302,7 +303,7 @@ def build_text_model(
     if config.group_size is not None:
         raise NotImplementedError("Quantized linear layers are not supported yet")
 
-    text = nn.ModuleDict(
+    text = MoEUpSlabModuleDict(
         {
             "blocks": nn.ModuleList(
                 [

--- a/kestrel/models/moondream/weights.py
+++ b/kestrel/models/moondream/weights.py
@@ -154,16 +154,21 @@ def _assign_md3_text_weights(
                 }
             )
             layer_has_fp8 = has_fp8_moe_scales and moe_scales.has_scales_for_layer(i)
-            if layer_has_fp8 and use_fp8_moe:
-                # FP8 MoE runtime path: keep raw FP8 bits + scales.
-                moe_layers_fp8.append((i, block))
-            else:
-                weight_map.update(
-                    {
-                        f"{prefix}.mlp.experts.weight": block["mlp"]["mlp"].up_experts.weight,
-                        f"{prefix}.mlp.output_experts.weight": block["mlp"]["mlp"].down_experts.weight,
-                    }
+            if not (layer_has_fp8 and use_fp8_moe):
+                # MD3's MoE is FP8-only: the up-projection base is stored in the 8-row
+                # gate/up interleave (THE layout the megakernel consumes) and every MoE
+                # LoRA up-B adapter is interleaved to match by construction. A non-FP8
+                # MoE checkpoint would land the up weight half-split (gate[0:inter],
+                # up[0:inter]) under an interleaved adapter -> scrambled expand output.
+                # That mismatch is unrepresentable: hard-fail instead of loading it.
+                raise ValueError(
+                    f"Non-FP8 MoE checkpoints are not supported: layer {i} "
+                    f"({prefix}.mlp.experts.weight) has no captured FP8 moe_quant "
+                    f"scales. MD3 MoE requires FP8 up/down scales so the up-projection "
+                    f"base can be stored in the interleaved gate/up layout."
                 )
+            # FP8 MoE runtime path: keep raw FP8 bits + scales.
+            moe_layers_fp8.append((i, block))
         else:
             weight_map.update(
                 {

--- a/kestrel/models/moondream/weights.py
+++ b/kestrel/models/moondream/weights.py
@@ -12,7 +12,10 @@ import safetensors
 import torch
 import torch.nn as nn
 
-from ._moe_layout import _interleave_gate_up_rows8
+from ._moe_layout import (
+    build_md3_moe_up_slab,
+    set_md3_moe_up_layer,
+)
 from .rope import precompute_freqs_cis
 from .text import build_tau_pos_tables
 
@@ -174,52 +177,52 @@ def _assign_md3_text_weights(
     for key, tensor in weight_map.items():
         tensor.data.copy_(get_tensor(key))
 
-    # Handle FP8 MoE weights: load raw FP8 tensors and attach scales
+    # Handle FP8 MoE weights: load raw FP8 tensors and attach scales.
+    #
+    # The up-projection weight (and its per-channel scale) is stored ONCE in a single engine-owned
+    # ``[NL, E, 2I, H]`` slab (see :mod:`._moe_layout`): each MoE layer's up rows land in the 8-row
+    # gate/up interleave -- gate[0:8], up[0:8], ... -- THE layout for MD3's FP8 MoE, which is also
+    # exactly the physical bytes the whole-model megakernel consumes (global layer indexing). So the
+    # native gated-GELU and the megakernel share one copy -- no per-layer duplicate, no per-session
+    # stack. The slab allocates once up front (peak vs 20 separate per-layer allocations improves).
+    # The down projection is untouched (the GELU emits standard [0:inter] order), so it keeps private
+    # per-layer buffers.
     if use_fp8_moe and get_raw_tensor is not None:
         assert moe_scales is not None
+        # Size + place the slab from the first MoE layer's up weight ([E, 2I, H] fp8-as-uint8).
+        first_layer_idx, first_block = moe_layers_fp8[0]
+        first_up = get_raw_tensor(
+            f"text_model.transformer.h.{first_layer_idx}.mlp.experts.weight")
+        E, two_inter, hidden = (
+            int(first_up.shape[0]), int(first_up.shape[1]), int(first_up.shape[2]))
+        device = first_block["mlp"]["mlp"].up_experts.weight.device
+        up_w_slab, up_scale_slab = build_md3_moe_up_slab(
+            text, num_experts=E, two_inter=two_inter, hidden=hidden, device=device)
+
         for layer_idx, block in moe_layers_fp8:
             prefix = f"text_model.transformer.h.{layer_idx}"
             fused_mlp = block["mlp"]["mlp"]
-
-            # Load FP8 weights (stored as float8_e4m3fn, viewed as uint8)
-            up_weight_fp8 = get_raw_tensor(f"{prefix}.mlp.experts.weight")
-            down_weight_fp8 = get_raw_tensor(f"{prefix}.mlp.output_experts.weight")
-
-            # Convert to uint8 view for storage
-            up_weight_uint8 = up_weight_fp8.view(torch.uint8)
-            down_weight_uint8 = down_weight_fp8.view(torch.uint8)
-
-            # Store the up-projection rows (and their per-channel scale) in the
-            # 8-row gate/up interleave -- gate[0:8], up[0:8], ... -- THE layout
-            # for MD3's FP8 MoE. The gated-GELU always reads this ordering and
-            # the up weight is now the same physical bytes the megakernel
-            # consumes, so it is no longer duplicated. Pure row permutation of
-            # the 2*inter axis; the down projection is untouched (the GELU emits
-            # standard [0:inter] order).
             inter = fused_mlp.hidden_size
-            up_weight_uint8 = _interleave_gate_up_rows8(up_weight_uint8, inter)
 
-            # Replace weight data with uint8 FP8 bits
-            # First resize the weight tensor to match uint8 storage
-            up_experts = fused_mlp.up_experts
-            down_experts = fused_mlp.down_experts
+            # Load FP8 weights (stored as float8_e4m3fn, viewed as uint8).
+            up_weight_uint8 = get_raw_tensor(
+                f"{prefix}.mlp.experts.weight").view(torch.uint8).to(device)
+            down_weight_uint8 = get_raw_tensor(
+                f"{prefix}.mlp.output_experts.weight").view(torch.uint8)
 
-            # Create new uint8 weight parameter and copy FP8 bits
-            device = up_experts.weight.device
-            up_experts.weight = nn.Parameter(
-                up_weight_uint8.to(device), requires_grad=False
-            )
-            down_experts.weight = nn.Parameter(
-                down_weight_uint8.to(device), requires_grad=False
-            )
-
-            # Register scale buffers (up scale carries the same row interleave)
             up_scale = moe_scales.up_scales[layer_idx]
             down_scale = moe_scales.down_scales[layer_idx]
             assert up_scale is not None and down_scale is not None
-            up_scale = _interleave_gate_up_rows8(up_scale, inter)
-            up_experts.register_buffer("scale", up_scale.to(device))
-            down_experts.register_buffer("scale", down_scale.to(device))
+
+            # Up weight + scale -> interleaved slab views (the ONLY copy of the up bytes).
+            set_md3_moe_up_layer(
+                fused_mlp, up_w_slab, up_scale_slab, layer_idx,
+                up_weight_uint8, up_scale.to(device), inter)
+
+            # Down projection: private per-layer uint8 weight + scale buffer.
+            fused_mlp.down_experts.weight = nn.Parameter(
+                down_weight_uint8.to(device), requires_grad=False)
+            fused_mlp.down_experts.register_buffer("scale", down_scale.to(device))
 
     # Tau weights (q/v scaling). Kestrel stores these fused as a single wqwv matrix
     # for performance, but older checkpoints store tau_wq and tau_wv separately.

--- a/kestrel/models/moondream/weights.py
+++ b/kestrel/models/moondream/weights.py
@@ -12,6 +12,7 @@ import safetensors
 import torch
 import torch.nn as nn
 
+from ._moe_layout import _interleave_gate_up_rows8
 from .rope import precompute_freqs_cis
 from .text import build_tau_pos_tables
 
@@ -188,6 +189,16 @@ def _assign_md3_text_weights(
             up_weight_uint8 = up_weight_fp8.view(torch.uint8)
             down_weight_uint8 = down_weight_fp8.view(torch.uint8)
 
+            # Store the up-projection rows (and their per-channel scale) in the
+            # 8-row gate/up interleave -- gate[0:8], up[0:8], ... -- THE layout
+            # for MD3's FP8 MoE. The gated-GELU always reads this ordering and
+            # the up weight is now the same physical bytes the megakernel
+            # consumes, so it is no longer duplicated. Pure row permutation of
+            # the 2*inter axis; the down projection is untouched (the GELU emits
+            # standard [0:inter] order).
+            inter = fused_mlp.hidden_size
+            up_weight_uint8 = _interleave_gate_up_rows8(up_weight_uint8, inter)
+
             # Replace weight data with uint8 FP8 bits
             # First resize the weight tensor to match uint8 storage
             up_experts = fused_mlp.up_experts
@@ -202,10 +213,11 @@ def _assign_md3_text_weights(
                 down_weight_uint8.to(device), requires_grad=False
             )
 
-            # Register scale buffers
+            # Register scale buffers (up scale carries the same row interleave)
             up_scale = moe_scales.up_scales[layer_idx]
             down_scale = moe_scales.down_scales[layer_idx]
             assert up_scale is not None and down_scale is not None
+            up_scale = _interleave_gate_up_rows8(up_scale, inter)
             up_experts.register_buffer("scale", up_scale.to(device))
             down_experts.register_buffer("scale", down_scale.to(device))
 

--- a/tests/moondream/test_moe.py
+++ b/tests/moondream/test_moe.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+import torch.nn as nn
 
 from kestrel.models.moondream.moe import MoEConfig, MoEModule
 from kestrel.models.moondream import runtime as runtime_mod
@@ -236,3 +237,129 @@ def test_non_fp8_moe_error_names_offending_tensor() -> None:
 
     with pytest.raises(ValueError, match=r"mlp\.experts\.weight"):
         _assign_md3_text_weights(lambda name: torch.zeros(1), model, moe_scales=None)
+
+
+# ---------------------------------------------------------------------------
+# Engine-owned MoE up-slab survives module moves (kestrel#121 codex P2).
+#
+# The slab is a plain attribute (not a param/buffer) so it does not double the
+# state_dict, but that means PyTorch's ``Module._apply`` (behind ``.to()`` /
+# ``.cuda()``) never visits it and moves each per-layer view INDEPENDENTLY --
+# tearing apart the cross-tensor storage aliasing the megakernel contract needs.
+# ``MoEUpSlabModuleDict._apply`` moves the slab with the same fn and re-points the
+# views. These tests pin: (a) the override restores aliasing after a move, and
+# (b) a plain ``nn.ModuleDict`` does NOT -- proving the override is load-bearing.
+# ---------------------------------------------------------------------------
+
+_MOVE_E, _MOVE_INTER, _MOVE_HIDDEN, _MOVE_NL, _MOVE_START = 4, 16, 8, 3, 1
+
+
+def _build_moe_slab_text(cls):
+    from kestrel.models.moondream._moe_layout import (
+        build_md3_moe_up_slab,
+        set_md3_moe_up_layer,
+    )
+    from kestrel.models.moondream.layers import build_dense_mlp, build_moe_mlp
+
+    blocks = nn.ModuleList()
+    for i in range(_MOVE_NL):
+        if i >= _MOVE_START:
+            mlp = build_moe_mlp(_MOVE_HIDDEN, _MOVE_INTER, _MOVE_E, torch.float32, top_k=2)
+        else:
+            mlp = build_dense_mlp(_MOVE_HIDDEN, 4 * _MOVE_HIDDEN, torch.float32)
+        blocks.append(nn.ModuleDict({"mlp": mlp}))
+    text = cls({"blocks": blocks})
+
+    two_inter = 2 * _MOVE_INTER
+    up_w_slab, up_scale_slab = build_md3_moe_up_slab(
+        text, num_experts=_MOVE_E, two_inter=two_inter, hidden=_MOVE_HIDDEN, device="cpu")
+
+    torch.manual_seed(0)
+    for li in range(_MOVE_START, _MOVE_NL):
+        raw_up = torch.randint(0, 256, (_MOVE_E, two_inter, _MOVE_HIDDEN), dtype=torch.uint8)
+        raw_scale = torch.rand(_MOVE_E, two_inter)
+        set_md3_moe_up_layer(
+            text.blocks[li].mlp["mlp"], up_w_slab, up_scale_slab, li, raw_up, raw_scale, _MOVE_INTER)
+    return text
+
+
+def _moe_up_views(text):
+    return [
+        (li, text.blocks[li].mlp["mlp"].up_experts)
+        for li in range(_MOVE_START, _MOVE_NL)
+    ]
+
+
+def _assert_slab_aliased(text) -> None:
+    """Mirror the megakernel session's contract check: every MoE layer's
+    up_experts weight/scale aliases the ONE slab storage at its ``[NL]`` offset."""
+    w_slab, s_slab = text.moe_up_w_slab, text.moe_up_scale_slab
+    w_base = w_slab.untyped_storage().data_ptr()
+    s_base = s_slab.untyped_storage().data_ptr()
+    w_stride = _MOVE_E * 2 * _MOVE_INTER * _MOVE_HIDDEN
+    s_stride = _MOVE_E * 2 * _MOVE_INTER
+    for li, up in _moe_up_views(text):
+        assert up.weight.untyped_storage().data_ptr() == w_base
+        assert up.weight.storage_offset() == li * w_stride
+        assert up.weight.device == w_slab.device
+        assert up.scale.untyped_storage().data_ptr() == s_base
+        assert up.scale.storage_offset() == li * s_stride
+
+
+def test_moe_up_slab_survives_module_move() -> None:
+    from kestrel.models.moondream._moe_layout import MoEUpSlabModuleDict
+
+    text = _build_moe_slab_text(MoEUpSlabModuleDict)
+    _assert_slab_aliased(text)
+    before = {li: up.weight.clone() for li, up in _moe_up_views(text)}
+    scale_before = {li: up.scale.clone() for li, up in _moe_up_views(text)}
+
+    # ``_apply(clone)`` reproduces exactly what a real ``.to(device)`` does: it
+    # allocates fresh storage per param/buffer (breaking naive aliasing), which is
+    # the CPU-only stand-in for a cross-device move.
+    text._apply(lambda t: t.clone())
+
+    _assert_slab_aliased(text)  # override re-established the single-slab aliasing
+    for li, up in _moe_up_views(text):
+        assert torch.equal(up.weight, before[li])
+        assert torch.equal(up.scale, scale_before[li])
+        assert up.scale.dtype == torch.float32
+
+
+def test_moe_up_slab_no_op_move_keeps_aliasing() -> None:
+    from kestrel.models.moondream._moe_layout import MoEUpSlabModuleDict
+
+    text = _build_moe_slab_text(MoEUpSlabModuleDict)
+    # Same-device ``.to`` is a no-op: fn returns the same tensors, the rebind is
+    # skipped, and the resident-slab aliasing is untouched.
+    text.to("cpu")
+    _assert_slab_aliased(text)
+
+
+def test_plain_moduledict_loses_slab_aliasing_on_move() -> None:
+    # Baseline (no override): a real move DOES tear the aliasing apart, so the
+    # megakernel contract would fail -- this is the bug the override fixes.
+    text = _build_moe_slab_text(nn.ModuleDict)
+    _assert_slab_aliased(text)  # aliased at load, before any move
+    text._apply(lambda t: t.clone())
+    w_base = text.moe_up_w_slab.untyped_storage().data_ptr()
+    aliased = [
+        up.weight.untyped_storage().data_ptr() == w_base for _, up in _moe_up_views(text)
+    ]
+    assert not any(aliased)  # every view is now a private copy
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA for a real device move")
+def test_moe_up_slab_survives_cuda_move() -> None:
+    from kestrel.models.moondream._moe_layout import MoEUpSlabModuleDict
+
+    text = _build_moe_slab_text(MoEUpSlabModuleDict)
+    before = {li: up.weight.clone() for li, up in _moe_up_views(text)}
+
+    text.to("cuda:0")
+
+    assert text.moe_up_w_slab.is_cuda
+    _assert_slab_aliased(text)
+    for li, up in _moe_up_views(text):
+        assert up.weight.is_cuda
+        assert torch.equal(up.weight.cpu(), before[li])

--- a/tests/moondream/test_moe.py
+++ b/tests/moondream/test_moe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from kestrel.models.moondream.moe import MoEConfig, MoEModule
@@ -166,3 +167,72 @@ def test_decode_lora_metadata_uses_compact_graph_stable_buffers() -> None:
         slot.meta.active_lora_meta.gpu[:7],
         torch.zeros((7,), dtype=torch.int32),
     )
+
+
+# ---------------------------------------------------------------------------
+# Non-FP8 MoE checkpoints are unrepresentable (kestrel#121)
+#
+# The MD3 MoE up-projection base is stored in the 8-row gate/up interleave and
+# every MoE LoRA up-B adapter is interleaved to match by construction. A non-FP8
+# MoE checkpoint would land the up weight half-split under an interleaved
+# adapter -> scrambled expand. The loader hard-fails instead of loading it, so
+# the base-vs-adapter layout coupling can never be violated. This test pins that
+# error path (delete-not-gate: the mismatch is unrepresentable).
+# ---------------------------------------------------------------------------
+
+
+class _Node(dict):
+    """Dict that also exposes its keys as attributes (mirrors the model tree's
+    dual item/attribute access used by the weight loader)."""
+
+    def __getattr__(self, key: str):
+        try:
+            return self[key]
+        except KeyError as exc:  # pragma: no cover - attribute miss path
+            raise AttributeError(key) from exc
+
+
+def _leaf(*, bias: bool = True) -> _Node:
+    node = _Node(weight=torch.zeros(1))
+    if bias:
+        node["bias"] = torch.zeros(1)
+    return node
+
+
+def _moe_block() -> _Node:
+    # is_moe is detected via ``hasattr(block.mlp, "router")``.
+    mlp = _Node(router=_leaf())
+    return _Node(
+        ln=_leaf(),
+        attn=_Node(qkv=_leaf(), proj=_leaf()),
+        mlp=mlp,
+    )
+
+
+def _fake_md3_model_with_moe() -> _Node:
+    text = _Node(
+        blocks=[_moe_block()],
+        wte=torch.zeros(1),
+        post_ln=_leaf(),
+        lm_head=_leaf(),
+    )
+    return _Node(text=text)
+
+
+def test_non_fp8_moe_checkpoint_raises() -> None:
+    from kestrel.models.moondream.weights import _assign_md3_text_weights
+
+    model = _fake_md3_model_with_moe()
+
+    with pytest.raises(ValueError, match="Non-FP8 MoE checkpoints are not supported"):
+        # No captured moe_quant scales -> the (deleted) non-FP8 MoE branch.
+        _assign_md3_text_weights(lambda name: torch.zeros(1), model, moe_scales=None)
+
+
+def test_non_fp8_moe_error_names_offending_tensor() -> None:
+    from kestrel.models.moondream.weights import _assign_md3_text_weights
+
+    model = _fake_md3_model_with_moe()
+
+    with pytest.raises(ValueError, match=r"mlp\.experts\.weight"):
+        _assign_md3_text_weights(lambda name: torch.zeros(1), model, moe_scales=None)


### PR DESCRIPTION
## Ownership story

MD3's FP8 MoE up-projection weight (+per-channel scale) was duplicated: the native gated-GELU read it per layer and the whole-model megakernel read its own stacked copy. This PR stores it ONCE, up front at weight load, in a single contiguous `[NL,E,2I,H]` uint8 slab (+ `[NL,E,2I]` f32 scale slab) in the 8-row gate/up interleave — the layout the megakernel consumes — and points each MoE layer's `up_experts.weight`/`scale` at a layer-view of it, so native and megakernel share the same physical bytes with no duplicate.

## Commits

1. **store up interleaved-by-8 at load** — the up rows (and scales) are stored in the `gate[0:8],up[0:8],…` interleave; the LoRA up-B is column-interleaved the same way so the native expand's RMW is an identity map.
2. **engine-owned up-weight slab** — allocate the slab up front (`build_md3_moe_up_slab`), each MoE layer's up view wired via `set_md3_moe_up_layer`, slabs stashed on `text.moe_up_w_slab` / `moe_up_scale_slab` as THE contract the megakernel asserts against and consumes zero-copy (kestrel-proprietary#384). Also wires the native side: the MoE module is marked `gate_up_interleaved` and `MoEModule._spec_for_weights` passes it into `MoeSpec`, so the native compact gated-GELU reads the interleaved rows (without this the native kernel reads the interleaved slab as half-split and corrupts output). Shared `_moe_layout` helpers are reused by the loader, the megakernel bench oracle, and the whole-model tests. Non-MoE models untouched; the down projection keeps its private per-layer half-split buffers.

`NL` is the full block count (global layer indexing); dense pre-MoE layers keep zero rows the megakernel never tiles. The slab allocates once instead of 20 separate per-layer copies.

## Sequencing

Merge before kestrel-proprietary#384 (the megakernel side requires this engine slab + the `gate_up_interleaved` companion in kestrel-kernels, included in #384). Validated together on p2: decode-bridge fingerprint cos 0.997372, native_argmax 103 == mk_argmax 103; full gate suite green.


## Reconciliation (interleave is unconditional, no knob)

The 8-row gate/up interleave is a fact of the MD3-loaded weights, not a mode: MD3's FP8 gated MoE is the only gated-GELU model, so the native compact gated-GELU passes `interleaved=True` unconditionally (`moe/compact.py` `_run_activation` + `apply_moe_lora_up_gelu`) and there is no `MoeSpec.gate_up_interleaved` / `_spec_for_weights` knob. The slab, hard-assert, and zero-copy consumption stay; only the redundant spec flag was dropped.