### PR TITLE
engine: bound autoregressive admission backlog

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1523,8 +1523,12 @@ class InferenceEngine:
                         continue
 
                     progressed = False
-                    # AR ingress (untagged — always the default model).
-                    while True:
+                    # AR ingress (untagged — always the default model). The
+                    # executor keeps a bounded preprocessing + execution
+                    # window so a large client backlog cannot starve device
+                    # progress while several batches remain available for
+                    # overlap.
+                    while ar_executor.has_ingress_capacity:
                         try:
                             item = self._scheduler_queue.get_nowait()
                         except queue.Empty:

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -62,6 +62,10 @@ class _AdmissionCoordinator:
     def has_pending(self) -> bool:
         return bool(self._pending_crops)
 
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending_crops)
+
     def submit(self, req: _AutoregressiveRequest) -> Optional[_ReadyAdmission]:
         if req.image is None:
             return _ReadyAdmission(req=req, crops=None, prefix_cache_hit=False)
@@ -203,6 +207,10 @@ class AutoregressiveExecutor:
             fail_request=self._fail_via_admission,
         )
         self._active: Dict[int, _AutoregressiveRequest] = {}
+        self._admission_capacity = max(
+            runtime.max_batch_slots,
+            runtime.max_batch_size * 4,
+        )
         # Admission-time failures surface as completions the kernel delivers.
         self._admission_failures: List[Completion] = []
 
@@ -223,6 +231,13 @@ class AutoregressiveExecutor:
             or self._admission.has_pending()
             or bool(self._active)
             or bool(self._admission_failures)
+        )
+
+    @property
+    def has_ingress_capacity(self) -> bool:
+        return (
+            len(self._active) + self._admission.pending_count
+            < self._admission_capacity
         )
 
     def advance(self) -> TickResult:
@@ -316,8 +331,7 @@ class AutoregressiveExecutor:
 
     def _promote_ready(self) -> bool:
         promoted = False
-        cap = self._runtime.max_batch_size * 4
-        while len(self._scheduler.waiting) < cap:
+        while len(self._scheduler.waiting) < self._admission_capacity:
             ready = self._admission.take_ready()
             if ready is None:
                 break

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -54,9 +54,11 @@ def _executor() -> AutoregressiveExecutor:
     ex = object.__new__(AutoregressiveExecutor)
     ex._runtime = SimpleNamespace(
         max_batch_size=1,
+        max_batch_slots=2,
         active_sequences={},
         release_sequence=lambda state: None,
     )
+    ex._admission_capacity = 4
     ex._to_engine_result = _fake_to_engine_result
     ex._active = {}
     ex._admission_failures = []
@@ -72,6 +74,7 @@ def _executor() -> AutoregressiveExecutor:
     )
     ex._admission = SimpleNamespace(
         has_pending=lambda: False,
+        pending_count=0,
         take_ready=lambda: None,
         fail_all=lambda exc: None,
     )
@@ -158,6 +161,16 @@ def test_idle_executor_reports_no_work() -> None:
     assert tick.completed == ()
     assert tick.has_work is False
     assert ex.has_work is False
+
+
+def test_ingress_capacity_counts_active_and_preprocessing_requests() -> None:
+    ex = _executor()
+    ex._active = {request_id: _pending(request_id) for request_id in range(3)}
+
+    assert ex.has_ingress_capacity is True
+
+    ex._admission.pending_count = 1
+    assert ex.has_ingress_capacity is False
 
 
 def test_shutdown_fails_in_flight_requests() -> None:


### PR DESCRIPTION
Large client backlogs currently make the kernel thread synchronously admit and enqueue every image preprocessing job before the first device advance. A 2,500-request ChartQA run therefore delays first GPU progress by 13-16 seconds.

This reuses the executor's existing four-batch scheduler window as one bound across preprocessing and active requests. The external ingress queue remains unbounded, while the kernel keeps several batches available for overlap and advances the device between refills.

H100 same-GPU MD2 ChartQA B64 (2,500 requests, exact 0.4.9 AOT kernels):
- requests/s: 46.86 -> 55.46 (+18.4%)
- first completion: 16.25s -> 5.77s
- accuracy: 77.80% -> 77.80%
- P50: 341.20ms -> 379.01ms
- P90: 1014.27ms -> 1014.83ms
- P99: 2035.00ms -> 1892.54ms

Verification: 39 focused engine tests pass on p2.