### PR TITLE
Fix Gemma vision input semantics

### DIFF
--- a/kestrel/models/gemma4/image.py
+++ b/kestrel/models/gemma4/image.py
@@ -6,9 +6,9 @@ import math
 from dataclasses import dataclass
 from typing import Any
 
-import kestrel_native
 import numpy as np
 import torch
+import torch.nn.functional as F
 from kestrel.utils.image import decode_to_srgb
 
 
@@ -68,9 +68,19 @@ def preprocess_image(
     resized_w = grid_w * PATCH_SIZE
 
     num_valid = grid_h * grid_w
+    pixels = torch.from_numpy(array).permute(2, 0, 1)
     if array.shape[:2] != (resized_h, resized_w):
-        array = kestrel_native.resize_bicubic(array, resized_h, resized_w)
-    pixels = torch.from_numpy(array)
+        # Match Gemma4ImageProcessor's uint8 antialiased bicubic boundary.
+        # The generic native resize has different edge and antialias semantics,
+        # which changes the vision tokens before model execution.
+        pixels = F.interpolate(
+            pixels.unsqueeze(0),
+            size=(resized_h, resized_w),
+            mode="bicubic",
+            align_corners=False,
+            antialias=True,
+        ).squeeze(0)
+    pixels = pixels.permute(1, 2, 0).contiguous()
     patches = (
         pixels.reshape(
             grid_h,

--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -536,6 +536,7 @@ class Gemma4VisionPatchEmbedder(nn.Module):
         pixel_position_ids: torch.Tensor,
         padding_positions: torch.Tensor,
     ) -> torch.Tensor:
+        pixel_values = 2 * (pixel_values - 0.5)
         hidden_states = self.input_proj(pixel_values.to(self.input_proj.weight.dtype))
         positions = pixel_position_ids.clamp(min=0)
         position_embeddings = (
@@ -574,7 +575,7 @@ class Gemma4VisionPooler(nn.Module):
         weights = F.one_hot(kernel_idxs.long(), length).float() / k_squared
         output = weights.transpose(1, 2) @ hidden_states.float()
         mask = torch.logical_not((weights == 0).all(dim=1))
-        return output.to(hidden_states.dtype), mask
+        return output, mask
 
     def forward(
         self,
@@ -593,7 +594,7 @@ class Gemma4VisionPooler(nn.Module):
             hidden_states, padding_positions = self._avg_pool_by_positions(
                 hidden_states, pixel_position_ids, output_length
             )
-        hidden_states = hidden_states * self.root_hidden_size
+        hidden_states = hidden_states.float() * self.root_hidden_size
         return hidden_states, padding_positions
 
 
@@ -828,7 +829,11 @@ class Gemma4VisionModel(nn.Module):
         hidden_states = hidden_states[pooler_mask]
 
         if self.config.standardize:
-            hidden_states = (hidden_states - self.std_bias) * self.std_scale
+            hidden_states = (
+                hidden_states - self.std_bias.float()
+            ) * self.std_scale.float()
+
+        hidden_states = hidden_states.to(inputs_embeds.dtype)
 
         return hidden_states
 

--- a/tests/test_gemma4_image.py
+++ b/tests/test_gemma4_image.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import torch
+
+from kestrel.models.gemma4.image import preprocess_image
+
+
+def _sha256_tensor(tensor) -> str:
+    raw = (
+        tensor.detach()
+        .cpu()
+        .contiguous()
+        .reshape(-1)
+        .view(torch.uint8)
+        .numpy()
+        .tobytes()
+    )
+    return hashlib.sha256(raw).hexdigest()
+
+
+def test_preprocess_image_matches_reference_antialiased_bicubic() -> None:
+    image = np.arange(37 * 61 * 3, dtype=np.uint8).reshape(37, 61, 3)
+
+    result = preprocess_image(image)
+
+    # Generated from the pinned Gemma4ImageProcessor reference implementation:
+    # uint8 Torchvision bicubic with antialiasing, then BF16 conversion.
+    assert result.num_image_tokens == 273
+    assert _sha256_tensor(result.pixel_values) == (
+        "34484611b0697c9f40f6f3698b20272e1f1f798daa611067e61e1ede48ce94ee"
+    )
+    assert _sha256_tensor(result.image_position_ids) == (
+        "6a8ec8b7ec82189bbf0b31e1a6e0294c0b69ef164d56eb5e2b07433f0508ca48"
+    )

--- a/tests/test_gemma4_vision.py
+++ b/tests/test_gemma4_vision.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from kestrel.models.gemma4.model import (
+    Gemma4VisionPatchEmbedder,
+    Gemma4VisionPooler,
+)
+
+
+def test_patch_embedder_applies_reference_pixel_scaling() -> None:
+    config = SimpleNamespace(
+        patch_size=1,
+        hidden_size=3,
+        position_embedding_size=2,
+    )
+    embedder = Gemma4VisionPatchEmbedder(config)
+    with torch.no_grad():
+        embedder.input_proj.weight.copy_(torch.eye(3))
+        embedder.position_embedding_table.zero_()
+
+    output = embedder(
+        torch.zeros((1, 1, 3)),
+        torch.zeros((1, 1, 2), dtype=torch.long),
+        torch.zeros((1, 1), dtype=torch.bool),
+    )
+
+    torch.testing.assert_close(output, -torch.ones_like(output))
+
+
+def test_vision_pooler_keeps_fp32_until_standardization() -> None:
+    pooler = Gemma4VisionPooler(SimpleNamespace(hidden_size=4))
+    hidden_states = torch.tensor(
+        [[[1.0], [2.0], [3.0], [4.0]]],
+        dtype=torch.bfloat16,
+    )
+    positions = torch.tensor([[[0, 0], [1, 0], [0, 1], [1, 1]]])
+
+    output, mask = pooler(
+        hidden_states,
+        positions,
+        torch.zeros((1, 4), dtype=torch.bool),
+        output_length=1,
+    )
+
+    assert output.dtype == torch.float32
+    torch.testing.assert_close(output, torch.tensor([[[5.0]]]))
+    assert mask.tolist() == [[True]]


### PR DESCRIPTION
## Summary
- match the pinned Gemma image processor antialiased uint8 bicubic resize exactly
- restore the checkpoint-defined `2 * (pixels - 0.5)` patch scaling
- keep pooled vision activations in FP32 through standardization before casting back

## Validation
- belka host-only: `tests/test_gemma4_image.py tests/test_gemma4_vision.py`: 3 passed
- canonical RTX 3090 Gemma C1 ChartQA generated-AOT run: 8/8 stopped, 5/8 correct; the prior row-19 token-0 divergence moved to token 24 and the answer corrected
- broader engine integration was not used as a gate because the host environment pins an older `kestrel-kernels` API (`resolve_compatible_programs` lacks `device_sms`); the three scoped tests are green

No local tests were run.