### PR TITLE
Skip unreachable native Qwen graph capture

### DIFF
--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -452,8 +452,12 @@ class Qwen35Runtime(UncachedPagedRuntime):
         self.spatial_tables = None
 
         self._initialize_generated_decode()
+        self._initialize_native_decode_graphs()
 
-        if self._use_cuda_graphs:
+    def _initialize_native_decode_graphs(self) -> None:
+        """Capture native graphs only when native decode remains reachable."""
+
+        if self._use_cuda_graphs and self.decode_path != "generated":
             self._decode_graphs.ensure_ready(self._decode_slots)
 
     def _initialize_generated_decode(self) -> None:

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -89,6 +89,31 @@ def test_qwen_required_generated_unavailable_refuses_before_graph_capture(
     assert runtime.generated_decode is None
 
 
+@pytest.mark.parametrize(
+    ("decode_path", "expected_captures"),
+    (("generated", 0), ("auto", 1), ("native", 1)),
+)
+def test_qwen_captures_native_graphs_only_when_native_decode_is_reachable(
+    decode_path: str,
+    expected_captures: int,
+) -> None:
+    captures: list[object] = []
+    slots = (object(), object())
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.decode_path = decode_path
+    runtime._use_cuda_graphs = True
+    runtime._decode_slots = slots
+    runtime._decode_graphs = SimpleNamespace(
+        ensure_ready=lambda actual_slots: captures.append(actual_slots)
+    )
+
+    runtime._initialize_native_decode_graphs()
+
+    assert len(captures) == expected_captures
+    if captures:
+        assert captures == [slots]
+
+
 def test_generated_requirement_unavailable_refuses_before_construction(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- skip native CUDA graph capture when Qwen is configured for fail-closed generated decode
- retain native graph capture for auto and native modes
- cover all three decode policies in the focused runtime tests

## Why
Forced-generated Qwen can never execute the native graph. Capturing it adds startup work and can fail on unrelated native-only AOT dependencies before the generated path runs.

## Validation
- p1 host-only: `tests/test_decode_path.py tests/qwen35/test_generated_decode.py`: 14 passed
- RTX 3090 canonical ChartQA startup advanced past generated binding and graph capture to the next independent AOT coverage gate

No local tests were run.