### PR TITLE
Fix Gemma reasoning channel parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes since `v0.1.2` are documented in this file.
 
 ## Unreleased
 
+## 0.6.1 — 2026-08-26
+
+- Corrected Gemma 4 reasoning-enabled queries so direct answers are returned
+  as answers and reasoning channel headers are parsed without appearing in
+  customer-visible output.
+
 ## 0.6.0 — 2026-08-26
 
 Kestrel 0.6.0 adds production speech transcription and substantially expands

--- a/kestrel/models/gemma4/prompt_template.py
+++ b/kestrel/models/gemma4/prompt_template.py
@@ -15,6 +15,8 @@ TURN_ID = 105
 END_OF_TURN_ID = 106
 NEWLINE_ID = 107
 THINK_ID = 98
+START_OF_CHANNEL_ID = 100
+THOUGHT_ID = 45_518
 END_OF_CHANNEL_ID = 101
 SYSTEM_ROLE_ID = 9731
 USER_ROLE_ID = 2364
@@ -56,6 +58,11 @@ class Gemma4PromptTemplate:
             post_reasoning_prefix=[],
             prefix_when_reasoning=list(_TURN_USER_PREFIX_WITH_THINK_IDS),
             stop_token_ids=stop_token_ids,
+            reasoning_start_token_ids=[
+                START_OF_CHANNEL_ID,
+                THOUGHT_ID,
+                NEWLINE_ID,
+            ],
         )
 
 
@@ -67,6 +74,8 @@ __all__ = [
     "Gemma4PromptTemplate",
     "IMAGE_TOKEN_ID",
     "START_OF_IMAGE_ID",
+    "START_OF_CHANNEL_ID",
     "THINK_ID",
+    "THOUGHT_ID",
     "TOOL_RESPONSE_ID",
 ]

--- a/kestrel/models/protocols.py
+++ b/kestrel/models/protocols.py
@@ -35,6 +35,11 @@ class QueryTemplate:
     answer_suppressed_token_ids: List[int] = field(default_factory=list)
     start_ground_points_id: Optional[int] = None
     end_ground_id: Optional[int] = None
+    # Some formats, such as Gemma 4, decide per response whether to reason.
+    # These fields follow the original dataclass fields to preserve positional
+    # construction. Models must set at most one marker form.
+    reasoning_start_token_id: Optional[int] = None
+    reasoning_start_token_ids: List[int] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/kestrel/skills/query.py
+++ b/kestrel/skills/query.py
@@ -184,6 +184,9 @@ class QuerySkillState(SkillState):
         self._query_template: Optional[QueryTemplate] = None
         self._reasoning_enabled = bool(query_request.reasoning)
         self._collecting_reasoning = self._reasoning_enabled
+        self._reasoning_start_tokens: List[int] = []
+        self._reasoning_start_seen = False
+        self._reasoning_start_prefix: Optional[Tuple[int, ...]] = None
         self._reasoning_tokens: List[int] = []
         self._answer_tokens: List[int] = []
         self._reasoning_chunks: List[Tuple[List[int], List[Tuple[float, float]]]] = []
@@ -277,6 +280,18 @@ class QuerySkillState(SkillState):
                     )
                     self._post_reasoning_idx = 0
                     return None
+                reasoning_start = self._reasoning_start_prefix or ()
+                if reasoning_start and not self._reasoning_start_seen:
+                    expected_id = reasoning_start[len(self._reasoning_start_tokens)]
+                    if token_id == expected_id:
+                        self._reasoning_start_tokens.append(token_id)
+                        if len(self._reasoning_start_tokens) == len(reasoning_start):
+                            self._reasoning_start_seen = True
+                            self._reasoning_start_tokens.clear()
+                        return None
+                    self._switch_to_direct_answer()
+                    self._answer_tokens.append(token_id)
+                    return None
                 if token_id == self._start_ground_id or token_id == self._end_ground_id:
                     self._flush_current_chunk()
                     self._pending_coord = None
@@ -323,6 +338,8 @@ class QuerySkillState(SkillState):
         reason: str,
     ) -> SkillFinalizeResult:
         if self._reasoning_enabled:
+            if self._reasoning_start_tokens and not self._reasoning_start_seen:
+                self._switch_to_direct_answer()
             self._flush_current_chunk()
 
         tokenizer = runtime.tokenizer
@@ -380,12 +397,27 @@ class QuerySkillState(SkillState):
         self._current_chunk_points.clear()
         self._pending_coord = None
 
+    def _switch_to_direct_answer(self) -> None:
+        self._collecting_reasoning = False
+        self._answer_tokens.extend(self._reasoning_start_tokens)
+        self._reasoning_start_tokens.clear()
+        self._answer_stream_offset = 0
+
     def _ensure_token_ids(self, runtime: "AutoregressiveRuntime") -> None:
         if self._answer_id is not None:
             return
         pt = runtime.prompt_template
         self._answer_id = pt.answer_id
         template = self._get_query_template(runtime)
+        scalar_start = template.reasoning_start_token_id
+        sequence_start = tuple(template.reasoning_start_token_ids)
+        if scalar_start is not None and sequence_start:
+            raise ValueError(
+                "query template must not set both reasoning start token fields"
+            )
+        self._reasoning_start_prefix = (
+            (int(scalar_start),) if scalar_start is not None else sequence_start
+        )
         self._start_ground_id = template.start_ground_points_id
         self._end_ground_id = template.end_ground_id
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kestrel"
-version = "0.6.0"
+version = "0.6.1"
 description = "A fast, efficient inference engine for multimodal models"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/tests/test_query_skill.py
+++ b/tests/test_query_skill.py
@@ -9,6 +9,15 @@ from typing import List, Optional
 
 import pytest
 
+from kestrel.models.gemma4.prompt_template import (
+    END_OF_CHANNEL_ID,
+    END_OF_TURN_ID,
+    Gemma4PromptTemplate,
+    NEWLINE_ID,
+    START_OF_CHANNEL_ID,
+    THINK_ID,
+    THOUGHT_ID,
+)
 from kestrel.models.moondream.config import TokenizerConfig
 from kestrel.models.protocols import QueryTemplate
 from kestrel.skills.query import QueryRequest, QuerySkill
@@ -45,6 +54,8 @@ class _Runtime:
         *,
         prefix_when_reasoning: Optional[List[int]] = None,
         stop_token_ids: Optional[List[int]] = None,
+        reasoning_start_token_id: Optional[int] = None,
+        reasoning_start_token_ids: Optional[List[int]] = None,
     ) -> None:
         self.prompt_template = _PromptTemplate(
             _query_template=QueryTemplate(
@@ -54,6 +65,8 @@ class _Runtime:
                 post_reasoning_prefix=[],
                 prefix_when_reasoning=prefix_when_reasoning,
                 stop_token_ids=stop_token_ids or [],
+                reasoning_start_token_id=reasoning_start_token_id,
+                reasoning_start_token_ids=reasoning_start_token_ids or [],
             )
         )
         self.tokenizer = _Tokenizer()
@@ -77,6 +90,26 @@ def test_query_template_stop_ids_default_empty() -> None:
     )
 
     assert template.stop_token_ids == []
+
+
+def test_query_template_preserves_positional_grounding_fields() -> None:
+    template = QueryTemplate(
+        [],
+        [],
+        [],
+        [],
+        None,
+        [],
+        [],
+        [],
+        7,
+        9,
+    )
+
+    assert template.start_ground_points_id == 7
+    assert template.end_ground_id == 9
+    assert template.reasoning_start_token_id is None
+    assert template.reasoning_start_token_ids == []
 
 
 def test_query_skill_uses_prefix_when_reasoning_override() -> None:
@@ -175,3 +208,163 @@ def test_reasoning_stop_token_is_not_emitted() -> None:
         "reasoning": {"text": "<42>", "grounding": []},
     }
     assert _ids(result.tokens) == [42, 88]
+
+
+@pytest.mark.parametrize(
+    "model_name", ("google/gemma-4-E2B-it", "google/gemma-4-E4B-it")
+)
+def test_gemma4_reasoning_prompt_and_generated_channel_use_distinct_tokens(
+    model_name: str,
+) -> None:
+    template = Gemma4PromptTemplate(model_name).query()
+
+    assert template is not None
+    assert template.prefix_when_reasoning is not None
+    assert THINK_ID in template.prefix_when_reasoning
+    assert template.reasoning_start_token_ids == [
+        START_OF_CHANNEL_ID,
+        THOUGHT_ID,
+        NEWLINE_ID,
+    ]
+
+
+@pytest.mark.parametrize(
+    "model_name", ("google/gemma-4-E2B-it", "google/gemma-4-E4B-it")
+)
+def test_gemma4_reasoning_request_accepts_unmarked_direct_answer(
+    model_name: str,
+) -> None:
+    runtime = SimpleNamespace(
+        prompt_template=Gemma4PromptTemplate(model_name),
+        tokenizer=_VisibleTokenizer(),
+    )
+    context = QueryRequest(question="hi", image=None, reasoning=True, stream=True)
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=42), position=0))
+    state.consume_step(
+        runtime, DecodeStep(TextToken(token_id=END_OF_TURN_ID), position=1)
+    )
+
+    assert state.pop_stream_delta(runtime) == "<42>"
+    result = state.finalize(runtime, reason="stop")
+    assert result.output == {
+        "answer": "<42>",
+        "reasoning": {"text": "", "grounding": []},
+    }
+
+
+@pytest.mark.parametrize(
+    "model_name", ("google/gemma-4-E2B-it", "google/gemma-4-E4B-it")
+)
+def test_gemma4_channel_marker_preserves_reasoning_answer_split(
+    model_name: str,
+) -> None:
+    runtime = SimpleNamespace(
+        prompt_template=Gemma4PromptTemplate(model_name),
+        tokenizer=_VisibleTokenizer(),
+    )
+    context = QueryRequest(question="hi", image=None, reasoning=True, stream=False)
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    for position, token_id in enumerate(
+        [
+            START_OF_CHANNEL_ID,
+            THOUGHT_ID,
+            NEWLINE_ID,
+            42,
+            END_OF_CHANNEL_ID,
+            43,
+            END_OF_TURN_ID,
+        ]
+    ):
+        state.consume_step(
+            runtime, DecodeStep(TextToken(token_id=token_id), position=position)
+        )
+
+    result = state.finalize(runtime, reason="stop")
+    assert result.output == {
+        "answer": "<43>",
+        "reasoning": {"text": "<42>", "grounding": []},
+    }
+
+
+def test_reasoning_start_partial_mismatch_restores_buffered_answer_tokens() -> None:
+    runtime = _Runtime(reasoning_start_token_ids=[30, 31, 32])
+    runtime.tokenizer = _VisibleTokenizer()
+    context = QueryRequest(question="hi", image=None, reasoning=True, stream=True)
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=30), position=0))
+    assert state.pop_stream_delta(runtime) is None
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=42), position=1))
+
+    assert state.pop_stream_delta(runtime) == "<30><42>"
+    assert state.finalize(runtime, reason="stop").output["answer"] == "<30><42>"
+
+
+def test_reasoning_start_partial_eof_restores_buffered_answer_tokens() -> None:
+    runtime = _Runtime(
+        stop_token_ids=[88], reasoning_start_token_ids=[30, 31, 32]
+    )
+    runtime.tokenizer = _VisibleTokenizer()
+    context = QueryRequest(question="hi", image=None, reasoning=True, stream=False)
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=30), position=0))
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=88), position=1))
+
+    assert state.finalize(runtime, reason="stop").output == {
+        "answer": "<30>",
+        "reasoning": {"text": "", "grounding": []},
+    }
+
+
+def test_reasoning_start_prefix_matches_across_stream_steps() -> None:
+    runtime = _Runtime(reasoning_start_token_ids=[30, 31, 32])
+    runtime.tokenizer = _VisibleTokenizer()
+    context = QueryRequest(question="hi", image=None, reasoning=True, stream=True)
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    for position, token_id in enumerate([30, 31, 32, 42, 0, 43]):
+        state.consume_step(
+            runtime, DecodeStep(TextToken(token_id=token_id), position=position)
+        )
+
+    assert state.pop_stream_delta(runtime) == "<43>"
+    assert state.finalize(runtime, reason="stop").output == {
+        "answer": "<43>",
+        "reasoning": {"text": "<42>", "grounding": []},
+    }
+
+
+def test_reasoning_start_scalar_contract_is_normalized_to_one_token() -> None:
+    runtime = _Runtime(reasoning_start_token_id=30)
+    runtime.tokenizer = _VisibleTokenizer()
+    context = QueryRequest(question="hi", image=None, reasoning=True, stream=False)
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    for position, token_id in enumerate([30, 42, 0, 43]):
+        state.consume_step(
+            runtime, DecodeStep(TextToken(token_id=token_id), position=position)
+        )
+
+    assert state.finalize(runtime, reason="stop").output == {
+        "answer": "<43>",
+        "reasoning": {"text": "<42>", "grounding": []},
+    }
+
+
+def test_reasoning_start_contract_rejects_scalar_and_sequence() -> None:
+    runtime = _Runtime(
+        reasoning_start_token_id=30,
+        reasoning_start_token_ids=[30, 31, 32],
+    )
+    context = QueryRequest(question="hi", image=None, reasoning=True, stream=False)
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    with pytest.raises(
+        ValueError,
+        match="query template must not set both reasoning start token fields",
+    ):
+        state.on_prefill(runtime)

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "kestrel"
-version = "0.6.0"
+version = "0.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- parse Gemma 4's multi-token reasoning channel header without exposing it in output
- return unmarked Gemma responses as direct answers, including partial-header prefixes
- preserve the existing positional `QueryTemplate` API while adding model-declared marker forms
- release the correction as Kestrel 0.6.1

## Validation

- `839 passed, 46 skipped` (`pytest --import-mode=importlib -q`)
- `126 passed` across query, chat, streaming, and speculative scheduler regressions
- `uv lock --check`
- `git diff --check`
- wheel and sdist pass `twine check`; wheel contents audited
