### PR TITLE
Add native Qwen video prefill support

### DIFF
--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -137,7 +137,7 @@ class PrefillScratch:
         self.tok_qv_lin = torch.empty(max_tokens, tau_out_dim, dtype=dtype, device=device)
         self.router_logits = torch.empty(max_tokens, n_experts, dtype=dtype, device=device) if n_experts else None
 
-    def ensure_size(self, tokens: int):
+    def ensure_size(self, tokens: int) -> None:
         """Grow buffers if needed (rare — only if tokens > initial max_tokens)."""
         if tokens <= self.qkv_out.size(0):
             return
@@ -146,6 +146,17 @@ class PrefillScratch:
         self.tok_qv_lin = torch.empty(tokens, self.tok_qv_lin.size(1), dtype=dtype, device=device)
         if self.router_logits is not None:
             self.router_logits = torch.empty(tokens, self.router_logits.size(1), dtype=dtype, device=device)
+
+    def buffers_for(self, tokens: int) -> dict[tuple[int, int], Tensor]:
+        """Return correctly sized views over this slot's persistent buffers."""
+        self.ensure_size(tokens)
+        buffers = {
+            (tokens, self.qkv_out.size(1)): self.qkv_out[:tokens],
+            (tokens, self.tok_qv_lin.size(1)): self.tok_qv_lin[:tokens],
+        }
+        if self.router_logits is not None:
+            buffers[(tokens, self.router_logits.size(1))] = self.router_logits[:tokens]
+        return buffers
 
 
 class PrefillInputStaging:
@@ -2034,6 +2045,9 @@ class MoondreamRuntime:
         input_staging = prefill_slot.input_staging
         if input_staging is None:
             raise RuntimeError("Prefill slot is missing input staging buffers")
+        prefill_scratch = prefill_slot.scratch
+        if prefill_scratch is None:
+            raise RuntimeError("Prefill slot is missing scratch buffers")
 
         lora_slots = [prepared.state.lora_slot for prepared in prepared_sequences]
         if batch_size > 1 and any(slot != 0 for slot in lora_slots):
@@ -2144,6 +2158,7 @@ class MoondreamRuntime:
                 paged_kv_seqlens_k=paged_kv_seqlens_k,
                 last_token_positions=last_token_positions,
                 input_staging=input_staging,
+                prefill_scratch=prefill_scratch,
             )
 
             gather_idx = last_token_positions.to(dtype=torch.long).view(
@@ -2269,6 +2284,7 @@ class MoondreamRuntime:
         paged_kv_seqlens_k: Tensor,
         last_token_positions: Tensor,
         input_staging: PrefillInputStaging,
+        prefill_scratch: PrefillScratch,
     ) -> tuple[Tensor, Tensor]:
         if batch_idx.ndim != 2:
             raise ValueError("batch_idx must be rank-2")
@@ -2336,21 +2352,7 @@ class MoondreamRuntime:
                 active_lora_max_rank=active_lora_max_rank,
             )
 
-        # Build scratch buffer pool for prefill to avoid per-layer allocations.
-        tc = self.config.text
-        head_dim = tc.dim // tc.n_heads
-        scratch_pool = {
-            (M, tc.dim + 2 * tc.n_kv_heads * head_dim): torch.empty(
-                M, tc.dim + 2 * tc.n_kv_heads * head_dim,
-                dtype=inputs_embeds.dtype, device=self.device),  # QKV
-            (M, 2 * tc.n_heads): torch.empty(
-                M, 2 * tc.n_heads,
-                dtype=inputs_embeds.dtype, device=self.device),  # tau_wqwv
-        }
-        if tc.moe and tc.moe.num_experts:
-            scratch_pool[(M, tc.moe.num_experts)] = torch.empty(
-                M, tc.moe.num_experts,
-                dtype=inputs_embeds.dtype, device=self.device)  # router
+        scratch_pool = prefill_scratch.buffers_for(int(M))
 
         hidden = text_decoder(
             inputs_embeds,

--- a/kestrel/models/qwen35/__init__.py
+++ b/kestrel/models/qwen35/__init__.py
@@ -3,7 +3,7 @@
 from kestrel.models.registry import ModelSpec, register
 
 from .prompt_template import Qwen35PromptTemplate
-from .runtime import Qwen35Runtime
+from .runtime import Qwen35Runtime, QwenVideoInputs
 from .skills import build_skill_registry
 
 
@@ -39,4 +39,4 @@ for _repo_id in _VARIANTS:
     )
 
 
-__all__ = ["Qwen35PromptTemplate", "Qwen35Runtime"]
+__all__ = ["Qwen35PromptTemplate", "Qwen35Runtime", "QwenVideoInputs"]

--- a/kestrel/models/qwen35/qwen_config.py
+++ b/kestrel/models/qwen35/qwen_config.py
@@ -193,6 +193,7 @@ class Qwen3_5Config:
     text_config: Qwen3_5TextConfig
     vision_config: Qwen3_5VisionConfig
     image_token_id: int
+    video_token_id: int
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Qwen3_5Config":
@@ -220,6 +221,7 @@ class Qwen3_5Config:
                 dict(required_config(data, "vision_config", "Qwen"))
             ),
             image_token_id=int(required_config(data, "image_token_id", "Qwen")),
+            video_token_id=int(required_config(data, "video_token_id", "Qwen")),
         )
 
 

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -71,6 +71,7 @@ def _rmsnorm_state(dim: int, eps: float) -> nn.ModuleDict:
 class _TextModelOutput:
     last_hidden_state: torch.Tensor
     past_key_values: Qwen35InferenceCache | None = None
+    vision_embeddings: torch.Tensor | None = None
 
 
 def _module_dtype(module: nn.Module) -> torch.dtype:
@@ -1288,11 +1289,16 @@ class Qwen3_5Model(nn.Module):
         vision_bilinear_weights: torch.Tensor | None = None,
         vision_position_ids: torch.Tensor | None = None,
         vision_cu_seqlens: torch.Tensor | None = None,
+        vision_embeddings: torch.Tensor | None = None,
     ) -> _TextModelOutput:
         inputs_embeds = self.language_model.embed_tokens(input_ids)
 
+        if pixel_values is not None and vision_embeddings is not None:
+            raise ValueError(
+                "pixel_values and precomputed vision_embeddings are mutually exclusive"
+            )
         if pixel_values is not None:
-            image_embeds = self.get_image_features(
+            image_features = self.get_image_features(
                 pixel_values,
                 image_grid_thw,
                 bilinear_indices=vision_bilinear_indices,
@@ -1300,18 +1306,28 @@ class Qwen3_5Model(nn.Module):
                 position_ids=vision_position_ids,
                 cu_seqlens=vision_cu_seqlens,
             )
-            image_embeds = torch.cat(image_embeds, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
-            image_token_mask = input_ids == self.config.image_token_id
-            image_mask = image_token_mask.unsqueeze(-1).expand_as(inputs_embeds).to(
+            vision_embeddings = torch.cat(image_features, dim=0)
+        if vision_embeddings is not None:
+            vision_embeddings = vision_embeddings.to(
+                inputs_embeds.device,
+                inputs_embeds.dtype,
+            )
+            vision_token_mask = (input_ids == self.config.image_token_id) | (
+                input_ids == self.config.video_token_id
+            )
+            vision_mask = vision_token_mask.unsqueeze(-1).expand_as(inputs_embeds).to(
                 inputs_embeds.device
             )
-            if inputs_embeds[image_mask].numel() != image_embeds.numel():
+            if inputs_embeds[vision_mask].numel() != vision_embeddings.numel():
                 raise ValueError(
-                    "Image features and image tokens do not match, "
-                    f"tokens: {image_token_mask.sum()}, "
-                    f"features: {image_embeds.shape[0]}"
+                    "Vision features and placeholder tokens do not match, "
+                    f"tokens: {vision_token_mask.sum()}, "
+                    f"features: {vision_embeddings.shape[0]}"
                 )
-            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+            inputs_embeds = inputs_embeds.masked_scatter(
+                vision_mask,
+                vision_embeddings,
+            )
 
         outputs = self.language_model(
             input_ids=None,
@@ -1332,6 +1348,7 @@ class Qwen3_5Model(nn.Module):
         return _TextModelOutput(
             last_hidden_state=outputs.last_hidden_state,
             past_key_values=outputs.past_key_values,
+            vision_embeddings=vision_embeddings,
         )
 
 

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -50,9 +50,7 @@ _kestrel_rmsnorm = _kestrel_runtime.dense.rmsnorm
 _kestrel_supports_packed_gdn = _kestrel_runtime.gated_delta.supports_packed_gdn
 _kestrel_add_rmsnorm = _kestrel_runtime.dense.add_rmsnorm
 _kestrel_gated_activation_into = _kestrel_runtime.dense.gated_activation_into
-_kestrel_fused_mlp_gelu_bias_residual = _kestrel_runtime.dense.fused_mlp_gelu_bias_residual
 _kestrel_text_mrope_apply = _kestrel_runtime.rotary.text_mrope_apply
-_kestrel_spatial_rope_apply = _kestrel_runtime.rotary.spatial_rope_apply
 _kestrel_moe_runtime = _kestrel_runtime.moe
 _kestrel_moe_topk_fwd = _kestrel_moe_runtime.topk_fwd
 _KESTREL_MOE_DECODE_MAX_TOKENS = 16
@@ -861,12 +859,8 @@ class Qwen3_5VisionMLP(nn.Module):
     def __init__(self, config):
         super().__init__()
         hidden_size = config.hidden_size
-        self.intermediate_size = config.intermediate_size
-        self.linear_fc1 = nn.Linear(hidden_size, self.intermediate_size, bias=True)
-        self.linear_fc2 = nn.Linear(self.intermediate_size, hidden_size, bias=True)
-        # cuBLASLt fused-MLP GELU epilogue mode that matches ``config.hidden_act``.
-        # The vision encoder uses ``gelu_pytorch_tanh`` (tanh approximation); plain
-        # ``gelu`` maps to the exact (erf) GELU.
+        self.linear_fc1 = nn.Linear(hidden_size, config.intermediate_size, bias=True)
+        self.linear_fc2 = nn.Linear(config.intermediate_size, hidden_size, bias=True)
         if config.hidden_act == "gelu_pytorch_tanh":
             self._gelu_approximate = "tanh"
         elif config.hidden_act == "gelu":
@@ -878,53 +872,20 @@ class Qwen3_5VisionMLP(nn.Module):
             value,
             approximate=self._gelu_approximate or "none",
         )
-    def forward(self, hidden_state, residual=None, hidden_workspace=None):
-        """``linear_fc2(act_fn(linear_fc1(hidden_state)))``, plus ``residual``.
 
-        When ``residual`` is given on CUDA bf16/fp16, fc1+GELU+fc2+bias+residual
-        fuse into a single cuBLASLt call (one kernel instead of the eager
-        fc1/GELU/fc2/add chain), eliminating the per-block GELU launch. Every
-        other case falls back to eager. Called through ``__call__`` so module
-        forward hooks (e.g. the profiler's ``vision.mlp``) still fire.
-        """
-        if (
-            residual is not None
-            and self._gelu_approximate is not None
-            and hidden_state.is_cuda
-            and hidden_state.ndim == 2
-            and hidden_state.dtype in (torch.bfloat16, torch.float16)
-            and self.linear_fc1.weight.dtype == hidden_state.dtype
-            and self.linear_fc2.weight.dtype == hidden_state.dtype
-        ):
-            x = hidden_state.contiguous()
-            residual = residual.contiguous()
-            m = x.shape[0]
-            out = torch.empty_like(residual)
-            if hidden_workspace is not None and hidden_workspace.shape[0] >= m:
-                hidden = hidden_workspace[:m]
-            else:
-                hidden = torch.empty(
-                    (m, self.intermediate_size), device=x.device, dtype=x.dtype
-                )
-            _kestrel_fused_mlp_gelu_bias_residual(
-                out,
-                hidden,
-                x,
-                self.linear_fc1.weight,
-                self.linear_fc1.bias,
-                self.linear_fc2.weight,
-                self.linear_fc2.bias,
-                residual,
-                approximate=self._gelu_approximate,
-            )
-            return out
-        out = self.linear_fc2(self.act_fn(self.linear_fc1(hidden_state)))
-        return out if residual is None else residual + out
+    def forward(self, hidden_state):
+        # Match the reference operation boundaries. The fused residual epilogue
+        # has different BF16 rounding that compounds across the vision stack.
+        return self.linear_fc2(self.act_fn(self.linear_fc1(hidden_state)))
 
 
 class Qwen3_5VisionPatchEmbed(nn.Module):
     def __init__(self, config) -> None:
         super().__init__()
+        self.in_channels = config.in_channels
+        self.temporal_patch_size = config.temporal_patch_size
+        self.patch_size = config.patch_size
+        self.hidden_size = config.hidden_size
         self.proj = nn.Linear(
             config.in_channels
             * config.temporal_patch_size
@@ -935,7 +896,35 @@ class Qwen3_5VisionPatchEmbed(nn.Module):
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        return self.proj(hidden_states)
+        # Preserve the checkpoint's flattened Linear parameter layout while
+        # using the reference Conv3D accumulation order. The Qwen vision stack
+        # is sensitive enough that the BF16 Linear and Conv3D results diverge
+        # materially after its residual blocks.
+        weight = self.proj.weight.view(
+            self.hidden_size,
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        )
+        patches = hidden_states.view(
+            -1,
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        )
+        output = F.conv3d(
+            patches,
+            weight,
+            self.proj.bias,
+            stride=(
+                self.temporal_patch_size,
+                self.patch_size,
+                self.patch_size,
+            ),
+        )
+        return output.view(-1, self.hidden_size)
 
 
 class Qwen3_5VisionPatchMerger(nn.Module):
@@ -951,6 +940,33 @@ class Qwen3_5VisionPatchMerger(nn.Module):
         x = self.norm(x).view(-1, self.hidden_size)
         x = self.linear_fc2(self.act_fn(self.linear_fc1(x)))
         return x
+
+
+def _apply_vision_rotary_embedding(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    query_dtype = query.dtype
+    key_dtype = key.dtype
+    query = query.float()
+    key = key.float()
+    cos = cos.unsqueeze(-2).float()
+    sin = sin.unsqueeze(-2).float()
+    query_half = query.shape[-1] // 2
+    key_half = key.shape[-1] // 2
+    rotated_query = torch.cat(
+        (-query[..., query_half:], query[..., :query_half]),
+        dim=-1,
+    )
+    rotated_key = torch.cat(
+        (-key[..., key_half:], key[..., :key_half]),
+        dim=-1,
+    )
+    query = query * cos + rotated_query * sin
+    key = key * cos + rotated_key * sin
+    return query.to(query_dtype), key.to(key_dtype)
 
 
 class Qwen3_5VisionAttention(nn.Module):
@@ -974,21 +990,38 @@ class Qwen3_5VisionAttention(nn.Module):
             self.qkv(hidden_states).reshape(seq_length, 3, self.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
         )
         cos, sin = position_embeddings
-        query_states, key_states = _kestrel_spatial_rope_apply(
-            query_states, key_states, cos, sin, axis_blocks=1
+        query_states, key_states = _apply_vision_rotary_embedding(
+            query_states,
+            key_states,
+            cos,
+            sin,
         )
 
         query_states = query_states.transpose(0, 1).unsqueeze(0)
         key_states = key_states.transpose(0, 1).unsqueeze(0)
         value_states = value_states.transpose(0, 1).unsqueeze(0)
 
-        attn_output = dense_attention(
-            query_states,
-            key_states,
-            value_states,
-            scaling=self.scaling,
-            causal=False,
-            cu_seqlens=cu_seqlens,
+        # Qwen's reference SDPA path evaluates each packed temporal sequence
+        # independently. Matching those boundaries is required for BF16 parity.
+        lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        query_chunks = torch.split(query_states, lengths, dim=2)
+        key_chunks = torch.split(key_states, lengths, dim=2)
+        value_chunks = torch.split(value_states, lengths, dim=2)
+        attn_output = torch.cat(
+            [
+                F.scaled_dot_product_attention(
+                    query,
+                    key,
+                    value,
+                    scale=self.scaling,
+                ).transpose(1, 2)
+                for query, key, value in zip(
+                    query_chunks,
+                    key_chunks,
+                    value_chunks,
+                )
+            ],
+            dim=1,
         )
 
         attn_output = attn_output.reshape(seq_length, -1).contiguous()
@@ -1009,7 +1042,6 @@ class Qwen3_5VisionBlock(nn.Module):
         hidden_states: torch.Tensor,
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
-        mlp_workspace: torch.Tensor | None = None,
     ) -> torch.Tensor:
         r"""
         cu_seqlens (`torch.Tensor`):
@@ -1020,9 +1052,7 @@ class Qwen3_5VisionBlock(nn.Module):
             cu_seqlens=cu_seqlens,
             position_embeddings=position_embeddings,
         )
-        hidden_states = self.mlp(
-            self.norm2(hidden_states), hidden_states, mlp_workspace
-        )
+        hidden_states = hidden_states + self.mlp(self.norm2(hidden_states))
         return hidden_states
 
 
@@ -1049,24 +1079,6 @@ class Qwen3_5VisionModel(nn.Module):
             ]
         )
         self.merger = Qwen3_5VisionPatchMerger(config)
-        # One shared fused-MLP fc1/gelu workspace for all blocks (the intermediate
-        # is consumed within each block's fused call and the blocks run
-        # sequentially, so a single buffer suffices instead of one per block).
-        self._mlp_hidden_workspace: torch.Tensor | None = None
-
-    def _mlp_workspace(self, num_tokens, dtype, device) -> torch.Tensor:
-        ws = self._mlp_hidden_workspace
-        if (
-            ws is None
-            or ws.shape[0] < num_tokens
-            or ws.dtype != dtype
-            or ws.device != device
-        ):
-            ws = torch.empty(
-                num_tokens, self.config.intermediate_size, dtype=dtype, device=device
-            )
-            self._mlp_hidden_workspace = ws
-        return ws[:num_tokens]
 
     def forward(
         self,
@@ -1088,23 +1100,11 @@ class Qwen3_5VisionModel(nn.Module):
         emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
         position_embeddings = (emb.cos(), emb.sin())
 
-        # Only the fused (CUDA bf16/fp16) MLP path consumes the workspace; skip
-        # the allocation entirely on eager/CPU/MPS fallbacks.
-        if hidden_states.is_cuda and hidden_states.dtype in (
-            torch.bfloat16,
-            torch.float16,
-        ):
-            mlp_workspace = self._mlp_workspace(
-                seq_len, hidden_states.dtype, hidden_states.device
-            )
-        else:
-            mlp_workspace = None
         for blk in self.blocks:
             hidden_states = blk(
                 hidden_states,
                 cu_seqlens=cu_seqlens,
                 position_embeddings=position_embeddings,
-                mlp_workspace=mlp_workspace,
             )
 
         return self.merger(hidden_states)

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -40,6 +40,7 @@ from .prompt_template import (
     Qwen35PromptTemplate,
     VISION_END_ID,
     VISION_START_ID,
+    VIDEO_PAD_ID,
     _NEWLINE_ID,
     _USER_ID,
 )
@@ -76,6 +77,28 @@ class QwenImageInputs:
 
 
 @dataclass
+class QwenVideoInputs:
+    """Native Qwen video patches or cached embeddings for one ordered clip.
+
+    Device-resident callers may provide ``pixel_values`` plus precomputed
+    fixed-grid vision metadata for the initial vision encode. A later exact
+    replay may instead provide ``vision_embeddings``; the two payloads are
+    mutually exclusive. The small ``video_grid_thw`` tensor remains the
+    authority for temporal-pair and M-RoPE layout.
+    """
+
+    pixel_values: torch.Tensor | None
+    video_grid_thw: torch.Tensor
+    num_video_tokens: int
+    timestamps_seconds: tuple[float, ...] = ()
+    vision_embeddings: torch.Tensor | None = None
+    vision_bilinear_indices: torch.Tensor | None = None
+    vision_bilinear_weights: torch.Tensor | None = None
+    vision_position_ids: torch.Tensor | None = None
+    vision_cu_seqlens: torch.Tensor | None = None
+
+
+@dataclass
 class _PackedPrefillBatch:
     input_ids: torch.Tensor
     cache_position_ids: torch.Tensor
@@ -95,6 +118,7 @@ class _PackedPrefillBatch:
     vision_bilinear_weights: Optional[torch.Tensor] = None
     vision_position_ids: Optional[torch.Tensor] = None
     vision_cu_seqlens: Optional[torch.Tensor] = None
+    vision_embeddings: Optional[torch.Tensor] = None
 
 
 class _QwenImagePreprocessor:
@@ -512,6 +536,8 @@ class Qwen35Runtime(UncachedPagedRuntime):
         """Return the exact Qwen vision expansion after preprocessing."""
         if image is None:
             return 0
+        if isinstance(image_crops, QwenVideoInputs):
+            return len(self._video_prompt_block(image_crops))
         if not isinstance(image_crops, QwenImageInputs):
             return super().image_kv_length(prompt_tokens, image, image_crops)
 
@@ -530,6 +556,99 @@ class Qwen35Runtime(UncachedPagedRuntime):
             )
         inserted_tokens = int(image_crops.num_image_tokens) + 2 * num_images
         return inserted_tokens - marker_count
+
+    def _video_prompt_block(self, video: QwenVideoInputs) -> list[Any]:
+        """Expand one native video placeholder into timestamped temporal groups."""
+
+        from kestrel.runtime.tokens import TextToken
+
+        grids = video.video_grid_thw
+        if tuple(grids.shape) != (1, 3):
+            raise ValueError("Qwen video_grid_thw must have shape [1, 3]")
+        grid_t, grid_h, grid_w = (int(value) for value in grids[0])
+        if grid_t <= 0 or grid_h <= 0 or grid_w <= 0:
+            raise ValueError("Qwen video grid dimensions must be positive")
+        spatial = int(self.architecture.vision_config.spatial_merge_size)
+        if grid_h % spatial or grid_w % spatial:
+            raise ValueError(
+                "Qwen video grid dimensions must be divisible by the spatial merge size"
+            )
+        frame_tokens = (grid_h // spatial) * (grid_w // spatial)
+        expected_tokens = grid_t * frame_tokens
+        if video.num_video_tokens != expected_tokens:
+            raise ValueError(
+                "Qwen video token count does not match its temporal/spatial grid"
+            )
+        timestamps = video.timestamps_seconds
+        if len(timestamps) != grid_t:
+            raise ValueError(
+                "Qwen video timestamps must contain one value per temporal patch"
+            )
+        if any(not np.isfinite(value) or value < 0 for value in timestamps):
+            raise ValueError("Qwen video timestamps must be finite and non-negative")
+        if any(
+            current <= previous
+            for previous, current in zip(timestamps, timestamps[1:])
+        ):
+            raise ValueError("Qwen video timestamps must increase")
+
+        block: list[TextToken] = []
+        for timestamp in timestamps:
+            timestamp_ids = self.tokenizer.encode(f"<{timestamp:.1f} seconds>").ids
+            block.extend(
+                TextToken(token_id=int(token_id))
+                for token_id in timestamp_ids
+            )
+            block.append(TextToken(token_id=VISION_START_ID))
+            block.extend(
+                TextToken(token_id=VIDEO_PAD_ID)
+                for _ in range(frame_tokens)
+            )
+            block.append(TextToken(token_id=VISION_END_ID))
+        return block
+
+    @torch.inference_mode()
+    def encode_video(self, video: QwenVideoInputs) -> torch.Tensor:
+        """Encode native, device-resident Qwen video patches once.
+
+        The returned merged embeddings may be supplied in a later
+        ``QwenVideoInputs`` instance to replay text prefill without decoding or
+        re-encoding the source frames.
+        """
+
+        if video.pixel_values is None or video.vision_embeddings is not None:
+            raise ValueError("encode_video requires pixel_values and no embeddings")
+        metadata = (
+            video.vision_bilinear_indices,
+            video.vision_bilinear_weights,
+            video.vision_position_ids,
+            video.vision_cu_seqlens,
+        )
+        if any(value is None for value in metadata):
+            raise ValueError(
+                "encode_video requires precomputed device-resident vision metadata"
+            )
+        if video.pixel_values.device != self.device:
+            raise ValueError("video pixels must be on the runtime device")
+        for value in metadata:
+            assert value is not None
+            if value.device != self.device:
+                raise ValueError("video vision metadata must be on the runtime device")
+
+        features = self.model.model.get_image_features(
+            video.pixel_values,
+            video.video_grid_thw,
+            bilinear_indices=video.vision_bilinear_indices,
+            bilinear_weights=video.vision_bilinear_weights,
+            position_ids=video.vision_position_ids,
+            cu_seqlens=video.vision_cu_seqlens,
+        )
+        embeddings = torch.cat(features, dim=0)
+        if int(embeddings.shape[0]) != int(video.num_video_tokens):
+            raise RuntimeError(
+                "Qwen video encoder output count does not match video tokens"
+            )
+        return embeddings
 
     def _load_model(self, source: str | Path) -> nn.Module:
         from .qwen_loader import load_qwen35_model
@@ -576,7 +695,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
         prompt_tokens: Sequence[Any],
         *,
         image: Optional[Any] = None,
-        image_crops: Optional[QwenImageInputs] = None,
+        image_crops: Optional[QwenImageInputs | QwenVideoInputs] = None,
         encoder_input: object | None = None,
         max_new_tokens: Optional[int] = None,
         lora_slot: int = 0,
@@ -592,6 +711,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
         tokens_list = list(prompt_tokens)
         num_image_tokens = 0
         num_images = 0
+        inserted_vision_tokens = 0
         chat_crops = None
         if image is not None:
             if image_crops is None:
@@ -601,52 +721,12 @@ class Qwen35Runtime(UncachedPagedRuntime):
                 # image is never preprocessed twice.
                 image_crops = self._image_preprocessor.process(image)
                 chat_crops = image_crops
-            grids = image_crops.image_grid_thw
-            num_images = int(grids.shape[0])
-            spatial = int(
-                self.architecture.vision_config.spatial_merge_size
-            )
-            # Per-image token count, computed the same way the position-id /
-            # vision-metadata paths expect (so the expanded pad count matches).
-            per_image = []
-            for i in range(num_images):
-                gt, gh, gw = (int(v) for v in grids[i])
-                per_image.append(gt * (gh // spatial) * (gw // spatial))
-            num_image_tokens = sum(per_image)
+            spatial = int(self.architecture.vision_config.spatial_merge_size)
+            if isinstance(image_crops, QwenVideoInputs):
+                if any(isinstance(token, ImageMarker) for token in tokens_list):
+                    raise ValueError("Qwen video prompts do not accept image markers")
+                video_block = self._video_prompt_block(image_crops)
 
-            markers = [
-                (i, t.index)
-                for i, t in enumerate(tokens_list)
-                if isinstance(t, ImageMarker)
-            ]
-            if markers:
-                # Chat path: the chat skill emitted one ImageMarker per image at
-                # its content position. Replace each with that image's vision
-                # block: <|vision_start|> + <|image_pad|>×N + <|vision_end|>.
-                if len(markers) != num_images:
-                    raise RuntimeError(
-                        f"Qwen chat prompt has {len(markers)} image marker(s) "
-                        f"but {num_images} image(s) were provided"
-                    )
-                for pos, idx in sorted(markers, reverse=True):
-                    block = (
-                        [TextToken(token_id=VISION_START_ID)]
-                        + [TextToken(token_id=IMAGE_PAD_ID)] * per_image[idx]
-                        + [TextToken(token_id=VISION_END_ID)]
-                    )
-                    tokens_list[pos : pos + 1] = block
-            else:
-                # Query path: no marker in the prompt; splice a single vision
-                # block after the first user-turn opener.
-                if num_images != 1:
-                    raise RuntimeError(
-                        "Qwen prompt without image markers supports exactly one image"
-                    )
-                image_block = (
-                    [TextToken(token_id=VISION_START_ID)]
-                    + [TextToken(token_id=IMAGE_PAD_ID)] * num_image_tokens
-                    + [TextToken(token_id=VISION_END_ID)]
-                )
                 query_template = self.prompt_template.query()
                 offset = derive_image_insertion_offset(
                     tokens_list,
@@ -655,7 +735,64 @@ class Qwen35Runtime(UncachedPagedRuntime):
                         len(query_template.prefix) if query_template else 0
                     ),
                 )
-                tokens_list = tokens_list[:offset] + image_block + tokens_list[offset:]
+                tokens_list = tokens_list[:offset] + video_block + tokens_list[offset:]
+                inserted_vision_tokens = len(video_block)
+            else:
+                grids = image_crops.image_grid_thw
+                num_images = int(grids.shape[0])
+                # Per-image token count, computed the same way the position-id /
+                # vision-metadata paths expect (so the expanded pad count matches).
+                per_image = []
+                for i in range(num_images):
+                    gt, gh, gw = (int(v) for v in grids[i])
+                    per_image.append(gt * (gh // spatial) * (gw // spatial))
+                num_image_tokens = sum(per_image)
+
+                markers = [
+                    (i, t.index)
+                    for i, t in enumerate(tokens_list)
+                    if isinstance(t, ImageMarker)
+                ]
+                if markers:
+                    # Chat path: the chat skill emitted one ImageMarker per image at
+                    # its content position. Replace each with that image's vision
+                    # block: <|vision_start|> + <|image_pad|>×N + <|vision_end|>.
+                    if len(markers) != num_images:
+                        raise RuntimeError(
+                            f"Qwen chat prompt has {len(markers)} image marker(s) "
+                            f"but {num_images} image(s) were provided"
+                        )
+                    for pos, idx in sorted(markers, reverse=True):
+                        block = (
+                            [TextToken(token_id=VISION_START_ID)]
+                            + [TextToken(token_id=IMAGE_PAD_ID)] * per_image[idx]
+                            + [TextToken(token_id=VISION_END_ID)]
+                        )
+                        tokens_list[pos : pos + 1] = block
+                else:
+                    # Query path: no marker in the prompt; splice a single vision
+                    # block after the first user-turn opener.
+                    if num_images != 1:
+                        raise RuntimeError(
+                            "Qwen prompt without image markers supports exactly one image"
+                        )
+                    image_block = (
+                        [TextToken(token_id=VISION_START_ID)]
+                        + [TextToken(token_id=IMAGE_PAD_ID)] * num_image_tokens
+                        + [TextToken(token_id=VISION_END_ID)]
+                    )
+                    query_template = self.prompt_template.query()
+                    offset = derive_image_insertion_offset(
+                        tokens_list,
+                        user_turn_opener=(IM_START_ID, _USER_ID, _NEWLINE_ID),
+                        fallback_offset=1 + (
+                            len(query_template.prefix) if query_template else 0
+                        ),
+                    )
+                    tokens_list = tokens_list[:offset] + image_block + tokens_list[offset:]
+                inserted_vision_tokens = num_image_tokens + 2 * num_images
+        elif isinstance(image_crops, QwenVideoInputs):
+            raise ValueError("Qwen video inputs require a non-None video owner")
 
         new_tokens = 128 if max_new_tokens is None else max_new_tokens
         target_length = len(tokens_list) + new_tokens
@@ -663,7 +800,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
             tokens=tokens_list,
             target_length=target_length,
             image_length=(
-                num_image_tokens + 2 * num_images if image is not None else 0
+                inserted_vision_tokens if image is not None else 0
             ),
             lora_slot=lora_slot,
             adapter_id=adapter_id,
@@ -680,7 +817,9 @@ class Qwen35Runtime(UncachedPagedRuntime):
         prefill_slot: Any,
         *,
         images: Optional[Sequence[Any]] = None,
-        image_crops_list: Optional[Sequence[Optional[QwenImageInputs]]] = None,
+        image_crops_list: Optional[
+            Sequence[Optional[QwenImageInputs | QwenVideoInputs]]
+        ] = None,
         encoder_inputs: Optional[Sequence[object | None]] = None,
     ) -> torch.Tensor:
         if encoder_inputs is not None and any(
@@ -958,14 +1097,30 @@ class Qwen35Runtime(UncachedPagedRuntime):
         start: int,
         end: int,
         mm_token_type_ids: np.ndarray,
-        image_grid_thw: np.ndarray,
+        vision_grid_thw: np.ndarray,
+        vision_modality_type: int,
     ) -> int:
+        if vision_modality_type not in (1, 2):
+            raise ValueError("Qwen vision modality type must be image (1) or video (2)")
         spatial_merge_size = int(
             self.architecture.vision_config.spatial_merge_size
         )
+        # The processor writes one timestamped video-pad group per temporal
+        # patch. Qwen's M-RoPE implementation therefore expands [T, H, W] into
+        # T logical [1, H, W] grids before assigning multimodal positions.
+        if vision_modality_type == 2:
+            position_grid_thw = np.repeat(
+                vision_grid_thw,
+                vision_grid_thw[:, 0],
+                axis=0,
+            ).copy()
+            position_grid_thw[:, 0] = 1
+        else:
+            position_grid_thw = vision_grid_thw
+
         cursor = start
         current_pos = 0
-        image_idx = 0
+        vision_idx = 0
         while cursor < end:
             modality_type = int(mm_token_type_ids[cursor - start])
             group_end = cursor + 1
@@ -982,20 +1137,20 @@ class Qwen35Runtime(UncachedPagedRuntime):
                 )
                 out[:, 0, cursor:group_end] = positions
                 current_pos += text_len
-            elif modality_type == 1:
-                if image_idx >= image_grid_thw.shape[0]:
-                    raise RuntimeError("Qwen image grid metadata ended early")
+            elif modality_type == vision_modality_type:
+                if vision_idx >= position_grid_thw.shape[0]:
+                    raise RuntimeError("Qwen vision grid metadata ended early")
                 grid_t, grid_h_raw, grid_w_raw = (
-                    int(v) for v in image_grid_thw[image_idx]
+                    int(v) for v in position_grid_thw[vision_idx]
                 )
-                image_idx += 1
+                vision_idx += 1
                 grid_h = grid_h_raw // spatial_merge_size
                 grid_w = grid_w_raw // spatial_merge_size
-                image_len = grid_t * grid_h * grid_w
-                if image_len != group_end - cursor:
+                vision_len = grid_t * grid_h * grid_w
+                if vision_len != group_end - cursor:
                     raise RuntimeError(
-                        "Qwen image token count does not match image grid: "
-                        f"tokens={group_end - cursor}, grid={image_len}"
+                        "Qwen vision token count does not match vision grid: "
+                        f"tokens={group_end - cursor}, grid={vision_len}"
                     )
                 offset = current_pos
                 temporal = np.repeat(np.arange(grid_t, dtype=np.int64), grid_h * grid_w)
@@ -1009,12 +1164,15 @@ class Qwen35Runtime(UncachedPagedRuntime):
                 out[2, 0, cursor:group_end] = width + offset
                 current_pos += max(grid_h_raw, grid_w_raw) // spatial_merge_size
             else:
-                raise NotImplementedError("Qwen packed prefill does not support video")
+                raise RuntimeError(
+                    "Qwen prompt contains a vision placeholder for the wrong "
+                    f"modality: expected={vision_modality_type}, got={modality_type}"
+                )
 
             cursor = group_end
 
-        if image_idx != image_grid_thw.shape[0]:
-            raise RuntimeError("Qwen image grid metadata has unused rows")
+        if vision_idx != position_grid_thw.shape[0]:
+            raise RuntimeError("Qwen vision grid metadata has unused rows")
         return int(out[:, 0, start:end].max()) + 1 - (end - start)
 
     def _fill_vision_metadata(
@@ -1105,11 +1263,11 @@ class Qwen35Runtime(UncachedPagedRuntime):
         self,
         scratch: Qwen35PrefillScratch,
         *,
-        total_tokens: int,
-        batch_size: int,
-        has_images: bool,
+        copy_pixel_values: bool,
+        copy_vision_grid: bool,
+        copy_vision_metadata: bool,
         pixel_rows: int,
-        image_grid_rows: int,
+        vision_grid_rows: int,
         vision_sequence_count: int,
     ) -> None:
         # One H2D for every text-metadata field (input ids, positions, slot
@@ -1118,13 +1276,15 @@ class Qwen35Runtime(UncachedPagedRuntime):
         # field to its live length, so shipping the whole packed buffer
         # (including unused tails) is safe.
         scratch.text_meta.copy_to_gpu()
-        if has_images:
+        if copy_pixel_values:
             if scratch.pixel_values is None:
                 raise RuntimeError("Qwen pixel scratch was not allocated")
             scratch.pixel_values.copy_to_gpu(pixel_rows)
+        if copy_vision_grid:
             if scratch.image_grid_thw is None:
-                raise RuntimeError("Qwen image grid scratch was not allocated")
-            scratch.image_grid_thw.copy_to_gpu(image_grid_rows)
+                raise RuntimeError("Qwen vision grid scratch was not allocated")
+            scratch.image_grid_thw.copy_to_gpu(vision_grid_rows)
+        if copy_vision_metadata:
             if (
                 scratch.vision_bilinear_indices is None
                 or scratch.vision_bilinear_weights is None
@@ -1169,7 +1329,9 @@ class Qwen35Runtime(UncachedPagedRuntime):
         prepared_sequences: Sequence[Any],
         *,
         prefill_slot: Any,
-        image_crops_list: Sequence[Optional[QwenImageInputs]],
+        image_crops_list: Sequence[
+            Optional[QwenImageInputs | QwenVideoInputs]
+        ],
         batch_indices: Sequence[int],
     ) -> _PackedPrefillBatch:
         from kestrel.runtime.tokens import TextToken
@@ -1178,16 +1340,32 @@ class Qwen35Runtime(UncachedPagedRuntime):
             raise ValueError("image_crops_list length must match prepared_sequences")
         if len(prepared_sequences) != len(batch_indices):
             raise ValueError("batch_indices length must match prepared_sequences")
+        video_inputs = [
+            crops for crops in image_crops_list if isinstance(crops, QwenVideoInputs)
+        ]
+        if video_inputs and (
+            len(prepared_sequences) != 1 or len(video_inputs) != 1
+        ):
+            raise NotImplementedError(
+                "Qwen native video prefill currently supports one sequence per batch"
+            )
 
         token_rows: list[list[int]] = []
         crop_grid_rows: list[np.ndarray | None] = []
+        vision_modality_types: list[int | None] = []
         lengths: list[int] = []
         total_tokens = 0
-        pixel_rows = 0
-        pixel_dim = 0
-        image_grid_rows = 0
-        vision_sequence_count = 0
-        has_images = False
+        staged_pixel_rows = 0
+        staged_pixel_dim = 0
+        vision_grid_rows = 0
+        staged_vision_sequence_count = 0
+        has_vision = False
+        direct_pixel_values: torch.Tensor | None = None
+        direct_vision_embeddings: torch.Tensor | None = None
+        direct_vision_bilinear_indices: torch.Tensor | None = None
+        direct_vision_bilinear_weights: torch.Tensor | None = None
+        direct_vision_position_ids: torch.Tensor | None = None
+        direct_vision_cu_seqlens: torch.Tensor | None = None
 
         for prepared, crops in zip(prepared_sequences, image_crops_list):
             tokens = prepared.tokens_list
@@ -1204,34 +1382,153 @@ class Qwen35Runtime(UncachedPagedRuntime):
             lengths.append(length)
             total_tokens += length
             if crops is not None:
-                has_images = True
-                crop_pixels = crops.pixel_values
-                if crop_pixels.ndim != 2:
-                    raise ValueError("Qwen image pixel_values must be rank-2")
-                if pixel_dim == 0:
-                    pixel_dim = int(crop_pixels.shape[1])
-                elif pixel_dim != int(crop_pixels.shape[1]):
-                    raise ValueError("Qwen image pixel feature dimension changed")
-                pixel_rows += int(crop_pixels.shape[0])
-                grid_np = crops.image_grid_thw.detach().cpu().numpy().astype(
+                has_vision = True
+                is_video = isinstance(crops, QwenVideoInputs)
+                grid = (
+                    crops.video_grid_thw
+                    if is_video
+                    else crops.image_grid_thw
+                )
+                grid_np = grid.detach().cpu().numpy().astype(
                     np.int64, copy=False
                 )
                 if grid_np.ndim != 2 or grid_np.shape[1] != 3:
-                    raise ValueError("Qwen image_grid_thw must have shape [N, 3]")
+                    raise ValueError("Qwen vision grid must have shape [N, 3]")
+                if np.any(grid_np <= 0):
+                    raise ValueError("Qwen vision grid dimensions must be positive")
+                spatial_merge_size = int(
+                    self.architecture.vision_config.spatial_merge_size
+                )
+                if np.any(grid_np[:, 1:] % spatial_merge_size):
+                    raise ValueError(
+                        "Qwen vision grid dimensions must be divisible by the "
+                        "spatial merge size"
+                    )
+                expected_vision_tokens = int(
+                    grid_np.prod(axis=1).sum()
+                ) // (spatial_merge_size**2)
+                declared_vision_tokens = int(
+                    crops.num_video_tokens
+                    if is_video
+                    else crops.num_image_tokens
+                )
+                if declared_vision_tokens != expected_vision_tokens:
+                    raise ValueError(
+                        "Qwen vision token count does not match its grid: "
+                        f"declared={declared_vision_tokens}, "
+                        f"grid={expected_vision_tokens}"
+                    )
+
+                if is_video:
+                    assert isinstance(crops, QwenVideoInputs)
+                    has_pixels = crops.pixel_values is not None
+                    has_embeddings = crops.vision_embeddings is not None
+                    if has_pixels == has_embeddings:
+                        raise ValueError(
+                            "Qwen video inputs require exactly one of pixel_values "
+                            "or vision_embeddings"
+                        )
+                    if has_embeddings:
+                        assert crops.vision_embeddings is not None
+                        embeddings = crops.vision_embeddings
+                        if embeddings.ndim != 2:
+                            raise ValueError(
+                                "Qwen video vision_embeddings must be rank-2"
+                            )
+                        if int(embeddings.shape[0]) != declared_vision_tokens:
+                            raise ValueError(
+                                "Qwen cached video embedding count does not match "
+                                "its placeholders"
+                            )
+                        if embeddings.device != self.device:
+                            raise ValueError(
+                                "Qwen cached video embeddings must be on the "
+                                "runtime device"
+                            )
+                        direct_vision_embeddings = embeddings
+                    else:
+                        assert crops.pixel_values is not None
+                        pixels = crops.pixel_values
+                        if pixels.ndim != 2:
+                            raise ValueError(
+                                "Qwen video pixel_values must be rank-2"
+                            )
+                        expected_pixel_rows = int(grid_np.prod(axis=1).sum())
+                        if int(pixels.shape[0]) != expected_pixel_rows:
+                            raise ValueError(
+                                "Qwen video patch count does not match its grid: "
+                                f"patches={int(pixels.shape[0])}, "
+                                f"grid={expected_pixel_rows}"
+                            )
+                        if pixels.device != self.device:
+                            raise ValueError(
+                                "Qwen video pixel_values must be on the runtime device"
+                            )
+                        metadata = (
+                            crops.vision_bilinear_indices,
+                            crops.vision_bilinear_weights,
+                            crops.vision_position_ids,
+                            crops.vision_cu_seqlens,
+                        )
+                        if any(value is None for value in metadata):
+                            raise ValueError(
+                                "Qwen device-resident video pixels require precomputed "
+                                "vision metadata"
+                            )
+                        (
+                            direct_vision_bilinear_indices,
+                            direct_vision_bilinear_weights,
+                            direct_vision_position_ids,
+                            direct_vision_cu_seqlens,
+                        ) = metadata
+                        expected_metadata_shapes = (
+                            (4, expected_pixel_rows),
+                            (4, expected_pixel_rows),
+                            (expected_pixel_rows, 2),
+                            (int(grid_np[:, 0].sum()) + 1,),
+                        )
+                        for value, expected_shape in zip(
+                            metadata, expected_metadata_shapes
+                        ):
+                            assert value is not None
+                            if tuple(value.shape) != expected_shape:
+                                raise ValueError(
+                                    "Qwen video vision metadata has shape "
+                                    f"{tuple(value.shape)}; expected {expected_shape}"
+                                )
+                            if value.device != self.device:
+                                raise ValueError(
+                                    "Qwen video vision metadata must be on the "
+                                    "runtime device"
+                                )
+                        direct_pixel_values = pixels
+                else:
+                    assert isinstance(crops, QwenImageInputs)
+                    crop_pixels = crops.pixel_values
+                    if crop_pixels.ndim != 2:
+                        raise ValueError("Qwen image pixel_values must be rank-2")
+                    if staged_pixel_dim == 0:
+                        staged_pixel_dim = int(crop_pixels.shape[1])
+                    elif staged_pixel_dim != int(crop_pixels.shape[1]):
+                        raise ValueError("Qwen image pixel feature dimension changed")
+                    staged_pixel_rows += int(crop_pixels.shape[0])
+                    staged_vision_sequence_count += int(grid_np[:, 0].sum())
+
                 crop_grid_rows.append(grid_np)
-                image_grid_rows += int(grid_np.shape[0])
-                vision_sequence_count += int(grid_np[:, 0].sum())
+                vision_modality_types.append(2 if is_video else 1)
+                vision_grid_rows += int(grid_np.shape[0])
             else:
                 crop_grid_rows.append(None)
+                vision_modality_types.append(None)
 
         scratch = self._prefill_scratch_for(
             prefill_slot,
             total_tokens=total_tokens,
             batch_size=len(prepared_sequences),
-            pixel_rows=pixel_rows,
-            pixel_dim=pixel_dim,
-            image_grid_rows=image_grid_rows,
-            vision_sequence_count=vision_sequence_count,
+            pixel_rows=staged_pixel_rows,
+            pixel_dim=staged_pixel_dim,
+            image_grid_rows=vision_grid_rows,
+            vision_sequence_count=staged_vision_sequence_count,
         )
 
         offset = 0
@@ -1239,8 +1536,14 @@ class Qwen35Runtime(UncachedPagedRuntime):
         grid_offset = 0
         scratch.text_meta.cu_seq_lens_q.np[0] = 0
 
-        for row, (token_ids, crops, grid_np, batch_idx) in enumerate(
-            zip(token_rows, image_crops_list, crop_grid_rows, batch_indices)
+        for row, (token_ids, crops, grid_np, modality_type, batch_idx) in enumerate(
+            zip(
+                token_rows,
+                image_crops_list,
+                crop_grid_rows,
+                vision_modality_types,
+                batch_indices,
+            )
         ):
             length = lengths[row]
             end = offset + length
@@ -1270,45 +1573,63 @@ class Qwen35Runtime(UncachedPagedRuntime):
                 )
                 scratch.text_meta.rope_deltas.np[row, 0] = 0
             else:
-                mm_types[ids_np == IMAGE_PAD_ID] = 1
+                assert modality_type is not None
+                placeholder_id = (
+                    VIDEO_PAD_ID if modality_type == 2 else IMAGE_PAD_ID
+                )
+                mm_types[ids_np == placeholder_id] = modality_type
                 assert grid_np is not None
+                declared_vision_tokens = int(
+                    crops.num_video_tokens
+                    if isinstance(crops, QwenVideoInputs)
+                    else crops.num_image_tokens
+                )
+                placeholder_count = int(np.count_nonzero(ids_np == placeholder_id))
+                if placeholder_count != declared_vision_tokens:
+                    raise ValueError(
+                        "Qwen vision placeholder count does not match inputs: "
+                        f"placeholders={placeholder_count}, "
+                        f"vision_tokens={declared_vision_tokens}"
+                    )
                 grid_end = grid_offset + grid_np.shape[0]
                 if scratch.image_grid_thw is None:
-                    raise RuntimeError("Qwen image grid scratch was not allocated")
+                    raise RuntimeError("Qwen vision grid scratch was not allocated")
                 scratch.image_grid_thw.np[grid_offset:grid_end] = grid_np
                 scratch.text_meta.rope_deltas.np[row, 0] = self._fill_multimodal_position_ids(
                     scratch.text_meta.position_ids.np,
                     start=offset,
                     end=end,
                     mm_token_type_ids=mm_types,
-                    image_grid_thw=grid_np,
+                    vision_grid_thw=grid_np,
+                    vision_modality_type=modality_type,
                 )
-                pixel_end = pixel_offset + int(crops.pixel_values.shape[0])
-                if scratch.pixel_values is None:
-                    raise RuntimeError("Qwen pixel scratch was not allocated")
-                scratch.pixel_values.cpu[pixel_offset:pixel_end].copy_(
-                    crops.pixel_values
-                )
-                pixel_offset = pixel_end
+                if isinstance(crops, QwenImageInputs):
+                    pixel_end = pixel_offset + int(crops.pixel_values.shape[0])
+                    if scratch.pixel_values is None:
+                        raise RuntimeError("Qwen pixel scratch was not allocated")
+                    scratch.pixel_values.cpu[pixel_offset:pixel_end].copy_(
+                        crops.pixel_values
+                    )
+                    pixel_offset = pixel_end
                 grid_offset = grid_end
             offset += length
 
-        if has_images:
+        if staged_pixel_rows:
             self._fill_vision_metadata(
                 scratch,
                 crop_grid_rows,
-                pixel_rows=pixel_rows,
-                vision_sequence_count=vision_sequence_count,
+                pixel_rows=staged_pixel_rows,
+                vision_sequence_count=staged_vision_sequence_count,
             )
 
         self._copy_prefill_metadata_to_gpu(
             scratch,
-            total_tokens=total_tokens,
-            batch_size=len(prepared_sequences),
-            has_images=has_images,
-            pixel_rows=pixel_rows,
-            image_grid_rows=image_grid_rows,
-            vision_sequence_count=vision_sequence_count,
+            copy_pixel_values=staged_pixel_rows > 0,
+            copy_vision_grid=has_vision,
+            copy_vision_metadata=staged_pixel_rows > 0,
+            pixel_rows=staged_pixel_rows,
+            vision_grid_rows=vision_grid_rows,
+            vision_sequence_count=staged_vision_sequence_count,
         )
         prefill_slot.batch_idx[: len(prepared_sequences)].copy_(
             scratch.text_meta.batch_indices.gpu[: len(prepared_sequences)]
@@ -1339,35 +1660,60 @@ class Qwen35Runtime(UncachedPagedRuntime):
             slot_mapping=scratch.text_meta.slot_mapping.gpu[:, :total_tokens],
             rope_deltas=scratch.text_meta.rope_deltas.gpu[:batch_size],
             pixel_values=(
-                scratch.pixel_values.gpu[:pixel_rows]
-                if has_images and scratch.pixel_values is not None
-                else None
+                direct_pixel_values
+                if direct_pixel_values is not None
+                else (
+                    scratch.pixel_values.gpu[:staged_pixel_rows]
+                    if staged_pixel_rows and scratch.pixel_values is not None
+                    else None
+                )
             ),
             image_grid_thw=(
-                scratch.image_grid_thw.gpu[:image_grid_rows]
-                if has_images and scratch.image_grid_thw is not None
+                scratch.image_grid_thw.gpu[:vision_grid_rows]
+                if has_vision and scratch.image_grid_thw is not None
                 else None
             ),
             vision_bilinear_indices=(
-                scratch.vision_bilinear_indices.gpu[:, :pixel_rows]
-                if has_images and scratch.vision_bilinear_indices is not None
-                else None
+                direct_vision_bilinear_indices
+                if direct_vision_bilinear_indices is not None
+                else (
+                    scratch.vision_bilinear_indices.gpu[:, :staged_pixel_rows]
+                    if staged_pixel_rows
+                    and scratch.vision_bilinear_indices is not None
+                    else None
+                )
             ),
             vision_bilinear_weights=(
-                scratch.vision_bilinear_weights.gpu[:, :pixel_rows]
-                if has_images and scratch.vision_bilinear_weights is not None
-                else None
+                direct_vision_bilinear_weights
+                if direct_vision_bilinear_weights is not None
+                else (
+                    scratch.vision_bilinear_weights.gpu[:, :staged_pixel_rows]
+                    if staged_pixel_rows
+                    and scratch.vision_bilinear_weights is not None
+                    else None
+                )
             ),
             vision_position_ids=(
-                scratch.vision_position_ids.gpu[:pixel_rows]
-                if has_images and scratch.vision_position_ids is not None
-                else None
+                direct_vision_position_ids
+                if direct_vision_position_ids is not None
+                else (
+                    scratch.vision_position_ids.gpu[:staged_pixel_rows]
+                    if staged_pixel_rows and scratch.vision_position_ids is not None
+                    else None
+                )
             ),
             vision_cu_seqlens=(
-                scratch.vision_cu_seqlens.gpu[: vision_sequence_count + 1]
-                if has_images and scratch.vision_cu_seqlens is not None
-                else None
+                direct_vision_cu_seqlens
+                if direct_vision_cu_seqlens is not None
+                else (
+                    scratch.vision_cu_seqlens.gpu[
+                        : staged_vision_sequence_count + 1
+                    ]
+                    if staged_pixel_rows and scratch.vision_cu_seqlens is not None
+                    else None
+                )
             ),
+            vision_embeddings=direct_vision_embeddings,
         )
 
     def _forward_packed_prefill(
@@ -1385,6 +1731,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
             vision_bilinear_weights=packed.vision_bilinear_weights,
             vision_position_ids=packed.vision_position_ids,
             vision_cu_seqlens=packed.vision_cu_seqlens,
+            vision_embeddings=packed.vision_embeddings,
             cache_position_ids=packed.cache_position_ids,
             slot_mapping=packed.slot_mapping,
             page_table=packed.paged_kv_page_table,
@@ -1451,4 +1798,4 @@ class Qwen35Runtime(UncachedPagedRuntime):
     def _decode_cache_for_slot(self, slot: DecodeSlot) -> Qwen35InferenceCache:
         return self._decode_caches[int(slot.slot_id)]
 
-__all__ = ["Qwen35Runtime", "QwenImageInputs"]
+__all__ = ["Qwen35Runtime", "QwenImageInputs", "QwenVideoInputs"]

--- a/tests/moondream/test_runtime_prefill.py
+++ b/tests/moondream/test_runtime_prefill.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
 import torch
 
 from kestrel.models.moondream import runtime as runtime_mod
@@ -61,12 +64,14 @@ def _make_runtime(seq_lens: dict[int, int]) -> tuple[runtime_mod.MoondreamRuntim
         paged_kv_seqlens_k,
         last_token_positions,
         input_staging,
+        prefill_scratch,
         block_sequence_ids=None,
     ):
         captured["position_ids_contiguous"] = position_ids.is_contiguous()
         captured["batch_idx_contiguous"] = batch_idx.is_contiguous()
         del attn_mask, position_ids, batch_idx, lora_slot, use_prefix_attn
         del input_staging, block_sequence_ids
+        captured["prefill_scratch"] = prefill_scratch
         captured["paged_kv_seqlens_q"] = paged_kv_seqlens_q
         captured["paged_kv_seqlens_k"] = paged_kv_seqlens_k
         captured["last_token_positions"] = last_token_positions
@@ -79,6 +84,12 @@ def _make_runtime(seq_lens: dict[int, int]) -> tuple[runtime_mod.MoondreamRuntim
 
 
 def _make_prefill_slot() -> runtime_mod.PrefillSlot:
+    text_config = SimpleNamespace(
+        dim=4,
+        n_heads=2,
+        n_kv_heads=1,
+        moe=SimpleNamespace(num_experts=3),
+    )
     return runtime_mod.PrefillSlot(
         slot_id=0,
         batch_idx=torch.zeros(8, dtype=torch.int64),
@@ -89,6 +100,12 @@ def _make_prefill_slot() -> runtime_mod.PrefillSlot:
         size_staging=torch.empty(0),
         coord_cpu=torch.empty(0),
         size_cpu=torch.empty(0),
+        scratch=runtime_mod.PrefillScratch(
+            16,
+            text_config,
+            torch.device("cpu"),
+            torch.float32,
+        ),
         input_staging=runtime_mod.PrefillInputStaging(
             max_batch_size=8,
             max_seq_length=16,
@@ -111,6 +128,7 @@ def test_launch_prepared_batch_omits_paged_kv_q_lengths_for_uniform_q_lengths() 
     )
 
     assert logits.shape == (2, 8)
+    assert captured["prefill_scratch"] is slot.scratch
     assert captured["position_ids_contiguous"]
     assert captured["batch_idx_contiguous"]
     assert captured["paged_kv_seqlens_q"] is None
@@ -159,3 +177,36 @@ def test_launch_prepared_batch_keeps_paged_kv_q_lengths_for_padded_q_lengths() -
         captured["last_token_positions"],
         torch.tensor([0, 2], dtype=torch.long),
     )
+
+
+def test_prefill_scratch_reuses_preallocated_storage() -> None:
+    text_config = SimpleNamespace(
+        dim=4,
+        n_heads=2,
+        n_kv_heads=1,
+        moe=SimpleNamespace(num_experts=3),
+    )
+    scratch = runtime_mod.PrefillScratch(
+        16,
+        text_config,
+        torch.device("cpu"),
+        torch.float32,
+    )
+
+    first = scratch.buffers_for(6)
+    second = scratch.buffers_for(6)
+
+    assert set(first) == {(6, 8), (6, 4), (6, 3)}
+    assert first[(6, 8)].data_ptr() == scratch.qkv_out.data_ptr()
+    assert first[(6, 4)].data_ptr() == scratch.tok_qv_lin.data_ptr()
+    assert first[(6, 3)].data_ptr() == scratch.router_logits.data_ptr()
+    assert all(first[key].data_ptr() == second[key].data_ptr() for key in first)
+
+
+def test_launch_prepared_batch_requires_prefill_scratch() -> None:
+    runtime, _ = _make_runtime({1: 1})
+    slot = _make_prefill_slot()
+    slot.scratch = None
+
+    with pytest.raises(RuntimeError, match="missing scratch buffers"):
+        runtime.launch_prepared_batch([_make_prepared(1, 10)], slot)

--- a/tests/qwen35/test_video_position_ids.py
+++ b/tests/qwen35/test_video_position_ids.py
@@ -1,0 +1,162 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import torch
+
+from kestrel.models.qwen35 import Qwen35Runtime, QwenVideoInputs
+from kestrel.models.qwen35.prompt_template import (
+    IM_START_ID,
+    VIDEO_PAD_ID,
+    VISION_END_ID,
+    VISION_START_ID,
+    _NEWLINE_ID,
+    _USER_ID,
+)
+from kestrel.runtime import TextToken
+
+
+def _runtime() -> Qwen35Runtime:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.architecture = SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2)
+    )
+    return runtime
+
+
+def test_video_position_ids_expand_temporal_grid_per_timestamp_group() -> None:
+    runtime = _runtime()
+    out = np.zeros((3, 1, 11), dtype=np.int64)
+    mm_types = np.asarray([0, 2, 2, 2, 2, 0, 2, 2, 2, 2, 0])
+
+    rope_delta = runtime._fill_multimodal_position_ids(
+        out,
+        start=0,
+        end=11,
+        mm_token_type_ids=mm_types,
+        vision_grid_thw=np.asarray([[2, 4, 4]], dtype=np.int64),
+        vision_modality_type=2,
+    )
+
+    np.testing.assert_array_equal(
+        out[:, 0],
+        np.asarray(
+            [
+                [0, 1, 1, 1, 1, 3, 4, 4, 4, 4, 6],
+                [0, 1, 1, 2, 2, 3, 4, 4, 5, 5, 6],
+                [0, 1, 2, 1, 2, 3, 4, 5, 4, 5, 6],
+            ],
+            dtype=np.int64,
+        ),
+    )
+    assert rope_delta == -4
+
+
+def test_video_position_ids_require_one_grid_per_pad_group() -> None:
+    runtime = _runtime()
+    out = np.zeros((3, 1, 5), dtype=np.int64)
+
+    with pytest.raises(RuntimeError, match="unused rows"):
+        runtime._fill_multimodal_position_ids(
+            out,
+            start=0,
+            end=5,
+            mm_token_type_ids=np.asarray([0, 2, 2, 2, 2]),
+            vision_grid_thw=np.asarray([[2, 4, 4]], dtype=np.int64),
+            vision_modality_type=2,
+        )
+
+
+class _Tokenizer:
+    def encode(self, text: str) -> SimpleNamespace:
+        timestamp_ids = {
+            "<0.1 seconds>": 901,
+            "<0.6 seconds>": 906,
+        }
+        return SimpleNamespace(ids=[timestamp_ids[text]])
+
+
+def _video_inputs(**updates: object) -> QwenVideoInputs:
+    values: dict[str, object] = {
+        "pixel_values": torch.empty((32, 1536)),
+        "video_grid_thw": torch.tensor([[2, 4, 4]]),
+        "num_video_tokens": 8,
+        "timestamps_seconds": (0.125, 0.625),
+    }
+    values.update(updates)
+    return QwenVideoInputs(**values)  # type: ignore[arg-type]
+
+
+def test_prepare_sequence_inserts_native_timestamped_video_groups() -> None:
+    runtime = _runtime()
+    runtime.tokenizer = _Tokenizer()
+    runtime.prompt_template = SimpleNamespace(
+        query=lambda: SimpleNamespace(prefix=[_USER_ID, _NEWLINE_ID])
+    )
+    runtime._prepare_uncached_sequence = lambda **kwargs: kwargs
+    prompt = [
+        TextToken(IM_START_ID),
+        TextToken(_USER_ID),
+        TextToken(_NEWLINE_ID),
+        TextToken(777),
+        TextToken(778),
+    ]
+    video = _video_inputs()
+
+    prepared = runtime.prepare_sequence(
+        prompt,
+        image=object(),
+        image_crops=video,
+        max_new_tokens=4,
+    )
+
+    inserted_ids = [
+        901,
+        VISION_START_ID,
+        *([VIDEO_PAD_ID] * 4),
+        VISION_END_ID,
+        906,
+        VISION_START_ID,
+        *([VIDEO_PAD_ID] * 4),
+        VISION_END_ID,
+    ]
+    assert runtime.image_kv_length(prompt, object(), video) == len(inserted_ids)
+    assert [token.token_id for token in prepared["tokens"]] == [
+        IM_START_ID,
+        _USER_ID,
+        _NEWLINE_ID,
+        *inserted_ids,
+        777,
+        778,
+    ]
+    assert prepared["image_length"] == len(inserted_ids)
+    assert prepared["target_length"] == len(prompt) + len(inserted_ids) + 4
+
+
+@pytest.mark.parametrize(
+    ("updates", "match"),
+    [
+        ({"num_video_tokens": 7}, "token count"),
+        ({"timestamps_seconds": (0.125,)}, "one value per temporal patch"),
+        ({"timestamps_seconds": (0.625, 0.125)}, "must increase"),
+    ],
+)
+def test_prepare_sequence_rejects_inconsistent_video_contract(
+    updates: dict[str, object],
+    match: str,
+) -> None:
+    runtime = _runtime()
+    runtime.tokenizer = _Tokenizer()
+    runtime.prompt_template = SimpleNamespace(
+        query=lambda: SimpleNamespace(prefix=[_USER_ID, _NEWLINE_ID])
+    )
+    runtime._prepare_uncached_sequence = lambda **kwargs: kwargs
+
+    with pytest.raises(ValueError, match=match):
+        runtime.prepare_sequence(
+            [TextToken(IM_START_ID), TextToken(_USER_ID), TextToken(_NEWLINE_ID)],
+            image=object(),
+            image_crops=_video_inputs(**updates),
+            max_new_tokens=1,
+        )

--- a/tests/qwen35/test_vision_reference_ops.py
+++ b/tests/qwen35/test_vision_reference_ops.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+from kestrel.models.qwen35.qwen_config import Qwen3_5VisionConfig
+from kestrel.models.qwen35.qwen_model import (
+    Qwen3_5VisionAttention,
+    Qwen3_5VisionPatchEmbed,
+    _apply_vision_rotary_embedding,
+)
+
+
+def _config() -> Qwen3_5VisionConfig:
+    return Qwen3_5VisionConfig(
+        depth=1,
+        hidden_size=8,
+        hidden_act="gelu_pytorch_tanh",
+        intermediate_size=16,
+        num_heads=2,
+        in_channels=3,
+        patch_size=2,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        out_hidden_size=8,
+        num_position_embeddings=16,
+    )
+
+
+def test_patch_embed_matches_reference_conv3d_accumulation() -> None:
+    torch.manual_seed(7)
+    module = Qwen3_5VisionPatchEmbed(_config())
+    hidden_states = torch.randn(5, 3 * 2 * 2 * 2)
+
+    expected = F.conv3d(
+        hidden_states.view(-1, 3, 2, 2, 2),
+        module.proj.weight.view(8, 3, 2, 2, 2),
+        module.proj.bias,
+        stride=(2, 2, 2),
+    ).view(-1, 8)
+
+    torch.testing.assert_close(module(hidden_states), expected)
+
+
+def test_vision_rotary_matches_fp32_reference_for_bfloat16_inputs() -> None:
+    torch.manual_seed(11)
+    query = torch.randn(6, 2, 4).bfloat16()
+    key = torch.randn(6, 2, 4).bfloat16()
+    angles = torch.randn(6, 4)
+    cos = angles.cos()
+    sin = angles.sin()
+
+    def rotate_half(value: torch.Tensor) -> torch.Tensor:
+        first, second = value.chunk(2, dim=-1)
+        return torch.cat((-second, first), dim=-1)
+
+    expected_query = (
+        query.float() * cos.unsqueeze(-2)
+        + rotate_half(query.float()) * sin.unsqueeze(-2)
+    ).bfloat16()
+    expected_key = (
+        key.float() * cos.unsqueeze(-2) + rotate_half(key.float()) * sin.unsqueeze(-2)
+    ).bfloat16()
+
+    actual_query, actual_key = _apply_vision_rotary_embedding(
+        query,
+        key,
+        cos,
+        sin,
+    )
+
+    assert torch.equal(actual_query, expected_query)
+    assert torch.equal(actual_key, expected_key)
+
+
+def test_vision_attention_keeps_packed_sequences_isolated() -> None:
+    torch.manual_seed(13)
+    module = Qwen3_5VisionAttention(_config())
+    hidden_states = torch.randn(5, 8)
+    cu_seqlens = torch.tensor([0, 2, 5], dtype=torch.int32)
+    position_embeddings = (torch.ones(5, 4), torch.zeros(5, 4))
+
+    baseline = module(hidden_states, cu_seqlens, position_embeddings)
+    changed = hidden_states.clone()
+    changed[2:] = torch.randn_like(changed[2:])
+    perturbed = module(changed, cu_seqlens, position_embeddings)
+
+    torch.testing.assert_close(perturbed[:2], baseline[:2])


### PR DESCRIPTION
## Summary

- add native Qwen video inputs for direct device-resident patches or cached visual embeddings
- reproduce the pinned Qwen timestamped temporal-group prompt and video M-RoPE position layout
- add direct vision encoding plus cached-embedding language replay without staging raw frame planes through host memory
- expose the supported video input surface and cover exact temporal position IDs

## Validation

- modified sources compile cleanly
- targeted Ruff formatting and strict Pyright checks pass
- exact processor, timestamp, and M-RoPE behavior was checked against the pinned Qwen artifacts
- paired H100 runtime smoke and canonical gate are pending

## Cross-repository scope

- live orchestration: https://github.com/m87-labs/kestrel-live/pull/1
- proprietary engine: https://github.com/m87-labs/kestrel-proprietary/pull/1974