### PR TITLE
Add fail-closed decode path control

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,15 @@ Adapters are automatically downloaded and cached on first use.
 RuntimeConfig(
     model="moondream3-preview",  # or "moondream2" / "moondream3.1-9B-A2B"
     max_batch_size=4,            # Max concurrent requests
+    decode_path="auto",          # "auto", "native", or fail-closed "generated"
 )
 ```
+
+`decode_path="native"` disables generated decode construction. For Qwen 3.5
+and Gemma 4, `decode_path="generated"` requires compatible bundled programs
+covering every active batch size up to `max_batch_size`; construction or decode
+fails instead of falling back to native execution. Moondream currently supports
+only the default `"auto"` policy.
 
 To run from local files instead of the registered HuggingFace weights or
 tokenizer, keep `model` set to the matching registered architecture and pass

--- a/kestrel/config.py
+++ b/kestrel/config.py
@@ -5,6 +5,7 @@ import ctypes
 from dataclasses import dataclass
 from pathlib import Path
 import re
+from typing import Literal
 
 import torch
 
@@ -30,6 +31,9 @@ _MPS_PAGES_BY_TOTAL_GIB = (
     (None, 65536), # 96+ GB Ultra
 )
 _SERVICE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+DecodePath = Literal["auto", "native", "generated"]
 
 
 def _format_cuda_version(version: int | str | None) -> str | None:
@@ -169,8 +173,17 @@ class RuntimeConfig:
     model: str = "moondream3-preview"
     service_name: str = "local"
     tokenizer_path: str | Path | None = None
+    # Decode implementation policy. ``generated`` is fail-closed: runtimes
+    # that support it must bind compatible generated programs for the complete
+    # configured batch domain and may not fall back to native decode.
+    decode_path: DecodePath = "auto"
 
     def __post_init__(self):
+        if self.decode_path not in ("auto", "native", "generated"):
+            raise ValueError(
+                "decode_path must be 'auto', 'native', or 'generated'"
+            )
+
         normalized_service_name = self.service_name.strip()
         self.service_name = normalized_service_name or "local"
         if not _SERVICE_NAME_PATTERN.fullmatch(self.service_name):
@@ -275,4 +288,4 @@ class RuntimeConfig:
         raise RuntimeError(" ".join(details))
 
 
-__all__ = ["RuntimeConfig"]
+__all__ = ["DecodePath", "RuntimeConfig"]

--- a/kestrel/models/gemma4/generated_decode.py
+++ b/kestrel/models/gemma4/generated_decode.py
@@ -27,7 +27,9 @@ def _rope_tables(runtime: Any) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
     }
 
 
-def create_generated_decode(runtime: Any) -> GeneratedDecode | None:
+def create_generated_decode(
+    runtime: Any, *, required: bool = False,
+) -> GeneratedDecode | None:
     """Describe Gemma inputs; shared runtime code owns binding and launch."""
 
     layers = runtime._kv_cache
@@ -55,15 +57,17 @@ def create_generated_decode(runtime: Any) -> GeneratedDecode | None:
         layer_kinds=tuple(config.layer_types),
         extra_runtime_inputs=rope_inputs,
     )
-    return GeneratedDecode.try_create(
-        runtime,
-        GeneratedDecodeSpec(
-            label="Gemma",
-            weight_root=runtime.model,
-            weight_layer_prefix="model.language_model.layers",
-            bindings=bindings,
-        ),
+    spec = GeneratedDecodeSpec(
+        label="Gemma",
+        weight_root=runtime.model,
+        weight_layer_prefix="model.language_model.layers",
+        bindings=bindings,
     )
+    if required:
+        return GeneratedDecode.require(
+            runtime, spec, capacity=runtime.max_batch_size
+        )
+    return GeneratedDecode.try_create(runtime, spec)
 
 
 __all__ = ["create_generated_decode"]

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -22,7 +22,6 @@ from kestrel.runtime.staging import AsyncPreprocessor, BatchedTensorStager
 from kestrel.runtime.tokenizer import load_tokenizer
 from kestrel.runtime.uncached_paged import UncachedPagedRuntime
 
-from .generated_decode import create_generated_decode
 from .image import MAX_IMAGE_TOKENS, MAX_PATCHES, preprocess_image
 from .loader import load_model
 from .paged_cache import paged_kv_specs
@@ -60,6 +59,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
             )
 
         self._model_name = cfg.model
+        self.decode_path = getattr(cfg, "decode_path", "auto")
         from kestrel.models.registry import get_spec
 
         model_spec = get_spec(self._model_name)
@@ -157,7 +157,21 @@ class Gemma4Runtime(UncachedPagedRuntime):
             pool=self._kv_pool,
             dtype=self.dtype,
         )
-        self._generated_decode = create_generated_decode(self)
+        self._initialize_generated_decode()
+
+    def _initialize_generated_decode(self) -> None:
+        """Apply the runtime-wide decode policy after model state is ready."""
+
+        self.generated_decode = None
+        if self.decode_path == "native":
+            return
+
+        from .generated_decode import create_generated_decode
+
+        self.generated_decode = create_generated_decode(
+            self,
+            required=self.decode_path == "generated",
+        )
 
     def _configure_model(self, cfg: Any) -> None:
         vision = self.model.model.vision_tower
@@ -458,12 +472,19 @@ class Gemma4Runtime(UncachedPagedRuntime):
     def decode_with_slot(self, slot: Any, batch_size: int) -> None:
         if batch_size == 0:
             return
+        use_generated = (
+            self.generated_decode is not None
+            and self.generated_decode.supports(batch_size)
+        )
+        if not use_generated and self.decode_path == "generated":
+            raise RuntimeError(
+                "required generated Gemma decode does not cover "
+                f"active batch size {batch_size}"
+            )
         with torch.cuda.stream(slot.compute_stream):
-            if (
-                self._generated_decode is not None
-                and self._generated_decode.supports(batch_size)
-            ):
-                self._generated_decode.run(slot, batch_size)
+            if use_generated:
+                assert self.generated_decode is not None
+                self.generated_decode.run(slot, batch_size)
             else:
                 self._run_native_decode(slot, batch_size)
 

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -492,6 +492,12 @@ class MoondreamRuntime:
         kv_pool: KVMemoryPool,
         compute_stream: torch.cuda.Stream | None,
     ) -> None:
+        self.decode_path = getattr(cfg, "decode_path", "auto")
+        if self.decode_path != "auto":
+            raise ValueError(
+                "Moondream runtimes currently support only decode_path='auto'"
+            )
+        self.generated_decode = None
         self._cfg = cfg
         self.device = cfg.resolved_device()
         self.execution_shape = ExecutionShape.AUTOREGRESSIVE

--- a/kestrel/models/qwen35/generated_decode.py
+++ b/kestrel/models/qwen35/generated_decode.py
@@ -19,7 +19,9 @@ def _state_tensors(state_pool: Any, field: str) -> list[torch.Tensor | None]:
     ]
 
 
-def create_generated_decode(runtime: Any) -> GeneratedDecode | None:
+def create_generated_decode(
+    runtime: Any, *, required: bool = False,
+) -> GeneratedDecode | None:
     bindings = PagedDecodeBindings(
         runtime._paged_kv,
         extra_runtime_inputs=lambda bound_runtime: {
@@ -57,30 +59,32 @@ def create_generated_decode(runtime: Any) -> GeneratedDecode | None:
             "gdn_recurrent_state": recurrent,
         }
 
-    return GeneratedDecode.try_create(
-        runtime,
-        GeneratedDecodeSpec(
-            label="Qwen",
-            weight_root=runtime.model,
-            weight_layer_prefix="model.language_model.layers",
-            bindings=bindings,
-            capacity_inputs=state_inputs,
-            preparations=(
-                DeviceInputPreparation(
-                    "gather_rope_deltas", ("rope_deltas",), ("batch_idx",)),
-                DeviceInputPreparation(
-                    "prepare_position_ids",
-                    ("position_ids",),
-                    ("input_pos", "rope_deltas"),
-                ),
+    spec = GeneratedDecodeSpec(
+        label="Qwen",
+        weight_root=runtime.model,
+        weight_layer_prefix="model.language_model.layers",
+        bindings=bindings,
+        capacity_inputs=state_inputs,
+        preparations=(
+            DeviceInputPreparation(
+                "gather_rope_deltas", ("rope_deltas",), ("batch_idx",)),
+            DeviceInputPreparation(
+                "prepare_position_ids",
+                ("position_ids",),
+                ("input_pos", "rope_deltas"),
             ),
-            not_ready_inputs=frozenset({"position_ids"}),
-            preparation_callbacks={
-                "gather_rope_deltas": runtime._gather_decode_rope_deltas,
-                "prepare_position_ids": runtime._prepare_decode_position_ids,
-            },
         ),
+        not_ready_inputs=frozenset({"position_ids"}),
+        preparation_callbacks={
+            "gather_rope_deltas": runtime._gather_decode_rope_deltas,
+            "prepare_position_ids": runtime._prepare_decode_position_ids,
+        },
     )
+    if required:
+        return GeneratedDecode.require(
+            runtime, spec, capacity=runtime.max_batch_size
+        )
+    return GeneratedDecode.try_create(runtime, spec)
 
 
 __all__ = ["create_generated_decode"]

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -281,6 +281,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
 
         self._spec = get_spec(cfg.model)
         self._model_name = cfg.model
+        self.decode_path = getattr(cfg, "decode_path", "auto")
         self.max_batch_size = getattr(cfg, "max_batch_size", 1)
         self.max_batch_slots = self.max_batch_size + 2
         self._padding_batch_idx = self.max_batch_slots - 1
@@ -429,7 +430,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
         )
         self.decode_slots: Sequence[Any] = self._decode_slots
         self._decode_caches = tuple(self._new_cache() for _ in self._decode_slots)
-        self._decode_megakernel = None
         self._decode_graphs = DecodeGraphManager[DecodeSlot](
             enabled=self._use_cuda_graphs,
             device=self.device,
@@ -445,19 +445,34 @@ class Qwen35Runtime(UncachedPagedRuntime):
 
         self.spatial_tables = None
 
-        from .generated_decode import create_generated_decode
+        self._initialize_generated_decode()
 
-        self._decode_megakernel = create_generated_decode(self)
+        if self._use_cuda_graphs:
+            self._decode_graphs.ensure_ready(self._decode_slots)
+
+    def _initialize_generated_decode(self) -> None:
+        """Apply the runtime-wide decode policy before graph capture."""
+
+        self.generated_decode = None
         self._decode_state_coordinator = None
         self._native_decode_state_requirements = ()
-        if self._decode_megakernel is not None:
+        if self.decode_path == "native":
+            return
+
+        from .generated_decode import create_generated_decode
+
+        self.generated_decode = create_generated_decode(
+            self,
+            required=self.decode_path == "generated",
+        )
+        if self.generated_decode is not None:
             from kestrel.runtime.carried_state import CarriedStateCoordinator
 
             native_requirements = {
                 _native_decode_state_requirements(
                     generated, self._linear_state_pool)
                 for generated
-                in self._decode_megakernel.state_requirements_by_capacity.values()
+                in self.generated_decode.state_requirements_by_capacity.values()
             }
             if len(native_requirements) != 1:
                 raise RuntimeError(
@@ -465,7 +480,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
             self._native_decode_state_requirements = next(
                 iter(native_requirements))
             self._decode_state_coordinator = CarriedStateCoordinator(
-                buffers=self._decode_megakernel.state_buffers,
+                buffers=self.generated_decode.state_buffers,
                 rows=range(self.max_batch_slots),
                 transitions={
                     "gdn_recurrent_state": (
@@ -473,9 +488,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
                     ),
                 },
             )
-
-        if self._use_cuda_graphs:
-            self._decode_graphs.ensure_ready(self._decode_slots)
 
     @property
     def cuda_graphs_enabled(self) -> bool:
@@ -698,7 +710,15 @@ class Qwen35Runtime(UncachedPagedRuntime):
     def decode_with_slot(self, slot: DecodeSlot, batch_size: int) -> None:
         if batch_size == 0:
             return
-        megakernel = getattr(self, "_decode_megakernel", None)
+        megakernel = self.generated_decode
+        use_generated = (
+            megakernel is not None and megakernel.supports(batch_size)
+        )
+        if not use_generated and self.decode_path == "generated":
+            raise RuntimeError(
+                "required generated Qwen decode does not cover "
+                f"active batch size {batch_size}"
+            )
         coordinator = getattr(self, "_decode_state_coordinator", None)
         rows = (
             tuple(
@@ -708,7 +728,8 @@ class Qwen35Runtime(UncachedPagedRuntime):
             if coordinator is not None
             else ()
         )
-        if megakernel is not None and megakernel.supports(batch_size):
+        if use_generated:
+            assert megakernel is not None
             stream = getattr(slot, "compute_stream", None)
             stream_context = (
                 torch.cuda.stream(stream) if stream is not None else nullcontext())

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -202,6 +202,31 @@ class GeneratedDecode:
     """Select bundled capacities and bind them to one serving runtime."""
 
     @classmethod
+    def _resolve_programs(
+        cls, runtime: Any, spec: GeneratedDecodeSpec,
+    ) -> tuple[Any, ...]:
+        if (
+            not spec.bindings.is_eligible(runtime)
+            or runtime.device.type != "cuda"
+            or runtime.dtype is not torch.bfloat16
+        ):
+            return ()
+        try:
+            from kestrel_kernels.generated_decode import resolve_compatible_programs
+        except ModuleNotFoundError as exc:
+            if exc.name != "kestrel_kernels.generated_decode":
+                raise
+            return ()
+
+        properties = torch.cuda.get_device_properties(runtime.device)
+        return tuple(resolve_compatible_programs(
+            spec.weight_root,
+            layer_prefix=spec.weight_layer_prefix,
+            arch=f"sm{properties.major}{properties.minor}",
+            device_sms=int(properties.multi_processor_count),
+        ))
+
+    @classmethod
     def require(
         cls,
         runtime: Any,
@@ -209,16 +234,17 @@ class GeneratedDecode:
         *,
         capacity: int,
     ) -> "GeneratedDecode":
-        generated = cls.try_create(runtime, spec)
-        if generated is None:
+        programs = cls._resolve_programs(runtime, spec)
+        if not programs:
             raise RuntimeError(
                 f"{spec.label} requires a compatible bundled generated-decode program"
             )
-        if not generated.supports(capacity):
-            raise RuntimeError(
-                f"generated {spec.label} decode does not cover capacity={capacity}"
-            )
-        return generated
+        return cls(
+            runtime,
+            spec=spec,
+            programs=programs,
+            required_capacity=capacity,
+        )
 
     @classmethod
     def try_create(
@@ -226,39 +252,39 @@ class GeneratedDecode:
         runtime: Any,
         spec: GeneratedDecodeSpec,
     ) -> "GeneratedDecode | None":
-        if (
-            not spec.bindings.is_eligible(runtime)
-            or runtime.device.type != "cuda"
-            or runtime.dtype is not torch.bfloat16
-        ):
-            return None
-        try:
-            from kestrel_kernels.generated_decode import resolve_compatible_programs
-        except ModuleNotFoundError as exc:
-            if exc.name != "kestrel_kernels.generated_decode":
-                raise
-            return None
-
-        properties = torch.cuda.get_device_properties(runtime.device)
-        programs = resolve_compatible_programs(
-            spec.weight_root,
-            layer_prefix=spec.weight_layer_prefix,
-            arch=f"sm{properties.major}{properties.minor}",
-            device_sms=int(properties.multi_processor_count),
-        )
+        programs = cls._resolve_programs(runtime, spec)
         if not programs:
             return None
         return cls(runtime, spec=spec, programs=programs)
 
-    def __init__(self, runtime: Any, *, spec: GeneratedDecodeSpec, programs) -> None:
+    def __init__(
+        self,
+        runtime: Any,
+        *,
+        spec: GeneratedDecodeSpec,
+        programs,
+        required_capacity: int | None = None,
+    ) -> None:
+        self._programs = tuple(programs)
+        self._spec = spec
+        if required_capacity is not None:
+            missing = [
+                batch_size
+                for batch_size in range(1, int(required_capacity) + 1)
+                if not self.supports(batch_size)
+            ]
+            if missing:
+                raise RuntimeError(
+                    f"generated {spec.label} decode does not cover active batch "
+                    f"sizes {missing}"
+                )
+
         from kestrel_kernels.generated_decode import (
             assemble_bindings,
             derive_runtime_extents,
             materialize_weights,
         )
 
-        self._programs = tuple(programs)
-        self._spec = spec
         contracts = {repr(program.descriptor["weights"]) for program in programs}
         if len(contracts) != 1:
             raise RuntimeError(

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Mapping, Protocol, Sequence
 
+from kestrel.config import DecodePath
 from kestrel.runtime.spec import SpecDecodeCaps
 from kestrel.runtime.state import (
     PrefillClassification,
@@ -42,6 +43,8 @@ if TYPE_CHECKING:
     import numpy as np
     import torch
     from torch import Tensor
+
+    from kestrel.runtime.generated_decode import GeneratedDecode
 
 
 class ExecutionShape(Enum):
@@ -102,6 +105,12 @@ class AutoregressiveRuntime(Runtime, Protocol):
     # behavior; a non-``None`` value advertises a drafter the scheduler can use.
     # Inert until scheduler integration reads it.
     spec: SpecDecodeCaps | None
+
+    # Runtime-wide decode implementation policy and the optional generated
+    # component it selected. All autoregressive runtimes expose both fields;
+    # ``generated_decode`` is ``None`` when this shared component is absent.
+    decode_path: DecodePath
+    generated_decode: GeneratedDecode | None
 
     # Streams
     copy_stream: Any

--- a/kestrel/runtime/uncached_paged.py
+++ b/kestrel/runtime/uncached_paged.py
@@ -17,6 +17,8 @@ class UncachedPagedRuntime:
     """Own page reservation and sequence state for uncached paged inference."""
 
     prefix_cache = None
+    decode_path = "auto"
+    generated_decode = None
 
     @property
     def model_name(self) -> str:

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -110,6 +110,8 @@ class FakeRuntime:
         self.execution_shape = ExecutionShape.AUTOREGRESSIVE
         # No speculative decoding in the fake; decode one token per step.
         self.spec = None
+        self.decode_path = "auto"
+        self.generated_decode = None
 
         # Capacity / shape
         self.max_batch_size = max_batch_size

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,28 @@ def test_runtime_config_preserves_model_path_device_positional_args() -> None:
     assert cfg.tokenizer_path is None
 
 
+def test_runtime_config_rejects_invalid_decode_path_before_download(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.model_download as model_download
+
+    monkeypatch.setattr(
+        model_download,
+        "ensure_model_weights",
+        lambda _model: pytest.fail("invalid decode_path must fail before download"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="decode_path must be 'auto', 'native', or 'generated'",
+    ):
+        RuntimeConfig(
+            model_path=None,
+            device="cpu",
+            decode_path="fallback",  # type: ignore[arg-type]
+        )
+
+
 def test_torch_cuda_driver_version_falls_back_to_libcuda(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -1,0 +1,239 @@
+from types import SimpleNamespace
+
+import pytest
+
+from kestrel.models.gemma4.runtime import Gemma4Runtime
+from kestrel.models.moondream.runtime import MoondreamRuntime
+from kestrel.models.qwen35 import generated_decode as qwen_generated
+from kestrel.models.qwen35.runtime import Qwen35Runtime
+from kestrel.runtime.generated_decode import GeneratedDecode
+
+
+class _Generated:
+    state_requirements_by_capacity = {}
+    state_buffers = ()
+
+    def __init__(self, *, supported: bool) -> None:
+        self.supported = supported
+        self.runs: list[int] = []
+
+    def supports(self, _batch_size: int) -> bool:
+        return self.supported
+
+    def run(self, _slot, batch_size: int) -> None:
+        self.runs.append(batch_size)
+
+
+def test_qwen_native_does_not_construct_generated_decode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.decode_path = "native"
+    monkeypatch.setattr(
+        qwen_generated,
+        "create_generated_decode",
+        lambda *_args, **_kwargs: pytest.fail(
+            "native mode must not construct generated decode"
+        ),
+    )
+
+    runtime._initialize_generated_decode()
+
+    assert runtime.generated_decode is None
+    assert runtime._decode_state_coordinator is None
+
+
+def test_gemma_native_does_not_construct_generated_decode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.gemma4 import generated_decode as gemma_generated
+
+    runtime = object.__new__(Gemma4Runtime)
+    runtime.decode_path = "native"
+    monkeypatch.setattr(
+        gemma_generated,
+        "create_generated_decode",
+        lambda *_args, **_kwargs: pytest.fail(
+            "native mode must not construct generated decode"
+        ),
+    )
+
+    runtime._initialize_generated_decode()
+
+    assert runtime.generated_decode is None
+
+
+def test_qwen_required_generated_unavailable_refuses_before_graph_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.decode_path = "generated"
+    graph_capture = SimpleNamespace(
+        ensure_ready=lambda _slots: pytest.fail(
+            "required generated failure must precede graph capture"
+        )
+    )
+    runtime._decode_graphs = graph_capture
+    calls: list[bool] = []
+
+    def unavailable(_runtime, *, required: bool = False):
+        calls.append(required)
+        raise RuntimeError("no compatible generated program")
+
+    monkeypatch.setattr(qwen_generated, "create_generated_decode", unavailable)
+
+    with pytest.raises(RuntimeError, match="no compatible generated program"):
+        runtime._initialize_generated_decode()
+
+    assert calls == [True]
+    assert runtime.generated_decode is None
+
+
+def test_generated_requirement_unavailable_refuses_before_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructions: list[object] = []
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "_resolve_programs",
+        classmethod(lambda _cls, _runtime, _spec: ()),
+    )
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "__init__",
+        lambda self, *_args, **_kwargs: constructions.append(self),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Qwen requires a compatible bundled generated-decode program",
+    ):
+        GeneratedDecode.require(
+            object(),
+            SimpleNamespace(label="Qwen"),
+            capacity=4,
+        )
+
+    assert constructions == []
+
+
+def test_generated_requirement_covers_complete_batch_domain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "_resolve_programs",
+        classmethod(
+            lambda _cls, _runtime, _spec: (SimpleNamespace(capacity=4),)
+        ),
+    )
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "supports",
+        lambda _self, batch_size: batch_size != 3,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"does not cover active batch sizes \[3\]",
+    ):
+        GeneratedDecode.require(
+            object(),
+            SimpleNamespace(label="Qwen"),
+            capacity=4,
+        )
+
+
+def test_qwen_required_generated_never_falls_back_to_native() -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.decode_path = "generated"
+    runtime.generated_decode = _Generated(supported=False)
+    runtime._decode_state_coordinator = None
+    runtime._decode_graphs = SimpleNamespace(
+        run=lambda *_args: pytest.fail("generated mode must not run native decode")
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="required generated Qwen decode does not cover active batch size 3",
+    ):
+        runtime.decode_with_slot(object(), 3)
+
+
+def test_qwen_selected_generated_failure_never_falls_back_to_native() -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.decode_path = "generated"
+    generated = _Generated(supported=True)
+
+    def fail_generated(_slot, _batch_size: int) -> None:
+        raise RuntimeError("generated launch failed")
+
+    generated.run = fail_generated
+    runtime.generated_decode = generated
+    runtime._decode_state_coordinator = None
+    runtime._decode_graphs = SimpleNamespace(
+        run=lambda *_args: pytest.fail("generated mode must not run native decode")
+    )
+
+    with pytest.raises(RuntimeError, match="generated launch failed"):
+        runtime.decode_with_slot(object(), 2)
+
+
+def test_qwen_auto_preserves_native_fallback() -> None:
+    native_batches: list[int] = []
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.decode_path = "auto"
+    runtime.generated_decode = _Generated(supported=False)
+    runtime._decode_state_coordinator = None
+    runtime._decode_graphs = SimpleNamespace(
+        run=lambda _slot, batch_size: native_batches.append(batch_size)
+    )
+
+    runtime.decode_with_slot(object(), 3)
+
+    assert native_batches == [3]
+
+
+def test_gemma_required_generated_never_falls_back_to_native(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.gemma4 import runtime as gemma_runtime
+
+    runtime = object.__new__(Gemma4Runtime)
+    runtime.decode_path = "generated"
+    runtime.generated_decode = _Generated(supported=False)
+    runtime._run_native_decode = lambda *_args: pytest.fail(
+        "generated mode must not run native decode"
+    )
+    monkeypatch.setattr(
+        gemma_runtime.torch.cuda,
+        "stream",
+        lambda _stream: pytest.fail(
+            "uncovered generated batches must refuse before stream work"
+        ),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="required generated Gemma decode does not cover active batch size 2",
+    ):
+        runtime.decode_with_slot(SimpleNamespace(compute_stream=object()), 2)
+
+
+def test_moondream_explicit_decode_path_refuses_before_runtime_work() -> None:
+    cfg = SimpleNamespace(
+        decode_path="native",
+        resolved_device=lambda: pytest.fail(
+            "unsupported policy must fail before runtime work"
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Moondream runtimes currently support only decode_path='auto'",
+    ):
+        MoondreamRuntime(
+            cfg,
+            kv_pool=object(),
+            compute_stream=None,
+        )


### PR DESCRIPTION
## What changed

- add `RuntimeConfig.decode_path` with `auto`, `native`, and fail-closed `generated` modes
- require complete generated-program coverage for every configured active batch size
- prevent Qwen and Gemma from silently falling back after explicit generated selection
- expose the selected policy/component uniformly on autoregressive runtimes
- reject explicit decode-path selection for Moondream until that runtime supports it
- preserve the current device-SM and exact-vs-dynamic program selector

## Why

The B200 release harness can request generated decode, but public Kestrel did not expose a supported way to enforce it. That allowed validation environments to fall back to native execution or refuse the release command entirely. This makes explicit generated mode a public, fail-closed runtime contract.

## Validation

- full CPU-hidden public suite on Python 3.12: **566 passed, 27 skipped**
- focused decode-path/config/Qwen/Gemma/runtime conformance: **20 passed, 6 skipped**
- rebased on `main` commit `4506312`, retaining its device-SM selection coverage
- `git diff --check` passes