### PR TITLE
Release request payloads before long awaits

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -523,7 +523,7 @@ class InferenceEngine:
         # image inside chat messages); prefer it over the top-level argument.
         effective_image = built.image if built.image is not None else image
         submit_fn = self.submit_streaming if stream else self.submit
-        return await submit_fn(
+        submission = submit_fn(
             built.request_context,
             max_new_tokens=built.max_new_tokens,
             adapter=adapter,
@@ -535,6 +535,10 @@ class InferenceEngine:
             _suppress_next_token_ids=suppress_next_token_ids,
             skill=skill_name,
         )
+        # The submission coroutine owns the built request now. Release the
+        # request-building frame's duplicate references before awaiting it.
+        del built, prompt, settings, image, effective_image
+        return await submission
 
     async def submit(
         self,
@@ -571,6 +575,10 @@ class InferenceEngine:
             stream_queue=None,
             skill=skill,
         )
+        # Ingress owns the request payload; the remainder of this frame only
+        # needs the result future, which may stay pending for a full decode.
+        del request_context, image
+        del generated_prefix, suppress_next_token_ids
         return await future
 
     @overload
@@ -845,6 +853,7 @@ class InferenceEngine:
         self._scheduler_event.set()
         if self._scheduler_error is not None:
             self._fail_all_pending(self._scheduler_failed_error())
+        del inputs, req
         return await future
 
     async def stream(

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -100,7 +100,9 @@ class ModelHandle:
                 f"run() is for single-pass models; {self._model!r} is "
                 f"{runtime.execution_shape.value} — use its typed verbs."
             )
-        return await self._engine.run(self._model, task, inputs)
+        submission = self._engine.run(self._model, task, inputs)
+        del inputs
+        return await submission
 
     async def stream(self, task: str, /, **initial_prompt: Any) -> "ModelStream":
         """Start a stateful streaming session on this model.
@@ -155,20 +157,34 @@ class ModelHandle:
         without it this would misroute to the autoregressive path.
         """
         await self._engine._ensure_started()
+        # Move the public verb's kwargs into this routing frame, then empty the
+        # original dict so its suspended coroutine does not pin media payloads.
+        owned_prompt = dict(prompt)
+        prompt.clear()
         runtime = self._engine._runtimes.get(self._model)
         if runtime is not None and (
             runtime.execution_shape is ExecutionShape.SINGLE_PASS
         ):
-            return await self.run(task, prompt)
+            submission = self.run(task, owned_prompt)
+            del owned_prompt
+            return await submission
         if runtime is not None and runtime.execution_shape is ExecutionShape.STREAMING:
-            return await self.stream(task, **prompt)
+            submission = self.stream(task, **owned_prompt)
+            del owned_prompt
+            return await submission
         self._require_default_ar(task)
-        settings = prompt.pop("settings", None)
-        stream = bool(prompt.get("stream", False))
-        image = prompt.pop("image", None)
-        return await self._engine._run_skill(
-            task, image=image, prompt=prompt, settings=settings, stream=stream
+        settings = owned_prompt.pop("settings", None)
+        stream = bool(owned_prompt.get("stream", False))
+        image = owned_prompt.pop("image", None)
+        submission = self._engine._run_skill(
+            task,
+            image=image,
+            prompt=owned_prompt,
+            settings=settings,
+            stream=stream,
         )
+        del owned_prompt, settings, image
+        return await submission
 
     async def chat(
         self, **prompt: Any

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -9,10 +9,13 @@ that contract with stub runtimes — no GPU.
 from __future__ import annotations
 
 import asyncio
+import gc
 import queue
 from types import SimpleNamespace
 from typing import Any
+import weakref
 
+import numpy as np
 import pytest
 
 from kestrel.engine import InferenceEngine, ModelHandle
@@ -174,6 +177,38 @@ def test_text_only_query_through_handle() -> None:
     assert out == "RESULT"
     assert captured["image"] is None
     assert captured["prompt"] == {"question": "just text?"}
+
+
+def test_query_releases_image_from_result_await_frames() -> None:
+    async def run() -> None:
+        eng = _engine()
+        submitted = asyncio.Event()
+        result_future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        image = np.zeros((2, 2, 3), dtype=np.uint8)
+        image_id = id(image)
+        image_ref = weakref.ref(image)
+
+        async def submit_request(**kwargs: Any):
+            assert id(kwargs["image"]) == image_id
+            assert id(kwargs["request_context"].image) == image_id
+            submitted.set()
+            return result_future, 1
+
+        eng._submit_request = submit_request  # type: ignore[method-assign]
+        task = asyncio.create_task(
+            eng.model("ar-model").query(image=image, question="what is this?")
+        )
+        await submitted.wait()
+        await asyncio.sleep(0)
+
+        del image
+        gc.collect()
+        assert image_ref() is None
+
+        result_future.set_result("RESULT")
+        assert await task == "RESULT"
+
+    asyncio.run(run())
 
 
 def test_capability_lifts_settings_and_mirrors_stream() -> None:


### PR DESCRIPTION
## Summary

- Transfer request/media ownership into ingress before long result awaits.
- Drop duplicate coroutine-frame references in model-handle, skill, submit, and single-pass paths.
- Cover the behavior with an existing image/query payload rather than a model-specific input.

This is a model-agnostic memory-lifetime improvement extracted from the Whisper integration.

## Validation

- Focused engine/handle/runtime suite: 54 passed.
- git diff --check: clean.