### PR TITLE
scheduler: revalidate prefill mode after binding

### DIFF
--- a/kestrel/runtime/state.py
+++ b/kestrel/runtime/state.py
@@ -103,3 +103,8 @@ class PreparedSequence:
     cache_result: _CacheLookupResult
     adapter_id: str | None
     image_hash: bytes | None
+
+    @property
+    def use_prefix_attn(self) -> bool:
+        """Return the attention mode after cache lookup and reservation."""
+        return bool(self.state.image_length) and not self.cache_result.can_reuse

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1827,6 +1827,32 @@ class GenerationScheduler:
                 progress = True
                 continue
 
+            # Prefix-cache state may change between candidate planning and
+            # binding: reservations for earlier rows can evict a prefix that a
+            # later candidate expected to reuse. The prepared sequence is the
+            # authoritative post-reservation mode. Defer a row that no longer
+            # matches the launch batch instead of handing mixed attention
+            # modes to the runtime.
+            if (
+                bound_batch
+                and prepared.use_prefix_attn
+                != bound_batch[0].prepared.use_prefix_attn
+            ):
+                self.runtime.abort_prepared_sequence(prepared)
+                lifecycle.prefill_started_at = None
+                lifecycle.prefill_completed_at = None
+                if acquired_lora:
+                    self.runtime.release_adapter_slot(request.lora_slot)
+                    request.lora_slot = 0
+                    lifecycle.lora_slot_ready = False
+                lifecycle.transition(
+                    RequestPhase.READY_FOR_PREFILL
+                    if (lifecycle.crops_ready and lifecycle.lora_slot_ready)
+                    else RequestPhase.WAITING_RESOURCES
+                )
+                progress = True
+                continue
+
             lifecycle.sequence_state = prepared.state
 
             self.waiting.remove(request)


### PR DESCRIPTION
## Summary

- derive the authoritative prefix-attention mode from the prepared sequence
- defer a row when reservation changes its mode after batch planning
- keep mixed attention modes out of a shared prefill launch

Prefix-cache reservations performed while binding earlier rows can evict a prefix that a later row expected to reuse. Revalidating after reservation closes that planning/binding race without adding a model-specific path.

## Verification

- `11 passed`: `tests/scheduler/test_launch_prefill_step.py`, `tests/scheduler/test_prefill_planner.py`
- tested against the `kestrel-kernels 0.4.9` nightly wheel