### PR TITLE
Size generated decode slots for artifact ABI

### DIFF
--- a/kestrel/models/moondream/generated_decode.py
+++ b/kestrel/models/moondream/generated_decode.py
@@ -5,7 +5,11 @@ from typing import Any, Mapping, Sequence
 
 import torch
 
-from kestrel.runtime.generated_decode import GeneratedDecode, GeneratedDecodeSpec
+from kestrel.runtime.generated_decode import (
+    GeneratedDecode,
+    GeneratedDecodeSpec,
+    _GeneratedDecodePlan,
+)
 
 
 def _logical_weight_sources(text: torch.nn.Module) -> dict[str, torch.Tensor]:
@@ -103,11 +107,7 @@ class MoondreamDecodeBindings:
         }
 
 
-def create_generated_decode(
-    runtime: Any,
-    *,
-    required: bool = False,
-) -> GeneratedDecode | None:
+def _prepare_generated_decode(runtime: Any) -> _GeneratedDecodePlan:
     spec = GeneratedDecodeSpec(
         label="Moondream",
         weight_root=runtime.model.text,
@@ -116,13 +116,29 @@ def create_generated_decode(
         engine_buffers=_engine_weight_buffers(runtime.model.text),
         bindings=MoondreamDecodeBindings(runtime.layer_caches),
     )
+    return GeneratedDecode.plan(runtime, spec)
+
+
+def create_generated_decode(
+    runtime: Any,
+    *,
+    required: bool = False,
+    plan: _GeneratedDecodePlan | None = None,
+) -> GeneratedDecode | None:
+    if plan is None:
+        plan = _prepare_generated_decode(runtime)
+    spec = plan.spec
     if required:
         return GeneratedDecode.require(
             runtime,
             spec,
             capacity=runtime.max_batch_size,
+            plan=plan,
         )
-    return GeneratedDecode.try_create(runtime, spec)
+    return GeneratedDecode.try_create(runtime, spec, plan=plan)
 
 
-__all__ = ["MoondreamDecodeBindings", "create_generated_decode"]
+__all__ = [
+    "MoondreamDecodeBindings",
+    "create_generated_decode",
+]

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -123,6 +123,15 @@ def _count_image_markers(tokens) -> int:
     return sum(1 for t in tokens if isinstance(t, ImageMarker))
 
 
+def _decode_slot_storage_capacity(
+    logical_capacity: int,
+    generated_capacity: int,
+) -> int:
+    """Keep scheduler capacity logical while satisfying generated program ABIs."""
+
+    return max(int(logical_capacity), int(generated_capacity))
+
+
 class PrefillScratch:
     """Pre-allocated scratch buffers for prefill to avoid per-layer allocations."""
 
@@ -814,6 +823,23 @@ class MoondreamRuntime:
                 dtype=self.dtype,
             )
 
+        generated_decode_plan = None
+        if self.decode_path != "native":
+            from .generated_decode import _prepare_generated_decode
+
+            generated_decode_plan = _prepare_generated_decode(self)
+        # Generated programs may round a logical C1 request up to a B8 physical
+        # ABI. Only the per-slot storage follows that ABI capacity; scheduler and
+        # page-table admission continue to use ``self.max_batch_slots``.
+        decode_slot_capacity = _decode_slot_storage_capacity(
+            self.max_batch_slots,
+            (
+                generated_decode_plan.slot_capacity
+                if generated_decode_plan is not None
+                else 0
+            ),
+        )
+
         # Create two ping-pong decode slots for pipelined decoding.
         # Each slot has its own staging buffers, paged-KV metadata buffers,
         # and RenderBuffer, but they share the decode compute stream and copy stream.
@@ -824,7 +850,7 @@ class MoondreamRuntime:
                 slot_id=slot_id,
                 device=self.device,
                 dtype=self.dtype,
-                max_batch_slots=self.max_batch_slots,
+                max_batch_slots=decode_slot_capacity,
                 kv_cache_pages=n_pages,
                 vocab_size=vocab_size,
                 hidden_dim=hidden_dim,
@@ -835,7 +861,7 @@ class MoondreamRuntime:
             )
             for slot_id in range(2)
         ]
-        self._initialize_generated_decode()
+        self._initialize_generated_decode(generated_decode_plan)
         # A shipped megakernel is already a single eager launch. Resolve its AOT
         # buckets once and omit only their redundant native CUDA graphs. Generic
         # generated programs take precedence; the legacy whole-model path remains
@@ -900,7 +926,7 @@ class MoondreamRuntime:
         self._allocate_vision_buffers()
         self._capture_vision_graphs()
 
-    def _initialize_generated_decode(self) -> None:
+    def _initialize_generated_decode(self, plan=None) -> None:
         """Apply the runtime-wide decode policy before graph capture."""
 
         self.generated_decode = None
@@ -909,10 +935,17 @@ class MoondreamRuntime:
 
         from .generated_decode import create_generated_decode
 
-        self.generated_decode = create_generated_decode(
-            self,
-            required=self.decode_path == "generated",
-        )
+        if plan is None:
+            self.generated_decode = create_generated_decode(
+                self,
+                required=self.decode_path == "generated",
+            )
+        else:
+            self.generated_decode = create_generated_decode(
+                self,
+                required=self.decode_path == "generated",
+                plan=plan,
+            )
 
     def _maybe_release_cuda_allocator_cache(self) -> None:
         """Release cached allocator blocks before CUDA graph capture.

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -118,6 +118,26 @@ class GeneratedDecodeSpec:
 
 
 @dataclass(frozen=True)
+class _GeneratedDecodePlan:
+    """Resolved programs kept stable across slot allocation and binding."""
+
+    runtime: Any
+    spec: GeneratedDecodeSpec
+    max_batch_size: int
+    compatible_programs: tuple[Any, ...]
+    selectable_programs: tuple[Any, ...]
+
+    @property
+    def slot_capacity(self) -> int:
+        """Physical rows required by every program this runtime can select."""
+
+        return max(
+            (int(program.capacity) for program in self.selectable_programs),
+            default=0,
+        )
+
+
+@dataclass(frozen=True)
 class _BoundInvocation:
     invocation: Any
     scalar_names: frozenset[str]
@@ -291,14 +311,55 @@ class GeneratedDecode:
         ))
 
     @classmethod
+    def plan(
+        cls,
+        runtime: Any,
+        spec: GeneratedDecodeSpec,
+    ) -> _GeneratedDecodePlan:
+        """Resolve once so slot storage and later bindings use one program set."""
+
+        max_batch_size = int(runtime.max_batch_size)
+        compatible_programs = cls._resolve_programs(runtime, spec)
+        return _GeneratedDecodePlan(
+            runtime=runtime,
+            spec=spec,
+            max_batch_size=max_batch_size,
+            compatible_programs=compatible_programs,
+            selectable_programs=_selectable_programs(
+                compatible_programs, max_batch_size
+            ),
+        )
+
+    @staticmethod
+    def _validate_plan(
+        runtime: Any,
+        spec: GeneratedDecodeSpec,
+        plan: _GeneratedDecodePlan,
+    ) -> None:
+        if plan.runtime is not runtime:
+            raise ValueError("generated decode plan belongs to a different runtime")
+        if plan.spec is not spec:
+            raise ValueError("generated decode plan belongs to a different spec")
+        if plan.max_batch_size != int(runtime.max_batch_size):
+            raise ValueError(
+                "generated decode plan batch limit changed between resolution "
+                "and binding"
+            )
+
+    @classmethod
     def require(
         cls,
         runtime: Any,
         spec: GeneratedDecodeSpec,
         *,
         capacity: int,
+        plan: _GeneratedDecodePlan | None = None,
     ) -> "GeneratedDecode":
-        programs = cls._resolve_programs(runtime, spec)
+        if plan is None:
+            programs = cls._resolve_programs(runtime, spec)
+        else:
+            cls._validate_plan(runtime, spec, plan)
+            programs = plan.compatible_programs
         if not programs:
             raise RuntimeError(
                 f"{spec.label} requires a compatible bundled generated-decode program"
@@ -315,11 +376,17 @@ class GeneratedDecode:
         cls,
         runtime: Any,
         spec: GeneratedDecodeSpec,
+        *,
+        plan: _GeneratedDecodePlan | None = None,
     ) -> "GeneratedDecode | None":
-        programs = cls._resolve_programs(runtime, spec)
-        if not programs:
-            return None
-        programs = _selectable_programs(programs, runtime.max_batch_size)
+        if plan is None:
+            programs = cls._resolve_programs(runtime, spec)
+            if not programs:
+                return None
+            programs = _selectable_programs(programs, runtime.max_batch_size)
+        else:
+            cls._validate_plan(runtime, spec, plan)
+            programs = plan.selectable_programs
         if not programs:
             return None
         return cls(runtime, spec=spec, programs=programs)

--- a/tests/moondream/test_generated_decode.py
+++ b/tests/moondream/test_generated_decode.py
@@ -5,9 +5,14 @@ import torch
 from kestrel.models.moondream.generated_decode import (
     _engine_weight_buffers,
     _logical_weight_sources,
+    _prepare_generated_decode,
     MoondreamDecodeBindings,
 )
-from kestrel.models.moondream.runtime import _FP8_KV_SUPPORTED_SMS
+from kestrel.models.moondream.runtime import (
+    _decode_slot_storage_capacity,
+    _FP8_KV_SUPPORTED_SMS,
+)
+from kestrel.runtime.generated_decode import GeneratedDecode
 
 
 def _cache(value: float) -> SimpleNamespace:
@@ -138,3 +143,37 @@ def test_moondream_slot_bindings_use_stable_hidden_and_metadata_buffers() -> Non
         "active_batch": 4,
         "kv_len": 7,
     }
+
+
+def test_moondream_allocates_selected_generated_program_abi_capacity(
+    monkeypatch,
+) -> None:
+    text = torch.nn.Module()
+    text.blocks = torch.nn.ModuleList()
+    text.moe_up_w_slab = torch.empty(1, dtype=torch.uint8)
+    text.moe_up_scale_slab = torch.empty(1)
+    runtime = SimpleNamespace(
+        max_batch_size=1,
+        max_batch_slots=3,
+        model=SimpleNamespace(text=text),
+        layer_caches=(),
+    )
+    program = SimpleNamespace(
+        capacity=8,
+        static_extent_bindings={},
+        runtime_extent_minimums={},
+    )
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "_resolve_programs",
+        classmethod(lambda _cls, _runtime, _spec: (program,)),
+    )
+
+    plan = _prepare_generated_decode(runtime)
+    storage_capacity = _decode_slot_storage_capacity(
+        runtime.max_batch_slots, plan.slot_capacity
+    )
+
+    assert plan.slot_capacity == 8
+    assert storage_capacity == 8
+    assert runtime.max_batch_slots == 3

--- a/tests/test_generated_decode_static_extents.py
+++ b/tests/test_generated_decode_static_extents.py
@@ -197,6 +197,78 @@ def test_generated_decode_skips_artifacts_above_runtime_batch_limit(monkeypatch)
     ]
 
 
+def test_generated_decode_plan_reports_selected_physical_slot_capacity(monkeypatch):
+    programs = _programs("b8")
+    monkeypatch.setattr(
+        runtime_decode.GeneratedDecode,
+        "_resolve_programs",
+        classmethod(lambda _cls, _runtime, _spec: programs),
+    )
+    runtime = SimpleNamespace(max_batch_size=1)
+    spec = object()
+
+    plan = runtime_decode.GeneratedDecode.plan(runtime, spec)
+
+    assert plan.spec is spec
+    assert plan.max_batch_size == 1
+    assert [program.name for program in plan.selectable_programs] == ["b8"]
+    assert plan.slot_capacity == 8
+
+
+def test_generated_decode_plan_reuses_exact_resolution_when_binding(monkeypatch):
+    programs = _programs("b1")
+    runtime = SimpleNamespace(max_batch_size=1)
+    spec = object()
+    plan = runtime_decode._GeneratedDecodePlan(
+        runtime=runtime,
+        spec=spec,
+        max_batch_size=1,
+        compatible_programs=programs,
+        selectable_programs=programs,
+    )
+    monkeypatch.setattr(
+        runtime_decode.GeneratedDecode,
+        "_resolve_programs",
+        classmethod(
+            lambda _cls, _runtime, _spec: pytest.fail(
+                "binding must reuse the pre-allocation resolution"
+            )
+        ),
+    )
+    constructions = []
+    monkeypatch.setattr(
+        runtime_decode.GeneratedDecode,
+        "__init__",
+        lambda self, *args, **kwargs: constructions.append((args, kwargs)),
+    )
+
+    generated = runtime_decode.GeneratedDecode.try_create(
+        runtime, spec, plan=plan
+    )
+
+    assert generated is not None
+    assert constructions[0][1]["programs"] is programs
+
+
+def test_generated_decode_plan_rejects_another_runtime():
+    runtime = SimpleNamespace(max_batch_size=1)
+    other_runtime = SimpleNamespace(max_batch_size=1)
+    spec = object()
+    programs = _programs("b1")
+    plan = runtime_decode._GeneratedDecodePlan(
+        runtime=runtime,
+        spec=spec,
+        max_batch_size=1,
+        compatible_programs=programs,
+        selectable_programs=programs,
+    )
+
+    with pytest.raises(ValueError, match="belongs to a different runtime"):
+        runtime_decode.GeneratedDecode.try_create(
+            other_runtime, spec, plan=plan
+        )
+
+
 def test_optional_generated_decode_falls_back_when_all_artifacts_are_unreachable(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

Moondream can have fewer logical scheduler slots than the static batch capacity compiled into its selected generated-decode artifact. On L4, the runtime allocated three rows while the artifact ABI required eight; slicing could not enlarge the backing tensors, so the generated kernel accessed beyond the allocation.

This change resolves the generated-decode plan before slot allocation, sizes only the per-slot tensor storage to the maximum selected artifact capacity, and reuses the same validated plan when binding. Scheduler, page-table, and LoRA capacities remain at their logical limits. The plan also validates runtime/spec identity so selection and binding cannot silently diverge.

## Validation

- Focused generated-decode and Moondream tests: 41 passed
- Full public suite before the final origin-validation hardening: 644 passed, 27 skipped
- Live L4 Moondream3 C1: 64 requests, 1,207 generated launches, zero native/fallback launches, 0.78125 accuracy, 68.06 decode tok/s
- `git diff --check`

Stacked on #174.