### PR TITLE
engine: keep initialization single-flight

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -314,7 +314,7 @@ class InferenceEngine:
             models=models,
             adapter_provider_uses_api_key=adapter_provider_uses_api_key,
         )
-        await engine._initialize()
+        await engine._ensure_started()
         return engine
 
     async def _initialize(self) -> None:

--- a/tests/test_engine_runtime_injection.py
+++ b/tests/test_engine_runtime_injection.py
@@ -72,6 +72,26 @@ def test_engine_registers_injected_runtime_under_config_model_id() -> None:
     assert engine.runtime is runtime
 
 
+def test_create_owns_one_initialization_task(monkeypatch) -> None:
+    runtime = FakeRuntime(model_name="injected", device="cpu")
+    initialization_count = 0
+
+    async def initialize(engine: InferenceEngine) -> None:
+        nonlocal initialization_count
+        initialization_count += 1
+        await engine._ensure_started()
+        engine._initialized = True
+        engine._init_task = None
+
+    monkeypatch.setattr(InferenceEngine, "_initialize", initialize)
+
+    async def run() -> None:
+        await InferenceEngine.create(_cpu_cfg(), runtime=runtime)
+
+    asyncio.run(run())
+    assert initialization_count == 1
+
+
 def test_engine_cohosted_runtime_reuses_injected_runtime_pool() -> None:
     """An injected default runtime supplies the shared KV pool for later builds."""
 


### PR DESCRIPTION
## Summary
- route `InferenceEngine.create()` through the existing single-flight startup coordinator
- prevent warmup queries from recursively starting a second initializer
- add a regression test for exactly-once initialization

## Why
`create()` called `_initialize()` directly, so its warmup query observed no owning `_init_task` and started a second initializer. Both initializers constructed telemetry reporters; one was overwritten and left an orphaned async task/client.

## Verification
- `python -m pytest --import-mode=importlib -q --disable-warnings` (546 passed, 27 skipped)
- source-free H100 release smoke confirmed the released behavior before the fix: inference completed correctly, but parallel engine startup emitted pending `PhotonReporter._telemetry_loop` teardown warnings