### PR TITLE
gemma4: fall back when generated decode is unavailable

### DIFF
--- a/kestrel/models/gemma4/generated_decode.py
+++ b/kestrel/models/gemma4/generated_decode.py
@@ -27,7 +27,7 @@ def _rope_tables(runtime: Any) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
     }
 
 
-def create_generated_decode(runtime: Any) -> GeneratedDecode:
+def create_generated_decode(runtime: Any) -> GeneratedDecode | None:
     """Describe Gemma inputs; shared runtime code owns binding and launch."""
 
     layers = runtime._kv_cache
@@ -55,7 +55,7 @@ def create_generated_decode(runtime: Any) -> GeneratedDecode:
         layer_kinds=tuple(config.layer_types),
         extra_runtime_inputs=rope_inputs,
     )
-    return GeneratedDecode.require(
+    return GeneratedDecode.try_create(
         runtime,
         GeneratedDecodeSpec(
             label="Gemma",
@@ -63,7 +63,6 @@ def create_generated_decode(runtime: Any) -> GeneratedDecode:
             weight_layer_prefix="model.language_model.layers",
             bindings=bindings,
         ),
-        capacity=runtime.max_batch_size,
     )
 
 

--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -153,7 +153,9 @@ class Gemma4TextAttention(nn.Module):
         paged_kv_layer: PagedKVCache,
         cache_position_ids: torch.Tensor,
         slot_mapping: torch.Tensor,
-        cu_seqlens: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        page_table: torch.Tensor | None = None,
+        paged_kv_seqlens_k: torch.Tensor | None = None,
     ) -> torch.Tensor:
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)
@@ -206,17 +208,33 @@ class Gemma4TextAttention(nn.Module):
             assert key_states is not None and value_states is not None
             transient_kv[self.layer_idx] = (key_states, value_states)
 
-        assert key_states is not None and value_states is not None
-        attn_out = attention_ops.dense_attention(
-            query_states,
-            key_states,
-            value_states,
-            scaling=1.0,
-            causal=not self.is_sliding,
-            window_size_left=(self.sliding_window - 1) if self.is_sliding else None,
-            window_size_right=0 if self.is_sliding else None,
-            cu_seqlens=cu_seqlens,
-        )
+        if page_table is not None:
+            if paged_kv_seqlens_k is None:
+                raise ValueError("paged Gemma attention requires K/V lengths")
+            attn_out = attention_ops.paged_attention(
+                query_states,
+                paged_kv_layer=paged_kv_layer,
+                page_table=page_table,
+                paged_kv_seqlens_k=paged_kv_seqlens_k,
+                scaling=1.0,
+                sliding_window=self.sliding_window,
+            )
+        else:
+            if paged_kv_seqlens_k is not None:
+                raise ValueError("paged K/V lengths require a page table")
+            assert key_states is not None and value_states is not None
+            attn_out = attention_ops.dense_attention(
+                query_states,
+                key_states,
+                value_states,
+                scaling=1.0,
+                causal=not self.is_sliding,
+                window_size_left=(
+                    self.sliding_window - 1 if self.is_sliding else None
+                ),
+                window_size_right=0 if self.is_sliding else None,
+                cu_seqlens=cu_seqlens,
+            )
         attn_out = attn_out.reshape(*input_shape, -1).contiguous()
         return self.o_proj(attn_out)
 
@@ -299,7 +317,9 @@ class Gemma4TextDecoderLayer(nn.Module):
         paged_kv_layer: PagedKVCache,
         cache_position_ids: torch.Tensor,
         slot_mapping: torch.Tensor,
-        cu_seqlens: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        page_table: torch.Tensor | None = None,
+        paged_kv_seqlens_k: torch.Tensor | None = None,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = _dense_runtime.rmsnorm(
@@ -315,6 +335,8 @@ class Gemma4TextDecoderLayer(nn.Module):
             cache_position_ids=cache_position_ids,
             slot_mapping=slot_mapping,
             cu_seqlens=cu_seqlens,
+            page_table=page_table,
+            paged_kv_seqlens_k=paged_kv_seqlens_k,
         )
         hidden_states = _dense_runtime.rmsnorm(
             hidden_states,
@@ -458,7 +480,9 @@ class Gemma4TextModel(nn.Module):
         per_layer_inputs: Optional[torch.Tensor],
         cache_position_ids: torch.Tensor,
         slot_mapping: torch.Tensor,
-        cu_seqlens: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        page_table: torch.Tensor | None = None,
+        paged_kv_seqlens_k: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if self.hidden_size_per_layer_input:
             per_layer_inputs = self.project_per_layer_inputs(inputs_embeds, per_layer_inputs)
@@ -489,6 +513,8 @@ class Gemma4TextModel(nn.Module):
                 cache_position_ids=cache_position_ids,
                 slot_mapping=slot_mapping,
                 cu_seqlens=cu_seqlens,
+                page_table=page_table,
+                paged_kv_seqlens_k=paged_kv_seqlens_k,
             )
 
         hidden_states = _dense_runtime.rmsnorm(

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -459,7 +459,61 @@ class Gemma4Runtime(UncachedPagedRuntime):
         if batch_size == 0:
             return
         with torch.cuda.stream(slot.compute_stream):
-            self._generated_decode.run(slot, batch_size)
+            if (
+                self._generated_decode is not None
+                and self._generated_decode.supports(batch_size)
+            ):
+                self._generated_decode.run(slot, batch_size)
+            else:
+                self._run_native_decode(slot, batch_size)
+
+    def _run_native_decode(self, slot: Any, batch_size: int) -> None:
+        batch_idx = slot.meta.batch_idx.gpu[:batch_size]
+        input_pos = slot.meta.input_pos.gpu[:batch_size]
+        positions = slot.cache_position_ids[:batch_size]
+        positions[:, 0].copy_(input_pos)
+        slot.position_ids[:batch_size].copy_(positions)
+        self.page_table.populate_paged_kv_metadata(
+            batch_idx=batch_idx,
+            input_pos=input_pos,
+            out_page_table=slot.paged_kv_page_table[:batch_size],
+            out_seqused_k=slot.paged_kv_seqlens_k[:batch_size],
+        )
+        slot.slot_mapping[:batch_size].copy_(
+            self.page_table.build_slot_mapping(
+                batch_idx=batch_idx,
+                positions=positions,
+            )
+        )
+
+        input_ids = slot.decode_token_ids[:batch_size].view(batch_size, 1)
+        language_model = self.model.model.language_model
+        inputs_embeds = language_model.embed(input_ids)
+        per_layer_inputs = (
+            language_model.get_per_layer_inputs(input_ids)
+            if self._config.text_config.hidden_size_per_layer_input
+            else None
+        )
+        hidden = language_model(
+            inputs_embeds=inputs_embeds,
+            position_ids=slot.position_ids[:batch_size],
+            kv_cache=self._kv_cache,
+            per_layer_inputs=per_layer_inputs,
+            cache_position_ids=positions,
+            slot_mapping=slot.slot_mapping[:batch_size],
+            cu_seqlens=None,
+            page_table=slot.paged_kv_page_table[:batch_size],
+            paged_kv_seqlens_k=slot.paged_kv_seqlens_k[:batch_size],
+        )[:, 0]
+        slot.hidden_last[:batch_size].copy_(hidden)
+        torch.mm(
+            hidden,
+            self.model.lm_head.weight.t(),
+            out=slot.logits[:batch_size],
+        )
+        cap = self._config.text_config.final_logit_softcapping
+        if cap is not None:
+            slot.logits[:batch_size].div_(cap).tanh_().mul_(cap)
 
 
 __all__ = ["Gemma4Runtime"]


### PR DESCRIPTION
## Summary
- make bundled generated decode an optional Gemma acceleration
- select the smallest covering generated capacity for each active batch
- execute the same Gemma model through shared paged attention when no compatible generated program covers the batch

This keeps covered batches on their existing one-launch generated programs while allowing unsupported devices, missing bundles, and larger configured capacities to run correctly instead of failing engine construction. The shared paged correctness fallback fix is m87-labs/kestrel-proprietary#1326.

## Validation
- focused Gemma and registry tests
- generated and native decode paths completed the same end-to-end evaluation slice with matching aggregate accuracy
- syntax and whitespace checks