### PR TITLE
Fail unreservable requests without stopping scheduler

### DIFF
--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -506,10 +506,13 @@ class GenerationScheduler:
         if not progressed:
             stalled = next((request for request in self.waiting if self._is_launchable_request(request)), None)
             if stalled is not None and not self.runtime.can_reserve(stalled.target_length):
-                raise RuntimeError(
-                    "Scheduler stalled: insufficient KV cache capacity for request "
+                error = RuntimeError(
+                    "Insufficient KV cache capacity for request "
                     f"{stalled.request_id} (needs {stalled.target_length} tokens)."
                 )
+                self.waiting.remove(stalled)
+                self._fail_request_early(stalled, error)
+                progressed = True
         return progressed
 
     def _drain_pipeline(self) -> None:
@@ -1523,8 +1526,11 @@ class GenerationScheduler:
 
     def _fail_request_early(self, request: GenerationRequest, exc: Exception) -> None:
         """Fail a request that couldn't be admitted (e.g., adapter load failure)."""
-        _LOGGER.exception(
-            "Failed to admit request %s: %s", request.request_id, exc
+        _LOGGER.error(
+            "Failed to admit request %s: %s",
+            request.request_id,
+            exc,
+            exc_info=exc,
         )
         lifecycle = request.lifecycle
         lifecycle.finish_reason = "error"
@@ -1538,7 +1544,7 @@ class GenerationScheduler:
             tokens=[],
             finish_reason="error",
             metrics=metrics,
-            output={"error": "Request failed during admission"},
+            output={"error": str(exc)},
         )
         self._completed.append(result)
 

--- a/tests/scheduler/test_launch_prefill_step.py
+++ b/tests/scheduler/test_launch_prefill_step.py
@@ -148,3 +148,32 @@ def test_launch_prefill_step_dequeues_requests_that_fail_to_bind(
     assert scheduler._completed[0].request_id == request.request_id
     assert request.lifecycle.phase == RequestPhase.COMPLETED
     assert len(runtime.released_prefill_slots) == 1
+
+
+def test_advance_rejects_only_request_that_cannot_fit_kv_cache() -> None:
+    oversized = _make_request(request_id=42, max_new_tokens=8)
+    admissible = _make_request(request_id=43, max_new_tokens=2)
+    scheduler = _make_scheduler(oversized, FakeRuntime(max_seq_length=4))
+    scheduler._compute_stream = None
+    scheduler.waiting.push(admissible)
+    scheduler._pipeline = PipelineState()
+    scheduler._pending_spec = None
+    scheduler._launch_prefill_step = lambda pipeline: False
+    scheduler.schedule_decode_step = lambda: None
+
+    progressed = GenerationScheduler.advance(scheduler)
+
+    assert progressed is True
+    assert list(scheduler.waiting) == [admissible]
+    assert oversized.lifecycle.phase == RequestPhase.COMPLETED
+    assert admissible.lifecycle.phase == RequestPhase.READY_FOR_PREFILL
+    completed = scheduler.pop_completed()
+    assert len(completed) == 1
+    assert completed[0].request_id == oversized.request_id
+    assert completed[0].finish_reason == "error"
+    assert completed[0].output == {
+        "error": (
+            "Insufficient KV cache capacity for request 42 "
+            "(needs 9 tokens)."
+        )
+    }


### PR DESCRIPTION
## What changed

- Reject a waiting request when the scheduler determines that no available KV-cache capacity can admit it.
- Complete that request through the existing per-request error path instead of raising out of the scheduler loop.
- Preserve the concrete admission error message for callers.
- Add regression coverage proving that an admissible request remains queued and unaffected.

## Why

The scheduler's terminal no-progress guard raised a process-level `RuntimeError` for a request that could never fit in the KV cache. The engine treated that as a fatal scheduler failure and shut down all work. This change confines the failure to the offending request, allowing the engine to continue serving other requests.

## Validation

- `pytest tests/scheduler tests/test_autoregressive_executor.py -q` on p1: 161 passed
- `git diff --check`