### PR TITLE
Support query-specific stop tokens

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1742,6 +1742,14 @@ class InferenceEngine:
             request_obj,
             request_context=request_obj.request_context,
         )
+        stop_token_ids = set(skill_state.stop_token_ids(runtime) or ())
+        if any(
+            isinstance(token, TextToken) and token.token_id in stop_token_ids
+            for token in request_obj.generated_prefix.tokens
+        ):
+            raise ValueError(
+                "settings._generated_prefix.tokens must not contain stop tokens"
+            )
         for token in request_obj.generated_prefix.tokens:
             skill_state.consume_step(
                 runtime,

--- a/kestrel/models/moondream/config.py
+++ b/kestrel/models/moondream/config.py
@@ -100,6 +100,7 @@ class TokenizerConfig:
                 if prefix_when_reasoning is not None
                 else None
             ),
+            stop_token_ids=list(template.get("stop_token_ids", [])),
         )
 
     def chat(self) -> Optional[ChatTemplate]:

--- a/kestrel/models/moondream/skills/query.py
+++ b/kestrel/models/moondream/skills/query.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 import numpy as np
 
 from ..runtime import CoordToken, TextToken, Token
+from kestrel.models.protocols import QueryTemplate
 from kestrel.utils.spatial_refs import build_spatial_tokens, normalize_spatial_refs
 
 from kestrel.skills.base import (
@@ -103,9 +104,8 @@ class QuerySkill(SkillSpec):
             if request_context.reasoning
             else template.answer_prefix
         )
-        # ``prefix_when_reasoning`` lets a model swap in a different pre-question
-        # structure for CoT (Gemma 4: extra ``<|turn>system\n<|think|>`` block
-        # to activate thinking). When None, the same ``prefix`` covers both.
+        # ``prefix_when_reasoning`` lets a prompt template swap in a different
+        # pre-question structure for CoT. When None, both modes use ``prefix``.
         pre_question: Sequence[int] = (
             template.prefix_when_reasoning
             if request_context.reasoning and template.prefix_when_reasoning is not None
@@ -165,6 +165,7 @@ class QuerySkillState(SkillState):
     ) -> None:
         super().__init__(spec, request)
         self._request = query_request
+        self._query_template: Optional[QueryTemplate] = None
         self._reasoning_enabled = bool(query_request.reasoning)
         self._collecting_reasoning = self._reasoning_enabled
         self._reasoning_tokens: List[int] = []
@@ -182,6 +183,12 @@ class QuerySkillState(SkillState):
         # post_reasoning_prefix one token at a time via allowed_token_ids.
         self._post_reasoning_tokens: Optional[List[int]] = None
         self._post_reasoning_idx: int = 0
+
+    def stop_token_ids(
+        self, runtime: "MoondreamRuntime"
+    ) -> Optional[Sequence[int]]:
+        stop_token_ids = self._get_query_template(runtime).stop_token_ids
+        return stop_token_ids or None
 
     def allowed_token_ids(
         self, runtime: "MoondreamRuntime"
@@ -220,6 +227,13 @@ class QuerySkillState(SkillState):
             self._ensure_token_ids(runtime)
         self.append_token(step.token)
 
+        template = self._get_query_template(runtime)
+        if isinstance(step.token, TextToken) and (
+            step.token.token_id == runtime.prompt_template.eos_id
+            or step.token.token_id in template.stop_token_ids
+        ):
+            return None
+
         # Track post-reasoning injection progress
         if (
             self._post_reasoning_tokens is not None
@@ -246,9 +260,8 @@ class QuerySkillState(SkillState):
                     # Replay the model's post-reasoning opener before the answer.
                     # Empty for models without the trained-in answer_id artifact
                     # (e.g. MD3); MD2 declares [answer_id] here.
-                    template = runtime.prompt_template.query()
-                    self._post_reasoning_tokens = (
-                        list(template.post_reasoning_prefix) if template else []
+                    self._post_reasoning_tokens = list(
+                        template.post_reasoning_prefix
                     )
                     self._post_reasoning_idx = 0
                     return None
@@ -362,3 +375,13 @@ class QuerySkillState(SkillState):
         self._answer_id = pt.answer_id
         self._start_ground_id = pt.start_ground_points_id
         self._end_ground_id = pt.end_ground_id
+
+    def _get_query_template(
+        self, runtime: "MoondreamRuntime"
+    ) -> QueryTemplate:
+        if self._query_template is None:
+            template = runtime.prompt_template.query()
+            if template is None:
+                raise ValueError("Model does not include a query template")
+            self._query_template = template
+        return self._query_template

--- a/kestrel/models/protocols.py
+++ b/kestrel/models/protocols.py
@@ -24,12 +24,11 @@ class QueryTemplate:
     answer_prefix: List[int]
     reasoning_prefix: List[int]
     post_reasoning_prefix: List[int]
-    # Optional override for ``prefix`` when ``reasoning=True``. Set this
-    # for models whose CoT mode needs a different *pre-question* structure
-    # (e.g. Gemma 4 emits an extra ``<|turn>system\n<|think|>`` block to
-    # activate thinking). ``None`` (default) keeps ``prefix`` for both
-    # modes — Moondream's pre-question layout is reasoning-independent.
+    # Optional override for ``prefix`` when ``reasoning=True``. ``None``
+    # keeps ``prefix`` for both modes, as Moondream's pre-question layout is
+    # reasoning-independent.
     prefix_when_reasoning: Optional[List[int]] = None
+    stop_token_ids: List[int] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -359,6 +359,7 @@ class _MdPromptTemplate:
     size_id: int = 6
     start_ground_points_id: int = 7
     end_ground_id: int = 9
+    query_stop_token_ids: tuple[int, ...] = ()
 
     def chat(self) -> None:
         return None
@@ -367,12 +368,17 @@ class _MdPromptTemplate:
         return QueryTemplate(
             prefix=[10, 11], answer_prefix=[20], reasoning_prefix=[21],
             post_reasoning_prefix=[3],
+            stop_token_ids=list(self.query_stop_token_ids),
         )
 
 
-def _md_runtime(model_name: str = "moondream2") -> SimpleNamespace:
+def _md_runtime(
+    model_name: str = "moondream2",
+    *,
+    stop_token_ids: tuple[int, ...] = (),
+) -> SimpleNamespace:
     return SimpleNamespace(
-        prompt_template=_MdPromptTemplate(),
+        prompt_template=_MdPromptTemplate(query_stop_token_ids=stop_token_ids),
         tokenizer=_Tokenizer(),
         model_name=model_name,
     )
@@ -469,6 +475,20 @@ def test_moondream_chat_finalizes_as_message() -> None:
         "message": {"role": "assistant", "content": "Paris"},
         "finish_reason": "stop",
     }
+
+
+def test_moondream_chat_uses_query_stop_ids() -> None:
+    from kestrel.models.moondream.skills.chat import MoondreamChatSkill
+
+    runtime = _md_runtime(stop_token_ids=(88,))
+    state = MoondreamChatSkill().create_state(
+        runtime, SimpleNamespace(), _md_ctx([{"role": "user", "content": "hi"}])
+    )
+
+    assert tuple(state.stop_token_ids(runtime)) == (88,)
+    _drive(state, runtime, _ords("A") + [88])
+    result = state.finalize(runtime, reason="stop")
+    assert result.output["message"]["content"] == "A"
 
 
 def test_moondream_chat_inherits_query_suppression() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -42,9 +42,15 @@ def _make_request(
 
 
 class _PrefixSkillState(SkillState):
-    def __init__(self, spec: SkillSpec, request: object) -> None:
+    def __init__(
+        self,
+        spec: SkillSpec,
+        request: object,
+        stop_token_ids: tuple[int, ...],
+    ) -> None:
         super().__init__(spec, request)
         self.positions: list[int] = []
+        self._stop_token_ids = stop_token_ids
 
     def consume_step(self, runtime: object, step: DecodeStep) -> None:
         self.positions.append(step.position)
@@ -53,10 +59,14 @@ class _PrefixSkillState(SkillState):
     def finalize(self, runtime: object, *, reason: str) -> SkillFinalizeResult:
         return SkillFinalizeResult(text="", tokens=list(self.tokens), output={})
 
+    def stop_token_ids(self, runtime: object) -> tuple[int, ...] | None:
+        return self._stop_token_ids or None
+
 
 class _PrefixSkill(SkillSpec):
-    def __init__(self) -> None:
+    def __init__(self, stop_token_ids: tuple[int, ...] = ()) -> None:
         super().__init__(name="prefix")
+        self._stop_token_ids = stop_token_ids
 
     def build_prompt_tokens(
         self, runtime: object, request_context: object
@@ -69,7 +79,7 @@ class _PrefixSkill(SkillSpec):
         request: object,
         request_context: object,
     ) -> _PrefixSkillState:
-        return _PrefixSkillState(self, request)
+        return _PrefixSkillState(self, request, self._stop_token_ids)
 
 
 class _FakeImagePreprocessor:
@@ -379,6 +389,19 @@ def test_build_generation_request_consumes_generated_prefix() -> None:
     assert generation_req.remaining_new_tokens == 2
     assert list(skill_state.tokens) == [TextToken(10), TextToken(11)]
     assert skill_state.positions == [0, 1]
+
+
+def test_build_generation_request_rejects_skill_stop_in_generated_prefix() -> None:
+    engine = object.__new__(InferenceEngine)
+    req = _make_request()
+    req.prompt_tokens = [TextToken(1)]
+    req.max_new_tokens = 4
+    req.skill = _PrefixSkill(stop_token_ids=(11,))
+    req.generated_prefix = GeneratedPrefix(tokens=(TextToken(10), TextToken(11)))
+    runtime = SimpleNamespace(max_seq_length=32, image_prefix_length=0)
+
+    with pytest.raises(ValueError, match="must not contain stop tokens"):
+        engine._build_generation_request(runtime, req, None)
 
 
 def test_extract_private_suppress_next_token_ids_setting() -> None:

--- a/tests/test_query_skill.py
+++ b/tests/test_query_skill.py
@@ -7,8 +7,13 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import List, Optional
 
+import pytest
+
+from kestrel.models.moondream.config import TokenizerConfig
 from kestrel.models.protocols import QueryTemplate
 from kestrel.models.moondream.skills.query import QueryRequest, QuerySkill
+from kestrel.runtime.tokens import TextToken
+from kestrel.skills.base import DecodeStep
 
 
 @dataclass
@@ -35,7 +40,12 @@ class _Tokenizer:
 
 
 class _Runtime:
-    def __init__(self, *, prefix_when_reasoning: Optional[List[int]] = None) -> None:
+    def __init__(
+        self,
+        *,
+        prefix_when_reasoning: Optional[List[int]] = None,
+        stop_token_ids: Optional[List[int]] = None,
+    ) -> None:
         self.prompt_template = _PromptTemplate(
             _query_template=QueryTemplate(
                 prefix=[10, 11],
@@ -43,13 +53,30 @@ class _Runtime:
                 reasoning_prefix=[21],
                 post_reasoning_prefix=[],
                 prefix_when_reasoning=prefix_when_reasoning,
+                stop_token_ids=stop_token_ids or [],
             )
         )
         self.tokenizer = _Tokenizer()
 
 
+class _VisibleTokenizer(_Tokenizer):
+    def decode(self, token_ids) -> str:
+        return "".join(f"<{token_id}>" for token_id in token_ids)
+
+
 def _ids(tokens) -> List[int]:
     return [t.token_id for t in tokens]
+
+
+def test_query_template_stop_ids_default_empty() -> None:
+    template = QueryTemplate(
+        prefix=[],
+        answer_prefix=[],
+        reasoning_prefix=[],
+        post_reasoning_prefix=[],
+    )
+
+    assert template.stop_token_ids == []
 
 
 def test_query_skill_uses_prefix_when_reasoning_override() -> None:
@@ -83,3 +110,68 @@ def test_query_skill_non_reasoning_ignores_override() -> None:
     tokens = skill.build_prompt_tokens(runtime, req)
     # bos + prefix + encoded question + answer_prefix  (override is reasoning-only)
     assert _ids(tokens) == [2, 10, 11, 42, 20]
+
+
+def test_tokenizer_config_preserves_query_stop_ids() -> None:
+    config = TokenizerConfig(
+        templates={
+            "query": {
+                "prefix": [10],
+                "answer_prefix": [20],
+                "reasoning_prefix": [21],
+                "post_reasoning_prefix": [],
+                "stop_token_ids": [88],
+            }
+        }
+    )
+
+    template = config.query()
+
+    assert template is not None
+    assert template.stop_token_ids == [88]
+
+
+@pytest.mark.parametrize("stop_id", [88, 99])
+def test_query_stop_tokens_are_not_emitted(stop_id: int) -> None:
+    runtime = _Runtime(stop_token_ids=[88])
+    runtime.tokenizer = _VisibleTokenizer()
+    context = QueryRequest(
+        question="hi",
+        image=None,
+        reasoning=False,
+        stream=True,
+    )
+    skill = QuerySkill()
+    state = skill.create_state(runtime, SimpleNamespace(), context)
+
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=42), position=0))
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=stop_id), position=1))
+
+    assert state.pop_stream_delta(runtime) == "<42>"
+    result = state.finalize(runtime, reason="stop")
+    assert result.text == "<42>"
+    assert result.output["answer"] == "<42>"
+    assert _ids(result.tokens) == [42, stop_id]
+
+
+def test_reasoning_stop_token_is_not_emitted() -> None:
+    runtime = _Runtime(stop_token_ids=[88])
+    runtime.tokenizer = _VisibleTokenizer()
+    context = QueryRequest(
+        question="hi",
+        image=None,
+        reasoning=True,
+        stream=True,
+    )
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=42), position=0))
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=88), position=1))
+
+    assert state.pop_stream_delta(runtime) is None
+    result = state.finalize(runtime, reason="stop")
+    assert result.output == {
+        "answer": "",
+        "reasoning": {"text": "<42>", "grounding": []},
+    }
+    assert _ids(result.tokens) == [42, 88]


### PR DESCRIPTION
Adds model-declared query stop tokens alongside the existing model EOS.

Query and flattened-chat states retain terminators in raw token results for metrics and logprob alignment, while excluding them from visible and streamed output.

Generated prefixes containing EOS or query stop tokens are rejected before replay.