### PR TITLE
Fix Moondream tau GELU semantics

### DIFF
--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -2320,11 +2320,6 @@ class MoondreamRuntime:
                 M, 2 * tc.n_heads,
                 dtype=inputs_embeds.dtype, device=self.device),  # tau_wqwv
         }
-        if tc.tau_attn:
-            qkv_dim = int(tc.dim * (1 + 2 * tc.n_kv_heads / tc.n_heads))
-            scratch_pool["gelu"] = torch.empty(
-                M, qkv_dim,
-                dtype=inputs_embeds.dtype, device=self.device)  # GELU for tau
         if tc.moe and tc.moe.num_experts:
             scratch_pool[(M, tc.moe.num_experts)] = torch.empty(
                 M, tc.moe.num_experts,

--- a/kestrel/models/moondream/text.py
+++ b/kestrel/models/moondream/text.py
@@ -34,7 +34,6 @@ tau_tail_apply_into = _KERNELS.tau.tau_tail_apply_into
 rotary_embedding = _KERNELS.rotary.rotary_embedding
 _fused_linear_bias_residual_into = _KERNELS.vision.fused_linear_bias_residual_into
 _kestrel_linear = _KERNELS.linear.linear
-_gelu_cute = _KERNELS.gelu.gelu_cute
 
 
 def text_encoder(input_ids: torch.Tensor, module: nn.Module) -> torch.Tensor:
@@ -105,7 +104,7 @@ def attn(
     kv_dim = n_kv_heads * head_dim
     if hasattr(module, "tau") and module.tau is not None:
         tau_wqwv = module.tau["wqwv"]
-        gelu_out = _gelu_cute(qkv_out, out=scratch_pool.get("gelu") if scratch_pool else None)
+        gelu_out = F.gelu(qkv_out, approximate="tanh")
         tok_qv_lin = _kestrel_linear(gelu_out, tau_wqwv)
         # _tau_pos_table is built by build_tau_pos_tables() after weight loading.
         tau_tail_apply_into(

--- a/tests/moondream/test_text.py
+++ b/tests/moondream/test_text.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from kestrel.models.moondream import text as text_mod
+
+
+class _StopAfterTau(RuntimeError):
+    pass
+
+
+def test_tau_attention_uses_moondream_tanh_gelu(monkeypatch) -> None:
+    qkv_weight = object()
+    tau_weight = object()
+    qkv_out = torch.randn((1, 1, 8), dtype=torch.bfloat16)
+    captured: dict[str, object] = {}
+
+    def fake_linear(inp, weight, bias=None):
+        del bias
+        if weight is qkv_weight:
+            return qkv_out
+        assert weight is tau_weight
+        captured["gelu_out"] = inp
+        return torch.empty((1, 1, 4), dtype=inp.dtype)
+
+    def fake_gelu(inp, *, approximate):
+        captured["gelu_input"] = inp
+        captured["approximate"] = approximate
+        return inp + 1
+
+    def fake_tau_tail_apply_into(**kwargs):
+        captured["tau_qkv"] = kwargs["qkv_out"]
+        captured["tau_tok_qv"] = kwargs["tok_qv_lin"]
+
+    def stop_after_tau(*args, **kwargs):
+        del args, kwargs
+        raise _StopAfterTau
+
+    monkeypatch.setattr(text_mod, "_kestrel_linear", fake_linear)
+    monkeypatch.setattr(text_mod.F, "gelu", fake_gelu)
+    monkeypatch.setattr(text_mod, "tau_tail_apply_into", fake_tau_tail_apply_into)
+    monkeypatch.setattr(text_mod, "rotary_embedding", stop_after_tau)
+
+    module = SimpleNamespace(
+        qkv=SimpleNamespace(weight=qkv_weight, bias=None),
+        tau={"wqwv": tau_weight},
+        _tau_pos_table=torch.ones((1, 2), dtype=torch.bfloat16),
+    )
+
+    with pytest.raises(_StopAfterTau):
+        text_mod.attn(
+            torch.zeros((1, 1, 4), dtype=torch.bfloat16),
+            module,
+            torch.empty((1, 1, 2)),
+            object(),
+            None,
+            2,
+            1,
+            torch.tensor([0]),
+            slot_mapping=torch.tensor([0]),
+        )
+
+    assert captured["gelu_input"] is qkv_out
+    assert captured["approximate"] == "tanh"
+    torch.testing.assert_close(captured["gelu_out"], qkv_out + 1)
+    assert captured["tau_qkv"] is qkv_out


### PR DESCRIPTION
## Summary

- use Moondream’s canonical tanh-approximate GELU in the text tau-attention path
- remove the now-unused exact-GELU scratch allocation
- add a focused regression that observes the arithmetic mode before attention continues

## Root cause

The model definition uses tanh-approximate GELU, but the optimized tau path routed through the exact-erf GELU kernel. Greedy decoding can cross token boundaries from that arithmetic mismatch. Until the newly merged packed tanh kernel is available in a released kernels dependency, the correct fail-safe implementation is PyTorch’s canonical tanh GELU.

## Validation

- remote focused suite: 10 passed (`test_text`, `test_runtime_prefill`, and `test_runtime_megakernel_fallback`)
- canonical 8-item Moondream ChartQA diagnostics on RTX 3090: the tanh path retained 6/8 quality and 171 output tokens; the previous exact-GELU native path produced 165 output tokens
