### PR TITLE
Use runtime intervals for generated decode selection

### DIFF
--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -122,6 +122,30 @@ class _BoundInvocation:
     required_launch_extents: frozenset[str]
 
 
+def _active_batch_interval(program: Any) -> tuple[int, int]:
+    """Return the inclusive request-count interval served by one program."""
+
+    capacity = int(program.capacity)
+    minimum = int(
+        getattr(program, "runtime_extent_minimums", {}).get("active_batch", 1)
+    )
+    if not 1 <= minimum <= capacity:
+        raise RuntimeError(
+            "generated decode program has invalid active-batch interval "
+            f"[{minimum}, {capacity}]"
+        )
+    static = program.static_extent_bindings.get("active_batch")
+    if static is not None:
+        static = int(static)
+        if not minimum <= static <= capacity:
+            raise RuntimeError(
+                "generated decode program has invalid static active batch "
+                f"{static} outside [{minimum}, {capacity}]"
+            )
+        return static, static
+    return minimum, capacity
+
+
 def _merge_disjoint(label: str, **namespaces: Mapping[str, Any]) -> dict[str, Any]:
     merged = {}
     owners = {}
@@ -205,15 +229,19 @@ def _select_program(programs: Sequence[Any], batch_size: int) -> tuple[int, Any]
         static_extents = program.static_extent_bindings
         if static_extents.keys() - {"active_batch"}:
             continue
-        static_batch = static_extents.get("active_batch")
-        if static_batch is not None and int(static_batch) != batch_size:
+        minimum_batch, maximum_batch = _active_batch_interval(program)
+        if not minimum_batch <= batch_size <= maximum_batch:
             continue
-        if int(program.capacity) < batch_size:
-            continue
-        candidates.append((static_batch is None, int(program.capacity), index, program))
+        candidates.append((int(program.capacity), index, program))
     if not candidates:
         return None
-    _dynamic, _capacity, index, program = min(candidates, key=lambda item: item[:3])
+    candidates.sort(key=lambda item: item[:-1])
+    if len(candidates) > 1 and candidates[0][0] == candidates[1][0]:
+        raise RuntimeError(
+            "generated decode programs ambiguously overlap at "
+            f"active batch {batch_size} and capacity {candidates[0][0]}"
+        )
+    _capacity, index, program = candidates[0]
     return index, program
 
 
@@ -375,6 +403,9 @@ class GeneratedDecode:
         for slot in runtime.decode_slots:
             for program_index, program in enumerate(self._programs):
                 capacity = program.capacity
+                minimum_batch, maximum_batch = _active_batch_interval(program)
+                if minimum_batch > int(runtime.max_batch_size):
+                    continue
                 requirements = self.state_requirements_by_capacity[capacity]
                 capacity_inputs = (
                     dict(spec.capacity_inputs(capacity, requirements))
@@ -393,11 +424,8 @@ class GeneratedDecode:
                     preparations=spec.preparations,
                 )
                 plans.setdefault(tuple(step.name for step in plan), plan)
-                construction_batch = int(
-                    program.static_extent_bindings.get(
-                        "active_batch",
-                        min(capacity, int(runtime.max_batch_size)),
-                    )
+                construction_batch = min(
+                    maximum_batch, int(runtime.max_batch_size)
                 )
                 extents = derive_runtime_extents(
                     program.descriptor, inputs, active_batch=construction_batch

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -232,16 +232,15 @@ def _select_program(programs: Sequence[Any], batch_size: int) -> tuple[int, Any]
         minimum_batch, maximum_batch = _active_batch_interval(program)
         if not minimum_batch <= batch_size <= maximum_batch:
             continue
-        candidates.append((int(program.capacity), index, program))
+        static_batch = program.static_extent_bindings.get("active_batch")
+        candidates.append(
+            (static_batch is None, int(program.capacity), index, program)
+        )
     if not candidates:
         return None
-    candidates.sort(key=lambda item: item[:-1])
-    if len(candidates) > 1 and candidates[0][0] == candidates[1][0]:
-        raise RuntimeError(
-            "generated decode programs ambiguously overlap at "
-            f"active batch {batch_size} and capacity {candidates[0][0]}"
-        )
-    _capacity, index, program = candidates[0]
+    _dynamic, _capacity, index, program = min(
+        candidates, key=lambda item: item[:3]
+    )
     return index, program
 
 

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -1,16 +1,20 @@
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
 import torch
 
 from kestrel.runtime.generated_decode import GeneratedDecode
 
 
-def _program(capacity, *, active_batch=None):
+def _program(capacity, *, active_batch=None, minimum_batch=1):
     static = {} if active_batch is None else {"active_batch": active_batch}
     return SimpleNamespace(
         capacity=capacity,
         static_extent_bindings=static,
+        runtime_extent_minimums=(
+            {} if minimum_batch == 1 else {"active_batch": minimum_batch}
+        ),
     )
 
 
@@ -43,7 +47,7 @@ def test_try_create_binds_physical_sm_count_to_program_resolution():
     )
 
 
-def test_program_selection_preserves_dynamic_and_exact_same_capacity_variants():
+def test_program_selection_rejects_overlapping_same_capacity_variants():
     generated = GeneratedDecode.__new__(GeneratedDecode)
     dynamic_b2 = _program(2)
     dynamic_b4 = _program(4)
@@ -61,7 +65,37 @@ def test_program_selection_preserves_dynamic_and_exact_same_capacity_variants():
     assert generated._program_for(1)[1] is dynamic_b2
     assert generated._program_for(2)[1] is dynamic_b2
     assert generated._program_for(3)[1] is dynamic_b4
-    assert generated._program_for(4)[1] is exact_b4
+    with pytest.raises(RuntimeError, match="ambiguously overlap"):
+        generated._program_for(4)
     assert generated._program_for(5)[1] is dynamic_b8
-    assert generated._program_for(8)[1] is exact_b8
+    with pytest.raises(RuntimeError, match="ambiguously overlap"):
+        generated._program_for(8)
     assert generated._program_for(9) is None
+
+
+def test_program_selection_partitions_dynamic_runtime_intervals():
+    generated = GeneratedDecode.__new__(GeneratedDecode)
+    b1 = _program(1, active_batch=1)
+    b2 = _program(2, minimum_batch=2)
+    b4 = _program(4, minimum_batch=3)
+    b8 = _program(8, minimum_batch=5)
+    generated._programs = (b1, b2, b4, b8)
+
+    assert [generated._program_for(batch_size)[1] for batch_size in range(1, 9)] == [
+        b1,
+        b2,
+        b4,
+        b4,
+        b8,
+        b8,
+        b8,
+        b8,
+    ]
+
+
+def test_program_selection_rejects_invalid_runtime_interval():
+    generated = GeneratedDecode.__new__(GeneratedDecode)
+    generated._programs = (_program(4, minimum_batch=5),)
+
+    with pytest.raises(RuntimeError, match="invalid active-batch interval"):
+        generated._program_for(4)

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -47,7 +47,7 @@ def test_try_create_binds_physical_sm_count_to_program_resolution():
     )
 
 
-def test_program_selection_rejects_overlapping_same_capacity_variants():
+def test_program_selection_preserves_legacy_static_preference():
     generated = GeneratedDecode.__new__(GeneratedDecode)
     dynamic_b2 = _program(2)
     dynamic_b4 = _program(4)
@@ -65,11 +65,9 @@ def test_program_selection_rejects_overlapping_same_capacity_variants():
     assert generated._program_for(1)[1] is dynamic_b2
     assert generated._program_for(2)[1] is dynamic_b2
     assert generated._program_for(3)[1] is dynamic_b4
-    with pytest.raises(RuntimeError, match="ambiguously overlap"):
-        generated._program_for(4)
+    assert generated._program_for(4)[1] is exact_b4
     assert generated._program_for(5)[1] is dynamic_b8
-    with pytest.raises(RuntimeError, match="ambiguously overlap"):
-        generated._program_for(8)
+    assert generated._program_for(8)[1] is exact_b8
     assert generated._program_for(9) is None
 
 


### PR DESCRIPTION
## Summary
- select generated-decode programs by their declared runtime batch interval
- keep static-before-dynamic selection for legacy wheels containing overlapping exact artifacts
- retain capacity ordering and fail when no compatible program exists

## Testing
- `.venv/bin/python -m pytest -q tests/test_generated_decode_device.py` (4 passed)