### PR TITLE
moondream: bind adapter workspace to indexed contractions

### DIFF
--- a/kestrel/models/moondream/decode_slot.py
+++ b/kestrel/models/moondream/decode_slot.py
@@ -49,7 +49,8 @@ class DecodeMetaBuffers:
             [
                 ("batch_idx", (max_batch_slots,), torch.int64),  # sequence batch idx
                 ("input_pos", (max_batch_slots,), torch.int32),  # token positions
-                ("lora_slot_ids", (max_batch_slots,), torch.int32),  # LoRA slots
+                ("lora_slot_ids", (max_batch_slots,), torch.int32),  # logical adapter slots
+                ("routed_storage_ids", (max_batch_slots,), torch.int32),
             ],
             device=device,
             pin_memory=True,
@@ -84,8 +85,12 @@ class DecodeMetaBuffers:
     def lora_slot_ids(self):
         return self._inputs.lora_slot_ids
 
+    @property
+    def routed_storage_ids(self):
+        return self._inputs.routed_storage_ids
+
     def copy_inputs_to_gpu(self) -> None:
-        """Stage batch_idx/input_pos/lora_slot_ids to the GPU in one H2D copy."""
+        """Stage the per-row decode metadata to the GPU in one H2D copy."""
         self._inputs.copy_to_gpu()
 
 

--- a/kestrel/models/moondream/lora_workspace.py
+++ b/kestrel/models/moondream/lora_workspace.py
@@ -130,6 +130,12 @@ class TextLoRAWorkspace:
         self.moe_lora_ranks = torch.zeros(
             max(0, max_slots - 1), dtype=torch.int32, device=device
         )
+        # Compiler/runtime metadata is indexed by the logical adapter slot, including
+        # slot 0. The native MoE kernels retain their compact zero-based rank table
+        # above; adapter loading updates both from the same physical rank.
+        self.routed_rank_by_slot = torch.zeros(
+            max_slots, dtype=torch.int32, device=device
+        )
         self._moe_lora_ranks_host = [0] * max(0, max_slots - 1)
 
         d_model = text_config.dim
@@ -153,25 +159,42 @@ class TextLoRAWorkspace:
             num_experts = moe_cfg.num_experts
             d_expert = moe_cfg.expert_inner_dim
             total_super_experts = (max_slots - 1) * num_experts
+            n_layers = text_config.n_layers
+            # One allocation per weight family gives the whole-model runtime a
+            # fixed-address slab while native per-layer workspaces remain views.
+            # Dense-prefix rows are unused and stay zero; retaining the absolute
+            # model-layer axis keeps the compiler/runtime binding mechanical.
+            self._moe_up_a = torch.zeros(
+                n_layers, total_super_experts, self.max_rank_per_expert, d_model,
+                device=device, dtype=dtype
+            )
+            self._moe_up_b = torch.zeros(
+                n_layers, total_super_experts, d_expert * 2, self.max_rank_per_expert,
+                device=device, dtype=dtype
+            )
+            self._moe_down_a = torch.zeros(
+                n_layers, total_super_experts, self.max_rank_per_expert, d_expert,
+                device=device, dtype=dtype
+            )
+            self._moe_down_b = torch.zeros(
+                n_layers, total_super_experts, d_model, self.max_rank_per_expert,
+                device=device, dtype=dtype
+            )
+            # The megakernel's route-owned down consumer reads rank-major slices.
+            # Native consumes output-major down-B, so this one family has a paired
+            # physical layout updated at adapter load time.
+            self._megakernel_moe_down_b = torch.zeros(
+                max_slots - 1, n_layers, num_experts,
+                self.max_rank_per_expert, d_model,
+                device=device, dtype=dtype
+            )
 
-            for _ in range(text_config.n_layers - self.start_layer):
+            for layer_idx in range(self.start_layer, n_layers):
                 workspace = MoELoRALayerWorkspace(
-                    up_a=torch.zeros(
-                        total_super_experts, self.max_rank_per_expert, d_model,
-                        device=device, dtype=dtype
-                    ),
-                    up_b=torch.zeros(
-                        total_super_experts, d_expert * 2, self.max_rank_per_expert,
-                        device=device, dtype=dtype
-                    ),
-                    down_a=torch.zeros(
-                        total_super_experts, self.max_rank_per_expert, d_expert,
-                        device=device, dtype=dtype
-                    ),
-                    down_b=torch.zeros(
-                        total_super_experts, d_model, self.max_rank_per_expert,
-                        device=device, dtype=dtype
-                    ),
+                    up_a=self._moe_up_a[layer_idx],
+                    up_b=self._moe_up_b[layer_idx],
+                    down_a=self._moe_down_a[layer_idx],
+                    down_b=self._moe_down_b[layer_idx],
                     lora_ranks=self.moe_lora_ranks,
                     num_experts=num_experts,
                 )
@@ -232,8 +255,12 @@ class TextLoRAWorkspace:
             layer.down_a[start:end].zero_()
             layer.down_b[start:end].zero_()
 
+        if self.moe:
+            self._megakernel_moe_down_b[slot - 1].zero_()
+
         self._moe_lora_ranks_host[slot - 1] = 0
         self.moe_lora_ranks[slot - 1].zero_()
+        self.routed_rank_by_slot[slot].zero_()
 
     def load_slot_(self, slot: int, adapter: LoRA) -> None:
         """Load adapter weights into a slot.
@@ -313,9 +340,48 @@ class TextLoRAWorkspace:
                 layer.down_b[ws_idx, :, :adapter_rank_per_expert].copy_(
                     adapter_layer.down_b[expert_id]
                 )
+                self._megakernel_moe_down_b[
+                    slot - 1, layer_idx, expert_id,
+                    :adapter_rank_per_expert, :
+                ].copy_(adapter_layer.down_b[expert_id].transpose(0, 1))
 
         self._moe_lora_ranks_host[slot - 1] = adapter_rank_per_expert
         self.moe_lora_ranks[slot - 1] = adapter_rank_per_expert
+        self.routed_rank_by_slot[slot] = adapter_rank_per_expert
+
+    def megakernel_runtime_tensors(
+        self,
+        *,
+        adapter_slot_ids: torch.Tensor,
+        routed_storage_ids: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        """Return the traced runtime inputs for indexed routed contractions.
+
+        The weight views preserve the engine-owned allocation and expose the
+        compiler's ``[storage, layer, expert, ...]`` logical axes. No adapter
+        dimension transform or rank sharding occurs in the compiler.
+        """
+        if not self.moe:
+            return {}
+        slots = self.max_slots - 1
+        layers = self._moe_up_a.shape[0]
+        experts = self.moe[0].num_experts
+        rank = self.max_rank_per_expert
+        return {
+            "adapter_slot_ids": adapter_slot_ids,
+            "routed_storage_ids": routed_storage_ids,
+            "routed_rank_by_slot": self.routed_rank_by_slot,
+            "moe_lora_a_up": self._moe_up_a.view(
+                layers, slots, experts, rank, self._moe_up_a.shape[-1]
+            ).permute(1, 0, 2, 3, 4),
+            "moe_lora_b_up": self._moe_up_b.view(
+                layers, slots, experts, self._moe_up_b.shape[-2], rank
+            ).permute(1, 0, 2, 3, 4),
+            "moe_lora_a_down": self._moe_down_a.view(
+                layers, slots, experts, rank, self._moe_down_a.shape[-1]
+            ).permute(1, 0, 2, 3, 4),
+            "moe_lora_b_down": self._megakernel_moe_down_b,
+        }
 
 
 # -----------------------------------------------------------------------------

--- a/kestrel/models/moondream/lora_workspace.py
+++ b/kestrel/models/moondream/lora_workspace.py
@@ -210,6 +210,11 @@ class TextLoRAWorkspace:
                 self.max_rank_per_expert, d_model,
                 device=device, dtype=dtype
             )
+            self._megakernel_moe_up_b_t = torch.zeros(
+                max_slots - 1, n_layers, num_experts,
+                self.max_rank_per_expert, d_expert * 2,
+                device=device, dtype=dtype,
+            )
 
             for layer_idx in range(self.start_layer, n_layers):
                 workspace = MoELoRALayerWorkspace(
@@ -279,6 +284,7 @@ class TextLoRAWorkspace:
 
         if self.moe:
             self._megakernel_moe_down_b[slot - 1].zero_()
+            self._megakernel_moe_up_b_t[slot - 1].zero_()
 
         self._moe_lora_ranks_host[slot - 1] = 0
         self.moe_lora_ranks[slot - 1].zero_()
@@ -357,6 +363,10 @@ class TextLoRAWorkspace:
                     adapter_layer.up_b[expert_id], layer.up_b.shape[1] // 2
                 )
                 layer.up_b[ws_idx, :, :adapter_rank_per_expert].copy_(up_b_src)
+                self._megakernel_moe_up_b_t[
+                    slot - 1, layer_idx, expert_id,
+                    :adapter_rank_per_expert, :
+                ].copy_(up_b_src.transpose(0, 1))
                 layer.down_a[ws_idx, :adapter_rank_per_expert, :].copy_(
                     adapter_layer.down_a[expert_id]
                 )
@@ -408,6 +418,7 @@ class TextLoRAWorkspace:
             "moe_lora_b_up": self._moe_up_b.view(
                 layers, slots, experts, self._moe_up_b.shape[-2], rank
             ).permute(1, 0, 2, 3, 4),
+            "moe_lora_b_up_t": self._megakernel_moe_up_b_t,
             "moe_lora_a_down": self._moe_down_a.view(
                 layers, slots, experts, rank, self._moe_down_a.shape[-1]
             ).permute(1, 0, 2, 3, 4),

--- a/kestrel/models/moondream/lora_workspace.py
+++ b/kestrel/models/moondream/lora_workspace.py
@@ -136,19 +136,41 @@ class TextLoRAWorkspace:
         self.routed_rank_by_slot = torch.zeros(
             max_slots, dtype=torch.int32, device=device
         )
+        self.dense_rank_by_slot = torch.zeros(
+            max_slots, dtype=torch.int32, device=device
+        )
         self._moe_lora_ranks_host = [0] * max(0, max_slots - 1)
 
         d_model = text_config.dim
         d_ffn = text_config.ff_dim
 
+        # One fixed-address allocation per dense weight family. Native per-layer
+        # workspaces and the whole-model compiler ABI are views of these same slabs.
+        self._dense_up_a = torch.zeros(
+            self.start_layer, max_slots, max_rank, d_model,
+            device=device, dtype=dtype,
+        )
+        self._dense_up_b = torch.zeros(
+            self.start_layer, max_slots, d_ffn, max_rank,
+            device=device, dtype=dtype,
+        )
+        self._dense_down_a = torch.zeros(
+            self.start_layer, max_slots, max_rank, d_ffn,
+            device=device, dtype=dtype,
+        )
+        self._dense_down_b = torch.zeros(
+            self.start_layer, max_slots, d_model, max_rank,
+            device=device, dtype=dtype,
+        )
+
         # Allocate dense layer workspaces: [0, start_layer)
         self.dense: list[DenseLoRALayerWorkspace] = []
-        for _ in range(self.start_layer):
+        for layer_idx in range(self.start_layer):
             workspace = DenseLoRALayerWorkspace(
-                up_a=torch.zeros(max_slots, max_rank, d_model, device=device, dtype=dtype),
-                up_b=torch.zeros(max_slots, d_ffn, max_rank, device=device, dtype=dtype),
-                down_a=torch.zeros(max_slots, max_rank, d_ffn, device=device, dtype=dtype),
-                down_b=torch.zeros(max_slots, d_model, max_rank, device=device, dtype=dtype),
+                up_a=self._dense_up_a[layer_idx],
+                up_b=self._dense_up_b[layer_idx],
+                down_a=self._dense_down_a[layer_idx],
+                down_b=self._dense_down_b[layer_idx],
             )
             self.dense.append(workspace)
 
@@ -261,6 +283,7 @@ class TextLoRAWorkspace:
         self._moe_lora_ranks_host[slot - 1] = 0
         self.moe_lora_ranks[slot - 1].zero_()
         self.routed_rank_by_slot[slot].zero_()
+        self.dense_rank_by_slot[slot].zero_()
 
     def load_slot_(self, slot: int, adapter: LoRA) -> None:
         """Load adapter weights into a slot.
@@ -348,6 +371,7 @@ class TextLoRAWorkspace:
         self._moe_lora_ranks_host[slot - 1] = adapter_rank_per_expert
         self.moe_lora_ranks[slot - 1] = adapter_rank_per_expert
         self.routed_rank_by_slot[slot] = adapter_rank_per_expert
+        self.dense_rank_by_slot[slot] = adapter_rank
 
     def megakernel_runtime_tensors(
         self,
@@ -361,16 +385,23 @@ class TextLoRAWorkspace:
         compiler's ``[storage, layer, expert, ...]`` logical axes. No adapter
         dimension transform or rank sharding occurs in the compiler.
         """
+        tensors = {
+            "adapter_slot_ids": adapter_slot_ids,
+            "routed_storage_ids": routed_storage_ids,
+            "routed_rank_by_slot": self.routed_rank_by_slot,
+            "dense_rank_by_slot": self.dense_rank_by_slot,
+            "dense_lora_a_up": self._dense_up_a.permute(1, 0, 2, 3),
+            "dense_lora_b_up": self._dense_up_b.permute(1, 0, 2, 3),
+            "dense_lora_a_down": self._dense_down_a.permute(1, 0, 2, 3),
+            "dense_lora_b_down": self._dense_down_b.permute(1, 0, 2, 3),
+        }
         if not self.moe:
-            return {}
+            return tensors
         slots = self.max_slots - 1
         layers = self._moe_up_a.shape[0]
         experts = self.moe[0].num_experts
         rank = self.max_rank_per_expert
-        return {
-            "adapter_slot_ids": adapter_slot_ids,
-            "routed_storage_ids": routed_storage_ids,
-            "routed_rank_by_slot": self.routed_rank_by_slot,
+        tensors.update({
             "moe_lora_a_up": self._moe_up_a.view(
                 layers, slots, experts, rank, self._moe_up_a.shape[-1]
             ).permute(1, 0, 2, 3, 4),
@@ -381,7 +412,8 @@ class TextLoRAWorkspace:
                 layers, slots, experts, rank, self._moe_down_a.shape[-1]
             ).permute(1, 0, 2, 3, 4),
             "moe_lora_b_down": self._megakernel_moe_down_b,
-        }
+        })
+        return tensors
 
 
 # -----------------------------------------------------------------------------

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -2389,6 +2389,8 @@ class MoondreamRuntime:
         slot.meta.input_pos.gpu[batch_size:graph_batch_size].zero_()
         slot.meta.lora_slot_ids.gpu[batch_size:graph_batch_size].zero_()
         slot.meta.lora_slot_ids.cpu[batch_size:graph_batch_size].zero_()
+        slot.meta.routed_storage_ids.gpu[batch_size:graph_batch_size].zero_()
+        slot.meta.routed_storage_ids.cpu[batch_size:graph_batch_size].zero_()
 
     def _prepare_decode_graph_step(self, slot: DecodeSlot, batch_size: int) -> None:
         # Only host-side LoRA metadata stays live here; the paged-KV metadata is
@@ -2406,6 +2408,7 @@ class MoondreamRuntime:
         slot.meta.input_pos.gpu.zero_()
         slot.meta.input_pos.cpu.zero_()
         slot.meta.lora_slot_ids.gpu.zero_()
+        slot.meta.routed_storage_ids.gpu.zero_()
         slot.meta.active_token_ids.gpu.zero_()
         slot.meta.active_token_ids.cpu.zero_()
         slot.meta.active_lora_ids.gpu.zero_()
@@ -2520,6 +2523,12 @@ class MoondreamRuntime:
         (``session.rebase_pages``, driven by the manager off the host-mirror composition check) and the
         kernel appends into the pre-reserved pages every steady step. The host mirrors
         (``slot.meta.*.np``) are threaded so that composition check stays device-sync-free."""
+        runtime_tensors = None
+        if self._lora_workspace is not None:
+            runtime_tensors = self._lora_workspace.megakernel_runtime_tensors(
+                adapter_slot_ids=slot.meta.lora_slot_ids.gpu[:batch_size],
+                routed_storage_ids=slot.meta.routed_storage_ids.gpu[:batch_size],
+            )
         return megakernel_decode.decode(
             model_name=self.model_name,
             text=self.model.text,
@@ -2533,6 +2542,7 @@ class MoondreamRuntime:
             input_pos=slot.meta.input_pos.gpu[:batch_size],
             batch_idx_host=slot.meta.batch_idx.np[:batch_size],
             input_pos_host=slot.meta.input_pos.np[:batch_size],
+            runtime_tensors=runtime_tensors,
         )
 
     def _native_decode_hidden(

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -2524,7 +2524,8 @@ class MoondreamRuntime:
         kernel appends into the pre-reserved pages every steady step. The host mirrors
         (``slot.meta.*.np``) are threaded so that composition check stays device-sync-free."""
         runtime_tensors = None
-        if self._lora_workspace is not None:
+        adapter_slots_cpu = slot.meta.lora_slot_ids.cpu[:batch_size]
+        if self._lora_workspace is not None and bool(torch.any(adapter_slots_cpu != 0)):
             runtime_tensors = self._lora_workspace.megakernel_runtime_tensors(
                 adapter_slot_ids=slot.meta.lora_slot_ids.gpu[:batch_size],
                 routed_storage_ids=slot.meta.routed_storage_ids.gpu[:batch_size],

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -2524,8 +2524,7 @@ class MoondreamRuntime:
         kernel appends into the pre-reserved pages every steady step. The host mirrors
         (``slot.meta.*.np``) are threaded so that composition check stays device-sync-free."""
         runtime_tensors = None
-        adapter_slots_cpu = slot.meta.lora_slot_ids.cpu[:batch_size]
-        if self._lora_workspace is not None and bool(torch.any(adapter_slots_cpu != 0)):
+        if self._lora_workspace is not None:
             runtime_tensors = self._lora_workspace.megakernel_runtime_tensors(
                 adapter_slot_ids=slot.meta.lora_slot_ids.gpu[:batch_size],
                 routed_storage_ids=slot.meta.routed_storage_ids.gpu[:batch_size],

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -2504,7 +2504,7 @@ class MoondreamRuntime:
         if (
             self._decode_graphs.enabled
             or self._megakernel_target is None
-            or self._lora_workspace is not None
+            or (self._lora_workspace is not None and batch_size != 1)
         ):
             return False
         return megakernel_decode.has_megakernel(*self._megakernel_target, batch_size)
@@ -2606,14 +2606,12 @@ class MoondreamRuntime:
         the manager captures native for it) -- the non-fatal fallback is preserved as an engine-side
         try/except, not a silent ``None`` on the hot path."""
         target = self._megakernel_target
-        # The rank-zero session has no adapter tensors or row-routing ABI. Skipping
-        # native capture while an adapter workspace is live would make later adapter
-        # requests silently execute the base model. The dynamic indexed-contraction
-        # runtime removes this guard only once those inputs are part of decode().
-        if target is None or self._lora_workspace is not None:
+        if target is None:
             return set()
         served: set[int] = set()
         for batch_size in batch_sizes:
+            if self._lora_workspace is not None and batch_size != 1:
+                continue
             if not megakernel_decode.has_megakernel(*target, batch_size):
                 continue
             try:
@@ -2652,12 +2650,12 @@ class MoondreamRuntime:
         if (
             target is None
             or self._decode_graphs.enabled
-            or self._lora_workspace is not None
         ):
             return
         served = [
             batch_size
             for batch_size in make_decode_graph_batch_sizes(self.max_batch_size)
+            if self._lora_workspace is None or batch_size == 1
             if megakernel_decode.has_megakernel(*target, batch_size)
         ]
         if not served:

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -2082,10 +2082,15 @@ class GenerationScheduler:
             idx_np = slot.meta.batch_idx.np
             pos_np = slot.meta.input_pos.np
             lora_np = slot.meta.lora_slot_ids.np
+            routed_storage_np = slot.meta.routed_storage_ids.np
             for i, seq in enumerate(sequences):
                 idx_np[i] = seq.state.batch_idx
                 pos_np[i] = seq.state.length
                 lora_np[i] = seq.state.lora_slot
+                # Slot 0 means no adapter. Routed slabs exclude that sentinel, so
+                # logical slot N maps to physical storage N-1; rank 0 prevents the
+                # sentinel row from dereferencing the placeholder storage id 0.
+                routed_storage_np[i] = max(0, seq.state.lora_slot - 1)
 
             # One H2D copy stages batch_idx/input_pos/lora_slot_ids together
             # (they share a packed buffer) instead of three separate launches.

--- a/scripts/chartqa_eval.py
+++ b/scripts/chartqa_eval.py
@@ -334,6 +334,9 @@ async def query_engine(
 
 
 async def eval_chartqa(cfg: EvalConfig) -> Dict[str, Any]:
+    from kestrel_kernels import megakernel
+
+    megakernel_launches_before = megakernel.launch_count()
     dataset = load_dataset("vikhyatk/chartqa", split=cfg.dataset_split)
     dataset = dataset.cast_column("image", HFImage(decode=False))
     limit = cfg.limit
@@ -579,6 +582,7 @@ async def eval_chartqa(cfg: EvalConfig) -> Dict[str, Any]:
         await engine.shutdown()
 
     wall_time_s = max(time.perf_counter() - start_time, 0.0)
+    megakernel_launches = megakernel.launch_count() - megakernel_launches_before
 
     results = [
         [entry for entry in chart_entries if entry is not None]
@@ -609,6 +613,7 @@ async def eval_chartqa(cfg: EvalConfig) -> Dict[str, Any]:
         "prefix_cache_enabled": cfg.enable_prefix_cache,
         "adapter": cfg.adapter,
         "megakernel_enabled": cfg.enable_megakernel,
+        "megakernel_launches": megakernel_launches,
     }
 
 
@@ -742,6 +747,7 @@ def print_results(results: Dict[str, Any]) -> None:
         f"Human Accuracy: {results['human_acc']:.2f}% "
         f"({results['human_correct']} / {results['human_total']})"
     )
+    print(f"Megakernel Launches: {results.get('megakernel_launches', 0)}")
 
     wall_time_s = results.get("wall_time_s", 0.0) or 0.0
     usage = results.get("token_usage")

--- a/scripts/chartqa_eval.py
+++ b/scripts/chartqa_eval.py
@@ -74,6 +74,7 @@ POT_MAX_TOKENS = 200
 @dataclass(slots=True)
 class EvalConfig:
     model: str
+    adapter: Optional[str]
     max_batch_size: int
     kv_cache_pages: Optional[int]
     dataset_split: str
@@ -302,15 +303,19 @@ async def query_engine(
     reasoning: bool,
     max_tokens: int,
     temperature: float,
+    adapter: Optional[str],
 ) -> Tuple[str, Optional[str], Optional[List[Dict[str, Any]]], EngineMetrics]:
+    settings: Dict[str, Any] = {
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    if adapter is not None:
+        settings["adapter"] = adapter
     response = await engine.query(
         image=image,
         question=prompt,
         reasoning=reasoning,
-        settings={
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-        },
+        settings=settings,
     )
     output = response.output
     answer = str(output.get("answer", "")).strip()
@@ -408,6 +413,7 @@ async def eval_chartqa(cfg: EvalConfig) -> Dict[str, Any]:
                     reasoning=True,
                     max_tokens=max_tokens,
                     temperature=temperature,
+                    adapter=cfg.adapter,
                 )
                 record_metrics(candidate_metrics)
                 candidate_answer = strip_trailing_percent(candidate_answer)
@@ -434,6 +440,7 @@ async def eval_chartqa(cfg: EvalConfig) -> Dict[str, Any]:
                 reasoning=cfg.cot_samples > 0,
                 max_tokens=max_tokens,
                 temperature=temperature,
+                adapter=cfg.adapter,
             )
             record_metrics(metrics)
             metrics_for_dump = metrics
@@ -533,6 +540,7 @@ async def eval_chartqa(cfg: EvalConfig) -> Dict[str, Any]:
                 reasoning=warmup_reasoning,
                 max_tokens=warmup_max_tokens,
                 temperature=warmup_temp,
+                adapter=cfg.adapter,
             )
 
     tasks: List[asyncio.Task[Tuple[int, int, Dict[str, Any], bool, bool]]] = []
@@ -594,6 +602,7 @@ async def eval_chartqa(cfg: EvalConfig) -> Dict[str, Any]:
         },
         "wall_time_s": wall_time_s,
         "prefix_cache_enabled": cfg.enable_prefix_cache,
+        "adapter": cfg.adapter,
     }
 
 
@@ -614,6 +623,11 @@ def parse_args() -> EvalConfig:
         type=int,
         default=4,
         help="Maximum batch size for the inference engine.",
+    )
+    parser.add_argument(
+        "--adapter",
+        default=None,
+        help="Optional finetune checkpoint ID in {finetune_id}@{step} form.",
     )
     parser.add_argument(
         "--kv-cache-pages",
@@ -680,6 +694,7 @@ def parse_args() -> EvalConfig:
 
     cfg = EvalConfig(
         model=args.model,
+        adapter=args.adapter,
         max_batch_size=args.max_batch_size,
         kv_cache_pages=args.kv_cache_pages,
         dataset_split=args.split,

--- a/scripts/chartqa_eval.py
+++ b/scripts/chartqa_eval.py
@@ -84,6 +84,7 @@ class EvalConfig:
     temperature: float
     debug: bool
     enable_prefix_cache: bool
+    enable_megakernel: bool
     dump_jsonl: Optional[Path] = None
     device: str | None = None
 
@@ -221,6 +222,10 @@ def execute_program_source(source: str, timeout: float = 10.0) -> str:
 
 
 async def create_engine(cfg: EvalConfig) -> InferenceEngine:
+    if not cfg.enable_megakernel:
+        from kestrel_kernels import megakernel
+
+        megakernel.deploy_target = lambda model_name, device: None
     runtime_kwargs: Dict[str, Any] = dict(
         model=cfg.model,
         max_batch_size=cfg.max_batch_size,
@@ -603,6 +608,7 @@ async def eval_chartqa(cfg: EvalConfig) -> Dict[str, Any]:
         "wall_time_s": wall_time_s,
         "prefix_cache_enabled": cfg.enable_prefix_cache,
         "adapter": cfg.adapter,
+        "megakernel_enabled": cfg.enable_megakernel,
     }
 
 
@@ -676,6 +682,11 @@ def parse_args() -> EvalConfig:
         help="Disable prefix caching (enabled by default).",
     )
     parser.add_argument(
+        "--disable-megakernel",
+        action="store_true",
+        help="Force native decode for same-script before/after evaluation.",
+    )
+    parser.add_argument(
         "--dump-jsonl",
         type=Path,
         default=None,
@@ -704,6 +715,7 @@ def parse_args() -> EvalConfig:
         temperature=float(args.temperature),
         debug=bool(args.debug),
         enable_prefix_cache=not args.disable_prefix_cache,
+        enable_megakernel=not args.disable_megakernel,
         dump_jsonl=args.dump_jsonl,
         device=args.device,
     )

--- a/tests/moondream/test_lora_workspace.py
+++ b/tests/moondream/test_lora_workspace.py
@@ -140,6 +140,34 @@ class TestWorkspaceAllocation:
             assert torch.all(layer.down_a[0] == 0)
             assert torch.all(layer.down_b[0] == 0)
 
+    def test_megakernel_runtime_tensors_are_workspace_views(
+        self, moe_config: TextConfig, device: torch.device
+    ):
+        workspace = TextLoRAWorkspace(
+            moe_config, max_slots=4, max_rank=8, device=device
+        )
+        logical = torch.tensor([0, 2], dtype=torch.int32, device=device)
+        storage = torch.tensor([0, 1], dtype=torch.int32, device=device)
+
+        tensors = workspace.megakernel_runtime_tensors(
+            adapter_slot_ids=logical,
+            routed_storage_ids=storage,
+        )
+
+        moe_cfg = moe_config.moe
+        assert moe_cfg is not None
+        rank = workspace.max_rank_per_expert
+        slots = workspace.max_slots - 1
+        assert tensors["moe_lora_a_up"].shape == (
+            slots, moe_config.n_layers, moe_cfg.num_experts, rank, moe_config.dim
+        )
+        assert tensors["moe_lora_b_down"].shape == (
+            slots, moe_config.n_layers, moe_cfg.num_experts, rank, moe_config.dim
+        )
+        assert tensors["adapter_slot_ids"] is logical
+        assert tensors["routed_storage_ids"] is storage
+        assert tensors["routed_rank_by_slot"] is workspace.routed_rank_by_slot
+
     def test_max_rank_per_expert_calculation(self, device: torch.device):
         """max_rank_per_expert is correctly computed as max_rank // experts_per_token."""
         config = TextConfig(
@@ -367,6 +395,14 @@ class TestLoadSlot:
                     layer.down_b[ws_idx, :, :rank_per_expert],
                     adapter_layer.down_b[expert_id],
                 )
+                assert torch.allclose(
+                    workspace._megakernel_moe_down_b[
+                        1, layer_idx, expert_id, :rank_per_expert
+                    ],
+                    adapter_layer.down_b[expert_id].transpose(0, 1),
+                )
+
+        assert workspace.routed_rank_by_slot.tolist() == [0, 0, rank_per_expert, 0]
 
     def test_moe_rank_not_divisible_by_experts_per_token_raises(
         self, moe_config: TextConfig, device: torch.device

--- a/tests/moondream/test_lora_workspace.py
+++ b/tests/moondream/test_lora_workspace.py
@@ -164,6 +164,10 @@ class TestWorkspaceAllocation:
         assert tensors["moe_lora_b_down"].shape == (
             slots, moe_config.n_layers, moe_cfg.num_experts, rank, moe_config.dim
         )
+        assert tensors["moe_lora_b_up_t"].shape == (
+            slots, moe_config.n_layers, moe_cfg.num_experts, rank,
+            moe_cfg.expert_inner_dim * 2,
+        )
         assert tensors["adapter_slot_ids"] is logical
         assert tensors["routed_storage_ids"] is storage
         assert tensors["routed_rank_by_slot"] is workspace.routed_rank_by_slot
@@ -414,6 +418,12 @@ class TestLoadSlot:
                         1, layer_idx, expert_id, :rank_per_expert
                     ],
                     adapter_layer.down_b[expert_id].transpose(0, 1),
+                )
+                assert torch.allclose(
+                    workspace._megakernel_moe_up_b_t[
+                        1, layer_idx, expert_id, :rank_per_expert
+                    ],
+                    layer.up_b[ws_idx, :, :rank_per_expert].transpose(0, 1),
                 )
 
         assert workspace.routed_rank_by_slot.tolist() == [0, 0, rank_per_expert, 0]

--- a/tests/moondream/test_lora_workspace.py
+++ b/tests/moondream/test_lora_workspace.py
@@ -167,6 +167,18 @@ class TestWorkspaceAllocation:
         assert tensors["adapter_slot_ids"] is logical
         assert tensors["routed_storage_ids"] is storage
         assert tensors["routed_rank_by_slot"] is workspace.routed_rank_by_slot
+        assert tensors["dense_rank_by_slot"] is workspace.dense_rank_by_slot
+        assert tensors["dense_lora_a_up"].shape == (
+            workspace.max_slots, workspace.start_layer, workspace.max_rank,
+            moe_config.dim,
+        )
+        assert tensors["dense_lora_b_down"].shape == (
+            workspace.max_slots, workspace.start_layer, moe_config.dim,
+            workspace.max_rank,
+        )
+        assert tensors["dense_lora_a_up"].untyped_storage().data_ptr() == (
+            workspace.dense[0].up_a.untyped_storage().data_ptr()
+        )
 
     def test_max_rank_per_expert_calculation(self, device: torch.device):
         """max_rank_per_expert is correctly computed as max_rank // experts_per_token."""
@@ -235,6 +247,7 @@ class TestClearSlot:
             layer.down_b[start:end].fill_(1.0)
 
         # Clear slot 1
+        workspace.dense_rank_by_slot[1] = 8
         workspace.clear_slot_(1)
 
         # Verify slot 1 is now zero
@@ -252,6 +265,7 @@ class TestClearSlot:
             assert torch.all(layer.up_b[start:end] == 0)
             assert torch.all(layer.down_a[start:end] == 0)
             assert torch.all(layer.down_b[start:end] == 0)
+        assert workspace.dense_rank_by_slot[1].item() == 0
 
     def test_clear_slot_preserves_other_slots(
         self, moe_config: TextConfig, device: torch.device
@@ -403,6 +417,7 @@ class TestLoadSlot:
                 )
 
         assert workspace.routed_rank_by_slot.tolist() == [0, 0, rank_per_expert, 0]
+        assert workspace.dense_rank_by_slot.tolist() == [0, 0, max_rank, 0]
 
     def test_moe_rank_not_divisible_by_experts_per_token_raises(
         self, moe_config: TextConfig, device: torch.device
@@ -425,6 +440,8 @@ class TestLoadSlot:
         )
 
         workspace.load_slot_(1, adapter)
+
+        assert workspace.dense_rank_by_slot[1].item() == adapter_rank
 
         for layer_idx, layer in enumerate(workspace.dense):
             adapter_layer = adapter.text.get_dense_lora(layer_idx)

--- a/tests/moondream/test_moe.py
+++ b/tests/moondream/test_moe.py
@@ -170,6 +170,21 @@ def test_decode_lora_metadata_uses_compact_graph_stable_buffers() -> None:
     )
 
 
+def test_adapter_workspace_serves_only_b1_megakernel_until_rows_are_emitted(
+    monkeypatch,
+) -> None:
+    runtime = runtime_mod.MoondreamRuntime.__new__(runtime_mod.MoondreamRuntime)
+    runtime._decode_graphs = SimpleNamespace(enabled=False)
+    runtime._megakernel_target = ("moondream3", 2048, 24)
+    runtime._lora_workspace = object()
+    monkeypatch.setattr(
+        runtime_mod.megakernel_decode, "has_megakernel", lambda *args: True
+    )
+
+    assert runtime._megakernel_eager_unwarmed(1)
+    assert not runtime._megakernel_eager_unwarmed(2)
+
+
 # ---------------------------------------------------------------------------
 # Non-FP8 MoE checkpoints are unrepresentable (kestrel#121)
 #


### PR DESCRIPTION
## Summary

- stage logical adapter slots and physical routed-storage IDs as distinct per-row decode metadata
- allocate routed and dense weight families as fixed-address whole-model slabs while retaining native per-layer views
- maintain independent logical-slot rank tables for routed and dense contraction extents
- maintain the route-owned rank-major down-B layout at adapter load time
- expose the complete traced runtime tensor binding to `kestrel_kernels.megakernel.decode`
- serve adapter-enabled B1 through the megakernel while keeping larger adapter batches native until every row has emitted work
- add workspace storage-alias, dynamic-rank, and serving-gate tests

Depends on kestrel-proprietary #413 and #414 and is stacked on kestrel #124.

## Validation

- `python -m py_compile` on the modified engine/workspace/test modules
- `git diff --check`
- Remote CPU and H100 integration tests pending.