### PR TITLE
moondream: keep decode padding mirrors in sync

### DIFF
--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -2386,7 +2386,9 @@ class MoondreamRuntime:
         slot.decode_coord_values[batch_size:graph_batch_size].zero_()
         slot.decode_size_values[batch_size:graph_batch_size].zero_()
         slot.meta.batch_idx.gpu[batch_size:graph_batch_size].zero_()
+        slot.meta.batch_idx.cpu[batch_size:graph_batch_size].zero_()
         slot.meta.input_pos.gpu[batch_size:graph_batch_size].zero_()
+        slot.meta.input_pos.cpu[batch_size:graph_batch_size].zero_()
         slot.meta.lora_slot_ids.gpu[batch_size:graph_batch_size].zero_()
         slot.meta.lora_slot_ids.cpu[batch_size:graph_batch_size].zero_()
 

--- a/tests/moondream/test_runtime_decode_padding.py
+++ b/tests/moondream/test_runtime_decode_padding.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+import torch
+
+from kestrel.models.moondream.runtime import MoondreamRuntime
+
+
+def _field(size: int):
+    return SimpleNamespace(
+        cpu=torch.ones(size, dtype=torch.int64),
+        gpu=torch.ones(size, dtype=torch.int64),
+    )
+
+
+def test_decode_padding_zeros_gpu_and_host_mirrors():
+    """Eager megakernel composition checks consume host mirrors, so padding must zero both sides."""
+    runtime = MoondreamRuntime.__new__(MoondreamRuntime)
+    slot = SimpleNamespace(
+        decode_token_ids=torch.ones(8, dtype=torch.int64),
+        decode_coord_values=torch.ones(8, 1),
+        decode_size_values=torch.ones(8, 2),
+        meta=SimpleNamespace(
+            batch_idx=_field(8),
+            input_pos=_field(8),
+            lora_slot_ids=_field(8),
+        ),
+    )
+
+    runtime._zero_decode_graph_padding(slot, batch_size=3, graph_batch_size=8)
+
+    for tensor in (
+        slot.meta.batch_idx.cpu,
+        slot.meta.batch_idx.gpu,
+        slot.meta.input_pos.cpu,
+        slot.meta.input_pos.gpu,
+        slot.meta.lora_slot_ids.cpu,
+        slot.meta.lora_slot_ids.gpu,
+    ):
+        assert torch.equal(tensor[:3], torch.ones_like(tensor[:3]))
+        assert torch.equal(tensor[3:], torch.zeros_like(tensor[3:]))


### PR DESCRIPTION
## Summary

- zero CPU host mirrors for padded decode rows alongside the existing GPU buffers
- pin the padding contract with a CPU regression test

## Root cause

The eager megakernel composition check consumes `batch_idx` and `input_pos` from CPU host mirrors to avoid a device synchronization. Power-of-two bucket padding zeroed only the GPU views, leaving stale live row/position values in those host mirrors. A long CoT run with a partially filled B8 bucket therefore interpreted padding as row 9 at position 749 while the GPU correctly used reserved row 0, and the reservation guard raised.

The paired kernels change in kp #435 treats reserved row 0 as padding for progression and extent checks. This engine change makes the host and GPU metadata agree at the source. Together they remove the false exception. Batch-composition changes still legitimately rebase the launch-local page map; that performance work is tracked in #435 and is not hidden by this correctness fix.

## Validation

- `tests/moondream/test_runtime_decode_padding.py` + `tests/test_decode_graph_manager.py`: 10 passed
- failure reproduced by MD2 ChartQA CoT with max batch 8 before the fix
- paired MD2 ChartQA CoT completed 1457 megakernel launches after the fix with exact native accuracy: 65.00% (260/400)
- final H100 bucket policy and full-path performance evidence are recorded in kp #435