### PR TITLE
Reserve exact image KV lengths

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1722,16 +1722,23 @@ class InferenceEngine:
             )
         prompt_tokens = req.prompt_tokens
         stream_cb = self._build_stream_callback(req)
-        if req.image is None and image_crops is None:
-            image_length = 0
-        elif isinstance(req.image, (list, tuple)):
-            # Multi-image chat: each image expands one ImageMarker token — which
-            # is already counted in prompt_length — into an image_prefix_length
-            # patch block, so it adds image_prefix_length - 1 KV positions per
-            # image. (target_length = prompt_length + image_length + max_new.)
-            image_length = len(req.image) * (runtime.image_prefix_length - 1)
-        else:
-            image_length = runtime.image_prefix_length
+        image_length = (
+            0
+            if req.image is None and image_crops is None
+            else runtime.image_kv_length(
+                prompt_tokens,
+                req.image,
+                image_crops,
+            )
+        )
+        if (
+            isinstance(image_length, bool)
+            or not isinstance(image_length, int)
+            or image_length < 0
+        ):
+            raise ValueError(
+                "runtime image_kv_length must return a non-negative integer"
+            )
         adapter = req.adapter
         request_obj = GenerationRequest(
             request_id=req.request_id,

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -1246,6 +1246,15 @@ class MoondreamRuntime:
     def preprocess_encoder_input_async(self, encoder_input: object):
         raise ValueError("MoondreamRuntime does not support encoder inputs")
 
+    def image_kv_length(self, prompt_tokens, image, image_crops) -> int:
+        """Return image KV positions added beyond the typed prompt tokens."""
+        del prompt_tokens, image_crops
+        if image is None:
+            return 0
+        if isinstance(image, (list, tuple)):
+            return len(image) * (self.image_prefix_length - 1)
+        return self.image_prefix_length
+
     def shutdown(self) -> None:
         """Release runtime resources (Runtime protocol).
 

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -499,6 +499,34 @@ class Qwen35Runtime(UncachedPagedRuntime):
     def cuda_graphs_enabled(self) -> bool:
         return self._use_cuda_graphs
 
+    def image_kv_length(
+        self,
+        prompt_tokens: Sequence[Any],
+        image: Any,
+        image_crops: Any,
+    ) -> int:
+        """Return the exact Qwen vision expansion after preprocessing."""
+        if image is None:
+            return 0
+        if not isinstance(image_crops, QwenImageInputs):
+            return super().image_kv_length(prompt_tokens, image, image_crops)
+
+        from kestrel.runtime.tokens import ImageMarker
+
+        num_images = int(image_crops.image_grid_thw.shape[0])
+        grid_tokens = int(image_crops.image_grid_thw.prod(-1).sum().item()) // 4
+        if grid_tokens != int(image_crops.num_image_tokens):
+            raise ValueError(
+                "Qwen preprocessed image token count does not match its grid"
+            )
+        marker_count = sum(isinstance(token, ImageMarker) for token in prompt_tokens)
+        if marker_count not in (0, num_images):
+            raise ValueError(
+                "Qwen image marker count must be zero or match preprocessed images"
+            )
+        inserted_tokens = int(image_crops.num_image_tokens) + 2 * num_images
+        return inserted_tokens - marker_count
+
     def _load_model(self, source: str | Path) -> nn.Module:
         from .qwen_loader import load_qwen35_model
 
@@ -558,7 +586,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
         from kestrel.runtime.tokens import ImageMarker
 
         tokens_list = list(prompt_tokens)
-        text_only_len = len(tokens_list)
         num_image_tokens = 0
         num_images = 0
         chat_crops = None
@@ -627,13 +654,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
                 tokens_list = tokens_list[:offset] + image_block + tokens_list[offset:]
 
         new_tokens = 128 if max_new_tokens is None else max_new_tokens
-        budget_for_finalize = (
-            text_only_len
-            + (self.image_prefix_length if image is not None else 0)
-            + new_tokens
-        )
-        actual_kv_budget = len(tokens_list) + new_tokens
-        target_length = max(budget_for_finalize, actual_kv_budget)
+        target_length = len(tokens_list) + new_tokens
         prepared = self._prepare_uncached_sequence(
             tokens=tokens_list,
             target_length=target_length,

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -153,6 +153,15 @@ class AutoregressiveRuntime(Runtime, Protocol):
 
     def preprocess_encoder_input_async(self, encoder_input: object) -> Future[Any]: ...
 
+    def image_kv_length(
+        self,
+        prompt_tokens: Sequence[Token],
+        image: Any,
+        image_crops: Any,
+    ) -> int:
+        """Return image KV positions added beyond the typed prompt tokens."""
+        ...
+
     # Slot lifecycle
     def acquire_prefill_slot(self, slot_id: int | None = ...) -> Any: ...
 

--- a/kestrel/runtime/uncached_paged.py
+++ b/kestrel/runtime/uncached_paged.py
@@ -54,6 +54,20 @@ class UncachedPagedRuntime:
             f"{type(self).__name__} does not support encoder inputs"
         )
 
+    def image_kv_length(
+        self,
+        prompt_tokens: Sequence[Token],
+        image: Any,
+        image_crops: Any,
+    ) -> int:
+        """Return image KV positions added beyond the typed prompt tokens."""
+        del prompt_tokens, image_crops
+        if image is None:
+            return 0
+        if isinstance(image, (list, tuple)):
+            return len(image) * (self.image_prefix_length - 1)
+        return self.image_prefix_length
+
     def shutdown(self) -> None:
         self._image_preprocessor.shutdown()
 

--- a/tests/qwen35/test_image_kv_length.py
+++ b/tests/qwen35/test_image_kv_length.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from kestrel.models.qwen35.runtime import Qwen35Runtime, QwenImageInputs
+from kestrel.runtime import ImageMarker, TextToken
+
+
+def _image_inputs(*, images: int, tokens: int) -> QwenImageInputs:
+    grid_width = tokens * 4 // images
+    return QwenImageInputs(
+        pixel_values=torch.empty((1, 3)),
+        image_grid_thw=torch.tensor(
+            [[1, 1, grid_width]] * images,
+            dtype=torch.long,
+        ),
+        num_image_tokens=tokens,
+    )
+
+
+def test_qwen_image_kv_length_uses_preprocessed_expansion() -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.image_prefix_length = 4096
+    crops = _image_inputs(images=1, tokens=256)
+
+    assert runtime.image_kv_length([TextToken(1)], object(), crops) == 258
+    assert runtime.image_kv_length([ImageMarker(0)], object(), crops) == 257
+    assert runtime.image_kv_length([TextToken(1)], object(), None) == 4096
+
+    multi = _image_inputs(images=2, tokens=600)
+    assert runtime.image_kv_length(
+        [ImageMarker(0), ImageMarker(1)],
+        [object(), object()],
+        multi,
+    ) == 602
+
+    inconsistent = _image_inputs(images=1, tokens=256)
+    inconsistent.num_image_tokens = 255
+    with pytest.raises(ValueError, match="does not match its grid"):
+        runtime.image_kv_length([TextToken(1)], object(), inconsistent)
+
+
+def test_qwen_prepare_sequence_reserves_exact_expanded_length() -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.architecture = SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2)
+    )
+    runtime._chat_image_crops = {}
+    runtime._prepare_uncached_sequence = lambda **kwargs: kwargs
+    crops = QwenImageInputs(
+        pixel_values=torch.empty((1, 3)),
+        image_grid_thw=torch.tensor([[1, 32, 32]]),
+        num_image_tokens=256,
+    )
+
+    prepared = runtime.prepare_sequence(
+        [TextToken(1), ImageMarker(0)],
+        image=object(),
+        image_crops=crops,
+        max_new_tokens=1536,
+    )
+
+    assert prepared["image_length"] == 258
+    assert len(prepared["tokens"]) == 259
+    assert prepared["target_length"] == 1795

--- a/tests/scheduler/_fake_runtime.py
+++ b/tests/scheduler/_fake_runtime.py
@@ -209,6 +209,19 @@ class FakeRuntime:
         fut.set_result(encoder_input)
         return fut
 
+    def image_kv_length(
+        self,
+        prompt_tokens: Sequence[Any],
+        image: Any,
+        image_crops: Any,
+    ) -> int:
+        del prompt_tokens, image_crops
+        if image is None:
+            return 0
+        if isinstance(image, (list, tuple)):
+            return len(image) * (self.image_prefix_length - 1)
+        return self.image_prefix_length
+
     def shutdown(self) -> None:
         pass
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -544,6 +544,35 @@ def test_build_generation_request_rejects_skill_stop_in_generated_prefix() -> No
         engine._build_generation_request(runtime, req, None)
 
 
+def test_build_generation_request_uses_runtime_image_kv_length() -> None:
+    engine = object.__new__(InferenceEngine)
+    req = _make_request(image=b"image")
+    req.skill = _PrefixSkill()
+    runtime = SimpleNamespace(
+        max_seq_length=32,
+        spec=None,
+        image_kv_length=lambda prompt_tokens, image, image_crops: 5,
+    )
+
+    generation_req, _ = engine._build_generation_request(runtime, req, object())
+
+    assert generation_req.image_length == 5
+    assert generation_req.target_length == 15
+
+
+@pytest.mark.parametrize("invalid", [-1, 1.5, True])
+def test_build_generation_request_rejects_invalid_image_kv_length(invalid) -> None:
+    engine = object.__new__(InferenceEngine)
+    req = _make_request(image=b"image")
+    runtime = SimpleNamespace(
+        spec=None,
+        image_kv_length=lambda prompt_tokens, image, image_crops: invalid,
+    )
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        engine._build_generation_request(runtime, req, object())
+
+
 def test_build_generation_request_rejects_encoder_input_with_spec_decode() -> None:
     engine = object.__new__(InferenceEngine)
     req = _make_request()


### PR DESCRIPTION
## Summary

- add a uniform runtime contract for the exact image KV expansion known after preprocessing
- use that expansion for engine admission instead of the conservative model-wide image prefix bound
- reserve Qwen sequence state from the exact expanded prompt length and fail closed on inconsistent preprocessing metadata

## Motivation

On RTX 3090, Qwen 3.5 reserved 4,096 image positions for every ChartQA request even when preprocessing produced roughly 256 image tokens. At C4, two requests consumed enough nominal KV capacity that the remaining two could never be admitted, so the runtime only issued B1/B2 decode calls. With this patch, a diagnostic C4 run reached four active sequences and issued B4 calls.

## Validation

- remote host-only focused suite: 210 passed
- remote live RTX 3090 diagnostic: maximum active rows increased from 2 to 4; generated decode exercised B1/B2/B3/B4 with zero native fallback
- an adjacent Qwen integration run on p1 reached 206 passing tests and 3 setup failures because that host installed an older kestrel-kernels API without the already-required device_sms argument; the failures reproduce before this patch and are unrelated to image KV accounting

No local tests were run.