### PR TITLE
scheduler: revalidate prefill mode after binding

### DIFF
--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -1913,6 +1913,7 @@ class MoondreamRuntime:
             cache_result=cache_result,
             adapter_id=adapter_id,
             image_hash=image_hash,
+            use_prefix_attn=bool(image_kv_length) and not cache_result.can_reuse,
         )
 
     def _build_prefill_inputs_for_prepared(

--- a/kestrel/runtime/state.py
+++ b/kestrel/runtime/state.py
@@ -103,3 +103,4 @@ class PreparedSequence:
     cache_result: _CacheLookupResult
     adapter_id: str | None
     image_hash: bytes | None
+    use_prefix_attn: bool = False

--- a/kestrel/runtime/uncached_paged.py
+++ b/kestrel/runtime/uncached_paged.py
@@ -128,6 +128,7 @@ class UncachedPagedRuntime:
             ),
             adapter_id=adapter_id,
             image_hash=image_hash,
+            use_prefix_attn=False,
         )
 
     def finalize_prepared_sequence_after_prefill(

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1827,6 +1827,32 @@ class GenerationScheduler:
                 progress = True
                 continue
 
+            # Prefix-cache state may change between candidate planning and
+            # binding: reservations for earlier rows can evict a prefix that a
+            # later candidate expected to reuse. The prepared sequence is the
+            # authoritative post-reservation mode. Defer a row that no longer
+            # matches the launch batch instead of handing mixed attention
+            # modes to the runtime.
+            if (
+                bound_batch
+                and prepared.use_prefix_attn
+                != bound_batch[0].prepared.use_prefix_attn
+            ):
+                self.runtime.abort_prepared_sequence(prepared)
+                lifecycle.prefill_started_at = None
+                lifecycle.prefill_completed_at = None
+                if acquired_lora:
+                    self.runtime.release_adapter_slot(request.lora_slot)
+                    request.lora_slot = 0
+                    lifecycle.lora_slot_ready = False
+                lifecycle.transition(
+                    RequestPhase.READY_FOR_PREFILL
+                    if (lifecycle.crops_ready and lifecycle.lora_slot_ready)
+                    else RequestPhase.WAITING_RESOURCES
+                )
+                progress = True
+                continue
+
             lifecycle.sequence_state = prepared.state
 
             self.waiting.remove(request)


### PR DESCRIPTION
Prefill planning classifies candidates against mutable prefix-cache state. Binding rows reserves pages one by one, so an earlier reservation can evict a later candidate's reusable prefix. The stale candidate then realizes a different attention mode and the runtime rejects the mixed launch.

Treat the post-reservation PreparedSequence as authoritative. If a bound row no longer matches the batch's realized attention mode, abort its temporary reservation and defer it to the next planning pass.

Reproduction/gate on H100 with the exact 0.4.9 AOT kernels: an unmodified 2,500-request MD2 B64 ChartQA run aborted with `All sequences in a prefill batch must share use_prefix_attn mode`; this branch completes at 53.66 req/s with 77.80% accuracy.

Verification: 22 focused scheduler/executor tests pass on p2.