### PR TITLE
moondream vision: pad the patch embedding to the tensor-core alignment (588 -> 592) -- +86.6us on the served tower

### DIFF
--- a/kestrel/models/moondream/vision.py
+++ b/kestrel/models/moondream/vision.py
@@ -56,13 +56,63 @@ def prepare_crops_from_overlap(
     return crops, overlap["tiling"]
 
 
+# Hopper `wgmma` operand descriptors require 16-byte alignment on the K-contiguous
+# operand; in bf16 that is 8 elements.  The natural SigLIP patch dimension is
+# 14*14*3 = 588, which is only 4-element aligned, so NO sm90 tile in cuBLAS's kernel
+# set is eligible and the heuristic falls back to an Ampere `s16816` kernel running on
+# a Hopper part.  Measured on H100 at nc=13 (M=9477, N=1152): 130.56 us for the
+# Ampere kernel against 36.96 us for the sm90 one it binds at K=592 -- 3.53x, or
+# +93.60 us per forward, on the single largest lever found on this path.
+#
+# Padding K to the next multiple of 8 is EXACT, not an approximation: the added
+# columns are zero on both operands, and a zero contributes exactly zero to every dot
+# product.  592 rather than 608 because a measured sweep put their walls inside each
+# other's spread while 592 costs +0.68% extra FLOPs against 608's +3.40%.
+PATCH_DIM_ALIGN = 8
+
+
+def aligned_patch_dim(raw_patch_dim: int) -> int:
+    """Round a patch dimension up to the tensor-core alignment (588 -> 592).
+
+    One owner for the rule: :func:`create_patches` and :func:`build_vision_model`
+    both derive their width from this, so the activation and the weight cannot
+    disagree about how wide the operand is.
+    """
+    return -(-raw_patch_dim // PATCH_DIM_ALIGN) * PATCH_DIM_ALIGN
+
+
 def create_patches(x: torch.Tensor, patch_size: int) -> torch.Tensor:
+    """Fold an image batch into patch rows, zero-padded to the aligned width.
+
+    The padding is intrinsic rather than opt-in: this function exists to produce the
+    operand `patch_emb` consumes, and an unpadded caller would silently build the
+    misaligned GEMM this alignment exists to avoid.  Callers that want the raw width
+    should slice ``[..., :channels * patch_size**2]``.
+    """
     bsz, channels, height, width = x.shape
     p1 = p2 = patch_size
-    x = x.reshape(bsz, channels, height // p1, p1, width // p2, p2)
+    gh, gw = height // p1, width // p2
+    n = gh * gw
+    raw = channels * p1 * p2
+    dim = aligned_patch_dim(raw)
+
+    x = x.reshape(bsz, channels, gh, p1, gw, p2)
     x = x.permute(0, 2, 4, 1, 3, 5)
-    x = x.reshape(bsz, (height // p1) * (width // p2), channels * p1 * p2)
-    return x
+    if dim == raw:
+        return x.reshape(bsz, n, raw)
+
+    # The permute makes `x` non-contiguous, so materializing it costs one copy no
+    # matter what.  Writing THROUGH a strided view of the padded buffer spends
+    # exactly that one copy -- a `reshape(...)` followed by a slice-assign would pay
+    # it twice, and this op moves ~11 MiB per forward at nc=13.  Only the 4 pad
+    # columns are zeroed, not the whole buffer.
+    out = x.new_empty(bsz, n, dim)
+    out.as_strided(
+        size=(bsz, gh, gw, channels, p1, p2),
+        stride=(n * dim, gw * dim, dim, p1 * p2, p2, 1),
+    ).copy_(x)
+    out[:, :, raw:].zero_()
+    return out
 
 
 def vision_encoder(
@@ -196,7 +246,13 @@ def build_vision_model(
     *,
     device: torch.device | str | None = None,
 ) -> nn.Module:
-    patch_dim = config.enc_patch_size * config.enc_patch_size * config.in_channels
+    # Padded to the tensor-core alignment; `create_patches` pads the activation to
+    # the same width from the same rule.  Checkpoints stay canonical at the RAW width
+    # and are padded on load (see `weights._copy_patch_emb_weight`), so no re-export
+    # is needed and a 588-column checkpoint keeps working unchanged.
+    patch_dim = aligned_patch_dim(
+        config.enc_patch_size * config.enc_patch_size * config.in_channels
+    )
     grid_size = config.crop_size // config.enc_patch_size
     num_patches = grid_size * grid_size
 
@@ -236,6 +292,19 @@ def build_vision_model(
         }
     )
     model.pos_emb = nn.Parameter(torch.zeros(1, num_patches, config.enc_dim, dtype=dtype, device=device))
+
+    # Zero the alignment pad on BOTH operands, not just the activation.
+    # `nn.Linear(592, ...)` random-inits all 592 columns, so a freshly-built model
+    # carries garbage where the pad is. It is numerically harmless *today* only
+    # because `create_patches` zeroes the matching activation columns -- a one-sided
+    # invariant that holds until someone feeds this Linear a differently-built
+    # operand. Zeroing here makes the pad inert from either side, and matches what a
+    # checkpoint load produces (`weights._copy_patch_emb_weight` zeroes it too), so a
+    # built-then-loaded model and a built-only model agree.
+    raw_patch_dim = config.enc_patch_size * config.enc_patch_size * config.in_channels
+    if patch_dim != raw_patch_dim:
+        with torch.no_grad():
+            model["patch_emb"].weight[:, raw_patch_dim:].zero_()
     return model
 
 
@@ -296,6 +365,7 @@ __all__ = [
     "prepare_crops",
     "prepare_crops_from_overlap",
     "create_patches",
+    "aligned_patch_dim",
     "vision_encoder",
     "vision_projection",
     "build_vision_model",

--- a/kestrel/models/moondream/weights.py
+++ b/kestrel/models/moondream/weights.py
@@ -250,13 +250,42 @@ def _assign_md3_text_weights(
         param.data = param.data.contiguous()
 
 
+def _copy_patch_emb_weight(param: torch.Tensor, src: torch.Tensor) -> None:
+    """Copy a checkpoint `patch_emb.weight` into the alignment-padded parameter.
+
+    The parameter is `[enc_dim, aligned_patch_dim]` (592 columns for SigLIP) while
+    every existing checkpoint carries the RAW width (588).  Checkpoints are NOT
+    re-exported for this: they load unchanged and the pad columns are zeroed here,
+    which is exact -- a zero column contributes exactly zero to every dot product.
+
+    A width that is neither the parameter's nor a prefix of it RAISES.  This is the
+    one place a real checkpoint could silently mis-load, and a wrong-shaped
+    `patch_emb` would produce a plausible-looking encoder that is quietly wrong, so
+    the mismatch is refused rather than broadcast, truncated or padded on faith.
+    """
+    if src.shape == param.shape:
+        param.data.copy_(src)
+        return
+    if src.ndim != 2 or src.shape[0] != param.shape[0] or src.shape[1] > param.shape[1]:
+        raise ValueError(
+            f"patch_emb.weight checkpoint shape {tuple(src.shape)} is not compatible "
+            f"with the model parameter {tuple(param.shape)}. The parameter is padded "
+            "to the tensor-core alignment, so a checkpoint may be narrower in the "
+            "input dimension (it is zero-extended) but nothing else may differ.")
+    k = src.shape[1]
+    param.data[:, :k].copy_(src)
+    param.data[:, k:].zero_()
+
+
 def _assign_md2_vision_weights(
     get_tensor: Callable[[str], torch.Tensor], model: nn.Module
 ) -> None:
     """Assign vision weights from Moondream 2 checkpoint format (model.vision.*)."""
     vision = model.vision
 
-    vision["patch_emb"].weight.data.copy_(get_tensor("model.vision.patch_emb.weight"))
+    _copy_patch_emb_weight(
+        vision["patch_emb"].weight, get_tensor("model.vision.patch_emb.weight")
+    )
     vision["patch_emb"].bias.data.copy_(get_tensor("model.vision.patch_emb.bias"))
     vision.pos_emb.data.copy_(get_tensor("model.vision.pos_emb"))
     vision["post_ln"].weight.data.copy_(get_tensor("model.vision.post_ln.weight"))
@@ -288,10 +317,16 @@ def _assign_md2_vision_weights(
 def _assign_md3_vision_weights(get_tensor: Callable[[str], torch.Tensor], model: nn.Module) -> None:
     """Assign vision weights from Moondream 3 checkpoint format (vision_encoder.*)."""
     vision = model.vision
+    # patch_emb.weight is NOT in this map: its parameter is padded to the tensor-core
+    # alignment, so it needs the zero-extending copy rather than the exact-shape
+    # `copy_` the loop below performs. Keeping it out means the generic loop stays
+    # strict for every other tensor instead of growing a shape-tolerant path that
+    # would mask a real mismatch elsewhere.
+    _copy_patch_emb_weight(
+        vision["patch_emb"].weight,
+        get_tensor("vision_encoder.encoder.model.visual.patch_embed.linear.weight"),
+    )
     weight_map: Dict[str, torch.Tensor] = {
-        "vision_encoder.encoder.model.visual.patch_embed.linear.weight": vision[
-            "patch_emb"
-        ].weight,
         "vision_encoder.encoder.model.visual.patch_embed.linear.bias": vision[
             "patch_emb"
         ].bias,

--- a/tests/moondream/test_vision_patch_alignment.py
+++ b/tests/moondream/test_vision_patch_alignment.py
@@ -1,0 +1,194 @@
+"""The patch operand is padded to the tensor-core alignment, exactly.
+
+The SigLIP patch dimension is ``14*14*3 = 588``, which is only 4-element aligned. In
+bf16 Hopper ``wgmma`` needs 8 elements (16 bytes), so at K=588 no sm90 tile in
+cuBLAS's kernel set is eligible and the heuristic falls back to an **Ampere**
+``s16816`` kernel on a Hopper part -- measured at 130.56 us against 36.96 us for the
+sm90 kernel bound at K=592, i.e. +93.60 us per forward at nc=13.
+
+Padding K to 592 fixes it and is EXACT, because the added columns are zero on both
+operands. These tests pin that exactness, and pin the checkpoint path: a real
+588-column checkpoint must keep loading with no re-export.
+"""
+
+import pytest
+import torch
+
+from kestrel.models.moondream.vision import (
+    PATCH_DIM_ALIGN,
+    aligned_patch_dim,
+    create_patches,
+)
+from kestrel.models.moondream.weights import _copy_patch_emb_weight
+
+
+def _naive_patches(x: torch.Tensor, patch_size: int) -> torch.Tensor:
+    """The obvious, unpadded implementation this optimisation must not change.
+
+    Deliberately written the slow, readable way. `create_patches` writes through a
+    strided view to avoid paying the copy twice, and clever strides are exactly the
+    kind of code that needs an independent reference to check it.
+    """
+    bsz, channels, height, width = x.shape
+    p1 = p2 = patch_size
+    y = x.reshape(bsz, channels, height // p1, p1, width // p2, p2)
+    y = y.permute(0, 2, 4, 1, 3, 5)
+    return y.reshape(bsz, (height // p1) * (width // p2), channels * p1 * p2)
+
+
+def test_aligned_patch_dim_rounds_up_to_the_wgmma_alignment():
+    assert aligned_patch_dim(588) == 592
+    assert PATCH_DIM_ALIGN == 8
+    # Already-aligned dims must not move: padding an aligned operand would be pure
+    # cost with no kernel change to pay for it.
+    assert aligned_patch_dim(592) == 592
+    assert aligned_patch_dim(1152) == 1152
+    for raw in range(1, 200):
+        out = aligned_patch_dim(raw)
+        assert out % PATCH_DIM_ALIGN == 0
+        assert 0 <= out - raw < PATCH_DIM_ALIGN
+
+
+def test_padded_patches_are_bit_identical_to_the_naive_result():
+    """The payload must survive the strided write BIT-EXACTLY, not approximately."""
+    torch.manual_seed(0)
+    x = torch.randn(3, 3, 378, 378)
+    got = create_patches(x, 14)
+    want = _naive_patches(x, 14)
+
+    assert got.shape == (3, 729, 592)
+    assert want.shape == (3, 729, 588)
+    # Bit-identical, asserted by equality on the raw payload -- not a cosine. At
+    # 1.3e6 elements a cosine cannot resolve identity from near-identity.
+    assert torch.equal(got[:, :, :588], want)
+
+
+def test_the_pad_columns_are_exactly_zero():
+    """Zero is what makes the pad exact; anything else silently changes the model."""
+    torch.manual_seed(1)
+    x = torch.randn(2, 3, 378, 378)
+    out = create_patches(x, 14)
+    tail = out[:, :, 588:]
+    assert tail.shape[-1] == 4
+    assert torch.equal(tail, torch.zeros_like(tail))
+
+
+def test_the_padded_linear_reproduces_the_unpadded_one_exactly_in_fp64():
+    """End to end: pad the operand AND the weight, get the same answer.
+
+    In fp64 the zero columns contribute exactly zero and the accumulation order for
+    the shared prefix is unchanged, so this is an equality assertion, not a
+    tolerance. (In bf16 the padded GEMM binds a different kernel with a different
+    accumulation order, so the two agree to fp-noise rather than bitwise -- which is
+    why the exactness argument is made here, in a dtype that can express it.)
+    """
+    torch.manual_seed(2)
+    x = torch.randn(2, 3, 56, 56, dtype=torch.float64)
+    raw, dim = 588, 592
+
+    w_raw = torch.randn(1152, raw, dtype=torch.float64)
+    b = torch.randn(1152, dtype=torch.float64)
+    w_pad = torch.zeros(1152, dim, dtype=torch.float64)
+    w_pad[:, :raw] = w_raw
+
+    ref = torch.nn.functional.linear(_naive_patches(x, 14), w_raw, b)
+    got = torch.nn.functional.linear(create_patches(x, 14), w_pad, b)
+    assert torch.equal(ref, got)
+
+
+def test_an_already_aligned_shape_is_not_padded_and_takes_the_fast_path():
+    """No pad where none is needed: 2*14*14 = 392, and 392 % 8 == 0."""
+    torch.manual_seed(3)
+    x = torch.randn(1, 2, 28, 28)
+    out = create_patches(x, 14)
+    assert out.shape[-1] == 392
+    assert torch.equal(out, _naive_patches(x, 14))
+
+
+def test_other_unaligned_shapes_pad_and_round_trip_exactly():
+    """The rule is derived from the tensor, not hardcoded for 588.
+
+    1*14*14 = 196 = 4 * 49, so it is 4-element aligned like 588 is -- the same
+    cliff, at a different width -- and rounds to 200.
+    """
+    torch.manual_seed(4)
+    x = torch.randn(1, 1, 28, 28)
+    out = create_patches(x, 14)
+    assert out.shape[-1] == 200
+    assert torch.equal(out[:, :, :196], _naive_patches(x, 14))
+    assert torch.equal(out[:, :, 196:], torch.zeros_like(out[:, :, 196:]))
+
+
+# --------------------------------------------------------------------------- #
+# the checkpoint path -- a real 588-column checkpoint must load unchanged      #
+# --------------------------------------------------------------------------- #
+
+def test_a_raw_width_checkpoint_loads_into_the_padded_parameter():
+    """This is the case that must not require a re-export."""
+    param = torch.nn.Parameter(torch.full((1152, 592), 7.0))
+    src = torch.randn(1152, 588)
+
+    _copy_patch_emb_weight(param, src)
+
+    assert torch.equal(param.data[:, :588], src)
+    # The pad must be ZEROED, not left holding whatever the parameter was
+    # initialised with -- nn.Linear's default init is random, and a random pad
+    # column multiplies a zero activation today but would silently corrupt the
+    # encoder the moment anything ever wrote a non-zero there.
+    assert torch.equal(param.data[:, 588:], torch.zeros(1152, 4))
+
+
+def test_an_already_padded_checkpoint_loads_unchanged():
+    param = torch.nn.Parameter(torch.zeros(1152, 592))
+    src = torch.randn(1152, 592)
+    _copy_patch_emb_weight(param, src)
+    assert torch.equal(param.data, src)
+
+
+def test_a_genuinely_wrong_shape_refuses():
+    """The one place a real checkpoint could silently mis-load.
+
+    A wrong-shaped patch_emb yields a plausible-looking encoder that is quietly
+    wrong, so the mismatch must raise rather than broadcast or truncate.
+    """
+    param = torch.nn.Parameter(torch.zeros(1152, 592))
+    with pytest.raises(ValueError, match="not compatible"):
+        _copy_patch_emb_weight(param, torch.randn(1152, 600))   # too wide
+    with pytest.raises(ValueError, match="not compatible"):
+        _copy_patch_emb_weight(param, torch.randn(768, 588))    # wrong out_features
+    with pytest.raises(ValueError, match="not compatible"):
+        _copy_patch_emb_weight(param, torch.randn(592))         # wrong rank
+
+
+def test_a_freshly_built_model_has_a_ZEROED_pad_before_any_checkpoint_load():
+    """The pad must be inert from BOTH sides, not just the activation side.
+
+    `nn.Linear(592, ...)` random-inits all 592 columns. That is harmless only while
+    `create_patches` keeps zeroing the matching activation columns -- a one-sided
+    invariant. This pins the weight side so the two cannot drift apart, and so a
+    built-only model matches a built-then-loaded one.
+    """
+    from kestrel.models.moondream.config import VisionConfig
+    from kestrel.models.moondream.vision import build_vision_model
+
+    cfg = VisionConfig()
+    model = build_vision_model(cfg, torch.float32, device="cpu")
+    pad = model["patch_emb"].weight[:, 588:]
+    assert pad.shape[-1] == 4
+    assert torch.equal(pad, torch.zeros_like(pad))
+    # The real columns must NOT have been zeroed with it.
+    assert model["patch_emb"].weight[:, :588].abs().sum() > 0
+
+
+def test_build_vision_model_uses_the_aligned_width():
+    from kestrel.models.moondream.config import VisionConfig
+    from kestrel.models.moondream.vision import build_vision_model
+
+    cfg = VisionConfig()
+    model = build_vision_model(cfg, torch.float32, device="cpu")
+    raw = cfg.enc_patch_size * cfg.enc_patch_size * cfg.in_channels
+    assert raw == 588
+    assert model["patch_emb"].weight.shape == (cfg.enc_dim, 592)
+    # And the activation the tower feeds it must agree, or the GEMM will not run.
+    x = torch.randn(1, cfg.in_channels, cfg.crop_size, cfg.crop_size)
+    assert create_patches(x, cfg.enc_patch_size).shape[-1] == 592


### PR DESCRIPTION
## What

`nn.Linear(588, 1152)` becomes `nn.Linear(592, 1152)` with four zero-filled input columns, and `create_patches` emits the matching 592-wide rows.

`588 = 14·14·3` is only **4-element aligned**. In bf16 Hopper `wgmma` operand descriptors need **8 elements (16 bytes)**, so at K=588 **no sm90 tile in cuBLAS's kernel set is eligible** and the heuristic falls back to an **Ampere `s16816`** kernel running on a Hopper part.

## Measured

Isolated GEMM, nc=13 (M=9477, N=1152), 1200 MHz, interleaved one-window A/B:

| | |
|---|---|
| Ampere `cutlass_80_tensorop_bf16_s16816gemm…align2` | **130.56 µs** |
| sm90 `nvjet_sm90_tst_192x144_64x5_1x2_h_bz_coopB_bias_TNT` | **36.96 µs** |
| | **+93.60 µs, 3.53×** |

**Served tower**, both arms running this same `vision_encoder`:

| | |
|---|---|
| K=588 tower (incumbent) | 21 476.6 µs |
| K=592 tower | 21 390.1 µs |
| **delta** | **+86.60 µs/forward** |
| disagreement / null bias | 0.001 pp / −0.097 pp |
| cos(K588, K592) | 0.999996 |
| clock | `locked@1200MHz`, 146 in-window samples, span 1200–1200 |

**93% of the kernel-level win survives into the tower.** The ~4–7 µs shortfall is the pad's own zero-fill and two extra launches (301→303).

## Exact, not approximate

The added columns are zero on **both** operands, so they contribute exactly zero to every dot product. A test asserts **equality — not a tolerance —** between the padded and unpadded linear **in fp64**, the dtype that can express the claim. (In bf16 the two bind different kernels with different accumulation order, so they agree to fp-noise; that is why the exactness argument is made in fp64.)

`592` rather than `608`: a measured sweep put their walls inside each other's spread, while 592 costs **+0.68%** extra FLOPs against 608's **+3.40%**.

## Real checkpoints load unchanged — no re-export

Checkpoints stay canonical at **588**. `_copy_patch_emb_weight` zero-extends on load for both the MD2 and MD3 formats.

It **raises** on any other mismatch rather than broadcasting, truncating, or padding on faith — this is the one place a real checkpoint could silently mis-load, and a wrong-shaped `patch_emb` yields a plausible-looking encoder that is quietly wrong. For MD3 the tensor is deliberately lifted **out** of the generic `weight_map` loop so that loop stays strict for everything else rather than growing a shape-tolerant path that would mask a genuine mismatch elsewhere.

## Design notes

**One owner for the width.** `aligned_patch_dim` is called by both `create_patches` and `build_vision_model`, so the activation and the weight cannot disagree about how wide the operand is.

**The pad is intrinsic to `create_patches`, not opt-in.** That function exists to produce the operand `patch_emb` consumes; an opt-in pad is a footgun that silently rebuilds the misaligned GEMM.

**The pad is zeroed on both operands.** `nn.Linear(592, …)` random-inits all 592 columns, so a freshly-built model carried garbage where the pad is — harmless *today* only because `create_patches` zeroes the matching activation columns, which is a **one-sided invariant**. `build_vision_model` now zeroes the weight pad too, so a built-only model matches a built-then-loaded one. Found by a bench guard refusing on live weights, not by reading the code.

**`create_patches` writes through a strided view** of the padded buffer rather than reshaping then slice-assigning: the permute makes the source non-contiguous so materializing costs one copy regardless, and this op moves ~11 MiB per forward at nc=13. Only the 4 pad columns are zeroed, not the whole buffer. The strided write is pinned by a test against a deliberately naive reference implementation.

## Tests

11 tests, all passing (plus the 66-test moondream suite, no regressions). They pin exactness (bit-equality by `torch.equal`, and fp64 equality end-to-end), the zeroed pad on both operands, the derived-not-hardcoded rule, and the checkpoint path including three refusal cases.

## Downstream

Full measurement write-up, including the served-tower A/B and the re-measured `native/TRT(fp16)` ratio (**1.0088 → 1.0054**, same pin, same engine artifact), is in kestrel-proprietary `mkl/docs/PATCH_EMBED_PAD_LANDED_2026_08_01.md`.

**Not touched:** the MPS/Metal vision path has its own implementation and was neither changed nor measured.
