### PR TITLE
Preserve Qwen GDN norm precision

### DIFF
--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -13,7 +13,7 @@ from safetensors import safe_open
 from safetensors.torch import load_file
 
 from .qwen_config import Qwen3_5Config
-from .qwen_model import Qwen3_5ForConditionalGeneration
+from .qwen_model import Qwen3_5ForConditionalGeneration, Qwen3_5RMSNormGated
 
 
 _GDN_IN_PROJ_PARTS = (
@@ -89,6 +89,14 @@ def _qwen_rms_norm_weight_keys(model: torch.nn.Module) -> set[str]:
     }
 
 
+def _qwen_gdn_norm_weight_keys(model: torch.nn.Module) -> set[str]:
+    return {
+        f"{name}.weight" if name else "weight"
+        for name, module in model.named_modules()
+        if isinstance(module, Qwen3_5RMSNormGated)
+    }
+
+
 def _loadable_tensor(
     key: str,
     value: torch.Tensor,
@@ -97,7 +105,20 @@ def _loadable_tensor(
     scale_inv: torch.Tensor | None = None,
     *,
     convert_fp8_to_bf16: bool = False,
+    exact_fp32_weight_keys: set[str] | None = None,
 ) -> torch.Tensor:
+    if exact_fp32_weight_keys is not None and key in exact_fp32_weight_keys:
+        if value.dtype != torch.float32:
+            raise ValueError(
+                f"Qwen GDN norm weight {key!r} requires an FP32 checkpoint tensor, "
+                f"got {value.dtype}"
+            )
+        if value.shape != expected_shape:
+            raise ValueError(
+                f"Qwen GDN norm weight {key!r} has shape {tuple(value.shape)}, "
+                f"expected {tuple(expected_shape)}"
+            )
+        return value
     if _is_float8_tensor(value):
         if not convert_fp8_to_bf16:
             raise ValueError(
@@ -363,6 +384,7 @@ def _load_sharded_safetensors(
     pending_fused_parts: dict[str, tuple[str, ...]] = {}
     pending_experts: dict[str, dict[int, dict[str, torch.Tensor]]] = {}
     qwen_rms_norm_weight_keys = _qwen_rms_norm_weight_keys(model)
+    qwen_gdn_norm_weight_keys = _qwen_gdn_norm_weight_keys(model)
     unexpected: list[str] = []
     device_arg = _torch_device_arg(device)
     shard_paths = [
@@ -391,6 +413,7 @@ def _load_sharded_safetensors(
                     expected_state[key].shape,
                     scale_inv_by_key.get(scale_key),
                     convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
+                    exact_fp32_weight_keys=qwen_gdn_norm_weight_keys,
                 )
                 loaded_keys.add(key)
                 continue

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -159,7 +159,7 @@ class Qwen3_5TextRotaryEmbedding(nn.Module):
 class Qwen3_5RMSNormGated(nn.Module):
     def __init__(self, hidden_size, eps=1e-6):
         super().__init__()
-        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=torch.float32))
         self.variance_epsilon = eps
         self.gated_rmsnorm = _kestrel_gated_rmsnorm
 

--- a/tests/qwen35/test_weights.py
+++ b/tests/qwen35/test_weights.py
@@ -1,0 +1,73 @@
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from kestrel.models.qwen35.qwen_loader import (
+    _load_sharded_safetensors,
+    _qwen_gdn_norm_weight_keys,
+    _qwen_rms_norm_weight_keys,
+)
+from kestrel.models.qwen35.qwen_model import Qwen3_5RMSNormGated
+
+
+def _gdn_norm_holder(hidden_size: int) -> torch.nn.Module:
+    model = torch.nn.Module()
+    model.norm = Qwen3_5RMSNormGated(hidden_size)
+    return model
+
+
+def test_gdn_norm_preserves_exact_fp32_checkpoint_weight_under_bf16_default(
+    tmp_path,
+) -> None:
+    previous_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        model = _gdn_norm_holder(4)
+    finally:
+        torch.set_default_dtype(previous_dtype)
+
+    exact_fp32_keys = _qwen_gdn_norm_weight_keys(model)
+    assert exact_fp32_keys == {"norm.weight"}
+    assert _qwen_rms_norm_weight_keys(model) == set()
+    assert model.norm.weight.dtype == torch.float32
+
+    checkpoint = torch.tensor(
+        [0.9991, 1.0009, 1.0071, 0.9929], dtype=torch.float32
+    )
+    assert not torch.equal(
+        checkpoint,
+        checkpoint.to(torch.bfloat16).to(torch.float32),
+    )
+    shard = tmp_path / "model.safetensors"
+    save_file({"norm.weight": checkpoint}, shard)
+    missing, unexpected = _load_sharded_safetensors(
+        model,
+        tmp_path,
+        [shard.name],
+        device=torch.device("cpu"),
+    )
+
+    assert missing == []
+    assert unexpected == []
+    assert model.norm.weight.dtype == torch.float32
+    torch.testing.assert_close(model.norm.weight, checkpoint, rtol=0, atol=0)
+
+
+def test_gdn_norm_rejects_rounded_checkpoint_weight(tmp_path) -> None:
+    model = _gdn_norm_holder(4)
+    shard = tmp_path / "model.safetensors"
+    save_file({"norm.weight": torch.full((4,), 0.5, dtype=torch.bfloat16)}, shard)
+
+    with pytest.raises(ValueError, match="requires an FP32 checkpoint tensor"):
+        _load_sharded_safetensors(
+            model,
+            tmp_path,
+            [shard.name],
+            device=torch.device("cpu"),
+        )
+    torch.testing.assert_close(
+        model.norm.weight,
+        torch.ones(4, dtype=torch.float32),
+        rtol=0,
+        atol=0,
+    )


### PR DESCRIPTION
## Summary
- construct Qwen GDN RMSNorm weights in FP32 even when the model default is BF16
- preserve official FP32 checkpoint tensors verbatim and reject rounded checkpoint inputs
- cover the real sharded safetensors loader path and fail-closed behavior

## Testing
- tests/qwen35: 5 passed, 3 skipped
- tests/test_model_download.py plus tests/qwen35: 12 passed, 3 skipped
- full CPU collection with importlib mode: 767 passed, 46 skipped; 40 unrelated failures from the checkout environment having an older kestrel-native audio API