### PR TITLE
moondream: pin the MoE gate/up interleave in tests

### DIFF
--- a/tests/moondream/test_lora_workspace.py
+++ b/tests/moondream/test_lora_workspace.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 
+from kestrel.models.moondream._moe_layout import _interleave_up_b_rows8
 from kestrel.models.moondream.config import TextConfig, TextMoeConfig
 from kestrel.models.moondream.lora import LoRA, TextLoRA, TextLoRAConfig
 from kestrel.models.moondream.lora_workspace import (
@@ -355,9 +356,15 @@ class TestLoadSlot:
                     layer.up_a[ws_idx, :rank_per_expert],
                     adapter_layer.up_a[expert_id],
                 )
+                # up_b's rows are interleaved into the base up slab's row order
+                # at load (see test_moe_up_b_is_stored_in_the_slab_row_order --
+                # this adapter's constant fill cannot see the permutation).
                 assert torch.allclose(
                     layer.up_b[ws_idx, :, :rank_per_expert],
-                    adapter_layer.up_b[expert_id],
+                    _interleave_up_b_rows8(
+                        adapter_layer.up_b[expert_id],
+                        adapter_layer.up_b.shape[-2] // 2,
+                    ),
                 )
                 assert torch.allclose(
                     layer.down_a[ws_idx, :rank_per_expert],
@@ -367,6 +374,54 @@ class TestLoadSlot:
                     layer.down_b[ws_idx, :, :rank_per_expert],
                     adapter_layer.down_b[expert_id],
                 )
+
+    def test_moe_up_b_is_stored_in_the_slab_row_order(
+        self, moe_config: TextConfig, device: torch.device
+    ):
+        """MoE up-B rows must land in the base up slab's 8-row gate/up order.
+
+        The LoRA expand is column-independent, so up_b's row order IS the
+        contract (kestrel-kernels MoeLoraState): a wrong order lands every
+        delta on the wrong neuron while passing every shape check. The other
+        load_slot tests fill up_b with a constant, which makes the permutation
+        invisible -- give each row a distinct value so it cannot hide.
+        """
+        max_rank = 8
+        workspace = TextLoRAWorkspace(
+            moe_config, max_slots=4, max_rank=max_rank, device=device
+        )
+        adapter = create_test_adapter(
+            moe_config, rank=max_rank, device=device, fill_value=1.0
+        )
+        moe_cfg = moe_config.moe
+        assert moe_cfg is not None
+
+        # Row-identifying values: up_b[..., row, :] == row.
+        for layer in adapter.text.moe:
+            rows = layer.up_b.shape[-2]
+            layer.up_b.data.copy_(
+                torch.arange(rows, dtype=layer.up_b.dtype, device=device)
+                .reshape(1, rows, 1)
+                .expand_as(layer.up_b)
+            )
+
+        workspace.load_slot_(2, adapter)
+
+        rank_per_expert = adapter.text.rank_per_expert
+        for moe_idx, layer in enumerate(workspace.moe):
+            adapter_layer = adapter.text.get_moe_lora(workspace.start_layer + moe_idx)
+            assert adapter_layer is not None
+            inter = adapter_layer.up_b.shape[-2] // 2
+            for expert_id in range(moe_cfg.num_experts):
+                ws_idx = (2 - 1) * moe_cfg.num_experts + expert_id
+                stored = layer.up_b[ws_idx, :, :rank_per_expert]
+                logical = adapter_layer.up_b[expert_id]
+                for n in range(inter):
+                    gate_row = 16 * (n // 8) + n % 8
+                    assert torch.allclose(stored[gate_row], logical[n])
+                    assert torch.allclose(stored[gate_row + 8], logical[inter + n])
+                # The plain half-split order must NOT be what was stored.
+                assert not torch.allclose(stored, logical)
 
     def test_moe_rank_not_divisible_by_experts_per_token_raises(
         self, moe_config: TextConfig, device: torch.device

--- a/tests/moondream/test_moe.py
+++ b/tests/moondream/test_moe.py
@@ -363,3 +363,105 @@ def test_moe_up_slab_survives_cuda_move() -> None:
     for li, up in _moe_up_views(text):
         assert up.weight.is_cuda
         assert torch.equal(up.weight.cpu(), before[li])
+
+
+# ---------------------------------------------------------------------------
+# THE PERMUTATION ITSELF (kestrel #121).
+#
+# The 8-row gate/up interleave is SHAPE-PRESERVING: gate row n lands at physical
+# row 16*(n//8) + n%8 and up row n at that + 8. No shape or dtype check can tell
+# a correct interleave from an inverted, by-16, or dropped one -- only the index
+# math can. Every downstream kernel (kestrel-kernels compact/warpgemv, the mkl
+# megakernel MoE consumers) assumes exactly this map, so it is pinned here rather
+# than left to whole-model cosine gates to notice.
+# ---------------------------------------------------------------------------
+
+def _expected_rows(inter: int) -> list[int]:
+    """Physical row for each logical row of a [gate | up] slab, per the contract."""
+    gate = [16 * (n // 8) + n % 8 for n in range(inter)]
+    return gate + [r + 8 for r in gate]
+
+
+def test_interleave_gate_up_rows8_matches_the_row_contract() -> None:
+    from kestrel.models.moondream._moe_layout import _interleave_gate_up_rows8
+
+    experts, inter, hidden = 2, 24, 3
+    # Row-identifying values: element (e, j, :) == j, so a permuted row is
+    # readable straight off the output.
+    plain = (torch.arange(2 * inter, dtype=torch.float32)[None, :, None]
+             .expand(experts, 2 * inter, hidden).contiguous())
+
+    out = _interleave_gate_up_rows8(plain, inter)
+
+    assert out.shape == plain.shape
+    for logical, physical in enumerate(_expected_rows(inter)):
+        assert torch.equal(out[:, physical], plain[:, logical]), (
+            f"logical row {logical} should land at physical row {physical}")
+    # Spot-check the contract literally: gate[8:16] occupies rows 16..23,
+    # up[8:16] occupies rows 24..31.
+    assert out[0, 16, 0] == 8 and out[0, 23, 0] == 15
+    assert out[0, 24, 0] == inter + 8 and out[0, 31, 0] == inter + 15
+
+
+def test_interleave_gate_up_rows8_permutes_scales_identically() -> None:
+    """Per-channel scales are [E, 2I] (no hidden tail) and MUST carry the same
+    permutation as the weight rows, or every neuron gets the wrong scale."""
+    from kestrel.models.moondream._moe_layout import _interleave_gate_up_rows8
+
+    experts, inter = 3, 16
+    plain = (torch.arange(2 * inter, dtype=torch.float32)[None, :]
+             .expand(experts, 2 * inter).contiguous())
+
+    out = _interleave_gate_up_rows8(plain, inter)
+
+    assert out.shape == plain.shape
+    for logical, physical in enumerate(_expected_rows(inter)):
+        assert torch.equal(out[:, physical], plain[:, logical])
+
+
+def test_interleave_up_b_rows8_permutes_rows_and_carries_rank() -> None:
+    """LoRA up-B is [*lead, 2I, rank]: rows follow the slab, rank is untouched
+    (the expand is column-independent, so a wrong row order lands every delta on
+    the wrong neuron while passing all shape checks)."""
+    from kestrel.models.moondream._moe_layout import _interleave_up_b_rows8
+
+    slots, experts, inter, rank = 2, 3, 16, 5
+    plain = (torch.arange(2 * inter, dtype=torch.float32)[None, None, :, None]
+             .expand(slots, experts, 2 * inter, rank).contiguous())
+    # Make the rank axis distinguishable so a rank/row transpose cannot pass.
+    plain = plain * 100 + torch.arange(rank, dtype=torch.float32)
+
+    out = _interleave_up_b_rows8(plain, inter)
+
+    assert out.shape == plain.shape
+    for logical, physical in enumerate(_expected_rows(inter)):
+        assert torch.equal(out[..., physical, :], plain[..., logical, :])
+
+
+def test_set_md3_moe_up_layer_writes_the_interleaved_slab() -> None:
+    """The loader entry point stores the PERMUTED bytes -- pinned end to end, so
+    a regression in the loader (not just the helper) is caught."""
+    from kestrel.models.moondream._moe_layout import (
+        MoEUpSlabModuleDict,
+        build_md3_moe_up_slab,
+        set_md3_moe_up_layer,
+    )
+
+    text = _build_moe_slab_text(MoEUpSlabModuleDict)
+    two_inter = 2 * _MOVE_INTER
+    up_w_slab, up_scale_slab = build_md3_moe_up_slab(
+        text, num_experts=_MOVE_E, two_inter=two_inter, hidden=_MOVE_HIDDEN, device="cpu")
+
+    raw_up = (torch.arange(two_inter, dtype=torch.uint8)[None, :, None]
+              .expand(_MOVE_E, two_inter, _MOVE_HIDDEN).contiguous())
+    raw_scale = (torch.arange(two_inter, dtype=torch.float32)[None, :]
+                 .expand(_MOVE_E, two_inter).contiguous())
+    layer = _MOVE_START
+    fused = text.blocks[layer].mlp["mlp"]
+    set_md3_moe_up_layer(
+        fused, up_w_slab, up_scale_slab, layer, raw_up, raw_scale, _MOVE_INTER)
+
+    weight, scale = fused.up_experts.weight, fused.up_experts.scale
+    for logical, physical in enumerate(_expected_rows(_MOVE_INTER)):
+        assert torch.equal(weight[:, physical], raw_up[:, logical])
+        assert torch.equal(scale[:, physical], raw_scale[:, logical])


### PR DESCRIPTION
The 8-row gate/up interleave (#121) is a **shape-preserving row permutation**: gate row `n` lives at physical row `16*(n//8) + n%8`, up row `n` at that `+ 8`, and the per-channel scales and LoRA up-B carry the same permutation. Nothing can distinguish a correct interleave from an inverted, by-16, or dropped one except the index math — so an engine that stopped interleaving, or interleaved the weight but not the scale, would ship green and silently mispair every neuron.

**Nothing pinned it.** No test referenced `_interleave_gate_up_rows8` / `_interleave_up_b_rows8` at all, and `test_load_slot_copies_moe_weights` compared the workspace's `up_b` against the adapter's using `create_test_adapter`'s **constant** fill — which passes with the interleave, without it, or with an inverted one.

This is the same class of hole that let kestrel-kernels' warpgemv runtime ship a mispaired fused gate/up kernel (kestrel-kernels#409): the fixtures were in plain `[gate | up]` layout, so they could not see the layout at all.

## What this pins

- **The helpers**, with row-identifying values, asserted against the contract's index math directly — weights (with a hidden tail), scales (without one), and up-B (with its rank axis carried through).
- **The loader entry point** (`set_md3_moe_up_layer`), so a regression in the loader rather than the helper is caught end to end.
- **MoE LoRA up-B at workspace load**, with row-distinct values so the ordering cannot hide behind a constant fill, plus the standing `load_slot` assertion restated in terms of the interleave it actually expects.

Tests only — no production code changes.

## Verification

Mutation-tested, since a test that cannot fail is worthless here:
- stacking the interleave on the wrong axis (`dim=2` → `dim=1`) fails all four helper/loader tests;
- dropping the up-B interleave at workspace load fails the new LoRA test — while **every pre-existing test still passes**, which is precisely the gap.

`tests/moondream`: 64 passed, 1 skipped.