### PR TITLE
qwen: streamline image preprocessing

### DIFF
--- a/kestrel/models/qwen35/qwen_image.py
+++ b/kestrel/models/qwen35/qwen_image.py
@@ -1,7 +1,6 @@
 """Local Qwen 3.5 image preprocessing."""
 
 import math
-from dataclasses import dataclass
 from typing import Any
 
 import kestrel_native
@@ -10,79 +9,57 @@ import torch
 from kestrel.utils.image import decode_to_srgb
 
 
-@dataclass(frozen=True)
-class QwenImageProcessorConfig:
-    shortest_edge: int = 65536
-    longest_edge: int = 16777216
-    patch_size: int = 16
-    temporal_patch_size: int = 2
-    merge_size: int = 2
-    image_mean: tuple[float, float, float] = (0.5, 0.5, 0.5)
-    image_std: tuple[float, float, float] = (0.5, 0.5, 0.5)
+_MIN_PIXELS = 256 * 256
+_MAX_PIXELS = 4096 * 4096
+_PATCH_SIZE = 16
+_TEMPORAL_PATCH_SIZE = 2
+_MERGE_SIZE = 2
+_RESIZE_FACTOR = _PATCH_SIZE * _MERGE_SIZE
 
 
-def smart_resize(
-    height: int,
-    width: int,
-    *,
-    factor: int,
-    min_pixels: int,
-    max_pixels: int,
-) -> tuple[int, int]:
+def _smart_resize(height: int, width: int) -> tuple[int, int]:
     if max(height, width) / min(height, width) > 200:
         raise ValueError(
             "absolute aspect ratio must be smaller than 200, got "
             f"{max(height, width) / min(height, width)}"
         )
-    h_bar = round(height / factor) * factor
-    w_bar = round(width / factor) * factor
-    if h_bar * w_bar > max_pixels:
-        beta = math.sqrt((height * width) / max_pixels)
-        h_bar = max(factor, math.floor(height / beta / factor) * factor)
-        w_bar = max(factor, math.floor(width / beta / factor) * factor)
-    elif h_bar * w_bar < min_pixels:
-        beta = math.sqrt(min_pixels / (height * width))
-        h_bar = math.ceil(height * beta / factor) * factor
-        w_bar = math.ceil(width * beta / factor) * factor
+    h_bar = round(height / _RESIZE_FACTOR) * _RESIZE_FACTOR
+    w_bar = round(width / _RESIZE_FACTOR) * _RESIZE_FACTOR
+    if h_bar * w_bar > _MAX_PIXELS:
+        beta = math.sqrt((height * width) / _MAX_PIXELS)
+        h_bar = max(
+            _RESIZE_FACTOR,
+            math.floor(height / beta / _RESIZE_FACTOR) * _RESIZE_FACTOR,
+        )
+        w_bar = max(
+            _RESIZE_FACTOR,
+            math.floor(width / beta / _RESIZE_FACTOR) * _RESIZE_FACTOR,
+        )
+    elif h_bar * w_bar < _MIN_PIXELS:
+        beta = math.sqrt(_MIN_PIXELS / (height * width))
+        h_bar = math.ceil(height * beta / _RESIZE_FACTOR) * _RESIZE_FACTOR
+        w_bar = math.ceil(width * beta / _RESIZE_FACTOR) * _RESIZE_FACTOR
     return h_bar, w_bar
 
 
-def preprocess_image(
-    image: Any,
-    config: QwenImageProcessorConfig = QwenImageProcessorConfig(),
-) -> tuple[torch.Tensor, torch.Tensor]:
+def preprocess_image(image: Any) -> tuple[torch.Tensor, torch.Tensor]:
     rgb = np.ascontiguousarray(decode_to_srgb(image))
     height, width = rgb.shape[:2]
-    resized_h, resized_w = smart_resize(
-        height,
-        width,
-        factor=config.patch_size * config.merge_size,
-        min_pixels=config.shortest_edge,
-        max_pixels=config.longest_edge,
-    )
+    resized_h, resized_w = _smart_resize(height, width)
     resized = kestrel_native.resize_bicubic(rgb, resized_h, resized_w)
     array = resized.astype(np.float32)
-    array *= 1.0 / 255.0
-    np.subtract(
-        array,
-        np.asarray(config.image_mean, dtype=np.float32),
-        out=array,
-    )
-    np.divide(
-        array,
-        np.asarray(config.image_std, dtype=np.float32),
-        out=array,
-    )
+    array *= 2.0 / 255.0
+    array -= 1.0
     channels = int(array.shape[2])
-    grid_h = resized_h // config.patch_size
-    grid_w = resized_w // config.patch_size
+    grid_h = resized_h // _PATCH_SIZE
+    grid_w = resized_w // _PATCH_SIZE
     patches = torch.from_numpy(array).reshape(
-        grid_h // config.merge_size,
-        config.merge_size,
-        config.patch_size,
-        grid_w // config.merge_size,
-        config.merge_size,
-        config.patch_size,
+        grid_h // _MERGE_SIZE,
+        _MERGE_SIZE,
+        _PATCH_SIZE,
+        grid_w // _MERGE_SIZE,
+        _MERGE_SIZE,
+        _PATCH_SIZE,
         channels,
     ).permute(0, 3, 1, 4, 6, 2, 5)
     pixel_values = (
@@ -93,24 +70,20 @@ def preprocess_image(
             -1,
             -1,
             -1,
-            config.temporal_patch_size,
+            _TEMPORAL_PATCH_SIZE,
             -1,
             -1,
         )
         .reshape(
             grid_h * grid_w,
             channels
-            * config.temporal_patch_size
-            * config.patch_size
-            * config.patch_size,
+            * _TEMPORAL_PATCH_SIZE
+            * _PATCH_SIZE
+            * _PATCH_SIZE,
         )
     )
     image_grid_thw = torch.tensor([[1, grid_h, grid_w]], dtype=torch.long)
     return pixel_values, image_grid_thw
 
 
-__all__ = [
-    "QwenImageProcessorConfig",
-    "preprocess_image",
-    "smart_resize",
-]
+__all__ = ["preprocess_image"]

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -116,14 +116,18 @@ class _QwenImagePreprocessor:
             pv, grid = preprocess_image(one)
             pixel_values_parts.append(pv)
             grid_parts.append(grid)
-        pixel_values = torch.cat(pixel_values_parts, dim=0)
-        image_grid_thw = torch.cat(grid_parts, dim=0)
+        if len(images) == 1:
+            pixel_values = pixel_values_parts[0]
+            image_grid_thw = grid_parts[0]
+        else:
+            pixel_values = torch.cat(pixel_values_parts, dim=0)
+            image_grid_thw = torch.cat(grid_parts, dim=0)
         num_image_tokens = int(image_grid_thw.prod(-1).sum().item()) // 4
         if num_image_tokens <= 0:
             raise RuntimeError("Qwen image preprocessing produced no image tokens")
         return QwenImageInputs(
-            pixel_values=pixel_values.detach().cpu(),
-            image_grid_thw=image_grid_thw.detach().cpu(),
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
             num_image_tokens=num_image_tokens,
         )
 


### PR DESCRIPTION
## Summary

- fold fixed Qwen image normalization into one in-place scale and bias
- avoid one-element tensor concatenation and redundant CPU detaches
- remove the unused configurable preprocessor facade in favor of the model architecture constants

## Verification

- bit-exact image tensors at 480x640, 1024x768, and 2048x1536
- 480x640 preprocessing: 4.35 ms -> 0.97 ms (4.47x)
- Qwen 3.5 9B C8 aggregate prefill: 21.65k -> 22.60k tok/s; vLLM 22.19k tok/s
- Qwen engine integration: 3 passed