### PR TITLE
Keep decode cohorts stable

### DIFF
--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -359,7 +359,6 @@ class GenerationScheduler:
         self._sampling_rng = torch.Generator(device=runtime.device)
         self._sampling_rng.manual_seed(torch.seed())
         self._pipeline = PipelineState()
-        self._last_deferred_request_id: int | None = None
         # Depth-1 spec overlap: the previously-launched macro-step's
         # (sequences, lazy SpecStepResult) awaiting commit while the GPU runs the
         # next step. None when no spec step is in flight.
@@ -669,11 +668,11 @@ class GenerationScheduler:
         # ``decoder.step`` call -- but the verify/draft CUDA graphs and staging
         # buffers are captured for ``max_batch_size`` states, so an oversized
         # batch overruns them. The non-spec path enforces the same bound via its
-        # ``max_batch_size`` dispatch cap (``_cap_decode_dispatch``); bound the
-        # spec batch at admission so the running set -- and thus every
-        # ``decoder.step`` -- never exceeds it. Excess launchable requests stay
-        # WAITING and are admitted as running rows retire (same deferral the
-        # non-spec path applies when more rows are dispatchable than fit).
+        # ``max_batch_size`` decode cohort; bound the spec batch at admission so
+        # the running set -- and thus every ``decoder.step`` -- never exceeds it.
+        # Excess launchable requests stay WAITING and are admitted as running
+        # rows retire. The non-spec path can instead keep one extra prefilled
+        # request resident because its page-table rows are allocated on demand.
         max_running = self.runtime.max_batch_size
         while decoder.free_slots > 0 and len(self.running) < max_running:
             request = next(
@@ -1985,29 +1984,6 @@ class GenerationScheduler:
                 return False
         return True
 
-    def _cap_decode_dispatch(
-        self,
-        dispatchable: List[RequestLifecycle],
-        limit: int,
-    ) -> List[RequestLifecycle]:
-        """Cap decode dispatch size while keeping deterministic, fair ordering."""
-        if len(dispatchable) <= limit:
-            self._last_deferred_request_id = None
-            return dispatchable
-
-        last_deferred = self._last_deferred_request_id
-        defer_idx: int | None = None
-        for idx in range(len(dispatchable) - 1, -1, -1):
-            if dispatchable[idx].request.request_id != last_deferred:
-                defer_idx = idx
-                break
-        if defer_idx is None:
-            defer_idx = len(dispatchable) - 1
-
-        deferred = dispatchable.pop(defer_idx)
-        self._last_deferred_request_id = deferred.request.request_id
-        return dispatchable[:limit]
-
     def schedule_decode_step(self) -> Optional[StepPlan]:
         """Select sequences for the next decode step.
 
@@ -2023,8 +1999,22 @@ class GenerationScheduler:
         if not len(self.running):
             return None
 
-        active: list[RequestLifecycle] = []
+        # Keep decode membership stable until a cohort member retires. Prefill
+        # may leave one additional request resident in ``running`` to preserve
+        # prefill headroom, but that tail request waits for a cohort slot instead
+        # of rotating into alternate token steps. Select the cohort BEFORE
+        # checking temporary dispatchability: otherwise a pipelined member with
+        # two in-flight references would let the resident tail slip into one
+        # launch, reintroducing composition churn and irregular inter-token
+        # latency.
+        cohort: list[RequestLifecycle] = []
         for seq in self.running:
+            if len(cohort) >= self.runtime.max_batch_size:
+                break
+            cohort.append(seq)
+
+        active: list[RequestLifecycle] = []
+        for seq in cohort:
             if not seq.needs_decode():
                 continue
             if not self._can_dispatch(seq):
@@ -2033,12 +2023,6 @@ class GenerationScheduler:
 
         if not active:
             return None
-
-        decode_limit = self.runtime.max_batch_size
-        if len(active) > decode_limit:
-            active = self._cap_decode_dispatch(active, decode_limit)
-        else:
-            self._last_deferred_request_id = None
 
         return StepPlan(sequences=active)
 

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -3,6 +3,7 @@
 
 from collections import Counter, deque
 from dataclasses import dataclass
+from itertools import islice
 from typing import Deque, List, Optional, Sequence
 
 import time
@@ -2007,7 +2008,7 @@ class GenerationScheduler:
         # two in-flight references would let the resident tail slip into one
         # launch, reintroducing composition churn and irregular inter-token
         # latency.
-        cohort = list(self.running)[: self.runtime.max_batch_size]
+        cohort = list(islice(self.running, self.runtime.max_batch_size))
 
         active: list[RequestLifecycle] = []
         for seq in cohort:

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -2007,11 +2007,7 @@ class GenerationScheduler:
         # two in-flight references would let the resident tail slip into one
         # launch, reintroducing composition churn and irregular inter-token
         # latency.
-        cohort: list[RequestLifecycle] = []
-        for seq in self.running:
-            if len(cohort) >= self.runtime.max_batch_size:
-                break
-            cohort.append(seq)
+        cohort = list(self.running)[: self.runtime.max_batch_size]
 
         active: list[RequestLifecycle] = []
         for seq in cohort:

--- a/tests/scheduler/test_decode_cohort.py
+++ b/tests/scheduler/test_decode_cohort.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass, field
+
+from kestrel.runtime import SequenceState, TextToken
+from kestrel.scheduler.queues import RunningQueue
+from kestrel.scheduler.scheduler import GenerationScheduler
+from kestrel.scheduler.types import GenerationRequest, RequestLifecycle
+
+from tests.scheduler._fake_runtime import FakeRuntime
+
+
+@dataclass
+class _SkillStateStub:
+    tokens: list[object] = field(default_factory=list)
+
+    @property
+    def token_count(self) -> int:
+        return len(self.tokens)
+
+
+def _make_lifecycle(request_id: int) -> RequestLifecycle:
+    request = GenerationRequest(
+        request_id=request_id,
+        prompt="prompt",
+        prompt_tokens=[TextToken(1)],
+        max_new_tokens=8,
+        skill=object(),
+        request_context=object(),
+    )
+    lifecycle = RequestLifecycle(
+        request=request,
+        skill_state=_SkillStateStub(),
+        sequence_state=SequenceState(
+            batch_idx=request_id,
+            length=1,
+            max_length=9,
+            prompt_length=1,
+        ),
+        packed_pending_ready=True,
+    )
+    request.lifecycle = lifecycle
+    return lifecycle
+
+
+def test_decode_cohort_stays_stable_until_a_member_retires() -> None:
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = FakeRuntime(max_batch_size=2, max_batch_slots=4)
+    scheduler.running = RunningQueue()
+    sequences = [_make_lifecycle(request_id) for request_id in (1, 2, 3)]
+    scheduler.running.extend(sequences)
+
+    assert scheduler.schedule_decode_step().sequences == sequences[:2]
+    assert scheduler.schedule_decode_step().sequences == sequences[:2]
+
+    scheduler.running.remove(sequences[0])
+    assert scheduler.schedule_decode_step().sequences == sequences[1:]
+
+
+def test_resident_tail_does_not_replace_temporarily_blocked_cohort_member() -> None:
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = FakeRuntime(max_batch_size=2, max_batch_slots=4)
+    scheduler.running = RunningQueue()
+    sequences = [_make_lifecycle(request_id) for request_id in (1, 2, 3)]
+    scheduler.running.extend(sequences)
+    sequences[0].inflight_refs = 2
+
+    plan = scheduler.schedule_decode_step()
+
+    assert plan.sequences == [sequences[1]]


### PR DESCRIPTION
## What changed

- keep the first `max_batch_size` running requests as a stable decode cohort
- retain the one-request prefill headroom as a resident tail request
- promote that resident request only after a cohort member retires
- remove the per-token deferred-request rotation state
- add regression coverage for stable membership and temporary pipeline backpressure

## Why

The previous scheduler alternated which request was omitted whenever the running set exceeded the forward microbatch by one. That avoided starvation, but changed launch composition every token and gave affected requests irregular inter-token latency. It also forced launch-local decode state to track gratuitous batch membership changes.

The extra resident request remains useful for prefill headroom. Treating it as prefetched work waiting for a real cohort slot preserves that benefit while making decode cadence predictable for the active cohort.

The resident request can wait longer between its prefill-produced first token and its next token; this is the explicit latency tradeoff for preserving prefill-ahead without time-slicing the active cohort.

## Validation

- `ssh p1 'cd ~/code/kestrel && ~/.local/bin/uv run --no-sync pytest tests/scheduler -q'`
- 150 passed
