### PR TITLE
Harden prefill failure resource ownership

### DIFF
--- a/kestrel/scheduler/pipeline.py
+++ b/kestrel/scheduler/pipeline.py
@@ -149,6 +149,10 @@ class PrefillLaunch:
     logits: object
     prepared_sequences: object
     prefill_slot: object
+    # Adapter slots acquired while binding each prepared row. The runtime takes
+    # ownership only after that row is installed; an abort must return the
+    # parallel slot explicitly.
+    abort_adapter_slots: object = ()
 
 
 @dataclass(slots=True)
@@ -170,6 +174,8 @@ class PrefillPendingCommit:
     slot_id: int
     prepared_sequences: object
     prefill_slot: object
+    # See ``PrefillLaunch.abort_adapter_slots``.
+    abort_adapter_slots: object = ()
     # See ``DecodePendingCommit.runtime_step``.
     runtime_step: object = None
 

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -12,7 +12,7 @@ import logging
 import torch
 from torch import Tensor
 
-from kestrel.device import NoopEvent, stream_context
+from kestrel.device import NoopEvent, stream_context, synchronize
 from kestrel.utils import CpuGpuBuffer
 from kestrel.runtime import (
     PrefillClassification,
@@ -163,7 +163,10 @@ class _BoundPrefill:
 
     candidate: _PrefillCandidate
     prepared: PreparedSequence
-    acquired_lora: bool
+    # If this row fails before runtime installation, the scheduler still owns
+    # this adapter reference. It may have been acquired in this bind or carried
+    # from an earlier deferred bind attempt.
+    abort_adapter_slot: int | None
 
 
 def _plan_prefill_launch_batch(
@@ -1525,7 +1528,7 @@ class GenerationScheduler:
         return self.runtime.acquire_adapter_slot(adapter_id, adapter)
 
     def _fail_request_early(self, request: GenerationRequest, exc: Exception) -> None:
-        """Fail a request that couldn't be admitted (e.g., adapter load failure)."""
+        """Fail an uninstalled request and release scheduler-owned resources."""
         _LOGGER.error(
             "Failed to admit request %s: %s",
             request.request_id,
@@ -1533,6 +1536,18 @@ class GenerationScheduler:
             exc_info=exc,
         )
         lifecycle = request.lifecycle
+        if lifecycle.lora_slot_ready and request.lora_slot:
+            # A request can carry a scheduler-owned adapter reference from an
+            # earlier bind that deferred on KV/prefix state. Terminal failures
+            # before installation have no runtime row whose release path could
+            # return it, so this helper is the final ownership backstop. Paths
+            # that already retired a prepared/installed row reset these fields
+            # first and are therefore no-ops here.
+            try:
+                self.runtime.release_adapter_slot(request.lora_slot)
+            finally:
+                request.lora_slot = 0
+                lifecycle.lora_slot_ready = False
         lifecycle.finish_reason = "error"
         lifecycle.error = exc
         lifecycle.finished = True
@@ -1618,6 +1633,75 @@ class GenerationScheduler:
     def _release_prefill_staging(self, staging: PrefillStaging) -> None:
         """Return a prefill staging bundle to the pool."""
         self._prefill_staging_pool.append(staging)
+
+    def _retire_failed_prepared_sequences(
+        self,
+        prepared_sequences: Sequence[PreparedSequence],
+        *,
+        sequences: Sequence[RequestLifecycle] = (),
+        abort_adapter_slots: Sequence[int | None] = (),
+        fence_compute_stream: bool = False,
+    ) -> None:
+        """Best-effort cleanup for rows that never reached a valid commit.
+
+        Runtime finalization may install rows one at a time. If a later row or
+        token materialization fails, release installed rows and abort the rest
+        so fatal cleanup never depends on ``active_sequences`` containing every
+        prepared row. Adapter slots remain scheduler-owned until installation;
+        aborting an uninstalled row therefore returns its parallel slot
+        explicitly, while ``release_sequence`` owns cleanup for an installed
+        row.
+
+        A prefill token makes its row runnable before the CPU commits it, so a
+        decode forward may already be queued when commit fails. Fence the
+        shared compute stream before reclaiming row resources on that path,
+        then remove the failed lifecycles from the running queue.
+        """
+
+        if fence_compute_stream:
+            try:
+                compute_stream = self._compute_stream
+                if compute_stream is None:
+                    synchronize(self.runtime.device)
+                else:
+                    compute_stream.synchronize()
+            except Exception:
+                _LOGGER.exception(
+                    "Failed to fence compute stream before prepared-row cleanup"
+                )
+
+        for index, prepared in enumerate(prepared_sequences):
+            sequence = sequences[index] if index < len(sequences) else None
+            adapter_slot = (
+                abort_adapter_slots[index]
+                if index < len(abort_adapter_slots)
+                else None
+            )
+            installed = prepared.state.batch_idx in self.runtime.active_sequences
+            retired = False
+            try:
+                if installed:
+                    self.runtime.release_sequence(prepared.state)
+                    retired = True
+                else:
+                    try:
+                        self.runtime.abort_prepared_sequence(prepared)
+                    finally:
+                        if adapter_slot is not None:
+                            self.runtime.release_adapter_slot(adapter_slot)
+                    retired = True
+            except Exception:
+                _LOGGER.exception(
+                    "Failed to retire prepared sequence row %s",
+                    prepared.state.batch_idx,
+                )
+            finally:
+                if sequence is not None:
+                    if sequence in self.running:
+                        self.running.remove(sequence)
+                    if adapter_slot is not None and retired:
+                        sequence.request.lora_slot = 0
+                        sequence.lora_slot_ready = False
 
     def _stage_prefill_sampling_params(
         self,
@@ -1706,6 +1790,7 @@ class GenerationScheduler:
                 slot_id=prefill_payload.slot_id,
                 prepared_sequences=prepared_sequences,
                 prefill_slot=prefill_slot,
+                abort_adapter_slots=prefill_payload.abort_adapter_slots,
                 runtime_step=runtime_step,
             ),
         )
@@ -1722,6 +1807,7 @@ class GenerationScheduler:
         staging = payload.staging
         prepared_sequences = payload.prepared_sequences
         prefill_slot = payload.prefill_slot
+        committed = False
         try:
             token_ids_cpu, logprobs_cpu = step.transfer.wait()
             prefill_slot.commit_done_event.synchronize()
@@ -1733,7 +1819,15 @@ class GenerationScheduler:
                 payload.prefill_slot.batch_idx[: len(step.sequences)].view(-1),
                 payload.runtime_step,
             )
+            committed = True
         finally:
+            if not committed:
+                self._retire_failed_prepared_sequences(
+                    prepared_sequences,
+                    sequences=step.sequences,
+                    abort_adapter_slots=payload.abort_adapter_slots,
+                    fence_compute_stream=True,
+                )
             self._release_prefill_staging(staging)
             self.runtime.release_prefill_slot(prefill_slot)
         return tokens, logprobs_cpu
@@ -1860,7 +1954,11 @@ class GenerationScheduler:
                 _BoundPrefill(
                     candidate=candidate,
                     prepared=prepared,
-                    acquired_lora=acquired_lora,
+                    abort_adapter_slot=(
+                        request.lora_slot
+                        if lifecycle.lora_slot_ready and request.lora_slot
+                        else None
+                    ),
                 )
             )
 
@@ -1872,18 +1970,24 @@ class GenerationScheduler:
         lifecycles = [request.lifecycle for request in requests]
         sequences = lifecycles
         prepared_sequences = [item.prepared for item in bound_batch]
+        abort_adapter_slots = tuple(item.abort_adapter_slot for item in bound_batch)
 
         def fail_bound_batch(
             exc: Exception,
             *,
             staging: PrefillStaging | None = None,
+            fence_compute_stream: bool = False,
         ) -> bool:
-            if staging is not None:
-                self._release_prefill_staging(staging)
             try:
-                for item in bound_batch:
-                    self.runtime.abort_prepared_sequence(item.prepared)
+                self._retire_failed_prepared_sequences(
+                    prepared_sequences,
+                    sequences=sequences,
+                    abort_adapter_slots=abort_adapter_slots,
+                    fence_compute_stream=fence_compute_stream,
+                )
             finally:
+                if staging is not None:
+                    self._release_prefill_staging(staging)
                 try:
                     self.runtime.release_prefill_slot(prefill_slot)
                 except Exception:
@@ -1893,13 +1997,6 @@ class GenerationScheduler:
                     lifecycle = request.lifecycle
                     lifecycle.prefill_started_at = None
                     lifecycle.prefill_completed_at = None
-                    if item.acquired_lora:
-                        try:
-                            self.runtime.release_adapter_slot(request.lora_slot)
-                        except Exception:
-                            pass
-                        request.lora_slot = 0
-                        lifecycle.lora_slot_ready = False
             for request in requests:
                 self._fail_request_early(request, exc)
             return True
@@ -1926,7 +2023,7 @@ class GenerationScheduler:
                 prefill_slot.commit_done_event.synchronize()
                 self.runtime.finalize_prepared_sequence_after_prefill(prepared_seq)
             except Exception as exc:
-                return fail_bound_batch(exc)
+                return fail_bound_batch(exc, fence_compute_stream=True)
 
             seq.first_token_time = lifecycle.prefill_started_at or time.perf_counter()
             self._finalize_sequence(seq, "length")
@@ -1936,13 +2033,11 @@ class GenerationScheduler:
         try:
             staging = self._acquire_prefill_staging()
         except Exception:
-            for item in bound_batch:
-                self.runtime.abort_prepared_sequence(item.prepared)
-                if item.acquired_lora:
-                    request = item.candidate.request
-                    self.runtime.release_adapter_slot(request.lora_slot)
-                    request.lora_slot = 0
-                    request.lifecycle.lora_slot_ready = False
+            self._retire_failed_prepared_sequences(
+                prepared_sequences,
+                sequences=sequences,
+                abort_adapter_slots=abort_adapter_slots,
+            )
             self.runtime.release_prefill_slot(prefill_slot)
             raise
 
@@ -1964,24 +2059,36 @@ class GenerationScheduler:
             for lifecycle in lifecycles:
                 lifecycle.prefill_completed_at = prefill_completed
         except Exception as exc:
-            return fail_bound_batch(exc, staging=staging)
+            return fail_bound_batch(
+                exc,
+                staging=staging,
+                fence_compute_stream=True,
+            )
 
         # Prefill has completed (KV/logits enqueued); notify skill.
-        for seq in sequences:
-            seq.skill_state.on_prefill(self.runtime)
+        try:
+            for seq in sequences:
+                seq.skill_state.on_prefill(self.runtime)
 
-        handle = LaunchHandle(
-            kind="prefill",
-            sequences=sequences,
-            payload=PrefillLaunch(
+            handle = LaunchHandle(
+                kind="prefill",
+                sequences=sequences,
+                payload=PrefillLaunch(
+                    staging=staging,
+                    slot_id=slot_id,
+                    logits=logits,
+                    prepared_sequences=prepared_sequences,
+                    prefill_slot=prefill_slot,
+                    abort_adapter_slots=abort_adapter_slots,
+                ),
+            )
+            pipeline.on_launch(handle)
+        except Exception as exc:
+            return fail_bound_batch(
+                exc,
                 staging=staging,
-                slot_id=slot_id,
-                logits=logits,
-                prepared_sequences=prepared_sequences,
-                prefill_slot=prefill_slot,
-            ),
-        )
-        pipeline.on_launch(handle)
+                fence_compute_stream=True,
+            )
         return True
 
     # ──────────────────────────────────────────────────────────────────────────
@@ -2157,7 +2264,25 @@ class GenerationScheduler:
             if plan is not None:
                 raise AssertionError("Prefill finalize does not support masks")
             with stream_context(self._compute_stream):
-                return self._finalize_prefill(handle)
+                try:
+                    return self._finalize_prefill(handle)
+                except BaseException:
+                    payload = handle.payload
+                    if isinstance(payload, PrefillLaunch):
+                        self._retire_failed_prepared_sequences(
+                            payload.prepared_sequences,
+                            sequences=handle.sequences,
+                            abort_adapter_slots=payload.abort_adapter_slots,
+                            fence_compute_stream=True,
+                        )
+                        self._release_prefill_staging(payload.staging)
+                        try:
+                            self.runtime.release_prefill_slot(payload.prefill_slot)
+                        except Exception:
+                            _LOGGER.exception(
+                                "Failed to release prefill slot after finalize failure"
+                            )
+                    raise
         raise AssertionError(f"Unsupported handle kind {handle.kind!r}")
 
     def _finalize_sampling_on_stream(

--- a/tests/scheduler/test_launch_prefill_step.py
+++ b/tests/scheduler/test_launch_prefill_step.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import pytest
 
 from kestrel.models.moondream.runtime import PrefillClassification, TextToken
+from kestrel.runtime import SequenceState
 from kestrel.scheduler.pipeline import PipelineState
 from kestrel.scheduler.queues import RequestQueue, RunningQueue
 from kestrel.scheduler.scheduler import GenerationScheduler, _PrefillCandidate
@@ -148,6 +150,81 @@ def test_launch_prefill_step_dequeues_requests_that_fail_to_bind(
     assert scheduler._completed[0].request_id == request.request_id
     assert request.lifecycle.phase == RequestPhase.COMPLETED
     assert len(runtime.released_prefill_slots) == 1
+
+
+def test_terminal_bound_failure_releases_adapter_from_deferred_bind() -> None:
+    request = _make_request()
+    # A previous attempt acquired the adapter, then deferred before launch.
+    # This attempt inherits the scheduler-owned reference without acquiring it.
+    request.adapter = "ft-1"
+    request.lora_slot = 7
+    request.lifecycle.lora_slot_ready = True
+    request.lifecycle.skill_state.on_prefill = lambda _runtime: (
+        (_ for _ in ()).throw(RuntimeError("on_prefill failed"))
+    )
+    prepared = SimpleNamespace(
+        state=SequenceState(batch_idx=1, length=1, max_length=9, lora_slot=7),
+        use_prefix_attn=False,
+    )
+    runtime = FakeRuntime(prepare_result=prepared)
+    scheduler = _make_scheduler(request, runtime)
+    scheduler._compute_stream = None
+    staging = object()
+    scheduler._acquire_prefill_staging = lambda: staging
+    scheduler._release_prefill_staging = lambda _staging: None
+    scheduler._stage_prefill_sampling_params = lambda *_args: None
+
+    progressed = GenerationScheduler._launch_prefill_step(
+        scheduler,
+        PipelineState(),
+    )
+
+    assert progressed is True
+    assert runtime.aborted_prepared == [prepared]
+    assert runtime.released_adapter_slots == [7]
+    assert request.lora_slot == 0
+    assert request.lifecycle.lora_slot_ready is False
+    assert request.lifecycle.phase == RequestPhase.COMPLETED
+
+
+def test_terminal_prepare_failure_releases_adapter_from_deferred_bind() -> None:
+    request = _make_request()
+    request.adapter = "ft-1"
+    request.lora_slot = 11
+    request.lifecycle.lora_slot_ready = True
+    runtime = FakeRuntime(prepare_exc=ValueError("invalid checkpoint state"))
+    scheduler = _make_scheduler(request, runtime)
+
+    progressed = GenerationScheduler._launch_prefill_step(
+        scheduler,
+        PipelineState(),
+    )
+
+    assert progressed is True
+    assert runtime.released_adapter_slots == [11]
+    assert request.lora_slot == 0
+    assert request.lifecycle.lora_slot_ready is False
+    assert request.lifecycle.phase == RequestPhase.COMPLETED
+
+
+def test_retryable_prepare_failure_preserves_deferred_adapter() -> None:
+    request = _make_request()
+    request.adapter = "ft-1"
+    request.lora_slot = 13
+    request.lifecycle.lora_slot_ready = True
+    runtime = FakeRuntime(prepare_exc=RuntimeError("Cannot reserve requested pages"))
+    scheduler = _make_scheduler(request, runtime)
+
+    progressed = GenerationScheduler._launch_prefill_step(
+        scheduler,
+        PipelineState(),
+    )
+
+    assert progressed is False
+    assert runtime.released_adapter_slots == []
+    assert request.lora_slot == 13
+    assert request.lifecycle.lora_slot_ready is True
+    assert list(scheduler.waiting) == [request]
 
 
 def test_advance_rejects_only_request_that_cannot_fit_kv_cache() -> None:

--- a/tests/scheduler/test_release_sequence.py
+++ b/tests/scheduler/test_release_sequence.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Sequence
 
 import pytest
 
 from kestrel.runtime import SequenceState, TextToken, Token
+from kestrel.scheduler.pipeline import (
+    LaunchHandle,
+    PendingCommit,
+    PrefillLaunch,
+    PrefillPendingCommit,
+)
+from kestrel.scheduler.queues import RunningQueue
 from kestrel.scheduler.scheduler import GenerationScheduler
 from kestrel.scheduler.types import GeneratedPrefix, GenerationRequest, RequestLifecycle
 
@@ -118,3 +126,140 @@ def test_release_sequence_releases_and_propagates_when_retention_fails() -> None
 
     assert runtime.released_sequences == [lifecycle.state]
     assert lifecycle.state.batch_idx not in runtime.active_sequences
+
+
+def test_failed_prepared_cleanup_releases_installed_and_aborts_uninstalled() -> None:
+    runtime = FakeRuntime()
+    installed = SequenceState(batch_idx=0, length=1, max_length=2)
+    uninstalled = SequenceState(batch_idx=1, length=1, max_length=2)
+    runtime.active_sequences[installed.batch_idx] = installed
+    installed_prepared = SimpleNamespace(state=installed)
+    uninstalled_prepared = SimpleNamespace(state=uninstalled)
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = runtime
+
+    scheduler._retire_failed_prepared_sequences(
+        [installed_prepared, uninstalled_prepared]
+    )
+
+    assert runtime.released_sequences == [installed]
+    assert runtime.aborted_prepared == [uninstalled_prepared]
+    assert runtime.active_sequences == {}
+
+
+def test_failed_prepared_cleanup_returns_adapter_owned_before_install() -> None:
+    runtime = FakeRuntime()
+    lifecycle = _make_lifecycle(runtime)
+    runtime.active_sequences.clear()
+    lifecycle.request.lora_slot = 7
+    lifecycle.lora_slot_ready = True
+    prepared = SimpleNamespace(state=lifecycle.state)
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = runtime
+    scheduler.running = RunningQueue()
+    scheduler.running.push(lifecycle)
+
+    scheduler._retire_failed_prepared_sequences(
+        [prepared],
+        sequences=[lifecycle],
+        abort_adapter_slots=[7],
+    )
+
+    assert runtime.aborted_prepared == [prepared]
+    assert runtime.released_adapter_slots == [7]
+    assert len(scheduler.running) == 0
+    assert lifecycle.request.lora_slot == 0
+    assert lifecycle.lora_slot_ready is False
+
+
+def test_prefill_finalize_failure_retires_adapter_and_slot() -> None:
+    runtime = FakeRuntime()
+    lifecycle = _make_lifecycle(runtime)
+    runtime.active_sequences.clear()
+    lifecycle.request.lora_slot = 9
+    lifecycle.lora_slot_ready = True
+    prepared = SimpleNamespace(state=lifecycle.state)
+    staging = object()
+    released_staging: list[object] = []
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = runtime
+    scheduler._compute_stream = None
+    scheduler.running = RunningQueue()
+    scheduler._release_prefill_staging = released_staging.append
+    scheduler._finalize_prefill = lambda _handle: (_ for _ in ()).throw(
+        RuntimeError("sampling failed")
+    )
+    slot = runtime.prefill_slots[0]
+    handle = LaunchHandle(
+        kind="prefill",
+        sequences=[lifecycle],
+        payload=PrefillLaunch(
+            staging=staging,
+            slot_id=0,
+            logits=object(),
+            prepared_sequences=[prepared],
+            prefill_slot=slot,
+            abort_adapter_slots=(9,),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="sampling failed"):
+        scheduler.finalize_sampling(handle)
+
+    assert runtime.aborted_prepared == [prepared]
+    assert runtime.released_adapter_slots == [9]
+    assert released_staging == [staging]
+    assert runtime.released_prefill_slots == [slot]
+    assert lifecycle.request.lora_slot == 0
+    assert lifecycle.lora_slot_ready is False
+
+
+def test_prefill_commit_failure_fences_before_returning_adapter() -> None:
+    runtime = FakeRuntime()
+    lifecycle = _make_lifecycle(runtime)
+    runtime.active_sequences.clear()
+    lifecycle.request.lora_slot = 12
+    lifecycle.lora_slot_ready = True
+    prepared = SimpleNamespace(state=lifecycle.state)
+    staging = object()
+    cleanup_order: list[str] = []
+
+    class _ComputeStream:
+        def synchronize(self) -> None:
+            cleanup_order.append("fence")
+
+    def abort_prepared(value: object) -> None:
+        cleanup_order.append("abort")
+        runtime.aborted_prepared.append(value)
+
+    runtime.abort_prepared_sequence = abort_prepared  # type: ignore[method-assign]
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = runtime
+    scheduler._compute_stream = _ComputeStream()
+    scheduler.running = RunningQueue()
+    scheduler.running.push(lifecycle)
+    scheduler._release_prefill_staging = lambda _staging: None
+    slot = runtime.prefill_slots[0]
+    transfer = SimpleNamespace(
+        wait=lambda: (_ for _ in ()).throw(RuntimeError("transfer failed"))
+    )
+    step = PendingCommit(
+        kind="prefill",
+        sequences=[lifecycle],
+        transfer=transfer,
+        payload=PrefillPendingCommit(
+            staging=staging,
+            slot_id=0,
+            prepared_sequences=[prepared],
+            prefill_slot=slot,
+            abort_adapter_slots=(12,),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="transfer failed"):
+        scheduler._commit_prefill(step)
+
+    assert cleanup_order == ["fence", "abort"]
+    assert runtime.released_adapter_slots == [12]
+    assert len(scheduler.running) == 0
+    assert runtime.released_prefill_slots == [slot]


### PR DESCRIPTION
## Summary

- Track scheduler-owned adapter slots until prepared rows are installed.
- Retire partially installed prefill batches ownership-completely on launch, finalize, and commit failures.
- Fence in-flight decode work before reclaiming failed prepared rows.

This is generic scheduler hardening extracted from the Whisper integration and has no encoder-input or model-specific dependency.

## Validation

- Full scheduler suite: 161 passed.
- Focused failure-path suite: 15 passed.
- git diff --check: clean.