### PR TITLE
metrics: align prefill timing with first token readiness

### DIFF
--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -91,7 +91,6 @@ class RequestLifecycle:
     ) -> "RequestMetrics":
         queued_at = self.submitted_at
         prefill_started_at = self.prefill_started_at or queued_at
-        prefill_completed_at = self.prefill_completed_at or prefill_started_at
         completed_at = self.completed_at or time.perf_counter()
         first_token_time = self.first_token_time or completed_at
         if self.sequence_state is not None:
@@ -105,9 +104,12 @@ class RequestLifecycle:
         return RequestMetrics(
             prompt_tokens=prompt_tokens,
             decode_tokens=decode_tokens,
-            prefill_time_ms=max((prefill_completed_at - prefill_started_at) * 1000.0, 0.0),
+            prefill_time_ms=max(
+                (first_token_time - prefill_started_at) * 1000.0,
+                0.0,
+            ),
             ttft_ms=max((first_token_time - queued_at) * 1000.0, 0.0),
-            decode_time_ms=max((completed_at - prefill_completed_at) * 1000.0, 0.0),
+            decode_time_ms=max((completed_at - first_token_time) * 1000.0, 0.0),
             cached_tokens=cached_tokens,
         )
 
@@ -271,6 +273,13 @@ StreamCallback = Callable[[StreamUpdate], None]
 
 @dataclass
 class RequestMetrics:
+    """Per-request token counts and model-phase timings.
+
+    Prefill ends when the first model token is ready, while decode covers the
+    remaining interval through request completion. Queue time is included only
+    in TTFT.
+    """
+
     prompt_tokens: int
     decode_tokens: int
     prefill_time_ms: float

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -12,6 +12,9 @@ from kestrel.models.moondream.image_crops import OverlapCropOutput
 from kestrel.skills import SkillSpec, SkillState, DecodeStep
 
 
+MODEL_PREFILL_TIMING_BOUNDARY = "scheduled_to_first_model_token"
+
+
 @dataclass(frozen=True, slots=True)
 class GeneratedPrefix:
     """Generated tokens that should be treated as already decoded."""

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -98,6 +98,9 @@ class RequestLifecycle:
         first_token_time = self.first_token_time or completed_at
         if decode_tokens == 0:
             first_token_time = completed_at
+        prefill_ended_at = first_token_time
+        if self.prefill_started_at is None:
+            prefill_ended_at = prefill_started_at
         if self.sequence_state is not None:
             prompt_tokens = self.sequence_state.prompt_length
             cached = self.sequence_state.reused_page_count
@@ -110,7 +113,7 @@ class RequestLifecycle:
             prompt_tokens=prompt_tokens,
             decode_tokens=decode_tokens,
             prefill_time_ms=max(
-                (first_token_time - prefill_started_at) * 1000.0,
+                (prefill_ended_at - prefill_started_at) * 1000.0,
                 0.0,
             ),
             ttft_ms=max((first_token_time - queued_at) * 1000.0, 0.0),

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -96,6 +96,8 @@ class RequestLifecycle:
         prefill_started_at = self.prefill_started_at or queued_at
         completed_at = self.completed_at or time.perf_counter()
         first_token_time = self.first_token_time or completed_at
+        if decode_tokens == 0:
+            first_token_time = completed_at
         if self.sequence_state is not None:
             prompt_tokens = self.sequence_state.prompt_length
             cached = self.sequence_state.reused_page_count

--- a/tests/scheduler/test_request_metrics.py
+++ b/tests/scheduler/test_request_metrics.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 import pytest
 
 from kestrel.models.moondream.runtime import TextToken
-from kestrel.scheduler.types import GenerationRequest, RequestLifecycle
+from kestrel.scheduler.types import (
+    MODEL_PREFILL_TIMING_BOUNDARY,
+    GenerationRequest,
+    RequestLifecycle,
+)
 from kestrel.skills import DecodeStep, SkillFinalizeResult, SkillState
 
 
@@ -41,6 +45,8 @@ def _lifecycle() -> RequestLifecycle:
 
 
 def test_metrics_split_model_prefill_at_first_token_ready() -> None:
+    assert MODEL_PREFILL_TIMING_BOUNDARY == "scheduled_to_first_model_token"
+
     lifecycle = _lifecycle()
     lifecycle.submitted_at = 1.0
     lifecycle.prefill_started_at = 3.0

--- a/tests/scheduler/test_request_metrics.py
+++ b/tests/scheduler/test_request_metrics.py
@@ -66,6 +66,7 @@ def test_metrics_without_generated_tokens_assigns_work_to_prefill() -> None:
     lifecycle.submitted_at = 1.0
     lifecycle.prefill_started_at = 2.0
     lifecycle.prefill_completed_at = 3.0
+    lifecycle.first_token_time = 2.0
     lifecycle.completed_at = 5.0
 
     metrics = lifecycle.build_metrics(decode_tokens=0)

--- a/tests/scheduler/test_request_metrics.py
+++ b/tests/scheduler/test_request_metrics.py
@@ -74,3 +74,15 @@ def test_metrics_without_generated_tokens_assigns_work_to_prefill() -> None:
     assert metrics.prefill_time_ms == pytest.approx(3_000.0)
     assert metrics.decode_time_ms == 0.0
     assert metrics.ttft_ms == pytest.approx(4_000.0)
+
+
+def test_metrics_before_prefill_does_not_assign_queue_time_to_prefill() -> None:
+    lifecycle = _lifecycle()
+    lifecycle.submitted_at = 1.0
+    lifecycle.completed_at = 5.0
+
+    metrics = lifecycle.build_metrics(decode_tokens=0)
+
+    assert metrics.prefill_time_ms == 0.0
+    assert metrics.decode_time_ms == 0.0
+    assert metrics.ttft_ms == pytest.approx(4_000.0)

--- a/tests/scheduler/test_request_metrics.py
+++ b/tests/scheduler/test_request_metrics.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from kestrel.models.moondream.runtime import TextToken
+from kestrel.scheduler.types import GenerationRequest, RequestLifecycle
+from kestrel.skills import DecodeStep, SkillFinalizeResult, SkillState
+
+
+@dataclass(frozen=True)
+class _SkillSpec:
+    name: str = "metrics"
+
+
+class _SkillState(SkillState):
+    def __init__(self, request: GenerationRequest) -> None:
+        super().__init__(_SkillSpec(), request)  # type: ignore[arg-type]
+
+    def consume_step(self, runtime: object, step: DecodeStep) -> None:
+        self.append_token(step.token)
+
+    def finalize(self, runtime: object, *, reason: str) -> SkillFinalizeResult:
+        return SkillFinalizeResult(text="", tokens=list(self.tokens), output={})
+
+
+def _lifecycle() -> RequestLifecycle:
+    request = GenerationRequest(
+        request_id=7,
+        prompt="prompt",
+        prompt_tokens=[TextToken(1)],
+        max_new_tokens=4,
+        skill=_SkillSpec(),  # type: ignore[arg-type]
+        request_context=object(),
+    )
+    skill_state = _SkillState(request)
+    lifecycle = RequestLifecycle(request=request, skill_state=skill_state)
+    request.lifecycle = lifecycle
+    return lifecycle
+
+
+def test_metrics_split_model_prefill_at_first_token_ready() -> None:
+    lifecycle = _lifecycle()
+    lifecycle.submitted_at = 1.0
+    lifecycle.prefill_started_at = 3.0
+    lifecycle.prefill_completed_at = 4.0
+    lifecycle.first_token_time = 7.0
+    lifecycle.completed_at = 11.0
+
+    metrics = lifecycle.build_metrics(decode_tokens=4)
+
+    assert metrics.prefill_time_ms == pytest.approx(4_000.0)
+    assert metrics.decode_time_ms == pytest.approx(4_000.0)
+    assert metrics.ttft_ms == pytest.approx(6_000.0)
+
+
+def test_metrics_without_generated_tokens_assigns_work_to_prefill() -> None:
+    lifecycle = _lifecycle()
+    lifecycle.submitted_at = 1.0
+    lifecycle.prefill_started_at = 2.0
+    lifecycle.prefill_completed_at = 3.0
+    lifecycle.completed_at = 5.0
+
+    metrics = lifecycle.build_metrics(decode_tokens=0)
+
+    assert metrics.prefill_time_ms == pytest.approx(3_000.0)
+    assert metrics.decode_time_ms == 0.0
+    assert metrics.ttft_ms == pytest.approx(4_000.0)


### PR DESCRIPTION
## Summary
- define prefill timing as scheduler admission through first model-token readiness
- define decode timing as first token readiness through request completion
- preserve TTFT as submission through first token, including queue time

This matches the phase boundary exported by vLLM (`first_token_ts - scheduled_ts`) and makes engine-side prefill throughput comparable without relying on client TTFT.

## Verification
- `153 passed` in `tests/scheduler` on p2
- `22 passed` across the focused metrics/executor/model-stream set
- `python -m py_compile` and `git diff --check`