### PR TITLE
Ship Kestrel 0.6.0 Blackwell serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,47 @@ All notable changes since `v0.1.2` are documented in this file.
 
 ## Unreleased
 
-- Added `openai/whisper-large-v3-turbo` transcription and English translation,
-  including bounded long-form files, live PCM, progressive results, segment and
-  word timestamps, language detection, and prompts.
+## 0.6.0 — 2026-08-26
+
+Kestrel 0.6.0 adds production speech transcription and substantially expands
+the fast, precompiled serving path on NVIDIA Blackwell. It also improves Qwen
+numerical consistency and makes partial generated-decode coverage fall back
+safely before requests begin.
+
+### Speech transcription
+
+- Added `openai/whisper-large-v3-turbo` transcription and English translation
+  for long-form audio files and live PCM streams.
+- Progressive results include segment and word timestamps, with language
+  detection and prompt support for domain-specific vocabulary.
+
+### Faster Blackwell inference
+
+- Qwen 3.5, Qwen 3.6, and Gemma 4 now use expanded precompiled B200 paths
+  across supported prefill and decode workloads, including on-GPU token
+  selection. These workloads require no compiler or JIT setup in the deployed
+  application.
+- Updated to `kestrel-kernels` 0.5.0. CUDA payloads are split into automatically
+  installed companion packages on Linux and Windows, keeping every individual
+  wheel within PyPI's file-size limit.
+
+### Model fidelity
+
+- Qwen recurrent state now remains in BF16 across prefill and decode on the
+  optimized path, aligning the numerical behavior of both phases without
+  giving up the B200 acceleration.
+- Corrected Gemma 4 image preprocessing and pooling to match the checkpoint's
+  reference behavior, and corrected Moondream tau-attention activation
+  semantics.
+
+### Serving reliability
+
+- Kestrel enables generated decode only when the installed bundle covers the
+  complete configured batch range. Partial coverage now selects the regular
+  optimized runtime during initialization instead of failing during a request.
+- Concurrent engine starts now share one initialization, failed prefill work
+  releases its cache and workspace resources, and multimodal requests reserve
+  KV cache from their exact image-token requirements.
 
 ## 0.5.0 — 2026-08-02
 

--- a/kestrel/models/qwen35/cache.py
+++ b/kestrel/models/qwen35/cache.py
@@ -88,9 +88,8 @@ class Qwen35InferenceCache:
 class Qwen35LinearStatePool:
     """Runtime-owned GDN state indexed by Kestrel batch slot."""
 
-    _KEY_MAJOR_RECURRENT_AXES = ("state_row", "value_head", "key", "value")
     _VALUE_MAJOR_RECURRENT_AXES = ("state_row", "value_head", "value", "key")
-    _RECURRENT_STORAGE_DTYPE = "fp32"
+    _GENERATED_RECURRENT_STORAGE_DTYPE = "bf16"
 
     def __init__(
         self,
@@ -103,6 +102,25 @@ class Qwen35LinearStatePool:
         self.max_batch_slots = int(max_batch_slots)
         self.device = device
         self.replay_capacity = int(replay_capacity)
+        self._conv_shape = (
+            self.max_batch_slots,
+            2 * int(config.linear_num_key_heads) * int(config.linear_key_head_dim)
+            + int(config.linear_num_value_heads) * int(config.linear_value_head_dim),
+            int(config.linear_conv_kernel_dim),
+        )
+        self._key_major_recurrent_shape = (
+            self.max_batch_slots,
+            int(config.linear_num_value_heads),
+            int(config.linear_key_head_dim),
+            int(config.linear_value_head_dim),
+        )
+        self._value_major_recurrent_shape = (
+            self.max_batch_slots,
+            int(config.linear_num_value_heads),
+            int(config.linear_value_head_dim),
+            int(config.linear_key_head_dim),
+        )
+        self._recurrent_mode: str | None = None
         self.layers: list[LinearAttentionState | None] = [
             (
                 LinearAttentionState(replay_capacity=self.replay_capacity)
@@ -113,32 +131,70 @@ class Qwen35LinearStatePool:
         ]
 
     def initialize_from_config(self, config: Any, *, dtype: torch.dtype) -> None:
-        """Allocate zero GDN state rows without waiting for first prefill."""
+        """Allocate shared convolution state before decode representation selection."""
 
-        conv_dim = 2 * int(config.linear_num_key_heads) * int(
-            config.linear_key_head_dim
-        ) + int(config.linear_num_value_heads) * int(config.linear_value_head_dim)
-        conv_shape = (
+        expected_conv_shape = (
             self.max_batch_slots,
-            conv_dim,
+            2 * int(config.linear_num_key_heads) * int(config.linear_key_head_dim)
+            + int(config.linear_num_value_heads) * int(config.linear_value_head_dim),
             int(config.linear_conv_kernel_dim),
         )
-        recurrent_shape = (
-            self.max_batch_slots,
-            int(config.linear_num_value_heads),
-            int(config.linear_key_head_dim),
-            int(config.linear_value_head_dim),
-        )
+        if expected_conv_shape != self._conv_shape:
+            raise RuntimeError("Qwen GDN convolution geometry changed")
         for storage in self.layers:
             if storage is None:
                 continue
-            storage.allocate_zeroed(
-                conv_shape=conv_shape,
-                recurrent_shape=recurrent_shape,
-                conv_dtype=dtype,
-                recurrent_dtype=torch.float32,
-                device=self.device,
-            )
+            tensor = storage.conv_states
+            if tensor is None:
+                storage.conv_states = torch.zeros(
+                    self._conv_shape, dtype=dtype, device=self.device)
+            elif tuple(tensor.shape) != self._conv_shape or tensor.dtype != dtype:
+                raise RuntimeError("Qwen GDN convolution state contract changed")
+
+    def initialize_native_recurrent(self) -> None:
+        """Select the FP32 replay representation for the native decode path."""
+
+        if self._recurrent_mode not in (None, "native"):
+            raise RuntimeError(
+                "Qwen generated recurrent state cannot switch to native replay")
+        self._recurrent_mode = "native"
+        for storage in self.layers:
+            if storage is None:
+                continue
+            tensor = storage.recurrent_states
+            if tensor is None:
+                storage.recurrent_states = torch.zeros(
+                    self._key_major_recurrent_shape,
+                    dtype=torch.float32,
+                    device=self.device,
+                )
+            elif (
+                tuple(tensor.shape) != self._key_major_recurrent_shape
+                or tensor.dtype != torch.float32
+            ):
+                raise RuntimeError("Qwen native recurrent state contract changed")
+            storage._ensure_replay_state(storage.recurrent_states)
+
+    def _initialize_generated_recurrent(self) -> None:
+        if self._recurrent_mode not in (None, "generated"):
+            raise RuntimeError(
+                "Qwen native replay state cannot switch to generated decode")
+        self._recurrent_mode = "generated"
+        for storage in self.layers:
+            if storage is None:
+                continue
+            tensor = storage.recurrent_states
+            if tensor is None:
+                storage.recurrent_states = torch.zeros(
+                    self._value_major_recurrent_shape,
+                    dtype=torch.bfloat16,
+                    device=self.device,
+                )
+            elif (
+                tuple(tensor.shape) != self._value_major_recurrent_shape
+                or tensor.dtype != torch.bfloat16
+            ):
+                raise RuntimeError("Qwen generated recurrent state contract changed")
 
     def zero_all(self) -> None:
         for storage in self.layers:
@@ -163,15 +219,41 @@ class Qwen35LinearStatePool:
                 raise ValueError("Cannot capture mismatched Qwen linear state")
             if not src_layer.has_previous_state:
                 raise RuntimeError("Cannot capture uninitialized Qwen GDN state")
-            self._ensure_storage(storage, src_layer, batch_size=batch_size)
+            self._capture_conv_rows(
+                storage, src_layer, indices, batch_size=batch_size)
+            if self._recurrent_mode == "generated":
+                target = storage.recurrent_states
+                if target is None or src_layer.recurrent_states is not target:
+                    raise RuntimeError(
+                        "Qwen prefill did not write the generated recurrent pool")
+                continue
+            if self._recurrent_mode != "native":
+                raise RuntimeError("Qwen recurrent decode representation is not selected")
+            self._validate_prefill_recurrent(src_layer, batch_size=batch_size)
             storage.copy_rows_from(
-                src_layer,
-                indices,
-                copy_replay_payload=copy_replay_payload,
-            )
+                src_layer, indices, copy_replay_payload=copy_replay_payload)
+
+    def bind_generated_prefill_state(self, cache: Qwen35InferenceCache) -> None:
+        """Expose the authoritative BF16 pool as packed-prefill final state."""
+
+        if self._recurrent_mode != "generated":
+            raise RuntimeError("Qwen generated recurrent state is not initialized")
+        for layer_idx, storage in enumerate(self.layers):
+            if storage is None:
+                continue
+            target = storage.recurrent_states
+            if target is None:
+                raise RuntimeError("Qwen generated recurrent state is incomplete")
+            layer = cache.layers[layer_idx]
+            if not isinstance(layer, LinearAttentionState):
+                raise ValueError("Cannot bind mismatched Qwen linear state")
+            layer.recurrent_states = target
 
     def bind_to_cache(self, cache: Qwen35InferenceCache) -> None:
         """Bind cache linear layers directly to runtime-owned persistent state."""
+
+        if self._recurrent_mode != "native":
+            raise RuntimeError("Qwen generated recurrent state cannot bind native replay")
 
         for layer_idx, storage in enumerate(self.layers):
             if storage is None:
@@ -197,128 +279,52 @@ class Qwen35LinearStatePool:
                 continue
             storage.clear(batch_idx)
 
-    @property
-    def replay_recurrent_form(self) -> "StatePhysicalForm":
-        """Return the native replay path's authoritative checkpoint form."""
-
-        from kestrel.runtime.carried_state import StatePhysicalForm
-
-        return StatePhysicalForm(
-            representation="replay",
-            storage_axis_order=self._VALUE_MAJOR_RECURRENT_AXES,
-            storage_dtype=self._RECURRENT_STORAGE_DTYPE,
-        )
-
     def recurrent_tensors_for_form(
         self,
         form: "StatePhysicalForm",
     ) -> list[torch.Tensor | None]:
         """Resolve compiler-selected recurrence storage without naming a path."""
 
-        field = self._recurrent_field_for_form(form)
+        if (
+            form.representation != "materialized"
+            or form.storage_axis_order != self._VALUE_MAJOR_RECURRENT_AXES
+            or form.storage_dtype != self._GENERATED_RECURRENT_STORAGE_DTYPE
+        ):
+            raise ValueError(
+                "generated Qwen recurrent state requires materialized BF16 "
+                "value-major storage"
+            )
+        self._initialize_generated_recurrent()
         return [
-            None if storage is None else getattr(storage, field)
+            None if storage is None else storage.recurrent_states
             for storage in self.layers
         ]
 
-    @classmethod
-    def _recurrent_field_for_form(
-        cls,
-        form: "StatePhysicalForm",
-    ) -> str:
-        if form.storage_dtype != cls._RECURRENT_STORAGE_DTYPE:
-            raise ValueError(
-                "recurrent state requires fp32 physical storage, got "
-                f"{form.storage_dtype!r}"
-            )
-        fields_by_order = {
-            cls._KEY_MAJOR_RECURRENT_AXES: "recurrent_states",
-            cls._VALUE_MAJOR_RECURRENT_AXES: "replay_checkpoint_states",
-        }
-        try:
-            return fields_by_order[form.storage_axis_order]
-        except KeyError as exc:
-            raise ValueError(
-                "unsupported recurrent-state storage axis order "
-                f"{form.storage_axis_order!r}"
-            ) from exc
-
-    def transition_recurrent_form(
-        self,
-        source: "StatePhysicalForm",
-        target: "StatePhysicalForm",
-        rows: tuple[int, ...],
-    ) -> None:
-        """Convert selected rows between native replay and materialized state."""
-
-        if source == target or not rows:
-            return
-        source_representation = source.representation
-        target_representation = target.representation
-        if source_representation == target_representation:
-            raise ValueError(
-                "recurrent-state converter does not support changing physical "
-                f"form within representation {source_representation!r}"
-            )
-        source_field = self._recurrent_field_for_form(source)
-        target_field = self._recurrent_field_for_form(target)
-        checkpoint_field = "replay_checkpoint_states"
-        if (source_representation == "replay" and source_field != checkpoint_field) or (
-            target_representation == "replay" and target_field != checkpoint_field
-        ):
-            raise ValueError(
-                "replay recurrence requires value-major checkpoint storage"
-            )
-        if (source_representation, target_representation) not in {
-            ("replay", "materialized"),
-            ("materialized", "replay"),
-        }:
-            raise ValueError(
-                "unsupported recurrent-state transition "
-                f"{source_representation!r} -> {target_representation!r}"
-            )
-        row_indices = torch.tensor(rows, dtype=torch.long, device=self.device)
-        for storage in self.layers:
-            if storage is None or storage.recurrent_states is None:
-                continue
-            if source_representation == "replay":
-                storage.materialize_recurrent_from_replay(
-                    row_indices,
-                    write_recurrent=(target_field == "recurrent_states"),
-                )
-            elif source_field == checkpoint_field:
-                storage.reset_replay_tail(row_indices)
-            else:
-                storage.seed_replay_rows(row_indices)
-
-    def _ensure_storage(
+    def _capture_conv_rows(
         self,
         storage: LinearAttentionState,
         src_layer: LinearAttentionState,
+        indices: torch.Tensor,
         *,
         batch_size: int = 1,
     ) -> None:
         conv_states = src_layer.conv_states
-        recurrent_states = src_layer.recurrent_states
-        if conv_states is None or recurrent_states is None:
-            raise RuntimeError("Initialized Qwen GDN state tensor is missing")
-        if (
-            conv_states.shape[0] != batch_size
-            or recurrent_states.shape[0] != batch_size
-        ):
+        if conv_states is None or conv_states.shape[0] != batch_size:
             raise RuntimeError(
-                "Qwen GDN prefill state batch dimension must match capture batch"
+                "Qwen GDN prefill convolution batch must match capture batch"
             )
+        if storage.conv_states is None:
+            raise RuntimeError("Qwen GDN convolution pool is not initialized")
+        storage.conv_states.index_copy_(0, indices, conv_states)
 
-        conv_shape = (self.max_batch_slots, *conv_states.shape[1:])
-        recurrent_shape = (self.max_batch_slots, *recurrent_states.shape[1:])
-        storage.allocate_zeroed(
-            conv_shape=conv_shape,
-            recurrent_shape=recurrent_shape,
-            conv_dtype=conv_states.dtype,
-            recurrent_dtype=recurrent_states.dtype,
-            device=self.device,
-        )
+    @staticmethod
+    def _validate_prefill_recurrent(
+        src_layer: LinearAttentionState, *, batch_size: int
+    ) -> None:
+        recurrent_states = src_layer.recurrent_states
+        if recurrent_states is None or recurrent_states.shape[0] != batch_size:
+            raise RuntimeError(
+                "Qwen GDN prefill recurrent batch must match capture batch")
 
 
 __all__ = [

--- a/kestrel/models/qwen35/gdn_state.py
+++ b/kestrel/models/qwen35/gdn_state.py
@@ -99,31 +99,6 @@ class LinearAttentionState:
         self.replay_checkpoint_states.index_copy_(0, indices, checkpoint_rows)
         self.replay_lengths.index_fill_(0, indices, 0)
 
-    def allocate_zeroed(
-        self,
-        *,
-        conv_shape: tuple[int, ...],
-        recurrent_shape: tuple[int, ...],
-        conv_dtype: torch.dtype,
-        recurrent_dtype: torch.dtype,
-        device: torch.device,
-    ) -> None:
-        for name, shape, dtype in (
-            ("conv_states", conv_shape, conv_dtype),
-            ("recurrent_states", recurrent_shape, recurrent_dtype),
-        ):
-            tensor = getattr(self, name)
-            if tensor is None:
-                setattr(
-                    self,
-                    name,
-                    torch.zeros(shape, dtype=dtype, device=device),
-                )
-            elif tuple(tensor.shape) != shape:
-                raise RuntimeError(f"Qwen GDN {name} shape changed")
-
-        self._ensure_replay_state(self.recurrent_states)
-
     def clear(self, row: int | None = None) -> None:
         for tensor in (
             self.conv_states,

--- a/kestrel/models/qwen35/generated_decode.py
+++ b/kestrel/models/qwen35/generated_decode.py
@@ -85,7 +85,11 @@ def create_generated_decode(
         return GeneratedDecode.require(
             runtime, spec, batch_sizes=range(1, runtime.max_batch_size + 1)
         )
-    return GeneratedDecode.try_create(runtime, spec)
+    return GeneratedDecode.try_create(
+        runtime,
+        spec,
+        required_batch_sizes=range(1, runtime.max_batch_size + 1),
+    )
 
 
 __all__ = ["create_generated_decode"]

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -35,15 +35,17 @@ _kestrel_causal_conv1d_packed = _kestrel_runtime.gated_delta.causal_conv1d_packe
 _kestrel_causal_conv1d_update_indexed = (
     _kestrel_runtime.gated_delta.causal_conv1d_update_indexed
 )
-_kestrel_packed_prefill_prepare = _kestrel_runtime.gated_delta.packed_prefill_prepare
+_kestrel_allocate_packed_gdn_prefill_workspace = (
+    _kestrel_runtime.gated_delta.allocate_packed_gated_delta_prefill_workspace
+)
+_kestrel_packed_gated_delta_rule_prefill = (
+    _kestrel_runtime.gated_delta.packed_gated_delta_rule_prefill
+)
 _kestrel_packed_recurrent_decode_replay_indexed = (
     _kestrel_runtime.gated_delta.packed_recurrent_gated_delta_rule_decode_replay_indexed
 )
 _kestrel_packed_recurrent_decode_replay_indexed_gqa = (
     _kestrel_runtime.gated_delta.packed_recurrent_gated_delta_rule_decode_replay_indexed_gqa
-)
-_kestrel_packed_recurrent_prefill = (
-    _kestrel_runtime.gated_delta.packed_recurrent_gated_delta_rule_prefill
 )
 _kestrel_gated_rmsnorm = _kestrel_runtime.gated_delta.gated_rmsnorm
 _kestrel_rmsnorm = _kestrel_runtime.dense.rmsnorm
@@ -71,6 +73,40 @@ def _rmsnorm_state(dim: int, eps: float) -> nn.ModuleDict:
 class _TextModelOutput:
     last_hidden_state: torch.Tensor
     past_key_values: Qwen35InferenceCache | None = None
+
+
+@dataclass
+class _PackedGatedDeltaPrefillWorkspaceCache:
+    workspace: Any | None = None
+    _served_signature: tuple[Any, ...] | None = None
+
+    def get(
+        self,
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        *,
+        head_dim: int,
+        allocate,
+    ):
+        signature = (
+            mixed_qkv.device,
+            mixed_qkv.dtype,
+            tuple(mixed_qkv.shape),
+            a.device,
+            a.dtype,
+            tuple(a.shape),
+            int(head_dim),
+        )
+        workspace = self.workspace
+        if workspace is not None and self._served_signature == signature:
+            return workspace
+        if workspace is None or not workspace.can_serve(
+            mixed_qkv, a, head_dim=head_dim
+        ):
+            workspace = allocate(mixed_qkv, a, head_dim=head_dim)
+            self.workspace = workspace
+        self._served_signature = signature
+        return workspace
 
 
 def _module_dtype(module: nn.Module) -> torch.dtype:
@@ -228,15 +264,20 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
         self.causal_conv1d_packed = _kestrel_causal_conv1d_packed
         self.causal_conv1d_update_indexed = _kestrel_causal_conv1d_update_indexed
-        self.packed_prefill_prepare = _kestrel_packed_prefill_prepare
+        self.allocate_packed_gdn_prefill_workspace = (
+            _kestrel_allocate_packed_gdn_prefill_workspace
+        )
+        self.packed_gated_delta_rule_prefill = (
+            _kestrel_packed_gated_delta_rule_prefill
+        )
         self.packed_recurrent_decode_replay_indexed = (
             _kestrel_packed_recurrent_decode_replay_indexed
         )
         self.packed_recurrent_decode_replay_indexed_gqa = (
             _kestrel_packed_recurrent_decode_replay_indexed_gqa
         )
-        self.packed_recurrent_prefill = _kestrel_packed_recurrent_prefill
         self.supports_packed_gdn = _kestrel_supports_packed_gdn
+        self._prefill_workspace_cache = _PackedGatedDeltaPrefillWorkspaceCache()
 
         self.in_proj = nn.Linear(
             self.hidden_size,
@@ -424,20 +465,20 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 final_state=packed_conv_state,
             )
             mixed_qkv = mixed_qkv.transpose(1, 2)
-            query, key, value, g, beta = self.packed_prefill_prepare(
+            workspace = self._prefill_workspace_cache.get(
+                mixed_qkv,
+                a,
+                head_dim=self.head_k_dim,
+                allocate=self.allocate_packed_gdn_prefill_workspace,
+            )
+            core_attn_out, _ = self.packed_gated_delta_rule_prefill(
                 mixed_qkv,
                 a,
                 b,
                 self.A_log,
                 self.dt_bias,
-            )
-            core_attn_out, _ = self.packed_recurrent_prefill(
-                query,
-                key,
-                value,
-                g,
-                beta,
                 recurrence_cu_seqlens,
+                workspace=workspace,
                 output_final_state=True,
                 final_state=packed_recurrent_state,
                 final_state_indices=state_indices,
@@ -1153,6 +1194,12 @@ class Qwen3_5TextModel(nn.Module):
         self.layers = nn.ModuleList(
             [Qwen3_5DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
+        self._gdn_prefill_workspace_cache = _PackedGatedDeltaPrefillWorkspaceCache()
+        for layer in self.layers:
+            if layer.layer_type == "linear_attention":
+                layer.linear_attn._prefill_workspace_cache = (
+                    self._gdn_prefill_workspace_cache
+                )
         self.norm = _rmsnorm_state(config.hidden_size, config.rms_norm_eps)
         self.rotary_emb = Qwen3_5TextRotaryEmbedding(config=config)
     def forward(

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -291,7 +291,16 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 state_indices = state_indices.to(
                     device=conv_state.device,
                     dtype=torch.long,
-                ).view(-1)
+                ).view(-1).contiguous()
+        else:
+            state_indices = (
+                None
+                if gdn_state_indices is None
+                else gdn_state_indices.to(
+                    device=hidden_states.device,
+                    dtype=torch.long,
+                ).view(-1).contiguous()
+            )
 
         in_proj = self.in_proj(hidden_states)
         mixed_qkv, z, b, a = torch.split(
@@ -362,16 +371,39 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 self.head_k_dim,
                 self.head_v_dim,
             )
-            if (
-                layer.recurrent_states is None
-                or tuple(layer.recurrent_states.shape) != recurrent_shape
-            ):
-                layer.recurrent_states = torch.empty(
-                    recurrent_shape,
-                    device=mixed_qkv.device,
-                    dtype=torch.float32,
+            if state_indices is None:
+                if (
+                    layer.recurrent_states is None
+                    or tuple(layer.recurrent_states.shape) != recurrent_shape
+                ):
+                    layer.recurrent_states = torch.empty(
+                        recurrent_shape,
+                        device=mixed_qkv.device,
+                        dtype=torch.float32,
+                    )
+                packed_recurrent_state = layer.recurrent_states
+            else:
+                expected_tail = (
+                    self.num_v_heads,
+                    self.head_v_dim,
+                    self.head_k_dim,
                 )
-            packed_recurrent_state = layer.recurrent_states
+                if (
+                    layer.recurrent_states is None
+                    or layer.recurrent_states.dtype != torch.bfloat16
+                    or tuple(layer.recurrent_states.shape[1:]) != expected_tail
+                    or not layer.recurrent_states.is_contiguous()
+                ):
+                    raise RuntimeError(
+                        "Qwen generated prefill requires contiguous BF16 "
+                        "value-major recurrent state"
+                    )
+                if int(state_indices.numel()) != num_sequences:
+                    raise RuntimeError(
+                        "Qwen generated prefill requires one recurrent-state "
+                        "index per packed sequence"
+                    )
+                packed_recurrent_state = layer.recurrent_states
             layer.has_previous_state = True
             if seq_idx is None:
                 seq_idx = _packed_seq_idx_from_cu_seqlens(
@@ -408,10 +440,12 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 recurrence_cu_seqlens,
                 output_final_state=True,
                 final_state=packed_recurrent_state,
+                final_state_indices=state_indices,
             )
-            # Seed ReplaySSM from the packed prefill's committed recurrent state.
-            seed_layer = cache_params.layers[self.layer_idx]
-            seed_layer._reset_replay_rows(seed_layer.recurrent_states, None)
+            if state_indices is None:
+                # Native decode consumes ReplaySSM state seeded from the packed
+                # prefill's committed FP32 recurrence.
+                layer._reset_replay_rows(layer.recurrent_states, None)
 
         # reshape input data into 2D tensor
         core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -49,25 +49,6 @@ from .qwen_image import preprocess_image
 _PREFILL_SCRATCH_TOKENS = 1024
 
 
-def _native_decode_state_requirements(generated, linear_state_pool):
-    from kestrel.runtime.carried_state import StateRepresentationRequirement
-
-    native = []
-    for requirement in generated:
-        form = (
-            linear_state_pool.replay_recurrent_form
-            if requirement.buffer == "gdn_recurrent_state"
-            else requirement.physical_form
-        )
-        native.append(StateRepresentationRequirement(
-            requirement.buffer,
-            form.representation,
-            form.storage_axis_order,
-            form.storage_dtype,
-        ))
-    return tuple(native)
-
-
 @dataclass
 class QwenImageInputs:
     pixel_values: torch.Tensor
@@ -451,22 +432,19 @@ class Qwen35Runtime(UncachedPagedRuntime):
 
         self.spatial_tables = None
 
+        self._initialize_decode_execution()
+
+    def _initialize_decode_execution(self) -> None:
         self._initialize_generated_decode()
-        self._initialize_native_decode_graphs()
-
-    def _initialize_native_decode_graphs(self) -> None:
-        """Capture native graphs only when native decode remains reachable."""
-
-        if self._use_cuda_graphs and self.decode_path != "generated":
+        if self._use_cuda_graphs and self.generated_decode is None:
             self._decode_graphs.ensure_ready(self._decode_slots)
 
     def _initialize_generated_decode(self) -> None:
         """Apply the runtime-wide decode policy before graph capture."""
 
         self.generated_decode = None
-        self._decode_state_coordinator = None
-        self._native_decode_state_requirements = ()
         if self.decode_path == "native":
+            self._linear_state_pool.initialize_native_recurrent()
             return
 
         from .generated_decode import create_generated_decode
@@ -475,29 +453,8 @@ class Qwen35Runtime(UncachedPagedRuntime):
             self,
             required=self.decode_path == "generated",
         )
-        if self.generated_decode is not None:
-            from kestrel.runtime.carried_state import CarriedStateCoordinator
-
-            native_requirements = {
-                _native_decode_state_requirements(
-                    generated, self._linear_state_pool)
-                for generated
-                in self.generated_decode.state_requirements_by_capacity.values()
-            }
-            if len(native_requirements) != 1:
-                raise RuntimeError(
-                    "generated decode capacities imply different native state forms")
-            self._native_decode_state_requirements = next(
-                iter(native_requirements))
-            self._decode_state_coordinator = CarriedStateCoordinator(
-                buffers=self.generated_decode.state_buffers,
-                rows=range(self.max_batch_slots),
-                transitions={
-                    "gdn_recurrent_state": (
-                        self._linear_state_pool.transition_recurrent_form
-                    ),
-                },
-            )
+        if self.generated_decode is None:
+            self._linear_state_pool.initialize_native_recurrent()
 
     @property
     def cuda_graphs_enabled(self) -> bool:
@@ -755,38 +712,19 @@ class Qwen35Runtime(UncachedPagedRuntime):
         use_generated = (
             megakernel is not None and megakernel.supports(batch_size)
         )
-        if not use_generated and self.decode_path == "generated":
+        if megakernel is not None and not use_generated:
             raise RuntimeError(
-                "required generated Qwen decode does not cover "
+                "selected generated Qwen decode does not cover "
                 f"active batch size {batch_size}"
             )
-        coordinator = getattr(self, "_decode_state_coordinator", None)
-        rows = (
-            tuple(
-                int(row)
-                for row in slot.meta.batch_idx.cpu[:batch_size].tolist()
-            )
-            if coordinator is not None
-            else ()
-        )
         if use_generated:
             assert megakernel is not None
             stream = getattr(slot, "compute_stream", None)
             stream_context = (
                 torch.cuda.stream(stream) if stream is not None else nullcontext())
             with stream_context:
-                if coordinator is not None:
-                    coordinator.prepare(
-                        megakernel.state_requirements_for(batch_size), rows)
                 megakernel.run(slot, batch_size)
             return
-        if coordinator is not None:
-            stream = getattr(slot, "compute_stream", None)
-            stream_context = (
-                torch.cuda.stream(stream) if stream is not None else nullcontext())
-            with stream_context:
-                coordinator.prepare(
-                    self._native_decode_state_requirements, rows)
         self._decode_graphs.run(slot, batch_size)
 
     def _zero_decode_graph_padding(
@@ -1375,6 +1313,8 @@ class Qwen35Runtime(UncachedPagedRuntime):
         packed: _PackedPrefillBatch,
     ) -> tuple[torch.Tensor, Qwen35InferenceCache]:
         cache = self._new_cache()
+        if self.generated_decode is not None:
+            self._linear_state_pool.bind_generated_prefill_state(cache)
         outputs = self.model.model(
             input_ids=packed.input_ids,
             past_key_values=cache,
@@ -1391,6 +1331,8 @@ class Qwen35Runtime(UncachedPagedRuntime):
             paged_kv_seqlens_k=packed.paged_kv_seqlens_k,
             cu_seq_lens_q=packed.cu_seq_lens_q,
             seq_idx=packed.seq_idx,
+            gdn_state_indices=(
+                packed.batch_indices if self.generated_decode is not None else None),
         )
         outputs.past_key_values.advance_to(packed.max_length)
         return outputs.last_hidden_state, outputs.past_key_values
@@ -1426,7 +1368,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
             # copied into the persistent decode pool.
             copy_replay_payload=False,
         )
-        self._mark_decode_state_coherent(host_batch_indices)
         rope_deltas = rope_deltas.to(device=self.device, dtype=torch.long)
         if rope_deltas.ndim == 1:
             rope_deltas = rope_deltas.view(-1, 1)
@@ -1441,12 +1382,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
             self._decode_rope_deltas[int(batch_idx)].zero_()
         if hasattr(self, "_linear_state_pool"):
             self._linear_state_pool.clear(int(batch_idx))
-        self._mark_decode_state_coherent((int(batch_idx),))
-
-    def _mark_decode_state_coherent(self, rows: Sequence[int]) -> None:
-        coordinator = getattr(self, "_decode_state_coordinator", None)
-        if coordinator is not None:
-            coordinator.mark_coherent(rows)
 
     def _decode_cache_for_slot(self, slot: DecodeSlot) -> Qwen35InferenceCache:
         return self._decode_caches[int(slot.slot_id)]

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -317,9 +317,16 @@ class GeneratedDecode:
         cls,
         runtime: Any,
         spec: GeneratedDecodeSpec,
+        *,
+        required_batch_sizes: Sequence[int] = (),
     ) -> "GeneratedDecode | None":
         programs = cls._resolve_programs(runtime, spec)
         if not programs:
+            return None
+        if any(
+            _select_program(programs, int(batch_size)) is None
+            for batch_size in required_batch_sizes
+        ):
             return None
         programs = _selectable_programs(programs, runtime.max_batch_size)
         if not programs:

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -2403,12 +2403,17 @@ class GenerationScheduler:
         # stochastic cases keep the generic sampling path below.
         pending_published = self._can_publish_greedy_tail(plan)
         if pending_published:
+            # Every active sequence's batch_idx comes from PageTable's
+            # free_batch_idx pool, whose rows are within the pending-token
+            # buffer. Reuse the exact staged indices without a synchronizing
+            # device-side bounds filter for fallback vocabularies.
             sampled_ids = greedy_tail_from_logits(
                 logits,
                 batch_idx,
                 self._pending_token_ids,
                 self._greedy_tail_workspaces[handle.slot_id],
                 out=slot.sampled_ids,
+                batch_indices_in_bounds=True,
             )
             temps = None
             top_ps = None

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1,40 +1,38 @@
 """Flexible batching scheduler for Moondream text inference."""
 
+import logging
+import time
 from collections import Counter, deque
 from dataclasses import dataclass
 from itertools import islice
 from typing import Deque, List, Optional, Sequence
 
-import time
-import logging
-
 import torch
+from kestrel_kernels.sampling import (
+    allocate_greedy_tail_workspace,
+    greedy_logprobs_from_logits,
+    greedy_tail_from_logits,
+    sample_step_from_logits,
+)
 from torch import Tensor
 
 from kestrel.device import NoopEvent, stream_context, synchronize
-from kestrel.utils import CpuGpuBuffer
+from kestrel.models.moondream.lora import AdapterProvider
 from kestrel.runtime import (
+    AutoregressiveRuntime,
     PrefillClassification,
     PreparedSequence,
-    AutoregressiveRuntime,
     SequenceState,
     TextToken,
     Token,
 )
-from kestrel.models.moondream.lora import AdapterProvider
+from kestrel.runtime.sampling import SamplingHooks
 from kestrel.skills import (
     SkillRegistry,
     SkillState,
 )
+from kestrel.utils import CpuGpuBuffer
 
-from .queues import RequestQueue, RunningQueue
-from .types import (
-    GenerationRequest,
-    RequestLifecycle,
-    RequestPhase,
-    SchedulerResult,
-    StepPlan,
-)
 from .pipeline import (
     DecodeLaunch,
     DecodePendingCommit,
@@ -44,13 +42,15 @@ from .pipeline import (
     PrefillLaunch,
     PrefillPendingCommit,
 )
-from kestrel_kernels.sampling import (
-    greedy_logprobs_from_logits,
-    sample_step_from_logits,
-)
+from .queues import RequestQueue, RunningQueue
 from .transfer import RenderBuffer
-from kestrel.runtime.sampling import SamplingHooks
-
+from .types import (
+    GenerationRequest,
+    RequestLifecycle,
+    RequestPhase,
+    SchedulerResult,
+    StepPlan,
+)
 
 _LOGGER = logging.getLogger(__name__)
 # Greedily build a prefill batch until aggregate query tokens reaches this floor.
@@ -343,6 +343,13 @@ class GenerationScheduler:
             (runtime.max_batch_slots,),
             dtype=torch.long,
             device=runtime.device,
+        )
+        self._greedy_tail_workspaces = tuple(
+            allocate_greedy_tail_workspace(
+                runtime.max_batch_size,
+                device=runtime.device,
+            )
+            for _ in runtime.decode_slots
         )
         # Persistent per-batch sampling parameters on GPU to avoid per-step
         # CPU->GPU copies during sampling/spatial decode.
@@ -2391,16 +2398,32 @@ class GenerationScheduler:
         # Reuse batch indices already copied in launch_forward_async
         batch_idx = slot.meta.batch_idx.gpu[:batch_size]
 
-        # Sample tokens directly into per-slot staging buffer for D2H.
-        # This prevents race with next step's sampling writing to shared buffer.
-        sampled_ids, temps, top_ps, sampled_logprobs = self._sample_batch(
-            logits,
-            sequences,
-            slot.sampled_ids,
-            batch_idx=batch_idx,
-            logprobs_out=slot.sampled_logprobs[:batch_size],
-            plan=plan,
-        )
+        # The ordinary all-greedy case publishes slot staging and next-step
+        # pending state in one launch. All constrained, processed, scored, and
+        # stochastic cases keep the generic sampling path below.
+        pending_published = self._can_publish_greedy_tail(plan)
+        if pending_published:
+            sampled_ids = greedy_tail_from_logits(
+                logits,
+                batch_idx,
+                self._pending_token_ids,
+                self._greedy_tail_workspaces[handle.slot_id],
+                out=slot.sampled_ids,
+            )
+            temps = None
+            top_ps = None
+            sampled_logprobs = None
+        else:
+            # Sample directly into per-slot staging to avoid racing the next
+            # step's write to the other ping-pong slot.
+            sampled_ids, temps, top_ps, sampled_logprobs = self._sample_batch(
+                logits,
+                sequences,
+                slot.sampled_ids,
+                batch_idx=batch_idx,
+                logprobs_out=slot.sampled_logprobs[:batch_size],
+                plan=plan,
+            )
 
         # Record event once sampled_ids staging is ready. The copy stream
         # waits on this for the D2H below, and the runtime's post_sample
@@ -2421,8 +2444,9 @@ class GenerationScheduler:
                 ready_event=slot.step_done_event,
             )
 
-        # Write to shared pending buffer for next step's input gathering.
-        self._pending_token_ids.index_copy_(0, batch_idx, sampled_ids)
+        if not pending_published:
+            # The fused greedy tail has already published these rows.
+            self._pending_token_ids.index_copy_(0, batch_idx, sampled_ids)
 
         # Record a second event after pending writes so we can safely release/reuse
         # batch indices (e.g. finalize a sequence and admit a new one into the same
@@ -2448,6 +2472,20 @@ class GenerationScheduler:
                 slot_id=handle.slot_id,
                 runtime_step=runtime_step,
             ),
+        )
+
+    def _can_publish_greedy_tail(self, plan: "_MaskPlan | None") -> bool:
+        return bool(
+            plan is not None
+            and plan.all_greedy
+            and not plan.any_return_logprobs
+            and plan.disallow is None
+            and plan.event is None
+            and not plan.suppress_rows
+            and self._hooks.process_logits is None
+            and self._hooks.adjust_sampling_params is None
+            and self._hooks.sample_greedy is None
+            and self._hooks.score_sampled_tokens is None
         )
 
     def commit_step(self, step: PendingCommit) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "httpx>=0.27",
     "kestrel-native==0.1.8",
     "kestrel-kernels==0.5.0",
+    "kestrel-kernels-bundle-a==0.5.0; sys_platform == 'linux' or sys_platform == 'win32'",
+    "kestrel-kernels-bundle-b==0.5.0; sys_platform == 'linux' or sys_platform == 'win32'",
     "huggingface-hub>=0.20",
     "numpy>=1.26",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kestrel"
-version = "0.5.1"
+version = "0.6.0"
 description = "A fast, efficient inference engine for multimodal models"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kestrel"
-version = "0.5.0"
+version = "0.5.1"
 description = "A fast, efficient inference engine for multimodal models"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/tests/qwen35/test_generated_decode.py
+++ b/tests/qwen35/test_generated_decode.py
@@ -1,7 +1,226 @@
 from types import SimpleNamespace
 
+import pytest
+import torch
+
 from kestrel.models.qwen35 import generated_decode as qwen_generated
+from kestrel.models.qwen35.cache import (
+    Qwen35InferenceCache,
+    Qwen35LinearStatePool,
+)
+from kestrel.models.qwen35.qwen_model import Qwen3_5GatedDeltaNet
 from kestrel.runtime import generated_decode as runtime_generated
+from kestrel.runtime.carried_state import (
+    StatePhysicalForm,
+    StateRepresentationRequirement,
+)
+
+
+def _linear_config():
+    return SimpleNamespace(
+        layer_types=("linear_attention", "full_attention", "linear_attention"),
+        linear_num_key_heads=1,
+        linear_num_value_heads=2,
+        linear_key_head_dim=2,
+        linear_value_head_dim=3,
+        linear_conv_kernel_dim=4,
+    )
+
+
+def _state_pool(config=None):
+    config = _linear_config() if config is None else config
+    pool = Qwen35LinearStatePool(
+        config=config,
+        max_batch_slots=4,
+        device=torch.device("cpu"),
+        replay_capacity=2,
+    )
+    pool.initialize_from_config(config, dtype=torch.bfloat16)
+    return pool
+
+
+def _generated_form():
+    return StatePhysicalForm(
+        representation="materialized",
+        storage_axis_order=("state_row", "value_head", "value", "key"),
+        storage_dtype="bf16",
+    )
+
+
+def _inference_cache(config=None):
+    config = _linear_config() if config is None else config
+    return Qwen35InferenceCache(
+        config=config,
+        paged_kv=(None, object(), None),
+        replay_capacity=2,
+    )
+
+
+def test_generated_state_pool_is_one_bf16_value_major_representation():
+    pool = _state_pool()
+
+    recurrent = pool.recurrent_tensors_for_form(_generated_form())
+
+    assert len(recurrent) == 3
+    assert recurrent[1] is None
+    for layer_idx in (0, 2):
+        state = recurrent[layer_idx]
+        storage = pool.layers[layer_idx]
+        assert state is not None and storage is not None
+        assert state is storage.recurrent_states
+        assert state.shape == (4, 2, 3, 2)
+        assert state.dtype == torch.bfloat16
+        assert state.is_contiguous()
+        assert storage.replay_checkpoint_states is None
+        assert storage.replay_k is None
+        assert storage.replay_u is None
+        assert storage.replay_g is None
+        assert storage.replay_lengths is None
+
+    with pytest.raises(RuntimeError, match="cannot switch to native replay"):
+        pool.initialize_native_recurrent()
+
+
+def test_native_state_pool_remains_mutually_exclusive_fp32_replay():
+    pool = _state_pool()
+
+    pool.initialize_native_recurrent()
+
+    for layer_idx in (0, 2):
+        storage = pool.layers[layer_idx]
+        assert storage is not None and storage.recurrent_states is not None
+        assert storage.recurrent_states.shape == (4, 2, 2, 3)
+        assert storage.recurrent_states.dtype == torch.float32
+        assert storage.replay_checkpoint_states is not None
+        assert storage.replay_checkpoint_states.shape == (4, 2, 3, 2)
+        assert storage.replay_checkpoint_states.dtype == torch.float32
+
+    with pytest.raises(RuntimeError, match="cannot switch to generated decode"):
+        pool.recurrent_tensors_for_form(_generated_form())
+
+
+@pytest.mark.parametrize(
+    "form",
+    (
+        StatePhysicalForm(
+            "materialized",
+            ("state_row", "value_head", "key", "value"),
+            "bf16",
+        ),
+        StatePhysicalForm(
+            "materialized",
+            ("state_row", "value_head", "value", "key"),
+            "fp32",
+        ),
+        StatePhysicalForm(
+            "replay",
+            ("state_row", "value_head", "value", "key"),
+            "bf16",
+        ),
+    ),
+)
+def test_generated_state_pool_rejects_incompatible_physical_forms(form):
+    with pytest.raises(ValueError, match="materialized BF16 value-major"):
+        _state_pool().recurrent_tensors_for_form(form)
+
+
+def test_generated_prefill_writes_pool_rows_directly_and_reset_is_row_scoped():
+    config = _linear_config()
+    pool = _state_pool(config)
+    recurrent = pool.recurrent_tensors_for_form(_generated_form())
+    cache = _inference_cache(config)
+    pool.bind_generated_prefill_state(cache)
+    indices = torch.tensor([3, 1], dtype=torch.long)
+
+    for layer_idx in (0, 2):
+        target = recurrent[layer_idx]
+        layer = cache.layers[layer_idx]
+        assert target is not None
+        assert layer.recurrent_states is target
+        target[3].fill_(layer_idx + 1)
+        target[1].fill_(layer_idx + 2)
+        layer.conv_states = torch.full(
+            (2, 10, 4), layer_idx + 3, dtype=torch.bfloat16)
+        layer.has_previous_state = True
+
+    pool.capture_batch_from_cache(indices, cache, batch_size=2)
+
+    for layer_idx in (0, 2):
+        storage = pool.layers[layer_idx]
+        assert storage is not None and storage.conv_states is not None
+        assert torch.all(storage.conv_states[3] == layer_idx + 3)
+        assert torch.all(storage.conv_states[1] == layer_idx + 3)
+        assert storage.replay_checkpoint_states is None
+    pool.clear(1)
+    for layer_idx in (0, 2):
+        state = recurrent[layer_idx]
+        storage = pool.layers[layer_idx]
+        assert state is not None and storage is not None
+        assert torch.count_nonzero(state[1]) == 0
+        assert torch.count_nonzero(storage.conv_states[1]) == 0
+        assert torch.count_nonzero(state[3]) > 0
+
+
+def test_indexed_prefill_passes_the_authoritative_bf16_pool_to_chunk_kernel():
+    config = SimpleNamespace(
+        hidden_size=4,
+        linear_num_key_heads=1,
+        linear_num_value_heads=2,
+        linear_key_head_dim=2,
+        linear_value_head_dim=2,
+        linear_conv_kernel_dim=2,
+        rms_norm_eps=1e-6,
+        layer_types=("linear_attention",),
+    )
+    module = Qwen3_5GatedDeltaNet(config, layer_idx=0).to(torch.bfloat16)
+    module.supports_packed_gdn = lambda *_args: True
+    module.causal_conv1d_packed = lambda *, x, final_state, **_kwargs: x
+
+    def prepare(mixed_qkv, *_args):
+        tokens = mixed_qkv.shape[1]
+        q = torch.zeros((1, tokens, 1, 2), dtype=torch.bfloat16)
+        v = torch.zeros((1, tokens, 2, 2), dtype=torch.bfloat16)
+        g = torch.zeros((1, tokens, 2), dtype=torch.float32)
+        beta = torch.zeros((1, tokens, 2), dtype=torch.bfloat16)
+        return q, q.clone(), v, g, beta
+
+    module.packed_prefill_prepare = prepare
+    captured = {}
+
+    def recurrent(query, _key, value, _g, _beta, _cu, **kwargs):
+        state = kwargs["final_state"]
+        indices = kwargs["final_state_indices"]
+        captured.update(state=state, indices=indices)
+        state[indices[0]].fill_(1)
+        state[indices[1]].fill_(2)
+        return torch.zeros_like(value), state
+
+    module.packed_recurrent_prefill = recurrent
+    pool = _state_pool(config)
+    recurrent_states = pool.recurrent_tensors_for_form(_generated_form())
+    cache = Qwen35InferenceCache(
+        config=config,
+        paged_kv=(None,),
+        replay_capacity=2,
+    )
+    pool.bind_generated_prefill_state(cache)
+    indices = torch.tensor([3, 1], dtype=torch.long)
+
+    module(
+        torch.zeros((1, 3, 4), dtype=torch.bfloat16),
+        cache_params=cache,
+        cu_seq_lens_q=torch.tensor([0, 1, 3], dtype=torch.int32),
+        gdn_state_indices=indices,
+    )
+
+    state = recurrent_states[0]
+    assert state is not None
+    assert captured["state"] is state
+    assert torch.equal(captured["indices"], indices)
+    assert torch.all(state[3] == 1)
+    assert torch.all(state[1] == 2)
+    assert torch.count_nonzero(state[0]) == 0
+    assert cache.layers[0].replay_checkpoint_states is None
 
 
 def test_generated_decode_binds_rope_offsets_without_dropping_old_bundle_prep(
@@ -95,3 +314,52 @@ def test_generated_decode_binds_rope_offsets_without_dropping_old_bundle_prep(
         "gather_rope_deltas",
         "prepare_position_ids",
     )
+
+
+def test_generated_capacity_inputs_resolve_state_after_cached_field_snapshot(
+    monkeypatch,
+):
+    config = _linear_config()
+    pool = _state_pool(config)
+    runtime = SimpleNamespace(
+        _decode_rope_deltas=object(),
+        _gather_decode_rope_deltas=lambda *_args: None,
+        _prepare_decode_position_ids=lambda *_args: None,
+        _paged_kv=(),
+        _linear_state_pool=pool,
+        model=SimpleNamespace(
+            model=SimpleNamespace(
+                language_model=SimpleNamespace(
+                    rotary_emb=SimpleNamespace(inv_freq=object())
+                )
+            )
+        ),
+        page_table=SimpleNamespace(page_table=object()),
+    )
+    captured = {}
+
+    def capture(_cls, _runtime, spec):
+        captured["spec"] = spec
+        return object()
+
+    monkeypatch.setattr(
+        qwen_generated.GeneratedDecode, "try_create", classmethod(capture))
+    qwen_generated.create_generated_decode(runtime)
+    requirement = StateRepresentationRequirement(
+        "gdn_recurrent_state",
+        "materialized",
+        ("state_row", "value_head", "value", "key"),
+        "bf16",
+    )
+
+    first = captured["spec"].capacity_inputs(4, (requirement,))
+    second = captured["spec"].capacity_inputs(4, (requirement,))
+
+    recurrent = first["gdn_recurrent_state"]
+    assert second["gdn_recurrent_state"] is recurrent
+    assert recurrent[1] is None
+    for layer_idx in (0, 2):
+        state = recurrent[layer_idx]
+        assert state is pool.layers[layer_idx].recurrent_states
+        assert state.dtype == torch.bfloat16
+        assert state.shape == (4, 2, 3, 2)

--- a/tests/qwen35/test_generated_decode.py
+++ b/tests/qwen35/test_generated_decode.py
@@ -8,7 +8,10 @@ from kestrel.models.qwen35.cache import (
     Qwen35InferenceCache,
     Qwen35LinearStatePool,
 )
-from kestrel.models.qwen35.qwen_model import Qwen3_5GatedDeltaNet
+from kestrel.models.qwen35.qwen_model import (
+    Qwen3_5GatedDeltaNet,
+    _PackedGatedDeltaPrefillWorkspaceCache,
+)
 from kestrel.runtime import generated_decode as runtime_generated
 from kestrel.runtime.carried_state import (
     StatePhysicalForm,
@@ -161,7 +164,7 @@ def test_generated_prefill_writes_pool_rows_directly_and_reset_is_row_scoped():
         assert torch.count_nonzero(state[3]) > 0
 
 
-def test_indexed_prefill_passes_the_authoritative_bf16_pool_to_chunk_kernel():
+def test_indexed_prefill_passes_authoritative_bf16_pool_to_combined_kernel():
     config = SimpleNamespace(
         hidden_size=4,
         linear_num_key_heads=1,
@@ -173,29 +176,33 @@ def test_indexed_prefill_passes_the_authoritative_bf16_pool_to_chunk_kernel():
         layer_types=("linear_attention",),
     )
     module = Qwen3_5GatedDeltaNet(config, layer_idx=0).to(torch.bfloat16)
+    assert not hasattr(module, "packed_prefill_prepare")
+    assert not hasattr(module, "packed_recurrent_prefill")
     module.supports_packed_gdn = lambda *_args: True
     module.causal_conv1d_packed = lambda *, x, final_state, **_kwargs: x
-
-    def prepare(mixed_qkv, *_args):
-        tokens = mixed_qkv.shape[1]
-        q = torch.zeros((1, tokens, 1, 2), dtype=torch.bfloat16)
-        v = torch.zeros((1, tokens, 2, 2), dtype=torch.bfloat16)
-        g = torch.zeros((1, tokens, 2), dtype=torch.float32)
-        beta = torch.zeros((1, tokens, 2), dtype=torch.bfloat16)
-        return q, q.clone(), v, g, beta
-
-    module.packed_prefill_prepare = prepare
+    workspace = SimpleNamespace(
+        out=torch.empty((1, 3, 2, 2), dtype=torch.bfloat16),
+        can_serve=lambda *_args, **_kwargs: True,
+    )
+    module.allocate_packed_gdn_prefill_workspace = (
+        lambda *_args, **_kwargs: workspace
+    )
     captured = {}
 
-    def recurrent(query, _key, value, _g, _beta, _cu, **kwargs):
+    def combined(mixed_qkv, _a, _b, _A_log, _dt_bias, _cu, **kwargs):
         state = kwargs["final_state"]
         indices = kwargs["final_state_indices"]
-        captured.update(state=state, indices=indices)
+        captured.update(
+            mixed_qkv=mixed_qkv,
+            state=state,
+            indices=indices,
+            workspace=kwargs["workspace"],
+        )
         state[indices[0]].fill_(1)
         state[indices[1]].fill_(2)
-        return torch.zeros_like(value), state
+        return torch.zeros_like(workspace.out), state
 
-    module.packed_recurrent_prefill = recurrent
+    module.packed_gated_delta_rule_prefill = combined
     pool = _state_pool(config)
     recurrent_states = pool.recurrent_tensors_for_form(_generated_form())
     cache = Qwen35InferenceCache(
@@ -217,10 +224,45 @@ def test_indexed_prefill_passes_the_authoritative_bf16_pool_to_chunk_kernel():
     assert state is not None
     assert captured["state"] is state
     assert torch.equal(captured["indices"], indices)
+    assert captured["workspace"] is workspace
     assert torch.all(state[3] == 1)
     assert torch.all(state[1] == 2)
     assert torch.count_nonzero(state[0]) == 0
     assert cache.layers[0].replay_checkpoint_states is None
+
+
+def test_packed_gdn_prefill_workspace_cache_reuses_capacity():
+    mixed_qkv = torch.empty((1, 3, 8), dtype=torch.bfloat16)
+    a = torch.empty((1, 3, 2), dtype=torch.bfloat16)
+    contract_checks = []
+
+    def can_serve(candidate, *_args, **_kwargs):
+        contract_checks.append(None)
+        return candidate.shape[1] <= 4
+
+    workspace = SimpleNamespace(
+        can_serve=can_serve,
+    )
+    allocations = []
+
+    def allocate(*_args, **_kwargs):
+        allocations.append(None)
+        return workspace
+
+    cache = _PackedGatedDeltaPrefillWorkspaceCache()
+    assert cache.get(mixed_qkv, a, head_dim=2, allocate=allocate) is workspace
+    assert cache.get(mixed_qkv, a, head_dim=2, allocate=allocate) is workspace
+    assert len(allocations) == 1
+    assert contract_checks == []
+
+    shorter_mixed_qkv = mixed_qkv[:, :2]
+    shorter_a = a[:, :2]
+    assert (
+        cache.get(shorter_mixed_qkv, shorter_a, head_dim=2, allocate=allocate)
+        is workspace
+    )
+    assert len(allocations) == 1
+    assert len(contract_checks) == 1
 
 
 def test_generated_decode_binds_rope_offsets_without_dropping_old_bundle_prep(

--- a/tests/qwen35/test_generated_decode.py
+++ b/tests/qwen35/test_generated_decode.py
@@ -272,6 +272,7 @@ def test_generated_decode_binds_rope_offsets_without_dropping_old_bundle_prep(
     rope_inv_freq = object()
     page_table = object()
     runtime = SimpleNamespace(
+        max_batch_size=4,
         _decode_rope_deltas=rope_deltas,
         _gather_decode_rope_deltas=lambda *_args: None,
         _prepare_decode_position_ids=lambda *_args: None,
@@ -288,9 +289,10 @@ def test_generated_decode_binds_rope_offsets_without_dropping_old_bundle_prep(
     )
     captured = {}
 
-    def capture(_cls, bound_runtime, spec):
+    def capture(_cls, bound_runtime, spec, *, required_batch_sizes=()):
         assert bound_runtime is runtime
         captured["spec"] = spec
+        captured["required_batch_sizes"] = tuple(required_batch_sizes)
         return object()
 
     monkeypatch.setattr(
@@ -302,6 +304,7 @@ def test_generated_decode_binds_rope_offsets_without_dropping_old_bundle_prep(
     result = qwen_generated.create_generated_decode(runtime)
 
     assert result is not None
+    assert captured["required_batch_sizes"] == (1, 2, 3, 4)
     spec = captured["spec"]
     inputs = spec.bindings.runtime_inputs(runtime)
     assert inputs["page_table"] is page_table
@@ -364,6 +367,7 @@ def test_generated_capacity_inputs_resolve_state_after_cached_field_snapshot(
     config = _linear_config()
     pool = _state_pool(config)
     runtime = SimpleNamespace(
+        max_batch_size=4,
         _decode_rope_deltas=object(),
         _gather_decode_rope_deltas=lambda *_args: None,
         _prepare_decode_position_ids=lambda *_args: None,
@@ -380,13 +384,15 @@ def test_generated_capacity_inputs_resolve_state_after_cached_field_snapshot(
     )
     captured = {}
 
-    def capture(_cls, _runtime, spec):
+    def capture(_cls, _runtime, spec, *, required_batch_sizes=()):
         captured["spec"] = spec
+        captured["required_batch_sizes"] = tuple(required_batch_sizes)
         return object()
 
     monkeypatch.setattr(
         qwen_generated.GeneratedDecode, "try_create", classmethod(capture))
     qwen_generated.create_generated_decode(runtime)
+    assert captured["required_batch_sizes"] == (1, 2, 3, 4)
     requirement = StateRepresentationRequirement(
         "gdn_recurrent_state",
         "materialized",

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -8,10 +8,11 @@ import torch
 
 from kestrel.models.moondream.region import SpatialDecodeTables
 from kestrel.models.moondream.runtime import TextToken
+from kestrel.runtime.sampling import SamplingHooks
+from kestrel.scheduler.pipeline import DecodeLaunch, LaunchHandle
 from kestrel.scheduler.scheduler import GenerationScheduler, _MaskPlan
 from kestrel.scheduler.spatial import compute_spatial_values
 from kestrel.scheduler.types import GeneratedPrefix, GenerationRequest, RequestLifecycle
-from kestrel.runtime.sampling import SamplingHooks
 from kestrel.skills import DecodeStep, SkillFinalizeResult, SkillRegistry, SkillState
 from tests.scheduler._fake_runtime import FakeRuntime
 
@@ -1010,6 +1011,131 @@ def test_sample_batch_plan_waits_through_event_abstraction(
 
     assert event.waits == 1
     assert sampled.tolist() == [1]
+
+
+def test_finalize_uses_slot_local_fused_greedy_tail_and_skips_pending_index_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class EventStub:
+        def __init__(self) -> None:
+            self.records = 0
+
+        def record(self) -> None:
+            self.records += 1
+
+    class PendingStub:
+        def index_copy_(self, *_args) -> None:
+            raise AssertionError("fused greedy tail must skip pending index_copy")
+
+    batch_indices = torch.tensor([1, 4], dtype=torch.long)
+    sampled_ids = torch.empty((2,), dtype=torch.long)
+    step_done = EventStub()
+    commit_done = EventStub()
+    transfer = object()
+    slot = SimpleNamespace(
+        compute_stream=object(),
+        logits=torch.tensor([[1.0, 4.0], [5.0, 2.0]]),
+        hidden_last=torch.empty((2, 1)),
+        sampled_ids=sampled_ids,
+        sampled_logprobs=torch.empty((2,), dtype=torch.float32),
+        meta=SimpleNamespace(batch_idx=SimpleNamespace(gpu=batch_indices)),
+        step_done_event=step_done,
+        commit_done_event=commit_done,
+        render=SimpleNamespace(transfer=lambda *_args, **_kwargs: transfer),
+    )
+    scheduler = object.__new__(GenerationScheduler)
+    other_slot = SimpleNamespace(compute_stream=object())
+    assert other_slot.compute_stream is not slot.compute_stream
+    scheduler.runtime = SimpleNamespace(decode_slots=(other_slot, slot))
+    scheduler._hooks = SamplingHooks()
+    scheduler._pending_token_ids = PendingStub()
+    scheduler._greedy_tail_workspaces = (object(), object())
+    scheduler._sample_batch = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        AssertionError("eligible greedy tail must not call generic sampling")
+    )
+    calls = []
+
+    def fused(logits, batch_idx, pending, workspace, *, out):
+        calls.append((logits, batch_idx, pending, workspace, out))
+        out.copy_(torch.tensor([1, 0]))
+        return out
+
+    monkeypatch.setattr("kestrel.scheduler.scheduler.greedy_tail_from_logits", fused)
+    sequences = [
+        SimpleNamespace(packed_pending_ready=False),
+        SimpleNamespace(packed_pending_ready=False),
+    ]
+    handle = LaunchHandle(
+        kind="decode",
+        sequences=sequences,
+        payload=DecodeLaunch(slot_id=1),
+    )
+    plan = _MaskPlan(
+        disallow=None,
+        event=None,
+        suppress_rows=[],
+        all_greedy=True,
+        any_return_logprobs=False,
+    )
+
+    result = scheduler._finalize_sampling_on_stream(handle, plan)
+
+    assert len(calls) == 1
+    assert calls[0][1].data_ptr() == batch_indices.data_ptr()
+    assert torch.equal(calls[0][1], batch_indices)
+    assert calls[0][2] is scheduler._pending_token_ids
+    assert calls[0][3] is scheduler._greedy_tail_workspaces[1]
+    assert calls[0][4] is sampled_ids
+    assert sampled_ids.tolist() == [1, 0]
+    assert step_done.records == 1
+    assert commit_done.records == 1
+    assert all(sequence.packed_pending_ready for sequence in sequences)
+    assert result.transfer is transfer
+
+
+@pytest.mark.parametrize(
+    ("plan", "hooks"),
+    [
+        (None, SamplingHooks()),
+        (
+            _MaskPlan(None, None, [], False, False),
+            SamplingHooks(),
+        ),
+        (
+            _MaskPlan(None, None, [], True, True),
+            SamplingHooks(),
+        ),
+        (
+            _MaskPlan(torch.zeros((1, 1), dtype=torch.bool), None, [], True, False),
+            SamplingHooks(),
+        ),
+        (
+            _MaskPlan(None, None, [(0, (1,))], True, False),
+            SamplingHooks(),
+        ),
+        (
+            _MaskPlan(None, None, [], True, False),
+            SamplingHooks(process_logits=lambda *_args, **_kwargs: None),
+        ),
+        (
+            _MaskPlan(None, None, [], True, False),
+            SamplingHooks(adjust_sampling_params=lambda *_args, **_kwargs: None),
+        ),
+        (
+            _MaskPlan(None, None, [], True, False),
+            SamplingHooks(sample_greedy=lambda *_args, **_kwargs: None),
+        ),
+        (
+            _MaskPlan(None, None, [], True, False),
+            SamplingHooks(score_sampled_tokens=lambda *_args, **_kwargs: None),
+        ),
+    ],
+)
+def test_greedy_tail_eligibility_rejects_modified_sampling(plan, hooks) -> None:
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler._hooks = hooks
+
+    assert not scheduler._can_publish_greedy_tail(plan)
 
 
 @pytest.mark.parametrize("temperature", [0.7, 0.0])

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -1024,6 +1024,8 @@ def test_finalize_uses_slot_local_fused_greedy_tail_and_skips_pending_index_copy
             self.records += 1
 
     class PendingStub:
+        shape = (8,)
+
         def index_copy_(self, *_args) -> None:
             raise AssertionError("fused greedy tail must skip pending index_copy")
 
@@ -1055,8 +1057,25 @@ def test_finalize_uses_slot_local_fused_greedy_tail_and_skips_pending_index_copy
     )
     calls = []
 
-    def fused(logits, batch_idx, pending, workspace, *, out):
-        calls.append((logits, batch_idx, pending, workspace, out))
+    def fused(
+        logits,
+        batch_idx,
+        pending,
+        workspace,
+        *,
+        out,
+        batch_indices_in_bounds=False,
+    ):
+        calls.append(
+            (
+                logits,
+                batch_idx,
+                pending,
+                workspace,
+                out,
+                batch_indices_in_bounds,
+            )
+        )
         out.copy_(torch.tensor([1, 0]))
         return out
 
@@ -1086,6 +1105,9 @@ def test_finalize_uses_slot_local_fused_greedy_tail_and_skips_pending_index_copy
     assert calls[0][2] is scheduler._pending_token_ids
     assert calls[0][3] is scheduler._greedy_tail_workspaces[1]
     assert calls[0][4] is sampled_ids
+    assert calls[0][5] is True
+    assert torch.all(calls[0][1] >= 0)
+    assert torch.all(calls[0][1] < scheduler._pending_token_ids.shape[0])
     assert sampled_ids.tolist() == [1, 0]
     assert step_done.records == 1
     assert commit_done.records == 1

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -213,7 +213,7 @@ def test_qwen_selected_generated_failure_never_falls_back_to_native() -> None:
         runtime.decode_with_slot(object(), 2)
 
 
-def test_qwen_auto_incomplete_generated_domain_selects_native_before_construction(
+def test_qwen_auto_sparse_generated_domain_selects_native_before_construction(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runtime = object.__new__(Qwen35Runtime)
@@ -235,15 +235,18 @@ def test_qwen_auto_incomplete_generated_domain_selects_native_before_constructio
     runtime._linear_state_pool = SimpleNamespace(
         initialize_native_recurrent=lambda: calls.append("native")
     )
-    partial = SimpleNamespace(
-        capacity=2,
-        runtime_extent_minimums={},
-        static_extent_bindings={"active_batch": 2},
+    sparse_programs = tuple(
+        SimpleNamespace(
+            capacity=batch_size,
+            runtime_extent_minimums={},
+            static_extent_bindings={"active_batch": batch_size},
+        )
+        for batch_size in (1, 2, 4)
     )
     monkeypatch.setattr(
         GeneratedDecode,
         "_resolve_programs",
-        classmethod(lambda _cls, _runtime, _spec: (partial,)),
+        classmethod(lambda _cls, _runtime, _spec: sparse_programs),
     )
     monkeypatch.setattr(
         GeneratedDecode,

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 from kestrel.models.gemma4.runtime import Gemma4Runtime
 from kestrel.models.moondream.runtime import MoondreamRuntime
@@ -29,6 +30,9 @@ def test_qwen_native_does_not_construct_generated_decode(
 ) -> None:
     runtime = object.__new__(Qwen35Runtime)
     runtime.decode_path = "native"
+    calls = []
+    runtime._linear_state_pool = SimpleNamespace(
+        initialize_native_recurrent=lambda: calls.append("native"))
     monkeypatch.setattr(
         qwen_generated,
         "create_generated_decode",
@@ -40,7 +44,7 @@ def test_qwen_native_does_not_construct_generated_decode(
     runtime._initialize_generated_decode()
 
     assert runtime.generated_decode is None
-    assert runtime._decode_state_coordinator is None
+    assert calls == ["native"]
 
 
 def test_gemma_native_does_not_construct_generated_decode(
@@ -89,29 +93,36 @@ def test_qwen_required_generated_unavailable_refuses_before_graph_capture(
     assert runtime.generated_decode is None
 
 
-@pytest.mark.parametrize(
-    ("decode_path", "expected_captures"),
-    (("generated", 0), ("auto", 1), ("native", 1)),
-)
-def test_qwen_captures_native_graphs_only_when_native_decode_is_reachable(
-    decode_path: str,
-    expected_captures: int,
-) -> None:
-    captures: list[object] = []
-    slots = (object(), object())
+def test_qwen_selected_generated_never_captures_native_decode_graphs() -> None:
     runtime = object.__new__(Qwen35Runtime)
-    runtime.decode_path = decode_path
     runtime._use_cuda_graphs = True
-    runtime._decode_slots = slots
+    runtime._decode_slots = (object(),)
     runtime._decode_graphs = SimpleNamespace(
-        ensure_ready=lambda actual_slots: captures.append(actual_slots)
-    )
+        ensure_ready=lambda _slots: pytest.fail(
+            "generated state must not prepare native decode graphs"))
 
-    runtime._initialize_native_decode_graphs()
+    def select_generated():
+        runtime.generated_decode = _Generated(supported=True)
 
-    assert len(captures) == expected_captures
-    if captures:
-        assert captures == [slots]
+    runtime._initialize_generated_decode = select_generated
+    runtime._initialize_decode_execution()
+
+
+def test_qwen_native_selection_captures_decode_graphs() -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime._use_cuda_graphs = True
+    runtime._decode_slots = (object(),)
+    captures = []
+    runtime._decode_graphs = SimpleNamespace(
+        ensure_ready=lambda slots: captures.append(slots))
+
+    def select_native():
+        runtime.generated_decode = None
+
+    runtime._initialize_generated_decode = select_native
+    runtime._initialize_decode_execution()
+
+    assert captures == [runtime._decode_slots]
 
 
 def test_generated_requirement_unavailable_refuses_before_construction(
@@ -173,14 +184,13 @@ def test_qwen_required_generated_never_falls_back_to_native() -> None:
     runtime = object.__new__(Qwen35Runtime)
     runtime.decode_path = "generated"
     runtime.generated_decode = _Generated(supported=False)
-    runtime._decode_state_coordinator = None
     runtime._decode_graphs = SimpleNamespace(
         run=lambda *_args: pytest.fail("generated mode must not run native decode")
     )
 
     with pytest.raises(
         RuntimeError,
-        match="required generated Qwen decode does not cover active batch size 3",
+        match="selected generated Qwen decode does not cover active batch size 3",
     ):
         runtime.decode_with_slot(object(), 3)
 
@@ -195,7 +205,6 @@ def test_qwen_selected_generated_failure_never_falls_back_to_native() -> None:
 
     generated.run = fail_generated
     runtime.generated_decode = generated
-    runtime._decode_state_coordinator = None
     runtime._decode_graphs = SimpleNamespace(
         run=lambda *_args: pytest.fail("generated mode must not run native decode")
     )
@@ -204,19 +213,81 @@ def test_qwen_selected_generated_failure_never_falls_back_to_native() -> None:
         runtime.decode_with_slot(object(), 2)
 
 
-def test_qwen_auto_preserves_native_fallback() -> None:
-    native_batches: list[int] = []
+def test_qwen_auto_selected_generated_state_refuses_native_fallback() -> None:
     runtime = object.__new__(Qwen35Runtime)
     runtime.decode_path = "auto"
     runtime.generated_decode = _Generated(supported=False)
-    runtime._decode_state_coordinator = None
     runtime._decode_graphs = SimpleNamespace(
-        run=lambda _slot, batch_size: native_batches.append(batch_size)
+        run=lambda *_args: pytest.fail("generated state must not run native decode")
     )
 
-    runtime.decode_with_slot(object(), 3)
+    with pytest.raises(
+        RuntimeError,
+        match="selected generated Qwen decode does not cover active batch size 3",
+    ):
+        runtime.decode_with_slot(object(), 3)
 
-    assert native_batches == [3]
+
+def test_qwen_auto_without_generated_program_selects_native_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.decode_path = "auto"
+    calls = []
+    runtime._linear_state_pool = SimpleNamespace(
+        initialize_native_recurrent=lambda: calls.append("native"))
+    monkeypatch.setattr(
+        qwen_generated, "create_generated_decode", lambda *_args, **_kwargs: None)
+
+    runtime._initialize_generated_decode()
+
+    assert runtime.generated_decode is None
+    assert calls == ["native"]
+
+
+def test_qwen_auto_probe_cannot_allocate_generated_then_fall_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.qwen35.cache import Qwen35LinearStatePool
+    from kestrel.runtime.carried_state import StatePhysicalForm
+
+    config = SimpleNamespace(
+        layer_types=("linear_attention",),
+        linear_num_key_heads=1,
+        linear_num_value_heads=2,
+        linear_key_head_dim=2,
+        linear_value_head_dim=3,
+        linear_conv_kernel_dim=4,
+    )
+    pool = Qwen35LinearStatePool(
+        config=config,
+        max_batch_slots=4,
+        device=torch.device("cpu"),
+        replay_capacity=2,
+    )
+    pool.initialize_from_config(config, dtype=torch.bfloat16)
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.decode_path = "auto"
+    runtime._linear_state_pool = pool
+
+    def touches_generated_state(*_args, **_kwargs):
+        pool.recurrent_tensors_for_form(StatePhysicalForm(
+            "materialized",
+            ("state_row", "value_head", "value", "key"),
+            "bf16",
+        ))
+        return None
+
+    monkeypatch.setattr(
+        qwen_generated, "create_generated_decode", touches_generated_state)
+
+    with pytest.raises(RuntimeError, match="cannot switch to native replay"):
+        runtime._initialize_generated_decode()
+
+    storage = pool.layers[0]
+    assert storage is not None and storage.recurrent_states is not None
+    assert storage.recurrent_states.dtype == torch.bfloat16
+    assert storage.replay_checkpoint_states is None
 
 
 def test_gemma_required_generated_never_falls_back_to_native(

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -213,19 +213,50 @@ def test_qwen_selected_generated_failure_never_falls_back_to_native() -> None:
         runtime.decode_with_slot(object(), 2)
 
 
-def test_qwen_auto_selected_generated_state_refuses_native_fallback() -> None:
+def test_qwen_auto_incomplete_generated_domain_selects_native_before_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     runtime = object.__new__(Qwen35Runtime)
     runtime.decode_path = "auto"
-    runtime.generated_decode = _Generated(supported=False)
-    runtime._decode_graphs = SimpleNamespace(
-        run=lambda *_args: pytest.fail("generated state must not run native decode")
+    runtime.max_batch_size = 4
+    runtime._paged_kv = ()
+    runtime._decode_rope_deltas = object()
+    runtime._gather_decode_rope_deltas = lambda *_args: None
+    runtime._prepare_decode_position_ids = lambda *_args: None
+    runtime.model = SimpleNamespace(
+        model=SimpleNamespace(
+            language_model=SimpleNamespace(
+                rotary_emb=SimpleNamespace(inv_freq=object())
+            )
+        )
+    )
+    runtime.page_table = SimpleNamespace(page_table=object())
+    calls = []
+    runtime._linear_state_pool = SimpleNamespace(
+        initialize_native_recurrent=lambda: calls.append("native")
+    )
+    partial = SimpleNamespace(
+        capacity=2,
+        runtime_extent_minimums={},
+        static_extent_bindings={"active_batch": 2},
+    )
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "_resolve_programs",
+        classmethod(lambda _cls, _runtime, _spec: (partial,)),
+    )
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "__init__",
+        lambda *_args, **_kwargs: pytest.fail(
+            "incomplete auto coverage must not allocate generated-only state"
+        ),
     )
 
-    with pytest.raises(
-        RuntimeError,
-        match="selected generated Qwen decode does not cover active batch size 3",
-    ):
-        runtime.decode_with_slot(object(), 3)
+    runtime._initialize_generated_decode()
+
+    assert runtime.generated_decode is None
+    assert calls == ["native"]
 
 
 def test_qwen_auto_without_generated_program_selects_native_state(

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "kestrel"
-version = "0.5.1"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -560,12 +560,14 @@ wheels = [
 
 [[package]]
 name = "kestrel"
-version = "0.5.0"
+version = "0.5.1"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "kestrel-kernels" },
+    { name = "kestrel-kernels-bundle-a", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "kestrel-kernels-bundle-b", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "kestrel-native" },
     { name = "numpy" },
     { name = "safetensors" },
@@ -587,7 +589,9 @@ eval = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "huggingface-hub", specifier = ">=0.20" },
-    { name = "kestrel-kernels", specifier = "==0.4.9" },
+    { name = "kestrel-kernels", specifier = "==0.5.0" },
+    { name = "kestrel-kernels-bundle-a", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = "==0.5.0" },
+    { name = "kestrel-kernels-bundle-b", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = "==0.5.0" },
     { name = "kestrel-native", specifier = "==0.1.8" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "safetensors", specifier = ">=0.4" },
@@ -606,7 +610,7 @@ eval = [
 
 [[package]]
 name = "kestrel-kernels"
-version = "0.4.9"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "kestrel-mps-torch-ext", marker = "sys_platform == 'darwin'" },
@@ -615,31 +619,53 @@ dependencies = [
     { name = "torch-c-dlpack-ext" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/59/d511486cd71b0183b4d96e1b14b682311f0d60413f5e535c3a61e06fdb44/kestrel_kernels-0.4.9-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:9019172e3b69efc3e8463591d0f12cd6140eaf41407c770d7d153d86ed191809", size = 801224, upload-time = "2026-08-03T02:22:12.722Z" },
-    { url = "https://files.pythonhosted.org/packages/02/39/ae8bd0f0f517f57e98a12c59577109c5bfed81a70bb5e5f74f2e03f42490/kestrel_kernels-0.4.9-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:6ffb10b2483db590b632d107c9e3dae6c7a239fd362f420d36e4bffa2d481949", size = 62101497, upload-time = "2026-08-03T02:22:38.347Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/c8/8de72fa9abae535249cd79e9e0b14eda4b5377b9493e327539cdcd7b28f2/kestrel_kernels-0.4.9-cp310-cp310-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:c52d46d5bf43e9d667470d99902e8c0ae0319d49a5178a3859fb1b8c63440dd3", size = 29291654, upload-time = "2026-08-03T02:22:53.201Z" },
-    { url = "https://files.pythonhosted.org/packages/41/6a/c1844935a9aa3499a815633234becaabe9f313192b22fde28f017ada28ff/kestrel_kernels-0.4.9-cp310-cp310-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:451e9fc8a42dbc08bfa3f4b757c3e014b2fcde6aea9fbc208bad8ae7fcbf555f", size = 94005145, upload-time = "2026-08-03T02:24:08.904Z" },
-    { url = "https://files.pythonhosted.org/packages/63/43/2af0bac7ae5f8d527b9198ec8e924590e677a92dd102fcf093290b05512c/kestrel_kernels-0.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:ee0b74e976d678ec8f9da580acf84d91df6e5d3019b507fed39b295848b9a478", size = 82959769, upload-time = "2026-08-03T02:24:55.883Z" },
-    { url = "https://files.pythonhosted.org/packages/74/94/7f04d263013608da353d42151958311f21cd7322d5cc5db6466ed4ae09b4/kestrel_kernels-0.4.9-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:fb12d5bee22fc0c26b2944b6b746af1ddaa2c7859121462dec0e93201bc903f6", size = 802433, upload-time = "2026-08-03T02:24:59.313Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/31/4719187997e434899411964d461b888cdc0cf676401ece66251fe5e50dba/kestrel_kernels-0.4.9-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:f05ce9c6b2c3660924eadeab6e75432642be33a94e978589955da99bf68fe793", size = 62101496, upload-time = "2026-08-03T02:25:26.348Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/6b/3f6dce23446204b4f1a3285d7173e836f60b3f9ed85b546bc815f2013d64/kestrel_kernels-0.4.9-cp311-cp311-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:7c23e5389f3bab02c397b2654ebea23b011dbcb6089d7b1bdd44a02e670fe4f2", size = 29291655, upload-time = "2026-08-03T02:25:51.528Z" },
-    { url = "https://files.pythonhosted.org/packages/84/48/00d45733bbdcba9d1b6a36c27decc0fd485c52fbe918feb11cddedbb0432/kestrel_kernels-0.4.9-cp311-cp311-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:a3eb0bf9a96e0d3723160367341f2f30759cd36aa3563d44ddc97b0e4125a8cc", size = 94005158, upload-time = "2026-08-03T02:27:08.417Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/71/f2bc010a1882efe9841b348519c9c58cc24fd4e50f508eaed46eda36fe88/kestrel_kernels-0.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:907d0d27f5d87132542dd1b0847f78095fe09bdb98bebcd0310ae54e675e5534", size = 82959762, upload-time = "2026-08-03T02:27:56.961Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/c0/43752ff608ad6ab9747ed805faf61bb46074859c57d8b4083daf9d314931/kestrel_kernels-0.4.9-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:2d2329c7e235e82807e3b98e8785d2159361592eb39ab1bb42c6b9b4048dc46d", size = 803296, upload-time = "2026-08-03T02:28:00.001Z" },
-    { url = "https://files.pythonhosted.org/packages/45/44/9e70524e9a9ee198063ef6ea593023cf50b809f33ff29e6b35615c89dae6/kestrel_kernels-0.4.9-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:d7f5a4cd7302b913f2369cdbb69c9e5613328d7728b1bdd113c2c4bc42ef4a27", size = 62101532, upload-time = "2026-08-03T02:28:34.592Z" },
-    { url = "https://files.pythonhosted.org/packages/28/54/86e10745d6f7ca7ce49a581888a44a362c841f764edfb8cc2a5e80b8bcea/kestrel_kernels-0.4.9-cp312-cp312-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:e70c4d53c40794837ff0401f13fef0f31eb5175fae748fa9ca9c2e8e467c6100", size = 29291614, upload-time = "2026-08-03T02:28:52.372Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/c8/43ff8b8f018b10ee42681f06fbe6861b4f00dcc8aa74f11e4c91ee489314/kestrel_kernels-0.4.9-cp312-cp312-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:1356d499ca0fec6292b78974884456ca2453600a3d42db75fe6b2d9aa070bb81", size = 94005144, upload-time = "2026-08-03T02:30:03.449Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d0/d5f28929b355a48b67f4876c1544702497b37b61b20db89bca1954767c1c/kestrel_kernels-0.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:7157c600b256e503b997e00a9e5cd9f348fb4f294f13c3df419cd5c9040a1261", size = 82959766, upload-time = "2026-08-03T02:31:25.957Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/42/bcdfde6089b80c9b18541e75d2c0ab6744755d1c41b7f2d01580b3709cfc/kestrel_kernels-0.4.9-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:f53b915daa157ad5e0424d1270bead336c1f2f9911522614138dcddfd9cf6136", size = 803408, upload-time = "2026-08-03T02:31:29.181Z" },
-    { url = "https://files.pythonhosted.org/packages/27/cb/bc4b3cb6d72fe63835c6db04834d7022627fad3bb267783276438bf7e713/kestrel_kernels-0.4.9-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:938882b45343f39644bfc229c43b34bcfe0b4327289b3328fb57431bc66dac3d", size = 62101529, upload-time = "2026-08-03T02:31:53.462Z" },
-    { url = "https://files.pythonhosted.org/packages/de/14/3b278ba3f54af0a412f1afe2a1fff5b9289195e69b50b503e3031c162ecc/kestrel_kernels-0.4.9-cp313-cp313-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:2b01296a79c274fb0777e0931b131fee9fcce43c400503d9e759c4ac831c9907", size = 29291614, upload-time = "2026-08-03T02:32:17.19Z" },
-    { url = "https://files.pythonhosted.org/packages/60/9c/22bfa68aadaaeeea145ce9c5e0040dd37deccfa7886ea1ff8394e6cc0c65/kestrel_kernels-0.4.9-cp313-cp313-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:9a36e12b63c9c2a5dd4044eab6c8c425254a9712168e17ba91253cd04902bab7", size = 94005128, upload-time = "2026-08-03T02:33:39.787Z" },
-    { url = "https://files.pythonhosted.org/packages/04/cd/1e3d9ab291388e06106b5275e2c7f0f815a3cc68fdca2b03b3b3df62b34a/kestrel_kernels-0.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:8639bfdcc558b9f28a8453aedd185a85a23a0b092e26d1f36845b65cfde65336", size = 82959752, upload-time = "2026-08-03T02:34:55.506Z" },
-    { url = "https://files.pythonhosted.org/packages/17/0f/397202e31572651e4608c1d3c43b3d10668dc5e079c457b4d75c7de9bf41/kestrel_kernels-0.4.9-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:0aab309ec71c22cadee13424add616bffc275b5bd14ae106bb424ee0a79535c0", size = 803721, upload-time = "2026-08-03T02:34:58.836Z" },
-    { url = "https://files.pythonhosted.org/packages/05/4e/17ff09fa4a82d39d4a4c0dd403e9d24bfd95e8ad24aa7764a09efb0b39c8/kestrel_kernels-0.4.9-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:e3a8a9456650d7b3936b0c8ffc972387eacda15bd05f877c4d2fef1e6ffdde78", size = 62101539, upload-time = "2026-08-03T02:35:41.959Z" },
-    { url = "https://files.pythonhosted.org/packages/91/f1/a19b6c5ce2fa1962a5ba0828e869c4fdd6583388031cb90a97fb72ce4ca3/kestrel_kernels-0.4.9-cp314-cp314-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:cf5e426e3019da4d807814625d9efd2991222514902d605e7de66b2d9f0431b8", size = 29291614, upload-time = "2026-08-03T02:36:01.147Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/bd/ce5d766d19eb36f99190fdb97fd9286dd8d116f9bf3136eaa87046bc1a85/kestrel_kernels-0.4.9-cp314-cp314-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:e5b877d4d24b5fe8048a3c08302ad2be8a4b87e43c14ce6a65d91ef1c5008a74", size = 94005147, upload-time = "2026-08-03T02:37:03.854Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/79/90a119cefafa0a467c376cffe25880781318b740abfd1117c05cacb758c1/kestrel_kernels-0.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:127f641abe5295935cb907ced503be07a5830f561f4f56450ff36dfcb135e524", size = 82980658, upload-time = "2026-08-03T02:38:10.838Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/3c/d3524cd8d5172a1bdcf3b4afc0165a12451750cfd5b26b28a9b57c1de074/kestrel_kernels-0.5.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:3d0f9ee5320642b4a37be75d33b6190d74f01aa46a08a3d93265abe4f63660ec", size = 859079, upload-time = "2026-08-26T12:21:57.347Z" },
+    { url = "https://files.pythonhosted.org/packages/72/18/995138526a5325568e8b6042ad48a4f3a7879f0fda583440775413a7d4c7/kestrel_kernels-0.5.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:665c3a6478dc31de41f76f83f8a87f3a75d73a6a9257dcb1adaa89084627e29c", size = 3655420, upload-time = "2026-08-26T12:22:00.058Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3e/97defe8f7678a0b49aa0d64ec8602d62ce555ab5de6b08479c609b7138e8/kestrel_kernels-0.5.0-cp310-cp310-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:25b3ccc6695049b2a181cdcaad99cd64f76d0a6d4487eabb2f343598b03d5d59", size = 3354834, upload-time = "2026-08-26T12:22:01.811Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cc/329aabd9455a7fc6091481ca5663dc1a90d9536018e752935cb82b01afbb/kestrel_kernels-0.5.0-cp310-cp310-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:6fa4c4d772c6cec5df2137c411fc78595373147e372bfe57ecf7ca452eaba166", size = 6739986, upload-time = "2026-08-26T12:22:03.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c1/656413f1550353c78ad1323ca152f9099bf9836bdc426caeaa37c08badac/kestrel_kernels-0.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:1c2b1ccff64cff6a257df917fa37a7329912f9243b6b06bf3bc5060328e1fee3", size = 3837217, upload-time = "2026-08-26T12:22:05.312Z" },
+    { url = "https://files.pythonhosted.org/packages/12/0d/dd90fec52bd01a12637e5d63d5f66824ffaacef1e4203687c5df33129375/kestrel_kernels-0.5.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:d31e9e23f4cc00360d75e68036bc4d01bf9e74eaf28838287fd31d58d75ddc87", size = 860283, upload-time = "2026-08-26T12:22:10.403Z" },
+    { url = "https://files.pythonhosted.org/packages/78/fc/14de562b19a9b8b9da28f0f7647eb567cde6602210018a4830082e2ec7ad/kestrel_kernels-0.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:14b477877a38a002c6782b58262e1433ce62ab1c6588f1523f2b1a7ec98ef56f", size = 3655415, upload-time = "2026-08-26T12:22:12.121Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/8051996d3f4f889c87376a42f45c2025d9bdf439e9636ea985ddfcd79c15/kestrel_kernels-0.5.0-cp311-cp311-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:68ae613b8bd1fc42ed8b90fa5fc033156ce7d54a2962a357cc11d72f499727db", size = 3354831, upload-time = "2026-08-26T12:22:14.029Z" },
+    { url = "https://files.pythonhosted.org/packages/84/6f/f048fd4f1fc1da72cb91dc96daa2aa6867377f452645d7c9e28d172f111f/kestrel_kernels-0.5.0-cp311-cp311-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:877d7f0f265c8217c97a666518085cc1c8589a2ac484fda03e1e4ccff393eddf", size = 6739963, upload-time = "2026-08-26T12:22:16.747Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/7c/4e4270f3e0623fcbe8934139fcb2cd9df3907f520a59afa1b3848cba8849/kestrel_kernels-0.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:f2971a9ee8be9c5c405d4cb4eba6a78e1f62257eb9f887982059db5c76583a01", size = 3837208, upload-time = "2026-08-26T12:22:18.877Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/72/e486bfe979881f81eba23032c04f927ab9371c83dce3a92a60717cfe1d52/kestrel_kernels-0.5.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:adb7494d01c2b26b740f9bad2718d47a90499fce54a9932e41a977b550dd1291", size = 861152, upload-time = "2026-08-26T12:22:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/13/99d1b4b01794dcbc327db56a04801429d857077e9c3fef6c2fb6cd28e0dd/kestrel_kernels-0.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:953e3d934d93a05b2ac6f5ef7328efb752c5d5292c6d444e908ab13a7e00f76d", size = 3655446, upload-time = "2026-08-26T12:22:22.502Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/a0c3ad2e011c0641fee1a4fd30afa1ee5741d4a30500b58cb4cb073cecac/kestrel_kernels-0.5.0-cp312-cp312-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:cece5148dbc42dbfb4a97a19e4bba5bc9a4c2072b7d364ba502f5f914d931386", size = 3354722, upload-time = "2026-08-26T12:22:24.514Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b4/a2b4482ef8fd5ce228f0dc9a22d38277c455092408f073b8215319c1402b/kestrel_kernels-0.5.0-cp312-cp312-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:38ecc42ad852ae9d356ba4680d3777bc04810faa1d73866fbf2f632b7f63c5ff", size = 6740005, upload-time = "2026-08-26T12:22:27.557Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e9/8510ed056f391bba0aa566e5d864f4449457a417251dd5e00aea0f5f9455/kestrel_kernels-0.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:a168a526c5fe829a4f6987f81708dbd17add178a5520c576bb9b2be5ff7a06fc", size = 3837223, upload-time = "2026-08-26T12:22:30.028Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f1/9390ddb51bdf708fc2fe0fe4eff0cc3e3d736512dd2d5fb4222e23125945/kestrel_kernels-0.5.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:58387a5ef35bfac7254c0d972bd1ac79e271f71ff17a9c2e7964bfca386f48d4", size = 861261, upload-time = "2026-08-26T12:22:32.01Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/6a/3d54b4701999aae53d3ffae6dea465bd6c30d44b6354b9caa5da2ac50465/kestrel_kernels-0.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:e1a145e19e36d0637c368c1ff56dc3891fed5fdf0ba54b786b97a92127153906", size = 3655442, upload-time = "2026-08-26T12:22:34.206Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/f93c09ab1be38518af11f613f96fe6df13f9bd1df5004ca6570f643f025b/kestrel_kernels-0.5.0-cp313-cp313-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:6d40c910d7e54aeb5c129fc8702862e93da5916b9d6939e1ef133ccb291abec9", size = 3354699, upload-time = "2026-08-26T12:22:36.257Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/92/8139cdd95cc42fe74733462104f95ae705d93d49ec6f848a5a693d1a2221/kestrel_kernels-0.5.0-cp313-cp313-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:9622a8cef7d57e164dae480040874a69301c0745b16957852405bae67a95122d", size = 6739996, upload-time = "2026-08-26T12:22:38.702Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/50/6592d8fb9f968d07bad2c8db2bd4dba3a59c2a78a238347404d50e0fe14c/kestrel_kernels-0.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:10f031026e22215227bb19fb19c36699e04b409ffe5d3c0dc4950d034b1cc175", size = 3837214, upload-time = "2026-08-26T12:22:40.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/68/9c3840e7480665153fdbfaac3046974fd956c5f4342ce476876fb2275f9e/kestrel_kernels-0.5.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:2c17bc63bda7bcf4a21953f545946ab1e1dd0d54ec322fc3b05cd30923962640", size = 861576, upload-time = "2026-08-26T12:22:42.445Z" },
+    { url = "https://files.pythonhosted.org/packages/32/e7/62eae8f036f4f2938e11fd0285918807b5fd6945931331d1b1c6e661ebe5/kestrel_kernels-0.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:691b577a5f1ece2f62e2afda1f5b86714a662a2d37a637d67a1adbd96cefbc33", size = 3655446, upload-time = "2026-08-26T12:22:44.285Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/32/ba3725b0b492f26616841d63e1fb717a161bb42eebf1b38274490667490a/kestrel_kernels-0.5.0-cp314-cp314-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:7d6d9fd4f50da39de53a821230a9f58f43ed00fa394fcbd546a946a08437b85f", size = 3354708, upload-time = "2026-08-26T12:22:46.638Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/aa376f92292e7ffd93283d729e33a55a61be3ed0ce082be27f386bbb78b6/kestrel_kernels-0.5.0-cp314-cp314-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:70d112fb7c44f5df1e8e2517d57866ca637e42f3113c9fc718f8c52938c076c0", size = 6740005, upload-time = "2026-08-26T12:22:49.193Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c9/fe8b558510625431fb95203aad92027ec83f7a2be7cd57c08cced512d579/kestrel_kernels-0.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:c57dc766adfb7c32e67e5beb8df2d28422d9f9f6663d66b0f04ebe6eae5216d4", size = 3837218, upload-time = "2026-08-26T12:22:51.252Z" },
+]
+
+[[package]]
+name = "kestrel-kernels-bundle-a"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/fe/cdf11bdfd11a05944424bb9b01e95e39cff98b17ee10561c7da7ba42dfa1/kestrel_kernels_bundle_a-0.5.0-py3-none-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:100f8414626a8485888c9b37d087412adae3303fdce8341595b3c957c43b7467", size = 39659078, upload-time = "2026-08-26T12:19:17.357Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c2/733cb826adef41a63b4555d0bef319054b65e8990496144dc329d9886e9a/kestrel_kernels_bundle_a-0.5.0-py3-none-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:83155f192071bbd29a0b16091d4031d078ba7b230e1274ec855605b3fbc75ac4", size = 14234986, upload-time = "2026-08-26T12:19:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1d/68055e5ffcc434244495219e00bf02450542e73f0bc5515fd3df429b936c/kestrel_kernels_bundle_a-0.5.0-py3-none-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:ba8b7053f912b25b299d5055f1964687edfd188df0dd78cb25c3b4600c794936", size = 76635628, upload-time = "2026-08-26T12:19:49.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/aa/43a59b1983fc375100c82964e2239d6d1a7c8d27c11587388b9ea0ccea83/kestrel_kernels_bundle_a-0.5.0-py3-none-win_amd64.whl", hash = "sha256:fc743a0331b58342edb72a240e52bd6ce2ea292beea068316125da718adacb1c", size = 52304836, upload-time = "2026-08-26T12:20:15.644Z" },
+]
+
+[[package]]
+name = "kestrel-kernels-bundle-b"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/2c/1059daba39b4b1ba826b8762523a9bba8f88e14f19a0af30ed1602efec0b/kestrel_kernels_bundle_b-0.5.0-py3-none-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:dff826b97d7d5298c0783c4573479b6f9c74a38ce37c31db001718cf130490f8", size = 39481286, upload-time = "2026-08-26T12:20:28.265Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8a/80f1e6b530fab59e282f9ff214f64c7405aab100795ddd6055d09e51ebd6/kestrel_kernels_bundle_b-0.5.0-py3-none-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:26aeaf6dddbb3ddc942b45e9f0e53500025d7f0d9a4b68d43dc573779001be74", size = 14466632, upload-time = "2026-08-26T12:20:34.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/7bab81f2fd3b842faa7a2bb7fd7e62534d6fbff076bd65f25a5a4f4f99eb/kestrel_kernels_bundle_b-0.5.0-py3-none-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:2ded32decee1da826cc2263d05eb14538577adfb5c1ddd2f276f7ce9511e289f", size = 76171703, upload-time = "2026-08-26T12:20:54.644Z" },
+    { url = "https://files.pythonhosted.org/packages/28/82/5c07a04cda049635c0ceb51e50771b30e93215148593c0d47db73a843f9a/kestrel_kernels_bundle_b-0.5.0-py3-none-win_amd64.whl", hash = "sha256:5ad4e7fc96b73c83e309be35158bde303582bf930ea156ea2c3412fd77e166fa", size = 51908670, upload-time = "2026-08-26T12:21:19.3Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- run supported Qwen 3.5, Qwen 3.6, and Gemma 4 B200 workloads through expanded precompiled prefill and generated-decode paths
- keep Qwen recurrent state in BF16 across prefill and decode, and fuse validated greedy token selection into the serving path
- select generated decode only when the installed bundle covers the complete configured batch domain; otherwise initialize the regular optimized runtime before serving
- release Kestrel 0.6.0 with the customer-reviewed changelog and production `kestrel-kernels==0.5.0` bundle lock

## Validation

- focused generated-decode, decode-path, device, and streaming runtime suite: 38 passed
- `uv lock --check`, Linux and Darwin platform resolution checks, wheel/sdist build, and `twine check`: passed
- production PyPI verification: all 33 `kestrel-kernels` 0.5.0 wheel hashes match the audited CI artifact set; clean dependency-resolving install and import passed
- B200 Gemma E4 C4 at 1845 MHz: 233.8687 decode tok/s versus vLLM 232.9275, accuracy 106/128 versus 102/128, zero fallback

## Release

`kestrel-kernels` 0.5.0 is live on PyPI. The Kestrel package version and lock are 0.6.0 and resolve both exact CUDA companion bundles on Linux and Windows while excluding them on Darwin.
