### PR TITLE
Run Moondream through compiler-generated decode

### DIFF
--- a/kestrel/models/moondream/_moe_layout.py
+++ b/kestrel/models/moondream/_moe_layout.py
@@ -74,10 +74,33 @@ def build_md3_moe_up_slab(
     stay zero (the megakernel never tiles them). Returns ``(up_w_slab, up_scale_slab)``; the caller
     fills each MoE layer's view via :func:`set_md3_moe_up_layer`."""
     n_layers = len(text.blocks)
+
+    # ``build_moe_mlp`` has already materialized one bf16 up-projection
+    # parameter per MoE layer.  The FP8 checkpoint never loads those
+    # placeholders: the slab below replaces them with uint8 views.  Drop all
+    # placeholder storages before requesting the single large slab, otherwise
+    # model construction transiently holds both layouts (12 GiB of bf16
+    # placeholders plus the 6 GiB FP8 slab for MD3) and cannot fit on a 24 GiB
+    # Ampere GPU.
+    target_device = torch.device(device)
+    for block in text.blocks:
+        if not hasattr(block.mlp, "router"):
+            continue
+        up_experts = block.mlp["mlp"].up_experts
+        up_experts.weight = nn.Parameter(
+            torch.empty(0, dtype=torch.uint8, device=target_device),
+            requires_grad=False,
+        )
+    if target_device.type == "cuda":
+        # The slab is one contiguous allocation whereas the discarded
+        # placeholders were per-layer allocations.  Return their cached CUDA
+        # segments before allocating the slab so the driver can satisfy it.
+        torch.cuda.empty_cache()
+
     up_w_slab = torch.zeros(
-        n_layers, num_experts, two_inter, hidden, dtype=torch.uint8, device=device)
+        n_layers, num_experts, two_inter, hidden, dtype=torch.uint8, device=target_device)
     up_scale_slab = torch.zeros(
-        n_layers, num_experts, two_inter, dtype=torch.float32, device=device)
+        n_layers, num_experts, two_inter, dtype=torch.float32, device=target_device)
     # Stash the slabs on the text module: THE contract the megakernel session asserts against (each
     # MoE layer's up_experts view must alias these). Plain attributes -- not buffers -- so they do
     # not appear twice in the state_dict (the per-layer views already round-trip the bytes).

--- a/kestrel/models/moondream/_moe_layout.py
+++ b/kestrel/models/moondream/_moe_layout.py
@@ -79,7 +79,7 @@ def build_md3_moe_up_slab(
     # parameter per MoE layer.  The FP8 checkpoint never loads those
     # placeholders: the slab below replaces them with uint8 views.  Drop all
     # placeholder storages before requesting the single large slab, otherwise
-    # model construction transiently holds both layouts (12 GiB of bf16
+    # model construction transiently holds both layouts (10 GiB of bf16
     # placeholders plus the 6 GiB FP8 slab for MD3) and cannot fit on a 24 GiB
     # Ampere GPU.
     target_device = torch.device(device)

--- a/kestrel/models/moondream/generated_decode.py
+++ b/kestrel/models/moondream/generated_decode.py
@@ -1,0 +1,95 @@
+"""Moondream tensors for bundled compiler-generated decode."""
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import torch
+
+from kestrel.runtime.generated_decode import GeneratedDecode, GeneratedDecodeSpec
+
+
+def _rope_tables(text: Any) -> tuple[torch.Tensor, torch.Tensor]:
+    cache = text.cos_sin_cache.float()
+    if int(cache.shape[-1]) % 2:
+        raise RuntimeError("Moondream rotary cache width must be even")
+    half = int(cache.shape[-1]) // 2
+    cos = torch.cat((cache[:, :half], cache[:, :half]), dim=1)
+    sin = torch.cat((cache[:, half:], cache[:, half:]), dim=1)
+    return cos.contiguous(), sin.contiguous()
+
+
+@dataclass(frozen=True)
+class MoondreamDecodeBindings:
+    layers: Sequence[Any]
+
+    def is_eligible(self, runtime: Any) -> bool:
+        return (
+            runtime._lora_workspace is None
+            and runtime.page_size == 1
+            and len(self.layers) == len(runtime.model.text.blocks)
+            and all(layer.cache.quantized for layer in self.layers)
+            and all(
+                int(layer.cache.k_cache.shape[2])
+                == int(layer.cache.v_cache.shape[2])
+                == 1
+                for layer in self.layers
+            )
+            and all(
+                hasattr(block.attn, "_tau_pos_table")
+                for block in runtime.model.text.blocks
+            )
+        )
+
+    def runtime_inputs(self, runtime: Any) -> Mapping[str, Any]:
+        rope_cos, rope_sin = _rope_tables(runtime.model.text)
+        caches = [layer.cache for layer in self.layers]
+        return {
+            "tau_pos": [
+                block.attn._tau_pos_table.detach().float().contiguous()
+                for block in runtime.model.text.blocks
+            ],
+            "rope_cos": rope_cos,
+            "rope_sin": rope_sin,
+            "mK_dequant_scale": [cache.k_scale_tensor for cache in caches],
+            "mV_dequant_scale": [cache.v_scale_tensor for cache in caches],
+            "mK": [cache.k_cache[:, :, 0, :] for cache in caches],
+            "mV": [cache.v_cache[:, :, 0, :] for cache in caches],
+            "page_table": runtime.page_table.page_table,
+        }
+
+    def slot_inputs(self, slot: Any, capacity: int) -> Mapping[str, Any]:
+        return {
+            "x": slot.hidden_last[:capacity],
+            "batch_idx": slot.meta.batch_idx.gpu[:capacity],
+            "input_pos": slot.meta.input_pos.gpu[:capacity],
+        }
+
+    @staticmethod
+    def launch_extents(slot: Any, batch_size: int) -> Mapping[str, int]:
+        return {
+            "active_batch": int(batch_size),
+            "kv_len": int(slot.meta.input_pos.cpu[:batch_size].max()) + 1,
+        }
+
+
+def create_generated_decode(
+    runtime: Any,
+    *,
+    required: bool = False,
+) -> GeneratedDecode | None:
+    spec = GeneratedDecodeSpec(
+        label="Moondream",
+        weight_root=runtime.model.text,
+        weight_layer_prefix="blocks",
+        bindings=MoondreamDecodeBindings(runtime.layer_caches),
+    )
+    if required:
+        return GeneratedDecode.require(
+            runtime,
+            spec,
+            capacity=runtime.max_batch_size,
+        )
+    return GeneratedDecode.try_create(runtime, spec)
+
+
+__all__ = ["MoondreamDecodeBindings", "create_generated_decode"]

--- a/kestrel/models/moondream/generated_decode.py
+++ b/kestrel/models/moondream/generated_decode.py
@@ -8,6 +8,30 @@ import torch
 from kestrel.runtime.generated_decode import GeneratedDecode, GeneratedDecodeSpec
 
 
+def _logical_weight_sources(text: torch.nn.Module) -> dict[str, torch.Tensor]:
+    """Expose Moondream's compiler namespace without changing module ownership."""
+
+    sources = dict(text.named_parameters(remove_duplicate=False))
+    sources.update(dict(text.named_buffers(remove_duplicate=False)))
+    for layer, block in enumerate(text.blocks):
+        if not hasattr(block.mlp, "router"):
+            continue
+        fused = block.mlp["mlp"]
+        prefix = f"blocks.{layer}.mlp."
+        sources[prefix + "up_experts.weight"] = fused.up_experts.weight
+        sources[prefix + "up_experts.scale"] = fused.up_experts.scale
+        sources[prefix + "down_experts.weight"] = fused.down_experts.weight
+        sources[prefix + "down_experts.scale"] = fused.down_experts.scale
+    return sources
+
+
+def _engine_weight_buffers(text: torch.nn.Module) -> dict[str, torch.Tensor]:
+    return {
+        "moe_up_w_slab": text.moe_up_w_slab,
+        "moe_up_scale_slab": text.moe_up_scale_slab,
+    }
+
+
 def _rope_tables(text: Any) -> tuple[torch.Tensor, torch.Tensor]:
     cache = text.cos_sin_cache.float()
     if int(cache.shape[-1]) % 2:
@@ -81,6 +105,8 @@ def create_generated_decode(
         label="Moondream",
         weight_root=runtime.model.text,
         weight_layer_prefix="blocks",
+        weight_sources=_logical_weight_sources(runtime.model.text),
+        engine_buffers=_engine_weight_buffers(runtime.model.text),
         bindings=MoondreamDecodeBindings(runtime.layer_caches),
     )
     if required:

--- a/kestrel/models/moondream/generated_decode.py
+++ b/kestrel/models/moondream/generated_decode.py
@@ -79,6 +79,9 @@ class MoondreamDecodeBindings:
             "mK": [cache.k_cache[:, :, 0, :] for cache in caches],
             "mV": [cache.v_cache[:, :, 0, :] for cache in caches],
             "page_table": runtime.page_table.page_table,
+            # Scalar launch arguments need a construction-time placeholder;
+            # ``launch_extents`` supplies the live maximum position for every run.
+            "kv_len": 1,
         }
 
     def slot_inputs(self, slot: Any, capacity: int) -> Mapping[str, Any]:

--- a/kestrel/models/moondream/generated_decode.py
+++ b/kestrel/models/moondream/generated_decode.py
@@ -68,14 +68,18 @@ class MoondreamDecodeBindings:
         rope_cos, rope_sin = _rope_tables(runtime.model.text)
         caches = [layer.cache for layer in self.layers]
         return {
-            "tau_pos": [
-                block.attn._tau_pos_table.detach().float().contiguous()
+            "tau_pos": torch.stack([
+                block.attn._tau_pos_table.detach().float()
                 for block in runtime.model.text.blocks
-            ],
+            ]).contiguous(),
             "rope_cos": rope_cos,
             "rope_sin": rope_sin,
-            "mK_dequant_scale": [cache.k_scale_tensor for cache in caches],
-            "mV_dequant_scale": [cache.v_scale_tensor for cache in caches],
+            "mK_dequant_scale": torch.stack([
+                cache.k_scale_tensor for cache in caches
+            ]).contiguous(),
+            "mV_dequant_scale": torch.stack([
+                cache.v_scale_tensor for cache in caches
+            ]).contiguous(),
             "mK": [cache.k_cache[:, :, 0, :] for cache in caches],
             "mV": [cache.v_cache[:, :, 0, :] for cache in caches],
             "page_table": runtime.page_table.page_table,

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -88,6 +88,7 @@ from .decode_slot import DecodeSlot, create_decode_slot
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_MAX_TOKENS = 768
+_FP8_KV_SUPPORTED_SMS = frozenset({86, 87, 89, 90, 100, 110, 120})
 
 
 @contextlib.contextmanager
@@ -493,10 +494,6 @@ class MoondreamRuntime:
         compute_stream: torch.cuda.Stream | None,
     ) -> None:
         self.decode_path = getattr(cfg, "decode_path", "auto")
-        if self.decode_path != "auto":
-            raise ValueError(
-                "Moondream runtimes currently support only decode_path='auto'"
-            )
         self.generated_decode = None
         self._cfg = cfg
         self.device = cfg.resolved_device()
@@ -633,8 +630,6 @@ class MoondreamRuntime:
 
         device_cc_major, device_cc_minor = get_device_capability(self.device)
         device_sm = device_cc_major * 10 + device_cc_minor
-        fp8_kv_supported_sms = {87, 89, 90, 100, 110, 120}
-
         # The whole-model decode megakernel now reads/appends the engine's fp8 (e4m3) KV pool
         # DIRECTLY: its ``kv_pool_layer`` builds a Uint8 (e4m3-byte) pool view and its attention read
         # + qkv-epi append carry the per-layer k/v dequant scales (bit-compatible with native
@@ -647,7 +642,7 @@ class MoondreamRuntime:
             and self._kv_layer_v_scales is not None
             and self.page_size == 1
             and hasattr(torch, "float8_e4m3fn")
-            and device_sm in fp8_kv_supported_sms
+            and device_sm in _FP8_KV_SUPPORTED_SMS
         ):
             self.kv_cache_dtype = torch.float8_e4m3fn
         else:
@@ -661,8 +656,10 @@ class MoondreamRuntime:
                         "falling back to standard KV cache.",
                         stacklevel=2,
                     )
-                elif device_sm not in fp8_kv_supported_sms:
-                    sm_list = "/".join(f"SM{sm}" for sm in sorted(fp8_kv_supported_sms))
+                elif device_sm not in _FP8_KV_SUPPORTED_SMS:
+                    sm_list = "/".join(
+                        f"SM{sm}" for sm in sorted(_FP8_KV_SUPPORTED_SMS)
+                    )
                     warnings.warn(
                         f"KV scales found in checkpoint but FP8 KV cache currently requires {sm_list} "
                         "decode kernels; falling back to standard KV cache.",
@@ -838,17 +835,29 @@ class MoondreamRuntime:
             )
             for slot_id in range(2)
         ]
+        self._initialize_generated_decode()
         # A shipped megakernel is already a single eager launch. Resolve its AOT
-        # buckets once and omit only their redundant native CUDA graphs.
+        # buckets once and omit only their redundant native CUDA graphs. Generic
+        # generated programs take precedence; the legacy whole-model path remains
+        # an automatic fallback for still-unmigrated architectures.
         megakernel_target = megakernel_decode.deploy_target(
             self.model_name, self.device
         )
         self._megakernel_buckets = frozenset(
             batch_size
             for batch_size in make_decode_graph_batch_sizes(self.max_batch_size)
-            if megakernel_target is not None
-            and self._lora_workspace is None
-            and megakernel_decode.has_megakernel(*megakernel_target, batch_size)
+            if (
+                self.generated_decode is not None
+                and self.generated_decode.supports(batch_size)
+            )
+            or (
+                self.decode_path == "auto"
+                and megakernel_target is not None
+                and self._lora_workspace is None
+                and megakernel_decode.has_megakernel(
+                    *megakernel_target, batch_size
+                )
+            )
         )
         self._decode_graphs = DecodeGraphManager[DecodeSlot](
             enabled=self._use_cuda_graphs,
@@ -890,6 +899,20 @@ class MoondreamRuntime:
         # Allocate vision encoder buffers (always, for consistency)
         self._allocate_vision_buffers()
         self._capture_vision_graphs()
+
+    def _initialize_generated_decode(self) -> None:
+        """Apply the runtime-wide decode policy before graph capture."""
+
+        self.generated_decode = None
+        if self.decode_path == "native":
+            return
+
+        from .generated_decode import create_generated_decode
+
+        self.generated_decode = create_generated_decode(
+            self,
+            required=self.decode_path == "generated",
+        )
 
     def _maybe_release_cuda_allocator_cache(self) -> None:
         """Release cached allocator blocks before CUDA graph capture.
@@ -2495,7 +2518,20 @@ class MoondreamRuntime:
             slot.decode_coord_values[:batch_size],
             slot.decode_size_values[:batch_size],
         )
-        if batch_size in self._megakernel_buckets:
+        use_generated = (
+            self.generated_decode is not None
+            and self.generated_decode.supports(batch_size)
+        )
+        if use_generated:
+            slot.hidden_last[:batch_size].copy_(embeds[:, 0, :])
+            self.generated_decode.run(slot, batch_size)
+            hidden = slot.hidden_last[:batch_size].unsqueeze(1)
+        elif self.decode_path == "generated":
+            raise RuntimeError(
+                "required generated Moondream decode does not cover "
+                f"active batch size {batch_size}"
+            )
+        elif batch_size in self._megakernel_buckets:
             try:
                 hidden = self._megakernel_decode_hidden(slot, batch_size, embeds)
             except megakernel_decode.MegakernelNotEligible as exc:

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -88,7 +88,7 @@ from .decode_slot import DecodeSlot, create_decode_slot
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_MAX_TOKENS = 768
-_FP8_KV_SUPPORTED_SMS = frozenset({86, 87, 89, 90, 100, 110, 120})
+_FP8_KV_SUPPORTED_SMS = frozenset({80, 86, 87, 89, 90, 100, 110, 120})
 
 
 @contextlib.contextmanager

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -104,6 +104,8 @@ class GeneratedDecodeSpec:
     weight_root: torch.nn.Module
     weight_layer_prefix: str
     bindings: GeneratedDecodeBindings
+    weight_sources: Mapping[str, torch.Tensor] | None = None
+    engine_buffers: Mapping[str, torch.Tensor] | None = None
     capacity_inputs: (
         Callable[[int, tuple[StateRepresentationRequirement, ...]], Mapping[str, Any]]
         | None
@@ -285,6 +287,7 @@ class GeneratedDecode:
             layer_prefix=spec.weight_layer_prefix,
             arch=f"sm{properties.major}{properties.minor}",
             device_sms=int(properties.multi_processor_count),
+            weight_sources=spec.weight_sources,
         ))
 
     @classmethod
@@ -392,6 +395,8 @@ class GeneratedDecode:
                 spec.weight_root,
                 self._programs[0].descriptor,
                 layer_prefix=spec.weight_layer_prefix,
+                engine_buffers=spec.engine_buffers,
+                weight_sources=spec.weight_sources,
             )
             shared_inputs = dict(spec.bindings.runtime_inputs(runtime))
             weights_ready.record(runtime.compute_stream)

--- a/tests/moondream/test_generated_decode.py
+++ b/tests/moondream/test_generated_decode.py
@@ -2,7 +2,11 @@ from types import SimpleNamespace
 
 import torch
 
-from kestrel.models.moondream.generated_decode import MoondreamDecodeBindings
+from kestrel.models.moondream.generated_decode import (
+    _engine_weight_buffers,
+    _logical_weight_sources,
+    MoondreamDecodeBindings,
+)
 from kestrel.models.moondream.runtime import _FP8_KV_SUPPORTED_SMS
 
 
@@ -18,6 +22,38 @@ def _cache(value: float) -> SimpleNamespace:
 
 def test_sm86_uses_checkpoint_fp8_kv_for_generated_decode() -> None:
     assert 86 in _FP8_KV_SUPPORTED_SMS
+
+
+def test_moondream_exposes_logical_moe_sources_and_engine_slabs() -> None:
+    class Experts(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.empty(2, 3))
+            self.register_buffer("scale", torch.empty(2))
+
+    fused = torch.nn.Module()
+    fused.up_experts = Experts()
+    fused.down_experts = Experts()
+    block = torch.nn.Module()
+    block.mlp = torch.nn.ModuleDict({
+        "router": torch.nn.Linear(3, 2),
+        "mlp": fused,
+    })
+    text = torch.nn.Module()
+    text.blocks = torch.nn.ModuleList([block])
+    text.moe_up_w_slab = torch.empty(1, dtype=torch.uint8)
+    text.moe_up_scale_slab = torch.empty(1)
+
+    sources = _logical_weight_sources(text)
+    buffers = _engine_weight_buffers(text)
+
+    assert sources["blocks.0.mlp.down_experts.weight"] is fused.down_experts.weight
+    assert sources["blocks.0.mlp.down_experts.scale"] is fused.down_experts.scale
+    assert sources["blocks.0.mlp.up_experts.weight"] is fused.up_experts.weight
+    assert sources["blocks.0.mlp.up_experts.scale"] is fused.up_experts.scale
+    assert set(buffers) == {"moe_up_w_slab", "moe_up_scale_slab"}
+    assert buffers["moe_up_w_slab"] is text.moe_up_w_slab
+    assert buffers["moe_up_scale_slab"] is text.moe_up_scale_slab
 
 
 def test_moondream_bindings_expose_compiler_runtime_resources() -> None:

--- a/tests/moondream/test_generated_decode.py
+++ b/tests/moondream/test_generated_decode.py
@@ -20,8 +20,8 @@ def _cache(value: float) -> SimpleNamespace:
     )
 
 
-def test_sm86_uses_checkpoint_fp8_kv_for_generated_decode() -> None:
-    assert 86 in _FP8_KV_SUPPORTED_SMS
+def test_ampere_uses_checkpoint_fp8_kv_for_generated_decode() -> None:
+    assert {80, 86}.issubset(_FP8_KV_SUPPORTED_SMS)
 
 
 def test_moondream_exposes_logical_moe_sources_and_engine_slabs() -> None:

--- a/tests/moondream/test_generated_decode.py
+++ b/tests/moondream/test_generated_decode.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import torch
+
+from kestrel.models.moondream.generated_decode import MoondreamDecodeBindings
+from kestrel.models.moondream.runtime import _FP8_KV_SUPPORTED_SMS
+
+
+def _cache(value: float) -> SimpleNamespace:
+    return SimpleNamespace(
+        quantized=True,
+        k_scale_tensor=torch.tensor(value, dtype=torch.float32),
+        v_scale_tensor=torch.tensor(value + 1, dtype=torch.float32),
+        k_cache=torch.full((3, 1, 1, 2), value, dtype=torch.float32),
+        v_cache=torch.full((3, 1, 1, 2), value + 1, dtype=torch.float32),
+    )
+
+
+def test_sm86_uses_checkpoint_fp8_kv_for_generated_decode() -> None:
+    assert 86 in _FP8_KV_SUPPORTED_SMS
+
+
+def test_moondream_bindings_expose_compiler_runtime_resources() -> None:
+    first = _cache(1)
+    second = _cache(2)
+    blocks = [
+        SimpleNamespace(
+            attn=SimpleNamespace(
+                _tau_pos_table=torch.full((5, 2), value, dtype=torch.bfloat16)
+            )
+        )
+        for value in (1, 2)
+    ]
+    text = SimpleNamespace(
+        blocks=blocks,
+        cos_sin_cache=torch.tensor(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]
+        ),
+    )
+    runtime = SimpleNamespace(
+        _lora_workspace=None,
+        page_size=1,
+        model=SimpleNamespace(text=text),
+        page_table=SimpleNamespace(page_table=torch.zeros(4, 7)),
+    )
+    bindings = MoondreamDecodeBindings(
+        (SimpleNamespace(cache=first), SimpleNamespace(cache=second))
+    )
+
+    assert bindings.is_eligible(runtime)
+    inputs = bindings.runtime_inputs(runtime)
+
+    assert set(inputs) == {
+        "tau_pos",
+        "rope_cos",
+        "rope_sin",
+        "mK_dequant_scale",
+        "mV_dequant_scale",
+        "mK",
+        "mV",
+        "page_table",
+    }
+    torch.testing.assert_close(
+        inputs["rope_cos"],
+        torch.tensor([[1.0, 2.0, 1.0, 2.0], [5.0, 6.0, 5.0, 6.0]]),
+    )
+    torch.testing.assert_close(
+        inputs["rope_sin"],
+        torch.tensor([[3.0, 4.0, 3.0, 4.0], [7.0, 8.0, 7.0, 8.0]]),
+    )
+    assert [tensor.shape for tensor in inputs["mK"]] == [
+        torch.Size((3, 1, 2)),
+        torch.Size((3, 1, 2)),
+    ]
+    assert all(tensor.dtype is torch.float32 for tensor in inputs["tau_pos"])
+
+
+def test_moondream_slot_bindings_use_stable_hidden_and_metadata_buffers() -> None:
+    bindings = MoondreamDecodeBindings(())
+    slot = SimpleNamespace(
+        hidden_last=torch.zeros(8, 16),
+        meta=SimpleNamespace(
+            batch_idx=SimpleNamespace(gpu=torch.arange(8)),
+            input_pos=SimpleNamespace(
+                gpu=torch.arange(8, dtype=torch.int32),
+                cpu=torch.tensor([3, 6, 4, 1, 0, 0, 0, 0], dtype=torch.int32),
+            ),
+        ),
+    )
+
+    inputs = bindings.slot_inputs(slot, 4)
+
+    assert inputs["x"].data_ptr() == slot.hidden_last.data_ptr()
+    assert inputs["batch_idx"].tolist() == [0, 1, 2, 3]
+    assert inputs["input_pos"].tolist() == [0, 1, 2, 3]
+    assert bindings.launch_extents(slot, 4) == {
+        "active_batch": 4,
+        "kv_len": 7,
+    }

--- a/tests/moondream/test_generated_decode.py
+++ b/tests/moondream/test_generated_decode.py
@@ -110,7 +110,10 @@ def test_moondream_bindings_expose_compiler_runtime_resources() -> None:
         torch.Size((3, 1, 2)),
         torch.Size((3, 1, 2)),
     ]
-    assert all(tensor.dtype is torch.float32 for tensor in inputs["tau_pos"])
+    assert inputs["tau_pos"].shape == (2, 5, 2)
+    assert inputs["tau_pos"].dtype is torch.float32
+    torch.testing.assert_close(inputs["mK_dequant_scale"], torch.tensor([1.0, 2.0]))
+    torch.testing.assert_close(inputs["mV_dequant_scale"], torch.tensor([2.0, 3.0]))
 
 
 def test_moondream_slot_bindings_use_stable_hidden_and_metadata_buffers() -> None:

--- a/tests/moondream/test_generated_decode.py
+++ b/tests/moondream/test_generated_decode.py
@@ -95,7 +95,9 @@ def test_moondream_bindings_expose_compiler_runtime_resources() -> None:
         "mK",
         "mV",
         "page_table",
+        "kv_len",
     }
+    assert inputs["kv_len"] == 1
     torch.testing.assert_close(
         inputs["rope_cos"],
         torch.tensor([[1.0, 2.0, 1.0, 2.0], [5.0, 6.0, 5.0, 6.0]]),

--- a/tests/moondream/test_moe.py
+++ b/tests/moondream/test_moe.py
@@ -283,6 +283,53 @@ def _build_moe_slab_text(cls):
     return text
 
 
+def test_moe_up_slab_releases_bf16_placeholders_before_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.moondream import _moe_layout
+    from kestrel.models.moondream.layers import build_dense_mlp, build_moe_mlp
+
+    blocks = nn.ModuleList(
+        [
+            nn.ModuleDict({"mlp": build_dense_mlp(8, 32, torch.bfloat16)}),
+            nn.ModuleDict({"mlp": build_moe_mlp(8, 16, 4, torch.bfloat16, top_k=2)}),
+            nn.ModuleDict({"mlp": build_moe_mlp(8, 16, 4, torch.bfloat16, top_k=2)}),
+        ]
+    )
+    text = _moe_layout.MoEUpSlabModuleDict({"blocks": blocks})
+    old_weights = [
+        text.blocks[index].mlp["mlp"].up_experts.weight
+        for index in (1, 2)
+    ]
+    assert all(weight.dtype == torch.bfloat16 and weight.numel() for weight in old_weights)
+
+    real_zeros = torch.zeros
+    observed_placeholder_shapes: list[tuple[int, ...]] = []
+
+    def recording_zeros(*shape, **kwargs):
+        observed_placeholder_shapes.extend(
+            tuple(text.blocks[index].mlp["mlp"].up_experts.weight.shape)
+            for index in (1, 2)
+        )
+        return real_zeros(*shape, **kwargs)
+
+    monkeypatch.setattr(_moe_layout.torch, "zeros", recording_zeros)
+    slab, _ = _moe_layout.build_md3_moe_up_slab(
+        text,
+        num_experts=4,
+        two_inter=32,
+        hidden=8,
+        device="cpu",
+    )
+
+    assert observed_placeholder_shapes[:2] == [(0,), (0,)]
+    assert slab.shape == (3, 4, 32, 8)
+    assert all(
+        text.blocks[index].mlp["mlp"].up_experts.weight.numel() == 0
+        for index in (1, 2)
+    )
+
+
 def _moe_up_views(text):
     return [
         (li, text.blocks[li].mlp["mlp"].up_experts)

--- a/tests/moondream/test_runtime_megakernel_fallback.py
+++ b/tests/moondream/test_runtime_megakernel_fallback.py
@@ -10,6 +10,8 @@ from kestrel.models.moondream.runtime import MoondreamRuntime
 def _forward_runtime(monkeypatch: pytest.MonkeyPatch):
     runtime = MoondreamRuntime.__new__(MoondreamRuntime)
     runtime.model = SimpleNamespace(text=object())
+    runtime.decode_path = "auto"
+    runtime.generated_decode = None
     runtime._embed_packed_token_batch = lambda *args: torch.ones(1, 1, 2)
     slot = SimpleNamespace(
         decode_token_ids=torch.zeros(1, dtype=torch.int64),
@@ -24,6 +26,64 @@ def _forward_runtime(monkeypatch: pytest.MonkeyPatch):
     runtime._megakernel_buckets = frozenset({1})
     monkeypatch.setattr(runtime_mod, "lm_head", lambda hidden, text: torch.ones(1, 3))
     return runtime, slot
+
+
+def test_generated_decode_owns_selected_step_without_native_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, slot = _forward_runtime(monkeypatch)
+
+    class Generated:
+        @staticmethod
+        def supports(batch_size: int) -> bool:
+            return batch_size == 1
+
+        @staticmethod
+        def run(bound_slot, batch_size: int) -> None:
+            assert batch_size == 1
+            torch.testing.assert_close(
+                bound_slot.hidden_last[:1], torch.ones(1, 2)
+            )
+            bound_slot.hidden_last[:1].fill_(3)
+
+    runtime.generated_decode = Generated()
+    runtime._megakernel_decode_hidden = lambda *_args: pytest.fail(
+        "selected generated decode must not run the legacy megakernel"
+    )
+    runtime._native_decode_hidden = lambda *_args: pytest.fail(
+        "selected generated decode must not run native decode"
+    )
+
+    runtime._run_decode_forward(slot, 1)
+
+    torch.testing.assert_close(slot.hidden_last, torch.full((1, 2), 3.0))
+
+
+def test_required_generated_decode_never_falls_back() -> None:
+    runtime = MoondreamRuntime.__new__(MoondreamRuntime)
+    runtime.decode_path = "generated"
+    runtime.generated_decode = SimpleNamespace(supports=lambda _batch: False)
+    runtime.model = SimpleNamespace(text=object())
+    runtime._embed_packed_token_batch = lambda *_args: torch.ones(1, 1, 2)
+    runtime._megakernel_decode_hidden = lambda *_args: pytest.fail(
+        "required generated decode must not run the legacy megakernel"
+    )
+    runtime._native_decode_hidden = lambda *_args: pytest.fail(
+        "required generated decode must not run native decode"
+    )
+    slot = SimpleNamespace(
+        decode_token_ids=torch.zeros(1, dtype=torch.int64),
+        decode_coord_values=torch.zeros(1, 1),
+        decode_size_values=torch.zeros(1, 2),
+        logits=torch.zeros(1, 3),
+        hidden_last=torch.zeros(1, 2),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="required generated Moondream decode does not cover active batch size 1",
+    ):
+        runtime._run_decode_forward(slot, 1)
 
 
 def test_graphs_on_capacity_ineligibility_falls_back_for_only_this_step(

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -245,20 +245,48 @@ def test_gemma_required_generated_never_falls_back_to_native(
         runtime.decode_with_slot(SimpleNamespace(compute_stream=object()), 2)
 
 
-def test_moondream_explicit_decode_path_refuses_before_runtime_work() -> None:
-    cfg = SimpleNamespace(
-        decode_path="native",
-        resolved_device=lambda: pytest.fail(
-            "unsupported policy must fail before runtime work"
+def test_moondream_native_does_not_construct_generated_decode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.moondream import generated_decode as md_generated
+
+    runtime = object.__new__(MoondreamRuntime)
+    runtime.decode_path = "native"
+    monkeypatch.setattr(
+        md_generated,
+        "create_generated_decode",
+        lambda *_args, **_kwargs: pytest.fail(
+            "native mode must not construct generated decode"
         ),
     )
 
-    with pytest.raises(
-        ValueError,
-        match="Moondream runtimes currently support only decode_path='auto'",
-    ):
-        MoondreamRuntime(
-            cfg,
-            kv_pool=object(),
-            compute_stream=None,
+    runtime._initialize_generated_decode()
+
+    assert runtime.generated_decode is None
+
+
+def test_moondream_required_generated_unavailable_refuses_before_graph_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.moondream import generated_decode as md_generated
+
+    runtime = object.__new__(MoondreamRuntime)
+    runtime.decode_path = "generated"
+    runtime._decode_graphs = SimpleNamespace(
+        ensure_ready=lambda _slots: pytest.fail(
+            "required generated failure must precede graph capture"
         )
+    )
+    calls: list[bool] = []
+
+    def unavailable(_runtime, *, required: bool = False):
+        calls.append(required)
+        raise RuntimeError("no compatible generated program")
+
+    monkeypatch.setattr(md_generated, "create_generated_decode", unavailable)
+
+    with pytest.raises(RuntimeError, match="no compatible generated program"):
+        runtime._initialize_generated_decode()
+
+    assert calls == [True]
+    assert runtime.generated_decode is None

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -23,10 +23,12 @@ def test_try_create_binds_physical_sm_count_to_program_resolution():
         device=torch.device("cuda", 0),
         dtype=torch.bfloat16,
     )
+    weight_sources = {"logical.weight": torch.empty(1)}
     spec = SimpleNamespace(
         bindings=SimpleNamespace(is_eligible=lambda value: value is runtime),
         weight_root=Mock(),
         weight_layer_prefix="model.layers",
+        weight_sources=weight_sources,
     )
     properties = SimpleNamespace(major=10, minor=0, multi_processor_count=148)
 
@@ -44,6 +46,7 @@ def test_try_create_binds_physical_sm_count_to_program_resolution():
         layer_prefix="model.layers",
         arch="sm100",
         device_sms=148,
+        weight_sources=weight_sources,
     )
 
 


### PR DESCRIPTION
## Summary
- bind Moondream logical weights, engine-owned slabs, runtime tables, KV state, and slot metadata to compiler-generated decode
- select generated decode before the legacy whole-model path and make explicit generated mode fail closed
- add SM86 FP8 KV support and release transient BF16 MoE placeholders before slab allocation
- keep native and legacy paths available only under automatic policy when generated coverage is absent

## Validation
- p1 host: 45 focused tests passed across Moondream generated bindings, MoE layout, fallback policy, decode-path policy, and generic generated-decode device resolution

## Dependency
This stacks on m87-labs/kestrel-proprietary#1860 and a kestrel-kernels build containing its explicit weight-source/runtime-resource APIs. It must remain draft until that package is built and pinned, then canonical presales ChartQA must pass with generated mode required.