### PR TITLE
runtime: materialize finite batch domains

### DIFF
--- a/kestrel/runtime/compilation.py
+++ b/kestrel/runtime/compilation.py
@@ -14,21 +14,27 @@ def materialize_dynamic_batch_domain(
     inputs_for_batch: Callable[[int], tuple[Any, ...]],
     synchronize: Callable[[], None] | None = None,
 ) -> None:
-    """Materialize the scalar-one and symbolic-positive batch regimes.
+    """Materialize every admitted batch before accepting serving work.
 
     ``torch.compile(dynamic=True)`` still specializes dimensions whose first
-    observed value is zero or one. A runtime that only initializes at batch one
-    can therefore compile the first grouped request in the serving path. Run
-    batch one and the largest admitted batch up front so both compiler regimes
-    are ready before public work is accepted.
+    observed value is zero or one. A symbolic graph can also retain
+    shape-specific first-execution work below the graph/compiler-cache layer.
+    The admitted batch domain is finite and small, so exercise it completely
+    before public work is accepted instead of relying on compiler internals to
+    make intermediate extents serving-ready. Keep capacity as the first
+    positive extent so it remains the representative symbolic compile input.
     """
 
     max_batch_size = int(max_batch_size)
     if max_batch_size < 1:
         raise ValueError("max_batch_size must be positive")
-    batches = (1,) if max_batch_size == 1 else (1, max_batch_size)
+    batch_sizes = (
+        (1,)
+        if max_batch_size == 1
+        else (1, max_batch_size, *range(2, max_batch_size))
+    )
     with torch.inference_mode():
-        for batch_size in batches:
+        for batch_size in batch_sizes:
             output = compiled(*inputs_for_batch(batch_size))
             del output
     if synchronize is not None:

--- a/tests/test_runtime_compilation.py
+++ b/tests/test_runtime_compilation.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock
+
+from kestrel.runtime.compilation import materialize_dynamic_batch_domain
+
+
+def test_materializes_every_admitted_batch() -> None:
+    observed: list[int] = []
+    synchronize = Mock()
+
+    def compiled(batch_size: int) -> None:
+        observed.append(batch_size)
+
+    materialize_dynamic_batch_domain(
+        compiled,
+        max_batch_size=4,
+        inputs_for_batch=lambda batch_size: (batch_size,),
+        synchronize=synchronize,
+    )
+
+    assert observed == [1, 4, 2, 3]
+    synchronize.assert_called_once_with()


### PR DESCRIPTION
## Summary

- exercise every admitted batch extent during dynamic compilation warmup
- preserve capacity as the first symbolic-positive compile/autotune input
- keep the helper target- and model-neutral
- prevent one-time per-shape setup from reaching serving requests

## B200 evidence

Controlled Gemma 4 vision-encoder runs used separate fresh Inductor caches on evee3.

- endpoint warm (`B1,B4`): 100.94 s initialization; first `B3` 51.09 ms; steady `B3` 11.94 ms
- full-domain warm (`B1,B4,B2,B3`): 93.00 s initialization; first served `B3` 12.58 ms; steady `B3` 12.58 ms
- the two intermediate warm calls add 103.02 ms inside the full-domain process
- both arms produced exactly two graphs and 206 cache files; unseen `B3` changed neither compiler counters nor cache size
- PyTorch 2.9 reproduced the same two-graph behavior; endpoint-warmed `B3` was 13.87 ms first-use versus 6.26 ms steady

The earlier multi-second observation is not attributed to intermediate-batch graph compilation here. This change only claims removal of the measured first-execution work, without graph or persistent cache growth.

## Verification

- `tests/test_runtime_compilation.py`: 1 passed on evee3
- `git diff --check`