### PR TITLE
engine: expose streaming segmentation

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -726,19 +726,58 @@ class InferenceEngine:
             settings=settings,
         )
 
+    @overload
+    async def segment(
+        self,
+        image: Optional[np.ndarray | bytes],
+        object: str,
+        *,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = ...,
+        stream: Literal[True],
+        settings: Optional[Mapping[str, object]] = ...,
+    ) -> EngineStream: ...
+
+    @overload
+    async def segment(
+        self,
+        image: Optional[np.ndarray | bytes],
+        object: str,
+        *,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = ...,
+        stream: Literal[False] = ...,
+        settings: Optional[Mapping[str, object]] = ...,
+    ) -> EngineResult: ...
+
+    @overload
+    async def segment(
+        self,
+        image: Optional[np.ndarray | bytes],
+        object: str,
+        *,
+        spatial_refs: Optional[Sequence[Sequence[float]]] = ...,
+        stream: bool = ...,
+        settings: Optional[Mapping[str, object]] = ...,
+    ) -> Union[EngineResult, EngineStream]: ...
+
     async def segment(
         self,
         image: Optional[np.ndarray | bytes],
         object: str,
         *,
         spatial_refs: Optional[Sequence[Sequence[float]]] = None,
+        stream: bool = False,
         settings: Optional[Mapping[str, object]] = None,
-    ) -> EngineResult:
+    ) -> Union[EngineResult, EngineStream]:
         return await self._run_skill(
             "segment",
             image=image,
-            prompt={"object": object, "spatial_refs": spatial_refs},
+            prompt={
+                "object": object,
+                "spatial_refs": spatial_refs,
+                "stream": stream,
+            },
             settings=settings,
+            stream=stream,
         )
 
     async def submit_streaming(

--- a/kestrel/models/moondream/skills/segment.py
+++ b/kestrel/models/moondream/skills/segment.py
@@ -68,7 +68,7 @@ class SegmentSkill(SkillSpec):
         request = SegmentRequest(
             object=obj,
             image=image,
-            stream=False,
+            stream=bool(prompt.get("stream", False)),
             spatial_refs=normalize_spatial_refs(prompt.get("spatial_refs")),
         )
         return BuiltRequest(

--- a/tests/test_point_spatial_refs.py
+++ b/tests/test_point_spatial_refs.py
@@ -14,6 +14,7 @@ from kestrel.models.moondream.skills import (
 )
 from kestrel.skills import QuerySkill
 from kestrel.models.moondream.skills.point import PointRequest
+from kestrel.models.moondream.skills.segment import SegmentRequest
 from kestrel.skills.query import QueryRequest
 
 
@@ -166,3 +167,28 @@ def test_engine_segment_requires_image_before_spatial_ref_validation() -> None:
     refs = np.array([[0.2, 0.3]], dtype=np.float32)
     with pytest.raises(ValueError, match="image must be provided for segmentation"):
         asyncio.run(engine.segment(None, "person", spatial_refs=refs))
+
+
+def test_engine_segment_propagates_streaming_to_skill_and_submitter() -> None:
+    engine = object.__new__(InferenceEngine)
+    engine._skills_override = _ALL_SKILLS()
+    captured: dict[str, object] = {}
+
+    async def fake_submit_streaming(
+        request_context: object, **kwargs: object
+    ) -> SimpleNamespace:
+        captured["request_context"] = request_context
+        captured["kwargs"] = kwargs
+        return SimpleNamespace()
+
+    engine.submit_streaming = fake_submit_streaming  # type: ignore[method-assign]
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+
+    asyncio.run(engine.segment(image, "person", stream=True))
+
+    request = captured["request_context"]
+    assert isinstance(request, SegmentRequest)
+    assert request.stream is True
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["skill"] == "segment"


### PR DESCRIPTION
## Summary

- propagate the public segment stream flag through the generic skill runner
- preserve the flag in SegmentRequest so the existing incremental SVG path stream activates
- add precise EngineResult/EngineStream overloads

This removes an API seam: the segment skill already implements incremental output, but InferenceEngine previously forced every segment request onto the non-streaming submit path.

## Verification

- uv run pytest tests/test_point_spatial_refs.py -q (8 passed)
- Python compile check
- git diff --check

This is intentionally a small Kestrel patch-release prerequisite for local segment streaming in moondream-python 2.0.