### PR TITLE
release: Kestrel 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kestrel"
-version = "0.4.2"
+version = "0.5.0"
 description = "A fast, efficient inference engine for vision-language models"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "kestrel"
-version = "0.4.2"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- bump the Kestrel package version from 0.4.2 to 0.5.0
- refresh the lockfile package metadata
- retain the production kestrel-kernels 0.4.9 and kestrel-native 0.1.6 pins

## Release artifact

Built from this branch:

- `kestrel-0.5.0-py3-none-any.whl` (331 KB)
- SHA-256: `96d14534b55bd28f0c41de78261fbcc4e2cfcb9fede7eb44c18ae23991c7e302`
- `kestrel-0.5.0.tar.gz` (286 KB)
- SHA-256: `abff1bf78ca8bb21f46faf0a6fc521601c4a125166ee7fbcb75929b178dfe227`

Wheel metadata reports version 0.5.0, Python 3.10-3.14, kestrel-kernels 0.4.9, and kestrel-native 0.1.6. Package inspection found no tests, scripts, docs, assets, private-model code, compiler code, or kernel source.

## Verification

- `uv lock`
- `uv build`
- `git diff --check`
- exact-wheel import on H100 from a private target: Kestrel 0.5.0, kernels 0.4.9, native 0.1.6
- exact-wheel real-image H100 smoke with AOT bundles and JIT disabled:
  - Moondream 2: completed at the model stop token
  - Moondream 3: completed at the model stop token
  - Qwen 3.5 4B: completed the intentionally capped 128-token generation
  - Gemma 4 E2B: completed the intentionally capped 128-token generation

No tag or package publication is performed by this PR.