### PR TITLE
runtime: support integrated speculative decoders

### DIFF
--- a/kestrel/config.py
+++ b/kestrel/config.py
@@ -2,7 +2,7 @@
 
 
 import ctypes
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 import re
 from typing import Literal
@@ -177,8 +177,18 @@ class RuntimeConfig:
     # that support it must bind compatible generated programs for the complete
     # configured batch domain and may not fall back to native decode.
     decode_path: DecodePath = "auto"
+    # Backend-owned, namespaced options. Keeping these in one mapping avoids
+    # adding model-specific fields to the shared engine configuration.
+    runtime_options: dict[str, object] = field(default_factory=dict)
 
     def __post_init__(self):
+        if not isinstance(self.runtime_options, dict) or not all(
+            isinstance(name, str) and name for name in self.runtime_options
+        ):
+            raise TypeError(
+                "runtime_options must be a dictionary with nonempty string keys"
+            )
+        self.runtime_options = dict(self.runtime_options)
         if self.decode_path not in ("auto", "native", "generated"):
             raise ValueError(
                 "decode_path must be 'auto', 'native', or 'generated'"

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import threading
 from concurrent.futures import Future
 from dataclasses import dataclass, field
 from typing import (
@@ -397,6 +398,7 @@ class _AutoregressiveRequest:
     return_logprobs: Optional[bool] = None
     generated_prefix: GeneratedPrefix = field(default_factory=GeneratedPrefix)
     suppress_next_token_ids: Optional[tuple[int, ...]] = None
+    cancel_event: threading.Event = field(default_factory=threading.Event, repr=False)
 
 
 @dataclass(slots=True)

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1023,6 +1023,14 @@ class InferenceEngine:
         loop = asyncio.get_running_loop()
         req_id = next(self._request_ids)
         future: asyncio.Future[EngineResult] = loop.create_future()
+        cancel_event = threading.Event()
+
+        def wake_cancelled_request(completed: asyncio.Future[EngineResult]) -> None:
+            if completed.cancelled():
+                cancel_event.set()
+                self._scheduler_event.set()
+
+        future.add_done_callback(wake_cancelled_request)
 
         skill_spec = self._skill_registry().resolve(skill)
         adapter_id = self._normalize_adapter_id(adapter)
@@ -1093,6 +1101,7 @@ class InferenceEngine:
             return_logprobs=return_logprobs,
             generated_prefix=generated_prefix,
             suppress_next_token_ids=suppress_next_token_ids,
+            cancel_event=cancel_event,
         )
         del prepared_prompt
         await self._queue.put(payload)

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -72,6 +72,8 @@ class _AdmissionCoordinator:
         return len(self._pending)
 
     def submit(self, req: _AutoregressiveRequest) -> Optional[_ReadyAdmission]:
+        if req.cancel_event.is_set():
+            return None
         crops_future: Future[Any] | None = None
         encoder_input_future: Future[Any] | None = None
         prefix_cache_hit = False
@@ -141,6 +143,9 @@ class _AdmissionCoordinator:
             pending = self._pending.get(req_id)
             if pending is None:
                 continue
+            if pending.req.cancel_event.is_set():
+                self._discard_pending(req_id, pending)
+                continue
             futures = (pending.crops_future, pending.encoder_input_future)
             failed: BaseException | None = None
             for future in futures:
@@ -189,6 +194,28 @@ class _AdmissionCoordinator:
                 encoder_input=encoder_input,
                 prefix_cache_hit=pending.prefix_cache_hit,
             )
+
+    def discard_cancelled(self) -> bool:
+        """Cancel preprocessing and forget requests abandoned by their caller."""
+
+        cancelled = [
+            (request_id, pending)
+            for request_id, pending in self._pending.items()
+            if pending.req.cancel_event.is_set()
+        ]
+        for request_id, pending in cancelled:
+            self._discard_pending(request_id, pending)
+        return bool(cancelled)
+
+    def _discard_pending(
+        self,
+        request_id: int,
+        pending: _PendingAdmission,
+    ) -> None:
+        self._pending.pop(request_id, None)
+        for future in (pending.crops_future, pending.encoder_input_future):
+            if future is not None and not future.done():
+                future.cancel()
 
     def fail_all(self, error: Optional[BaseException] = None) -> None:
         exc = error or RuntimeError("Engine shut down")
@@ -320,7 +347,8 @@ class AutoregressiveExecutor:
 
     def advance(self) -> TickResult:
         scheduler = self._scheduler
-        progressed = self._promote_ready()
+        progressed = self._discard_cancelled()
+        progressed = self._promote_ready() or progressed
 
         if scheduler.has_pending_work():
             progressed = scheduler.advance() or progressed
@@ -373,6 +401,8 @@ class AutoregressiveExecutor:
 
     def _admit_ready(self, ready: _ReadyAdmission) -> None:
         req = ready.req
+        if req.cancel_event.is_set():
+            return
         try:
             generation_req, skill_state = self._build_generation_request(
                 self._runtime, req, ready.crops, ready.encoder_input
@@ -406,6 +436,14 @@ class AutoregressiveExecutor:
         generation_req.lifecycle = lifecycle
         self._scheduler.enqueue_request(generation_req, skill_state)
         self._active[req.request_id] = req
+
+    def _discard_cancelled(self) -> bool:
+        progressed = self._admission.discard_cancelled()
+        for request_id, request in tuple(self._active.items()):
+            if not request.cancel_event.is_set():
+                continue
+            progressed = self._scheduler.cancel_request(request_id) or progressed
+        return progressed
 
     def _promote_ready(self) -> bool:
         promoted = False
@@ -459,8 +497,9 @@ class AutoregressiveExecutor:
         for state in runtime_sequences:
             try:
                 if decoder is not None:
+                    batch_idx = state.batch_idx
                     decoder.retire(state)
-                    self._runtime.active_sequences.pop(state.batch_idx, None)
+                    self._runtime.active_sequences.pop(batch_idx, None)
                     self._runtime.release_adapter_slot(
                         getattr(state, "lora_slot", 0)
                     )

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Protocol, Sequence, runtime_checkable
 if TYPE_CHECKING:
     import torch
 
+    from kestrel.runtime.state import SequenceState
     from kestrel.runtime.tokens import Token
 
 
@@ -241,7 +242,7 @@ class SpecDecoder(Protocol):
 
     def admit(
         self,
-        state: Any,
+        state: "SequenceState",
         prompt_tokens: "Sequence[Token]",
         *,
         request_context: object,
@@ -325,7 +326,7 @@ class SpecDecoder(Protocol):
 
     def step(
         self,
-        states: Sequence[Any],
+        states: Sequence["SequenceState"],
         *,
         allowed_token_ids: Sequence[Sequence[int] | None] | None = None,
         suppressed_token_ids: Sequence[Sequence[int] | None] | None = None,
@@ -380,7 +381,7 @@ class SpecDecoder(Protocol):
         """
         ...
 
-    def retire(self, state: Any) -> None:
+    def retire(self, state: "SequenceState") -> None:
         """Release the pool row held by a finished sequence's ``state``."""
         ...
 

--- a/kestrel/runtime/spec.py
+++ b/kestrel/runtime/spec.py
@@ -244,6 +244,7 @@ class SpecDecoder(Protocol):
         state: Any,
         prompt_tokens: "Sequence[Token]",
         *,
+        request_context: object,
         image: Any | None = None,
         image_crops: Any | None = None,
         allowed_token_ids: Sequence[int] | None = None,
@@ -253,6 +254,12 @@ class SpecDecoder(Protocol):
         top_p: float = 1.0,
     ) -> "tuple[int, float | None]":
         """Prefill ``prompt_tokens`` into a free pool row for ``state``.
+
+        ``request_context`` is the opaque, model-owned value returned by the
+        request's skill.  The scheduler never inspects it; it is forwarded so
+        a decoder can honor request-local model policy that is not part of the
+        generic sampling envelope (for example a decoding strategy, grammar,
+        or deterministic RNG seed).
 
         ``prompt_tokens`` is the request's *typed* prefill sequence -- the same
         ``Sequence[Token]`` the non-spec ``AutoregressiveRuntime.prepare_sequence``
@@ -390,6 +397,11 @@ class SpecDecodeCaps:
     the proposer consumes (e.g. DFlash's ``target_layer_ids``); an empty tuple
     means the proposer needs no target hidden states.
 
+    ``proposer`` is optional for runtimes whose speculative algorithm is an
+    integrated model forward rather than a separable draft-then-verify pair.
+    Such runtimes advertise their algorithm through ``decoder`` alone. At
+    least one of ``proposer`` or ``decoder`` must be present.
+
     ``decoder`` is the runtime's :class:`SpecDecoder` — the per-macro-step
     entry point the scheduler drives (draft + verify + accept + commit). It is
     optional only so the inert scaffolding (and its CPU-only tests) can still
@@ -397,6 +409,10 @@ class SpecDecodeCaps:
     actually wants the scheduler to speculate must set it.
     """
 
-    proposer: SpecProposer
+    proposer: SpecProposer | None = None
     capture_hidden_layers: tuple[int, ...] = ()
     decoder: SpecDecoder | None = None
+
+    def __post_init__(self) -> None:
+        if self.proposer is None and self.decoder is None:
+            raise ValueError("speculative decoding requires a proposer or decoder")

--- a/kestrel/runtime/state.py
+++ b/kestrel/runtime/state.py
@@ -40,6 +40,8 @@ class SequenceState:
     cache_lock_node: TreeNode | None = None
     cache_owned_page_count: int = 0  # Pages belonging to cache (not freed on release)
     reused_page_count: int = 0  # Pages reused from cache hit (for metrics)
+    # Uniform request contract used by both ordinary and speculative decode.
+    return_logprobs: bool = False
 
     def __post_init__(self) -> None:
         if self.prompt_length is None:

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -889,13 +889,8 @@ class GenerationScheduler:
                 prompt_length=kv_prompt_length,
                 image_length=request.image_length,
                 lora_slot=request.lora_slot,
+                return_logprobs=request.return_logprobs is True,
             )
-            # The spec decoder reads ``return_logprobs`` off the state to decide
-            # whether ``step`` computes per-committed-token logprobs for this row
-            # (matching the non-spec sampler, which gates the logprob gather on
-            # the request). ``SequenceState`` is a plain dataclass, so attach it
-            # as an extra attribute the decoder picks up via ``getattr``.
-            state.return_logprobs = request.return_logprobs is True
 
             # Run the skill's prefill hook BEFORE building the mask + admitting:
             # ``admit`` prefills *and* samples the first (bonus) token in one

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -424,6 +424,54 @@ class GenerationScheduler:
         request.skill_state = skill_state
         self.waiting.push(request)
 
+    def cancel_request(self, request_id: int) -> bool:
+        """Finalize one queued or running request at a scheduler-safe boundary."""
+
+        request = next(
+            (item for item in self.waiting if item.request_id == request_id),
+            None,
+        )
+        if request is not None:
+            self.waiting.remove(request)
+            lifecycle = request.lifecycle
+            if lifecycle.lora_slot_ready and request.lora_slot:
+                self.runtime.release_adapter_slot(request.lora_slot)
+                request.lora_slot = 0
+                lifecycle.lora_slot_ready = False
+            request.encoder_input = None
+            lifecycle.finish_reason = "cancelled"
+            lifecycle.finished = True
+            lifecycle.finalized = True
+            lifecycle.completed_at = time.perf_counter()
+            lifecycle.first_token_time = lifecycle.completed_at
+            lifecycle.transition(RequestPhase.COMPLETED)
+            self._completed.append(self._build_result(lifecycle))
+            return True
+
+        sequence = next(
+            (
+                item
+                for item in self.running
+                if item.request.request_id == request_id
+            ),
+            None,
+        )
+        if sequence is None:
+            return False
+        # Non-speculative prefill has a separate in-flight ownership protocol:
+        # unlike decode, its launch is not represented by ``inflight_refs``.
+        # It therefore cannot be retired from this generic safe point yet.
+        # The caller's future is still cancelled, and the existing path drains
+        # that request normally. Integrated speculative decoders use explicit
+        # transactional rows and can be retired here or by their pending step.
+        if self.runtime.spec is None:
+            return False
+        self.running.remove(sequence)
+        self._finalize_sequence(sequence, "cancelled")
+        if self.runtime.spec is not None and sequence.inflight_refs == 0:
+            self._retire_spec_row(sequence.state)
+        return True
+
     def _materialize_tokens(
         self,
         token_ids_cpu: Tensor,
@@ -964,6 +1012,7 @@ class GenerationScheduler:
                     first_token_id, first_logprob = decoder.admit(
                         state,
                         prompt_tokens,
+                        request_context=request.request_context,
                         image=request.image,
                         image_crops=request.image_crops,
                         allowed_token_ids=allowed_token_ids,
@@ -1115,6 +1164,7 @@ class GenerationScheduler:
         # sentinel means ``admit`` never reserved one, so there is nothing to
         # retire.
         if state.batch_idx >= 0:
+            batch_idx = state.batch_idx
             if decoder is not None:
                 try:
                     decoder.retire(state)
@@ -1125,7 +1175,7 @@ class GenerationScheduler:
             # failure path it is absent; on the admit-token materialization
             # failure path it was registered just before -- pop it
             # unconditionally so neither leaves a dangling entry.
-            self.runtime.active_sequences.pop(state.batch_idx, None)
+            self.runtime.active_sequences.pop(batch_idx, None)
         lifecycle = request.lifecycle
         if lifecycle.lora_slot_ready and request.lora_slot:
             # Release the LoRA slot we acquired for this failed admission so its
@@ -1154,8 +1204,9 @@ class GenerationScheduler:
         ``lora_slot == 0`` (a base-model request), so this is unconditional.
         """
         decoder = self.runtime.spec.decoder
+        batch_idx = state.batch_idx
         decoder.retire(state)
-        self.runtime.active_sequences.pop(state.batch_idx, None)
+        self.runtime.active_sequences.pop(batch_idx, None)
         self.runtime.release_adapter_slot(state.lora_slot)
 
     def _spec_decode_step(self) -> bool:
@@ -1501,6 +1552,19 @@ class GenerationScheduler:
         # ``tokens``/``logprobs`` resolve lazily off the (already-landed) D2H;
         # ``side_values`` holds device tensors read at ``step`` time.
         tokens = result.tokens
+        if all(seq.finalized for seq in active):
+            # Cancellation/finalization can turn an entire pending macro-step
+            # into zombies. Resolving ``tokens`` above fences its device work;
+            # do not run model-specific materialization for values that will be
+            # discarded. Apart from avoiding wasted CPU work, this ensures a
+            # cancelled row can always reach its retirement path even if its
+            # token materializer rejects output that no caller will observe.
+            for seq in active:
+                seq.inflight_refs -= 1
+                if seq.inflight_refs == 0:
+                    seq.transition(RequestPhase.COMPLETED)
+                    self._retire_spec_row(seq.state)
+            return
         logprobs = result.logprobs  # None when nobody requested logprobs
         side_values = result.side_values
         # Type the whole step's committed ids up front (coord/size via the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "torch-c-dlpack-ext>=0.1.3",
     "httpx>=0.27",
     "kestrel-native==0.1.8",
-    "kestrel-kernels==0.4.10",
+    "kestrel-kernels==0.5.0",
     "huggingface-hub>=0.20",
     "numpy>=1.26",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "torch-c-dlpack-ext>=0.1.3",
     "httpx>=0.27",
     "kestrel-native==0.1.8",
-    "kestrel-kernels==0.4.9",
+    "kestrel-kernels==0.4.10",
     "huggingface-hub>=0.20",
     "numpy>=1.26",
 ]

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -125,7 +125,7 @@ class _FakeDecoder:
         if self._admit_side_values is not None:
             state.admit_side_values = self._admit_side_values
         self.admitted.append(row)
-        want_logprobs = getattr(state, "return_logprobs", None) is True
+        want_logprobs = state.return_logprobs
         self.admit_kwargs[row] = {
             # The *typed* prompt tokens the scheduler forwards (the non-spec
             # ``prepare_sequence`` contract): asserted to survive admission whole,
@@ -140,7 +140,7 @@ class _FakeDecoder:
             "suppress_next_token_ids": suppress_next_token_ids,
             "temperature": temperature,
             "top_p": top_p,
-            "return_logprobs": getattr(state, "return_logprobs", None),
+            "return_logprobs": state.return_logprobs,
         }
         # New contract: ``admit`` returns ``(first_token_id, first_logprob)``.
         # ``first_logprob`` is the real selected-token logprob when the request

--- a/tests/scheduler/test_spec_decode_path.py
+++ b/tests/scheduler/test_spec_decode_path.py
@@ -110,6 +110,7 @@ class _FakeDecoder:
         state,
         prompt_token_ids,
         *,
+        request_context=None,
         image=None,
         image_crops=None,
         allowed_token_ids=None,
@@ -131,6 +132,7 @@ class _FakeDecoder:
             # not be stripped to ``int(t.token_id)`` (which would raise on
             # ImageMarker/Coord/Size tokens that lack ``token_id``).
             "prompt_tokens": list(prompt_token_ids),
+            "request_context": request_context,
             "image": image,
             "image_crops": image_crops,
             "allowed_token_ids": allowed_token_ids,
@@ -338,6 +340,118 @@ def test_spec_finish_on_eos_within_run_retires_and_completes() -> None:
     completed = sched.pop_completed()
     assert [c.request_id for c in completed] == [0]
     assert completed[0].finish_reason == "stop"
+
+
+def test_spec_retire_may_invalidate_state_batch_index() -> None:
+    class _InvalidatingDecoder(_FakeDecoder):
+        def retire(self, state) -> None:  # noqa: ANN001
+            super().retire(state)
+            state.batch_idx = -1
+
+    decoder = _InvalidatingDecoder(
+        n_rows=1,
+        first_tokens={0: 999},
+        plans={0: []},
+    )
+    runtime = _spec_runtime(decoder, eos_id=999)
+    scheduler = _make_scheduler(runtime)
+    request = _enqueue(scheduler, 0, prompt_len=3, max_new=2)
+
+    assert scheduler._spec_admit() is True
+
+    assert request.lifecycle.state.batch_idx == -1
+    assert decoder.retired == [0]
+    assert runtime.active_sequences == {}
+
+
+def test_cancelled_running_spec_request_retires_transactional_row() -> None:
+    decoder = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12]]},
+    )
+    runtime = _spec_runtime(decoder)
+    scheduler = _make_scheduler(runtime)
+    request = _enqueue(scheduler, 17, prompt_len=3, max_new=8)
+
+    assert scheduler._spec_admit() is True
+    assert scheduler.cancel_request(request.request_id) is True
+
+    assert decoder.retired == [0]
+    assert runtime.active_sequences == {}
+    assert list(scheduler.running) == []
+    (result,) = scheduler.pop_completed()
+    assert result.request_id == request.request_id
+    assert result.finish_reason == "cancelled"
+
+
+def test_cancelled_waiting_spec_request_never_claims_a_row() -> None:
+    decoder = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12]]},
+    )
+    scheduler = _make_scheduler(_spec_runtime(decoder))
+    request = _enqueue(scheduler, 19, prompt_len=3, max_new=8)
+
+    assert scheduler.cancel_request(request.request_id) is True
+
+    assert decoder.admitted == []
+    assert decoder.retired == []
+    assert list(scheduler.waiting) == []
+    (result,) = scheduler.pop_completed()
+    assert result.finish_reason == "cancelled"
+
+
+def test_cancelled_spec_request_defers_row_reuse_until_pending_step_commits() -> None:
+    decoder = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12]]},
+    )
+    runtime = _spec_runtime(decoder)
+    scheduler = _make_scheduler(runtime)
+    request = _enqueue(scheduler, 18, prompt_len=3, max_new=8)
+
+    assert scheduler._spec_admit() is True
+    lifecycle = request.lifecycle
+    state = lifecycle.state
+    assert scheduler._spec_decode_step() is True
+    assert lifecycle.inflight_refs == 1
+    assert [token.token_id for token in lifecycle.skill_state.tokens] == [11]
+
+    assert scheduler.cancel_request(request.request_id) is True
+    assert decoder.retired == []
+    assert state.batch_idx in runtime.active_sequences
+
+    scheduler._drain_spec()
+    assert decoder.retired == [0]
+    assert runtime.active_sequences == {}
+    assert [token.token_id for token in lifecycle.skill_state.tokens] == [11]
+
+
+def test_cancelled_pending_cohort_skips_discarded_token_materialization() -> None:
+    decoder = _FakeDecoder(
+        n_rows=1,
+        first_tokens={0: 11},
+        plans={0: [[12]]},
+    )
+    runtime = _spec_runtime(decoder)
+    scheduler = _make_scheduler(runtime)
+    request = _enqueue(scheduler, 20, prompt_len=3, max_new=8)
+
+    assert scheduler._spec_admit() is True
+    assert scheduler._spec_decode_step() is True
+    assert scheduler.cancel_request(request.request_id) is True
+
+    def fail_materialization(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("discarded zombie tokens must not be materialized")
+
+    scheduler._materialize_spec_tokens = fail_materialization
+    scheduler._drain_spec()
+
+    assert decoder.retired == [0]
+    assert runtime.active_sequences == {}
 
 
 def test_spec_finish_on_additional_runtime_eos_id() -> None:
@@ -954,6 +1068,7 @@ def test_spec_admit_forwards_image_mask_and_sampling_params() -> None:
 
     assert sched._spec_admit() is True
     kw = dec.admit_kwargs[0]
+    assert kw["request_context"] is req.request_context
     assert kw["image"] is img
     assert list(kw["allowed_token_ids"]) == [12, 13]
     assert list(kw["suppressed_token_ids"]) == [99]

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -75,12 +75,14 @@ def _executor() -> AutoregressiveExecutor:
             ex._scheduler._completed.pop(0) for _ in list(ex._scheduler._completed)
         ],
         enqueue_request=lambda req, state: None,
+        cancel_request=lambda request_id: False,
     )
     ex._admission = SimpleNamespace(
         has_pending=lambda: False,
         pending_count=0,
         take_ready=lambda: None,
         fail_all=lambda exc: None,
+        discard_cancelled=lambda: False,
     )
     return ex
 
@@ -175,6 +177,20 @@ def test_ingress_capacity_counts_active_and_preprocessing_requests() -> None:
 
     ex._admission.pending_count = 1
     assert ex.has_ingress_capacity is False
+
+
+def test_cancelled_active_request_is_forwarded_to_scheduler() -> None:
+    ex = _executor()
+    request = _pending(7)
+    request.cancel_event.set()
+    ex._active[request.request_id] = request
+    cancelled: list[int] = []
+    ex._scheduler.cancel_request = lambda request_id: (
+        cancelled.append(request_id) or True
+    )
+
+    assert ex._discard_cancelled() is True
+    assert cancelled == [7]
 
 
 def test_shutdown_fails_in_flight_requests() -> None:
@@ -314,12 +330,14 @@ def test_shutdown_retires_spec_rows_through_the_decoder() -> None:
         # Model the decoder reclaiming its pool row: the freed row index
         # becomes reusable for a future admit.
         free_rows.add(state.batch_idx)
+        state.batch_idx = -1
 
     def _release_sequence(st: Any) -> None:
         released_via_release_sequence.append(st)
 
     decoder = SimpleNamespace(retire=_retire)
     state = SimpleNamespace(batch_idx=7, lora_slot=3)
+    original_batch_idx = state.batch_idx
 
     ex = _executor()
     ex._runtime = SimpleNamespace(
@@ -341,8 +359,8 @@ def test_shutdown_retires_spec_rows_through_the_decoder() -> None:
     # Adapter slot the spec admit acquired was released.
     assert released_slots == [state.lora_slot]
     # The row is freed from the registry and reusable (decoder reclaimed it).
-    assert state.batch_idx not in ex._runtime.active_sequences
-    assert state.batch_idx in free_rows
+    assert original_batch_idx not in ex._runtime.active_sequences
+    assert original_batch_idx in free_rows
 
 
 def test_shutdown_retires_base_model_spec_row_with_zero_slot() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,28 @@ def test_runtime_config_preserves_model_path_device_positional_args() -> None:
     assert cfg.tokenizer_path is None
 
 
+def test_runtime_config_copies_namespaced_runtime_options() -> None:
+    options = {"backend.graph_limit": 384}
+    cfg = RuntimeConfig(
+        model_path="/weights/model.safetensors",
+        device="cpu",
+        runtime_options=options,
+    )
+
+    options["backend.graph_limit"] = 1
+    assert cfg.runtime_options == {"backend.graph_limit": 384}
+
+
+@pytest.mark.parametrize("options", [[], {"": 1}, {1: "value"}])
+def test_runtime_config_rejects_invalid_runtime_options(options) -> None:  # noqa: ANN001
+    with pytest.raises(TypeError, match="nonempty string keys"):
+        RuntimeConfig(
+            model_path="/weights/model.safetensors",
+            device="cpu",
+            runtime_options=options,
+        )
+
+
 def test_runtime_config_rejects_invalid_decode_path_before_download(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -366,6 +366,29 @@ def test_admission_coordinator_promotes_completed_crops() -> None:
     assert failures == []
 
 
+def test_admission_coordinator_cancels_abandoned_preprocessing() -> None:
+    crop_future: Future[object] = Future()
+    coordinator = _AdmissionCoordinator(
+        runtime=_FakeRuntime(
+            prefix_cache=None,
+            prefix_hit=False,
+            image_preprocessor=_FakeImagePreprocessor([crop_future]),
+        ),
+        wake_event=threading.Event(),
+        fail_request=lambda *_: None,
+    )
+    request = _make_request(
+        image=np.zeros((4, 4, 3), dtype=np.uint8),
+    )
+
+    assert coordinator.submit(request) is None
+    request.cancel_event.set()
+
+    assert coordinator.discard_cancelled() is True
+    assert crop_future.cancelled()
+    assert not coordinator.has_pending()
+
+
 def test_admission_coordinator_skips_failed_crop_and_keeps_promoting() -> None:
     image = np.zeros((4, 4, 3), dtype=np.uint8)
     failed_future: Future[object] = Future()

--- a/tests/test_spec_interface.py
+++ b/tests/test_spec_interface.py
@@ -6,6 +6,8 @@ No model construction, no GPU.
 
 from __future__ import annotations
 
+import pytest
+
 from kestrel.runtime.spec import (
     DraftResult,
     SpecDecodeCaps,
@@ -45,6 +47,18 @@ def test_spec_decode_caps_defaults_to_no_hidden_layers() -> None:
     # The spec-step decoder is optional on the scaffolding (CPU tests build caps
     # that only advertise a proposer); it defaults to None.
     assert caps.decoder is None
+
+
+def test_integrated_decoder_does_not_require_separate_proposer() -> None:
+    decoder = _StubDecoder()
+    caps = SpecDecodeCaps(decoder=decoder)
+    assert caps.proposer is None
+    assert caps.decoder is decoder
+
+
+def test_spec_decode_caps_rejects_empty_capability() -> None:
+    with pytest.raises(ValueError, match="requires a proposer or decoder"):
+        SpecDecodeCaps()
 
 
 class _StubState:


### PR DESCRIPTION
## Status

Production companion for LocateAnything support in
m87-labs/kestrel-proprietary#1754. Current Kestrel `main` through `f920e71` is
merged, and the release head is `4cee678`.

## Architecture

Some speculative decoders own proposal, verification, acceptance,
transactional KV, and fallback as one model macro-step. Requiring a separable
proposer forces model semantics into the scheduler and cannot safely represent
these runtimes.

This change keeps the boundary generic:

- speculative capabilities may expose an integrated decoder without a separate
  proposer;
- scheduler admission forwards opaque, model-owned request context;
- preprocessing can publish the exact image KV length required by a
  multimodal runtime;
- backend settings remain in `RuntimeConfig.runtime_options` rather than adding
  model-specific fields;
- `SequenceState` ownership is explicit at the runtime boundary;
- cancellation propagates through preprocessing, queued work, in-flight
  integrated speculative steps, and decoder-owned transactional-row retirement;
- retirement preserves the original batch index after decoder-owned row state
  is invalidated;
- ordinary runtimes retain the same public API and semantics.

The scheduler does not inspect LocateAnything mode, grammar, PBD shape, or KV
policy.

## Qualification

- 119/119 focused scheduler, engine, config, lifecycle, and
  speculative-interface tests pass after merging current `main`;
- the proprietary release gate passes exact slow, fast, and hybrid decoding at
  C1/C2 and previously qualified exact C1/C2/C4/C8 lifecycle behavior;
- cancellation, continuous replacement, bounded generation, recreation, image
  KV propagation, and transactional-row retirement are covered;
- the companion pins the production kernel API at `kestrel-kernels==0.5.0`;
- GitHub reports the branch cleanly mergeable.

## Merge order

Merge this PR before m87-labs/kestrel-proprietary#1754, then publish the pinned
kernel package and qualified H100 AOT artifact before the deployment-image
smoke.

## Review order

1. Speculative decoder protocol and capability types.
2. `SequenceState`, opaque request context, and image-KV plumbing.
3. Scheduler admission, retirement, and cancellation paths.
4. Focused regression tests.

No model-specific type or option is added to the public runtime surface.
