### PR TITLE
moondream: simplify eager megakernel lifecycle

### DIFF
--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -826,6 +826,18 @@ class MoondreamRuntime:
             )
             for slot_id in range(2)
         ]
+        # A shipped megakernel is already a single eager launch. Resolve its AOT
+        # buckets once and omit only their redundant native CUDA graphs.
+        megakernel_target = megakernel_decode.deploy_target(
+            self.model_name, self.device
+        )
+        self._megakernel_buckets = frozenset(
+            batch_size
+            for batch_size in make_decode_graph_batch_sizes(self.max_batch_size)
+            if megakernel_target is not None
+            and self._lora_workspace is None
+            and megakernel_decode.has_megakernel(*megakernel_target, batch_size)
+        )
         self._decode_graphs = DecodeGraphManager[DecodeSlot](
             enabled=self._use_cuda_graphs,
             device=self.device,
@@ -836,16 +848,8 @@ class MoondreamRuntime:
             prepare_step=self._prepare_decode_graph_step,
             zero_padding=self._zero_decode_graph_padding,
             zero_for_capture=self._zero_decode_graph_capture_buffers,
-            plan_eager=self._plan_megakernel_buckets,
+            eager_batch_sizes=self._megakernel_buckets,
         )
-        # Whole-model decode megakernel: the deploy target (model_kind, arch, num_sms) for this
-        # loaded model, resolved once (None => no megakernel here). DecodeGraphManager owns each
-        # slot's eager-bucket plan: a served bucket skips native capture and routes each step to the
-        # eager megakernel instead of a replayed native graph.
-        self._megakernel_target: tuple[str, int, int] | None = megakernel_decode.deploy_target(
-            self.model_name, self.device
-        )
-        self._megakernel_failed_buckets: set[int] = set()
 
         # Shared pending coord/size values, indexed by batch_idx. These
         # are the runtime-side equivalent of the scheduler's
@@ -870,14 +874,6 @@ class MoondreamRuntime:
         if self._use_cuda_graphs:
             self._maybe_release_cuda_allocator_cache()
             self._ensure_cuda_graphs_ready()
-        else:
-            # Graphs OFF (eager serve): there is no capture pass to warm the megakernel, so build the
-            # served buckets' sessions HERE, at init. The first megakernel decode is a multi-minute
-            # in-process CuTe JIT trace; deferring it to the first LIVE decode step pegs the scheduler
-            # thread (0% GPU, one core busy) mid-serve and reads as a concurrency stall. Warming at init
-            # moves that one-time build out of the serving loop (mirrors the graphs-on warmup that
-            # ``_plan_megakernel_buckets`` runs at capture time).
-            self._warm_megakernel_eager()
 
         # Allocate vision encoder buffers (always, for consistency)
         self._allocate_vision_buffers()
@@ -2458,11 +2454,8 @@ class MoondreamRuntime:
     ) -> None:
         """Run decode forward pass and write results to slot output buffers.
 
-        This is the core forward computation. For a bucket in this slot's eager capture plan
-        (decided + warmed at graph-build time) it runs the megakernel EAGERLY -- these buckets have
-        no captured native graph, so this is the real production decode, not a warmup. Every other
-        bucket runs the native decoder and is captured into / replayed from its CUDA graph exactly
-        as before.
+        Megakernel buckets run as one eager launch and have no redundant CUDA
+        graph. Every other bucket runs the native decoder inside its graph.
 
         Args:
             slot: DecodeSlot with inputs in its buffers.
@@ -2473,36 +2466,13 @@ class MoondreamRuntime:
             slot.decode_coord_values[:batch_size],
             slot.decode_size_values[:batch_size],
         )
-        if batch_size in self._decode_graphs.eager_buckets(slot):
-            # Graphs on: a bucket warmed + capture-skipped at graph-build time. The session is built,
-            # so this is the real production decode. Capacity is dynamic per active row even though
-            # bucket eligibility is static: a request can outgrow the compiled KV extent, or this
-            # composition can select a shorter reservation. That expected ineligibility runs native
-            # eagerly for this step; kernel/build failures still surface.
+        if batch_size in self._megakernel_buckets:
             try:
                 hidden = self._megakernel_decode_hidden(slot, batch_size, embeds)
             except megakernel_decode.MegakernelNotEligible as exc:
                 _LOGGER.info(
                     "megakernel decode ineligible for bucket %d this step; native (%s)",
                     batch_size, exc,
-                )
-                hidden = self._native_decode_hidden(slot, batch_size, embeds)
-        elif self._megakernel_eager_unwarmed(batch_size):
-            # Graphs off: there is no capture to skip, so route the megakernel here, building lazily
-            # on the first step and falling back to native on a build/kernel failure (the non-fatal
-            # fallback the warmup try/except gives the graphs-on path).
-            try:
-                hidden = self._megakernel_decode_hidden(slot, batch_size, embeds)
-            except megakernel_decode.MegakernelNotEligible as exc:
-                _LOGGER.info(
-                    "megakernel decode ineligible for bucket %d this step; native (%s)",
-                    batch_size, exc,
-                )
-                hidden = self._native_decode_hidden(slot, batch_size, embeds)
-            except Exception as exc:  # non-fatal: a build/kernel failure -> native
-                self._megakernel_failed_buckets.add(batch_size)
-                _LOGGER.warning(
-                    "megakernel decode failed for bucket %d; native (%s)", batch_size, exc
                 )
                 hidden = self._native_decode_hidden(slot, batch_size, embeds)
         else:
@@ -2513,28 +2483,12 @@ class MoondreamRuntime:
         slot.logits[:batch_size].copy_(logits)
         slot.hidden_last[:batch_size].copy_(hidden[:, 0, :])
 
-    def _megakernel_eager_unwarmed(self, batch_size: int) -> bool:
-        """Whether to serve ``batch_size`` through the megakernel on the NON-graph path (graphs
-        disabled). With graphs on, the per-slot served buckets are decided + warmed at graph-build
-        time; with graphs off there is no capture to skip, so gate directly on ``has_megakernel``
-        and build lazily on the first step (with a native fallback)."""
-        if (
-            self._decode_graphs.enabled
-            or self._megakernel_target is None
-            or self._lora_workspace is not None
-            or batch_size in self._megakernel_failed_buckets
-        ):
-            return False
-        return megakernel_decode.has_megakernel(*self._megakernel_target, batch_size)
-
     def _megakernel_decode_hidden(
         self, slot: DecodeSlot, batch_size: int, embeds: Tensor
     ) -> Tensor:
-        """Run one eager whole-model megakernel decode step; return hidden ``[B, 1, H]``. The session
-        is built lazily on the first call for a bucket -- the
-        engine performs that first call at graph-build time via ``_plan_megakernel_buckets`` instead of
-        capturing a native graph, so by production steady-state it is warm. Raises on a genuine
-        megakernel error (the caller only reaches here for a bucket whose warmup succeeded).
+        """Run one whole-model megakernel launch; return hidden ``[B, 1, H]``.
+
+        The packaged AOT session is loaded lazily on the first real decode.
 
         Native and megakernel decode consume the same authoritative global page table plus the
         engine's ``batch_idx`` and ``input_pos`` controls. Their canonical CPU staging views guard
@@ -2601,98 +2555,6 @@ class MoondreamRuntime:
             moe_lora_metadata=moe_lora_metadata,
             dense_lora_scratch=self._dense_lora_decode_scratch,
         )
-
-    def _plan_megakernel_buckets(
-        self, slot: DecodeSlot, batch_sizes: list[int]
-    ) -> set[int]:
-        """Decide + WARM the decode buckets the whole-model megakernel serves for ``slot``, called
-        once per slot at graph-build time (see ``DecodeGraphManager._capture_slot_graphs``). Returns
-        the subset of ``batch_sizes`` that will be served eagerly -- those buckets are NOT captured as
-        native graphs; ``_run_decode_forward`` routes them through the megakernel each step.
-
-        The decision is the cheap ``has_megakernel`` gate; a gated-in bucket is then WARMED by
-        actually running the first (session-building) megakernel decode on the zeroed capture buffers
-        (the same warmup point native capture used). If that build raises, the bucket is EXCLUDED (and
-        the manager captures native for it) -- the non-fatal fallback is preserved as an engine-side
-        try/except, not a silent ``None`` on the hot path."""
-        target = self._megakernel_target
-        # The rank-zero session has no adapter tensors or row-routing ABI. Skipping
-        # native capture while an adapter workspace is live would make later adapter
-        # requests silently execute the base model. The dynamic indexed-contraction
-        # runtime removes this guard only once those inputs are part of decode().
-        if target is None or self._lora_workspace is not None:
-            return set()
-        served: set[int] = set()
-        for batch_size in batch_sizes:
-            if not megakernel_decode.has_megakernel(*target, batch_size):
-                continue
-            try:
-                # Host-side LoRA metadata (matches the per-step prepare) then one eager,
-                # session-building megakernel launch on the zeroed capture buffers.
-                self._prepare_decode_graph_step(slot, batch_size)
-                embeds = self._embed_packed_token_batch(
-                    slot.decode_token_ids[:batch_size],
-                    slot.decode_coord_values[:batch_size],
-                    slot.decode_size_values[:batch_size],
-                )
-                self._megakernel_decode_hidden(slot, batch_size, embeds)
-            except Exception as exc:  # a warmup/build failure -> capture native for this bucket
-                self._megakernel_failed_buckets.add(batch_size)
-                _LOGGER.warning(
-                    "megakernel warmup failed for decode bucket %d; capturing native instead (%s)",
-                    batch_size, exc,
-                )
-                continue
-            served.add(batch_size)
-        return served
-
-    def _warm_megakernel_eager(self) -> None:
-        """Graphs OFF: build the megakernel session for every served decode bucket NOW, at init.
-
-        On the eager (non-graph) serve path ``_run_decode_forward`` routes a bucket through the
-        megakernel and builds its session lazily on the FIRST call (``_megakernel_eager_unwarmed``).
-        That first build is a multi-minute, single-threaded CuTe JIT trace of the whole-model VM -- if
-        it lands on the first live decode step it blocks the scheduler thread (0% GPU, one core pegged,
-        no completions) and looks exactly like a concurrency stall. Warming here does that one-time
-        build off the serving path, at the same point the graphs-on path warms via
-        ``_plan_megakernel_buckets``. A build failure disables that bucket for this runtime, so later
-        steps use native directly instead of retrying the failed build.
-        """
-        target = self._megakernel_target
-        if (
-            target is None
-            or self._decode_graphs.enabled
-            or self._lora_workspace is not None
-        ):
-            return
-        served = [
-            batch_size
-            for batch_size in make_decode_graph_batch_sizes(self.max_batch_size)
-            if megakernel_decode.has_megakernel(*target, batch_size)
-        ]
-        if not served:
-            return
-        slot = self._decode_slots[0]
-        for batch_size in served:
-            try:
-                # Zero the slot buffers (valid token id 0 / positions), stage host-side metadata, then
-                # run one session-building megakernel decode -- the same warmup shape the capture path
-                # uses. ``inference_mode`` matches the scheduler's per-step launch context.
-                self._zero_decode_graph_capture_buffers(slot)
-                self._prepare_decode_graph_step(slot, batch_size)
-                embeds = self._embed_packed_token_batch(
-                    slot.decode_token_ids[:batch_size],
-                    slot.decode_coord_values[:batch_size],
-                    slot.decode_size_values[:batch_size],
-                )
-                with torch.inference_mode():
-                    self._megakernel_decode_hidden(slot, batch_size, embeds)
-            except Exception as exc:  # non-fatal: keep this bucket native for the runtime lifetime
-                self._megakernel_failed_buckets.add(batch_size)
-                _LOGGER.warning(
-                    "eager megakernel warmup failed for decode bucket %d; using native (%s)",
-                    batch_size, exc,
-                )
 
     def acquire_adapter_slot(self, adapter_id: str, adapter: LoRA) -> int:
         """Acquire a slot for an adapter, loading weights if necessary.

--- a/kestrel/runtime/decode_graph.py
+++ b/kestrel/runtime/decode_graph.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Collection, Sequence
 from typing import Any, Generic, TypeVar
 
 import torch
@@ -43,7 +43,7 @@ class DecodeGraphManager(Generic[SlotT]):
         prepare_step: Callable[[SlotT, int], None],
         zero_padding: Callable[[SlotT, int, int], None] | None = None,
         zero_for_capture: Callable[[SlotT], None] | None = None,
-        plan_eager: Callable[[SlotT, list[int]], set[int]] | None = None,
+        eager_batch_sizes: Collection[int] = (),
     ) -> None:
         self.enabled = enabled
         self.device = resolve_device(device)
@@ -54,17 +54,11 @@ class DecodeGraphManager(Generic[SlotT]):
         self._prepare_step = prepare_step
         self._zero_padding = zero_padding or _noop_padding
         self._zero_for_capture = zero_for_capture
-        # Optional: given a slot and the batch buckets about to be captured, return the SUBSET this
-        # runtime will serve EAGERLY instead of a captured native graph (the whole-model decode
-        # megakernel). Those buckets are NOT captured (no graph, no graph-pool memory) and ``run``
-        # routes them to the eager ``run_forward`` instead of a graph replay. The callback also
-        # WARMS the eager path (builds its session) and MUST exclude any bucket whose warmup fails,
-        # so a build failure transparently falls back to native capture.
-        self._plan_eager = plan_eager
+        # Batch buckets served by a runtime-owned eager path. They do not need a
+        # redundant CUDA graph; all other buckets retain native graph replay.
+        self._eager_batch_sizes = frozenset(int(size) for size in eager_batch_sizes)
         self._batch_sizes: list[int] = []
         self._graphs: dict[int, dict[int, Any]] = {}
-        # Per-slot buckets served eagerly (megakernel), so no native graph was captured for them.
-        self._eager_buckets: dict[int, frozenset[int]] = {}
 
     @property
     def batch_sizes(self) -> list[int]:
@@ -73,13 +67,7 @@ class DecodeGraphManager(Generic[SlotT]):
     def clear(self) -> None:
         """Drop all captured decode graphs."""
         self._graphs.clear()
-        self._eager_buckets.clear()
         self._batch_sizes = []
-
-    def eager_buckets(self, slot: SlotT) -> frozenset[int]:
-        """Buckets served eagerly (megakernel) for ``slot`` -- i.e. buckets for which NO native decode
-        graph was captured. Empty when there is no eager plan or graphs are disabled."""
-        return self._eager_buckets.get(id(slot), frozenset())
 
     def ensure_ready(self, slots: Sequence[SlotT]) -> None:
         """Capture missing graph sets for ``slots`` when graph replay is enabled."""
@@ -105,7 +93,6 @@ class DecodeGraphManager(Generic[SlotT]):
     def run(self, slot: SlotT, batch_size: int) -> None:
         """Prepare one decode step and execute via graph replay or eager forward."""
         graphs = self._graphs.get(id(slot)) if self.enabled else None
-        eager = self._eager_buckets.get(id(slot), frozenset())
         if graphs is None:
             graph_batch_size = batch_size
         else:
@@ -115,8 +102,11 @@ class DecodeGraphManager(Generic[SlotT]):
                     f"Batch size {batch_size} exceeds max graph capacity "
                     f"{self._batch_sizes[-1] if self._batch_sizes else 0}"
                 )
-            # A bucket served eagerly (megakernel) has NO captured graph by design; run it eager.
-            if graph_batch_size not in graphs and graph_batch_size not in eager:
+            # A bucket owned by an eager path has no captured graph by design.
+            if (
+                graph_batch_size not in graphs
+                and graph_batch_size not in self._eager_batch_sizes
+            ):
                 raise RuntimeError(
                     f"No CUDA graph captured for batch size {graph_batch_size}"
                 )
@@ -126,9 +116,8 @@ class DecodeGraphManager(Generic[SlotT]):
 
         self._prepare_step(slot, graph_batch_size)
 
-        if graphs is None or graph_batch_size in eager:
-            # Eager: no graph (globally disabled) or an eager-served bucket -> run the forward, which
-            # routes the megakernel-served bucket through the megakernel each step.
+        if graphs is None or graph_batch_size in self._eager_batch_sizes:
+            # No graph globally, or this bucket belongs to an eager path.
             self._run_forward(slot, graph_batch_size)
         else:
             graphs[graph_batch_size].replay()
@@ -156,22 +145,12 @@ class DecodeGraphManager(Generic[SlotT]):
                 zero_for_capture(slot)
                 try:
                     torch.cuda.synchronize(device=self.device)
-                    # Decide (and WARM) the eager megakernel buckets BEFORE any capture. This runs
-                    # OUTSIDE ``torch.cuda.graph`` (it builds a session + does one eager launch, both
-                    # illegal under capture) and at the SAME warmup point capture used to touch these
-                    # buckets. Any bucket whose warmup fails is excluded -> it is captured native.
-                    eager = self._plan_eager(slot, list(self._batch_sizes)) if self._plan_eager else set()
-                    eager = frozenset(int(b) for b in eager)
-                    self._eager_buckets[id(slot)] = eager
-                    if self.device.type == "cuda":
-                        torch.cuda.synchronize(device=self.device)
                     reserved_before = (
                         torch.cuda.memory_reserved(self.device) if self.device.type == "cuda" else 0
                     )
                     for batch_size in reversed(self._batch_sizes):
-                        if batch_size in eager:
-                            # Served eagerly by the megakernel: capture no native graph, allocate no
-                            # graph pool for this bucket.
+                        if batch_size in self._eager_batch_sizes:
+                            # The runtime serves this bucket eagerly, so it needs no graph pool.
                             continue
                         graph = torch.cuda.CUDAGraph()
                         with torch.inference_mode():
@@ -188,15 +167,14 @@ class DecodeGraphManager(Generic[SlotT]):
                 finally:
                     zero_for_capture(slot)
 
-        if eager:
+        if self._eager_batch_sizes:
             reserved_after = (
                 torch.cuda.memory_reserved(self.device) if self.device.type == "cuda" else 0
             )
             logger.info(
-                "decode-graph capture: %d bucket(s) served eagerly by the megakernel %s "
-                "(no native graph captured); captured %d native bucket(s) using %.1f MiB of graph "
-                "pool. Skipping capture for the eager buckets avoids their graph pools entirely.",
-                len(eager), sorted(eager), len(cuda_graphs),
+                "decode-graph capture: %d eager bucket(s) %s omitted; captured %d bucket(s) "
+                "using %.1f MiB of graph pool",
+                len(self._eager_batch_sizes), sorted(self._eager_batch_sizes), len(cuda_graphs),
                 max(0, reserved_after - reserved_before) / (1024 * 1024),
             )
 

--- a/tests/moondream/test_runtime_megakernel_fallback.py
+++ b/tests/moondream/test_runtime_megakernel_fallback.py
@@ -20,8 +20,8 @@ def _forward_runtime(monkeypatch: pytest.MonkeyPatch):
     )
     runtime._decode_graphs = SimpleNamespace(
         enabled=True,
-        eager_buckets=lambda candidate: frozenset({1}) if candidate is slot else frozenset(),
     )
+    runtime._megakernel_buckets = frozenset({1})
     monkeypatch.setattr(runtime_mod, "lm_head", lambda hidden, text: torch.ones(1, 3))
     return runtime, slot
 
@@ -42,7 +42,6 @@ def test_graphs_on_capacity_ineligibility_falls_back_for_only_this_step(
 
     assert len(native_calls) == 1
     assert torch.equal(slot.hidden_last, torch.full((1, 2), 2.0))
-    assert runtime._decode_graphs.eager_buckets(slot) == frozenset({1})
 
 
 def test_graphs_on_genuine_megakernel_failure_remains_fatal(
@@ -116,7 +115,7 @@ def test_capture_zero_clears_all_host_and_device_metadata() -> None:
         assert not mirrored_value.gpu.any()
 
 
-def test_graphs_on_routing_uses_the_slot_capture_plan(
+def test_static_megakernel_bucket_applies_to_every_slot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runtime, eager_slot = _forward_runtime(monkeypatch)
@@ -139,19 +138,15 @@ def test_graphs_on_routing_uses_the_slot_capture_plan(
     runtime._run_decode_forward(eager_slot, 1)
     runtime._run_decode_forward(native_slot, 1)
 
-    assert len(megakernel_calls) == 1
-    assert len(native_calls) == 1
+    assert len(megakernel_calls) == 2
+    assert len(native_calls) == 0
 
 
 def test_eager_capacity_ineligibility_does_not_disable_bucket(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runtime, slot = _forward_runtime(monkeypatch)
-    runtime._megakernel_target = ("moondream3", 90, 132)
-    runtime._megakernel_failed_buckets = set()
-    runtime._decode_graphs = SimpleNamespace(
-        enabled=False, eager_buckets=lambda slot: frozenset()
-    )
+    runtime._decode_graphs = SimpleNamespace(enabled=False)
     runtime._lora_workspace = None
     native_calls = []
     runtime._megakernel_decode_hidden = lambda *args: (_ for _ in ()).throw(
@@ -160,39 +155,6 @@ def test_eager_capacity_ineligibility_does_not_disable_bucket(
     runtime._native_decode_hidden = lambda *args: (
         native_calls.append(args) or torch.full((1, 1, 2), 2.0)
     )
-    monkeypatch.setattr(runtime_mod.megakernel_decode, "has_megakernel", lambda *args: True)
-
     runtime._run_decode_forward(slot, 1)
 
     assert len(native_calls) == 1
-    assert runtime._megakernel_failed_buckets == set()
-    assert runtime._megakernel_eager_unwarmed(1)
-
-
-def test_failed_eager_warmup_disables_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
-    runtime = MoondreamRuntime.__new__(MoondreamRuntime)
-    runtime._megakernel_target = ("moondream3", 90, 132)
-    runtime._megakernel_failed_buckets = set()
-    runtime._decode_graphs = SimpleNamespace(
-        enabled=False, eager_buckets=lambda slot: frozenset()
-    )
-    runtime._lora_workspace = None
-    runtime.max_batch_size = 1
-    runtime._decode_slots = [SimpleNamespace(
-        decode_token_ids=torch.zeros(1, dtype=torch.int64),
-        decode_coord_values=torch.zeros(1, 1),
-        decode_size_values=torch.zeros(1, 2),
-    )]
-    runtime._zero_decode_graph_capture_buffers = lambda slot: None
-    runtime._prepare_decode_graph_step = lambda slot, batch_size: None
-    runtime._embed_packed_token_batch = lambda *args: torch.zeros(1, 1, 1)
-    runtime._megakernel_decode_hidden = lambda *args: (_ for _ in ()).throw(
-        RuntimeError("build failed")
-    )
-    monkeypatch.setattr(runtime_mod, "make_decode_graph_batch_sizes", lambda max_batch: [1])
-    monkeypatch.setattr(runtime_mod.megakernel_decode, "has_megakernel", lambda *args: True)
-
-    runtime._warm_megakernel_eager()
-
-    assert runtime._megakernel_failed_buckets == {1}
-    assert not runtime._megakernel_eager_unwarmed(1)

--- a/tests/test_decode_graph_manager.py
+++ b/tests/test_decode_graph_manager.py
@@ -33,15 +33,9 @@ class FakeDecodeGraphManager(DecodeGraphManager[FakeSlot]):
         self.events = events
 
     def _capture_slot_graphs(self, slot: FakeSlot) -> dict[int, FakeGraph]:
-        # Mirror the real method's capture-skip: buckets the plan serves eagerly get no captured
-        # graph (the real path also runs the CUDA graph mechanics + memory log, which need a GPU).
-        eager = (
-            frozenset(int(b) for b in self._plan_eager(slot, list(self.batch_sizes)))
-            if self._plan_eager is not None
-            else frozenset()
+        captured = tuple(
+            b for b in self.batch_sizes if b not in self._eager_batch_sizes
         )
-        self._eager_buckets[id(slot)] = eager
-        captured = tuple(b for b in self.batch_sizes if b not in eager)
         self.events.append(("capture", slot.slot_id, captured))
         return {
             batch_size: FakeGraph(self.events, slot.slot_id, batch_size)
@@ -55,7 +49,7 @@ def _make_manager(
     enabled: bool,
     max_batch: int,
     capture: bool = False,
-    plan_eager=None,
+    eager_batch_sizes=(),
 ) -> DecodeGraphManager[FakeSlot]:
     cls = FakeDecodeGraphManager if capture else DecodeGraphManager
     kwargs = {"events": events} if capture else {}
@@ -75,7 +69,7 @@ def _make_manager(
         zero_padding=lambda slot, batch_size, graph_batch_size: events.append(
             ("pad", slot.slot_id, batch_size, graph_batch_size)
         ),
-        plan_eager=plan_eager,
+        eager_batch_sizes=eager_batch_sizes,
         **kwargs,
     )
 
@@ -147,25 +141,14 @@ def test_clear_forces_recapture() -> None:
     ]
 
 
-def test_plan_eager_skips_capture_and_routes_bucket_to_forward() -> None:
-    # An eager-served bucket (the megakernel B1) is NOT captured, and run() routes it to the eager
-    # forward instead of a graph replay; a non-eager bucket still replays its captured graph.
+def test_eager_batch_skips_capture_and_routes_to_forward() -> None:
     events: list[tuple] = []
-    planned: list[tuple] = []
-
-    def plan_eager(slot, batch_sizes):
-        planned.append((slot.slot_id, tuple(batch_sizes)))
-        return {1}
-
     manager = _make_manager(
-        events, enabled=True, max_batch=8, capture=True, plan_eager=plan_eager
+        events, enabled=True, max_batch=8, capture=True, eager_batch_sizes={1}
     )
     slot = FakeSlot(slot_id=0)
     manager.ensure_ready([slot])
 
-    # Bucket 1 was warmed + skipped: no captured graph, tracked as eager.
-    assert planned == [(0, (1, 2, 4, 8))]
-    assert manager.eager_buckets(slot) == frozenset({1})
     assert ("capture", 0, (2, 4, 8)) in events
 
     # B1 decode step routes eager (forward), NOT a replay.
@@ -179,33 +162,32 @@ def test_plan_eager_skips_capture_and_routes_bucket_to_forward() -> None:
     assert events == [("prepare", 0, 4), ("replay", 0, 4)]
 
 
-def test_plan_eager_exclusion_falls_back_to_native_capture() -> None:
-    # A bucket the plan does NOT serve (e.g. warmup build failed, or ineligible B8) keeps the
-    # captured native path exactly as before.
+def test_empty_eager_set_captures_every_bucket() -> None:
     events: list[tuple] = []
-    manager = _make_manager(
-        events, enabled=True, max_batch=8, capture=True, plan_eager=lambda s, bs: set()
-    )
+    manager = _make_manager(events, enabled=True, max_batch=8, capture=True)
     slot = FakeSlot(slot_id=0)
     manager.ensure_ready([slot])
 
-    assert manager.eager_buckets(slot) == frozenset()
     assert ("capture", 0, (1, 2, 4, 8)) in events
     events.clear()
     manager.run(slot, 8)
     assert events == [("prepare", 0, 8), ("replay", 0, 8)]
 
 
-def test_clear_drops_eager_buckets() -> None:
+def test_clear_keeps_static_eager_configuration() -> None:
     events: list[tuple] = []
     manager = _make_manager(
-        events, enabled=True, max_batch=2, capture=True, plan_eager=lambda s, bs: {1}
+        events, enabled=True, max_batch=2, capture=True, eager_batch_sizes={1}
     )
     slot = FakeSlot(slot_id=0)
     manager.ensure_ready([slot])
-    assert manager.eager_buckets(slot) == frozenset({1})
     manager.clear()
-    assert manager.eager_buckets(slot) == frozenset()
+    manager.ensure_ready([slot])
+
+    assert events == [
+        ("capture", 0, (2,)),
+        ("capture", 0, (2,)),
+    ]
 
 
 def test_run_raises_when_batch_exceeds_graph_capacity() -> None:


### PR DESCRIPTION
## Summary

- resolve the immutable megakernel bucket set once when constructing the runtime
- lazily load the AOT megakernel session on the first real decode step
- keep megakernel buckets eager and avoid graph capture around a single AOT launch
- remove warmup launches, per-slot eager plans, failed-warmup state, and duplicate routing branches
- preserve per-step native fallback only for declaratively ineligible workloads; surface genuine runtime failures

## E2E evidence

H100 SXM, exact production `kestrel-kernels==0.4.8` AOT workflow wheel, ChartQA CoT=1, 200 charts / 400 requests per arm, prefix cache enabled, forward and reverse same-process A/B:

| Model / bucket | Native output tok/s | Megakernel output tok/s | Speedup | Accuracy |
| --- | ---: | ---: | ---: | --- |
| MD3 B1, FP8 KV | 335.02 | 414.51 | 1.237x | 76.50% vs 77.38%; repeat drift in both arms |
| MD2 B1, BF16 KV | 389.92 | 456.44 | 1.171x | 65.63% vs 65.50%; repeat drift in both arms |
| MD2 B2, BF16 KV | 626.56 | 714.42 | 1.140x | 65.00% vs 65.25%; native repeat drifted |

Every megakernel arm reported zero native fallbacks. MD3 routed every launch through B1/A1/U1; MD2 B2 routed every launch through B2/A2/U2.

## Verification

- `python -m pytest tests -q`: 539 passed, 4 skipped
- focused lifecycle tests: 16 passed
- private p2 environment gate: KNOWN-GOOD, including MD3 canonical fingerprint argmax 103 / cosine 0.999219

No package was published as part of this work.