### PR TITLE
decode: select exact generated artifacts by static extent

### DIFF
--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -198,6 +198,40 @@ def _state_requirements(descriptor: Mapping[str, Any]):
     )
 
 
+def _select_program(programs: Sequence[Any], batch_size: int) -> tuple[int, Any] | None:
+    batch_size = int(batch_size)
+    candidates = []
+    for index, program in enumerate(programs):
+        static_extents = program.static_extent_bindings
+        if static_extents.keys() - {"active_batch"}:
+            continue
+        static_batch = static_extents.get("active_batch")
+        if static_batch is not None and int(static_batch) != batch_size:
+            continue
+        if int(program.capacity) < batch_size:
+            continue
+        candidates.append((static_batch is None, int(program.capacity), index, program))
+    if not candidates:
+        return None
+    _dynamic, _capacity, index, program = min(candidates, key=lambda item: item[:3])
+    return index, program
+
+
+def _selectable_programs(
+    programs: Sequence[Any], max_batch_size: int
+) -> tuple[Any, ...]:
+    selected_indexes = set()
+    for batch_size in range(1, int(max_batch_size) + 1):
+        selected = _select_program(programs, batch_size)
+        if selected is not None:
+            selected_indexes.add(selected[0])
+    return tuple(
+        program
+        for index, program in enumerate(programs)
+        if index in selected_indexes
+    )
+
+
 class GeneratedDecode:
     """Select bundled capacities and bind them to one serving runtime."""
 
@@ -255,6 +289,9 @@ class GeneratedDecode:
         programs = cls._resolve_programs(runtime, spec)
         if not programs:
             return None
+        programs = _selectable_programs(programs, runtime.max_batch_size)
+        if not programs:
+            return None
         return cls(runtime, spec=spec, programs=programs)
 
     def __init__(
@@ -265,7 +302,8 @@ class GeneratedDecode:
         programs,
         required_capacity: int | None = None,
     ) -> None:
-        self._programs = tuple(programs)
+        available_programs = tuple(programs)
+        self._programs = available_programs
         self._spec = spec
         if required_capacity is not None:
             missing = [
@@ -279,19 +317,25 @@ class GeneratedDecode:
                     f"sizes {missing}"
                 )
 
+        self._programs = _selectable_programs(
+            available_programs, runtime.max_batch_size
+        )
+        if not self._programs:
+            raise ValueError("generated decode has no selectable batch artifact")
+
         from kestrel_kernels.generated_decode import (
             assemble_bindings,
             derive_runtime_extents,
             materialize_weights,
         )
 
-        contracts = {repr(program.descriptor["weights"]) for program in programs}
+        contracts = {repr(program.descriptor["weights"]) for program in self._programs}
         if len(contracts) != 1:
             raise RuntimeError(
                 f"generated {spec.label} capacities disagree on weight storage"
             )
         self.state_requirements_by_capacity = {}
-        for program in programs:
+        for program in self._programs:
             requirements = _state_requirements(program.descriptor)
             existing = self.state_requirements_by_capacity.setdefault(
                 program.capacity, requirements
@@ -319,7 +363,7 @@ class GeneratedDecode:
         with torch.cuda.stream(runtime.compute_stream):
             self.weight_storage = materialize_weights(
                 spec.weight_root,
-                programs[0].descriptor,
+                self._programs[0].descriptor,
                 layer_prefix=spec.weight_layer_prefix,
             )
             shared_inputs = dict(spec.bindings.runtime_inputs(runtime))
@@ -349,13 +393,29 @@ class GeneratedDecode:
                     preparations=spec.preparations,
                 )
                 plans.setdefault(tuple(step.name for step in plan), plan)
-                construction_batch = min(capacity, int(runtime.max_batch_size))
+                construction_batch = int(
+                    program.static_extent_bindings.get(
+                        "active_batch",
+                        min(capacity, int(runtime.max_batch_size)),
+                    )
+                )
                 extents = derive_runtime_extents(
                     program.descriptor, inputs, active_batch=construction_batch
                 )
                 launch_extents = dict(
                     spec.bindings.launch_extents(slot, construction_batch)
                 )
+                static_extents = program.static_extent_bindings
+                mismatched = {
+                    name: (static_extents[name], launch_extents[name])
+                    for name in static_extents.keys() & launch_extents.keys()
+                    if int(static_extents[name]) != int(launch_extents[name])
+                }
+                if mismatched:
+                    raise RuntimeError(
+                        f"generated {spec.label} construction extents disagree "
+                        f"with static artifact bindings {mismatched}"
+                    )
                 extents.update(launch_extents)
                 bindings = assemble_bindings(
                     program.descriptor,
@@ -372,7 +432,7 @@ class GeneratedDecode:
                     ]
                     if item["transport"] == "scalar"
                 )
-                unknown = launch_extents.keys() - scalar_names
+                unknown = launch_extents.keys() - scalar_names - static_extents.keys()
                 if unknown:
                     raise RuntimeError(
                         f"generated {spec.label} has unknown launch extents "
@@ -398,21 +458,7 @@ class GeneratedDecode:
             )
 
     def _program_for(self, batch_size: int) -> tuple[int, Any] | None:
-        batch_size = int(batch_size)
-        candidates = []
-        for index, program in enumerate(self._programs):
-            static_batch = program.static_extent_bindings.get("active_batch")
-            if static_batch is not None and int(static_batch) != batch_size:
-                continue
-            if int(program.capacity) < batch_size:
-                continue
-            candidates.append(
-                (static_batch is None, int(program.capacity), index, program)
-            )
-        if not candidates:
-            return None
-        _dynamic, _capacity, index, program = min(candidates, key=lambda item: item[:3])
-        return index, program
+        return _select_program(self._programs, batch_size)
 
     def supports(self, batch_size: int) -> bool:
         return self._program_for(batch_size) is not None

--- a/tests/test_generated_decode_static_extents.py
+++ b/tests/test_generated_decode_static_extents.py
@@ -1,0 +1,228 @@
+import contextlib
+import sys
+from dataclasses import dataclass
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from kestrel.runtime import generated_decode as runtime_decode
+
+
+class _Stream:
+    def wait_event(self, _event) -> None:
+        pass
+
+
+class _Event:
+    def record(self, _stream) -> None:
+        pass
+
+
+class _Invocation:
+    def __init__(self, name: str, launches: list[tuple[str, dict]]) -> None:
+        self.name = name
+        self.launches = launches
+
+    def launch(self, **extents) -> None:
+        self.launches.append((self.name, dict(extents)))
+
+
+@dataclass(frozen=True)
+class _Program:
+    name: str
+    capacity: int
+    static_extent_bindings: dict[str, int]
+    launches: list[tuple[str, dict]]
+
+    @property
+    def descriptor(self):
+        scalar_arguments = (
+            []
+            if "active_batch" in self.static_extent_bindings
+            else [
+                {
+                    "name": "active_batch",
+                    "transport": "scalar",
+                    "source": "external",
+                }
+            ]
+        )
+        return {
+            "name": self.name,
+            "weights": [],
+            "carried_state": [],
+            "device_program": {
+                "argument_plan": {"arguments": scalar_arguments},
+                "physical_abi": {"operands": []},
+            },
+        }
+
+    def bind(self, _bindings):
+        return _Invocation(self.name, self.launches)
+
+
+class _Bindings:
+    def runtime_inputs(self, _runtime):
+        return {}
+
+    def slot_inputs(self, _slot, _capacity):
+        return {}
+
+    def launch_extents(self, _slot, batch_size):
+        return {"active_batch": int(batch_size)}
+
+
+def _programs(*names: str):
+    launches: list[tuple[str, dict]] = []
+    definitions = {
+        "b1": (1, {"active_batch": 1}),
+        "b2": (2, {}),
+        "b4": (4, {}),
+        "b4_exact": (4, {"active_batch": 4}),
+        "b8": (8, {}),
+        "b8_exact": (8, {"active_batch": 8}),
+        "b4_multi_exact": (4, {"active_batch": 4, "kv_len": 16}),
+    }
+    return tuple(_Program(name, *definitions[name], launches) for name in names)
+
+
+def _build(monkeypatch, programs, *, bindings=None, max_batch_size=8):
+    launches = programs[0].launches
+    kernels = ModuleType("kestrel_kernels")
+    generated = ModuleType("kestrel_kernels.generated_decode")
+    generated.assemble_bindings = lambda _descriptor, **_kwargs: {}
+    generated.derive_runtime_extents = lambda _descriptor, _inputs, *, active_batch: {
+        "active_batch": int(active_batch)
+    }
+    generated.materialize_weights = lambda *_args, **_kwargs: SimpleNamespace(
+        buffers={}
+    )
+    monkeypatch.setitem(sys.modules, "kestrel_kernels", kernels)
+    monkeypatch.setitem(sys.modules, "kestrel_kernels.generated_decode", generated)
+    monkeypatch.setattr(
+        runtime_decode.torch.cuda, "current_stream", lambda _device: _Stream()
+    )
+    monkeypatch.setattr(runtime_decode.torch.cuda, "Event", _Event)
+    monkeypatch.setattr(
+        runtime_decode.torch.cuda, "stream", lambda _stream: contextlib.nullcontext()
+    )
+    runtime = SimpleNamespace(
+        max_batch_size=max_batch_size,
+        device=SimpleNamespace(type="cuda"),
+        compute_stream=_Stream(),
+        decode_slots=(SimpleNamespace(slot_id=0, compute_stream=_Stream()),),
+    )
+    spec = runtime_decode.GeneratedDecodeSpec(
+        label="test",
+        weight_root=SimpleNamespace(),
+        weight_layer_prefix="layers",
+        bindings=bindings or _Bindings(),
+    )
+    return runtime_decode.GeneratedDecode(
+        runtime, spec=spec, programs=programs
+    ), launches
+
+
+def test_generated_decode_constructs_and_selects_dynamic_exact_siblings(monkeypatch):
+    generated, launches = _build(
+        monkeypatch,
+        _programs("b1", "b2", "b4", "b4_exact", "b8", "b8_exact"),
+    )
+
+    for active_batch in (3, 4, 5, 6, 7, 8):
+        generated.run(SimpleNamespace(slot_id=0), active_batch)
+
+    assert launches == [
+        ("b4", {"active_batch": 3}),
+        ("b4_exact", {}),
+        ("b8", {"active_batch": 5}),
+        ("b8", {"active_batch": 6}),
+        ("b8", {"active_batch": 7}),
+        ("b8_exact", {}),
+    ]
+
+
+def test_generated_decode_missing_covering_artifact_fails_before_launch(monkeypatch):
+    generated, launches = _build(
+        monkeypatch,
+        _programs("b1", "b2", "b4_exact", "b8_exact"),
+    )
+
+    assert not generated.supports(3)
+    with pytest.raises(ValueError, match="no generated decode capacity covers 3"):
+        generated.run(SimpleNamespace(slot_id=0), 3)
+    assert launches == []
+
+
+def test_generated_decode_rejects_mismatched_static_construction_extent(monkeypatch):
+    class _MismatchedBindings(_Bindings):
+        def launch_extents(self, _slot, _batch_size):
+            return {"active_batch": 3}
+
+    with pytest.raises(
+        RuntimeError,
+        match="construction extents disagree with static artifact bindings",
+    ):
+        _build(
+            monkeypatch,
+            _programs("b4_exact"),
+            bindings=_MismatchedBindings(),
+        )
+
+
+def test_generated_decode_uses_dynamic_fallback_for_other_static_extents(monkeypatch):
+    generated, launches = _build(
+        monkeypatch,
+        _programs("b4", "b4_multi_exact"),
+    )
+
+    generated.run(SimpleNamespace(slot_id=0), 4)
+
+    assert [program.name for program in generated._programs] == ["b4"]
+    assert launches == [("b4", {"active_batch": 4})]
+
+
+def test_generated_decode_skips_artifacts_above_runtime_batch_limit(monkeypatch):
+    generated, _launches = _build(
+        monkeypatch,
+        _programs("b1", "b2", "b4", "b4_exact", "b8", "b8_exact"),
+        max_batch_size=4,
+    )
+
+    assert [program.name for program in generated._programs] == [
+        "b1",
+        "b2",
+        "b4",
+        "b4_exact",
+    ]
+
+
+def test_optional_generated_decode_falls_back_when_all_artifacts_are_unreachable(
+    monkeypatch,
+):
+    programs = _programs("b8_exact")
+    monkeypatch.setattr(
+        runtime_decode.GeneratedDecode,
+        "_resolve_programs",
+        classmethod(lambda _cls, _runtime, _spec: programs),
+    )
+    runtime = SimpleNamespace(max_batch_size=4)
+
+    assert runtime_decode.GeneratedDecode.try_create(runtime, object()) is None
+
+
+def test_required_generated_decode_rejects_all_unreachable_artifacts(monkeypatch):
+    programs = _programs("b8_exact")
+    monkeypatch.setattr(
+        runtime_decode.GeneratedDecode,
+        "_resolve_programs",
+        classmethod(lambda _cls, _runtime, _spec: programs),
+    )
+    runtime = SimpleNamespace(max_batch_size=4)
+    spec = SimpleNamespace(label="test")
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"does not cover active batch sizes \[1, 2, 3, 4\]",
+    ):
+        runtime_decode.GeneratedDecode.require(runtime, spec, capacity=4)


### PR DESCRIPTION
## Summary

- construct exact generated-decode artifacts with their compiler-bound `active_batch`
- accept matching static launch extents without treating them as missing scalar ABI arguments
- reject construction-time values that disagree with an artifact's static bindings
- preserve current main's model-independent exact-versus-dynamic program selection

## Compatibility

This port uses the selection logic already present on current main and introduces no new `kestrel-kernels` API. The existing `kestrel-kernels==0.4.9` dependency remains valid, resolving the prior dependency review blocker.

Descriptors without static bindings remain dynamic coverings. Exact and dynamic artifacts at the same capacity stay independently bound and the exact artifact is selected only for its matching live batch.

## Verification

- `uv run --group dev pytest -q tests/test_generated_decode_device.py tests/test_generated_decode_static_extents.py`: 9 passed
- `PYTHONPATH=$PWD uv run --group dev pytest -q --import-mode=importlib`: 604 passed, 27 skipped
- new constructor-level regression covers dynamic B3/B5-B7 and exact B4/B8 launches
- missing B3 coverage raises before launch
- mismatched static construction extents fail closed
- artifacts with additional static extents fall back to a dynamic sibling
- exact artifacts above the configured runtime batch limit are not bound
- optional generated decode falls back when every resolved artifact is unreachable
- required generated decode retains a fail-closed coverage error
- Ruff check and format check pass for the new test
- `git diff --check` passes

## Performance context

The dependent exact-artifact measurements reported B4 decode +2.34% and B8 +4.57% on H100 E2B. B2 was neutral at 0.9986x and is not claimed as a speedup.

Depends on the already merged m87-labs/kestrel-proprietary#1345.
