### PR TITLE
Coalesce idle prefill admissions

### DIFF
--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import queue
 import threading
+import time
 from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Protocol
@@ -37,6 +38,9 @@ from kestrel.engine._types import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+# Qwen3-ASR preprocessing measured about 1 ms warm on the H100 host; a 5 ms
+# idle-only window absorbed sibling completion skew without delaying lone requests.
+_IDLE_ADMISSION_BATCH_WAIT_S = 0.005
 
 
 @dataclass(slots=True)
@@ -131,10 +135,16 @@ class _AdmissionCoordinator:
                 )
         return None
 
-    def take_ready(self) -> Optional[_ReadyAdmission]:
+    def take_ready(self, timeout: float = 0.0) -> Optional[_ReadyAdmission]:
+        deadline = time.perf_counter() + timeout
         while True:
             try:
-                req_id = self._ready.get_nowait()
+                remaining = deadline - time.perf_counter()
+                req_id = (
+                    self._ready.get_nowait()
+                    if remaining <= 0
+                    else self._ready.get(timeout=remaining)
+                )
             except queue.Empty:
                 return None
 
@@ -320,7 +330,9 @@ class AutoregressiveExecutor:
 
     def advance(self) -> TickResult:
         scheduler = self._scheduler
-        progressed = self._promote_ready()
+        progressed = self._promote_ready(
+            coalesce=not scheduler.has_pending_work(),
+        )
 
         if scheduler.has_pending_work():
             progressed = scheduler.advance() or progressed
@@ -407,14 +419,27 @@ class AutoregressiveExecutor:
         self._scheduler.enqueue_request(generation_req, skill_state)
         self._active[req.request_id] = req
 
-    def _promote_ready(self) -> bool:
+    def _promote_ready(self, *, coalesce: bool = False) -> bool:
         promoted = False
+        deadline: float | None = None
+        promoted_count = 0
         while len(self._scheduler.waiting) < self._admission_capacity:
-            ready = self._admission.take_ready()
+            timeout = None
+            if (
+                coalesce
+                and promoted
+                and promoted_count < self._runtime.max_batch_size
+                and self._admission.pending_count
+            ):
+                if deadline is None:
+                    deadline = time.perf_counter() + _IDLE_ADMISSION_BATCH_WAIT_S
+                timeout = max(0.0, deadline - time.perf_counter())
+            ready = self._admission.take_ready(0.0 if timeout is None else timeout)
             if ready is None:
                 break
             self._admit_ready(ready)
             promoted = True
+            promoted_count += 1
         return promoted
 
     def _collect(self) -> List[Completion]:

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -79,7 +79,7 @@ def _executor() -> AutoregressiveExecutor:
     ex._admission = SimpleNamespace(
         has_pending=lambda: False,
         pending_count=0,
-        take_ready=lambda: None,
+        take_ready=lambda _timeout=0.0: None,
         fail_all=lambda exc: None,
     )
     return ex
@@ -175,6 +175,34 @@ def test_ingress_capacity_counts_active_and_preprocessing_requests() -> None:
 
     ex._admission.pending_count = 1
     assert ex.has_ingress_capacity is False
+
+
+def test_idle_executor_collects_a_ready_preprocessing_cohort() -> None:
+    ex = _executor()
+    ex._runtime.max_batch_size = 4
+    waiting = ex._scheduler.waiting
+    ready = [object(), object()]
+    timeouts = []
+
+    def take_ready(timeout=0.0):
+        timeouts.append(timeout)
+        if not ready:
+            return None
+        ex._admission.pending_count -= 1
+        return ready.pop(0)
+
+    ex._admission.pending_count = len(ready)
+    ex._admission.take_ready = take_ready
+    ex._admit_ready = waiting.append
+    launched = []
+    ex._scheduler.has_pending_work = lambda: bool(waiting)
+    ex._scheduler.advance = lambda: launched.append(len(waiting)) or True
+
+    ex.advance()
+
+    assert launched == [2]
+    assert timeouts[0] == 0.0
+    assert 0 < timeouts[1] <= 0.005
 
 
 def test_shutdown_fails_in_flight_requests() -> None:


### PR DESCRIPTION
## Summary
- give concurrently preprocessing requests one shared 5 ms collection window when an autoregressive lane is idle
- launch the collected cohort together instead of fragmenting it into singleton prefills
- preserve immediate admission while decode or prefill work is already active

## Why
Warm Qwen3-ASR preprocessing takes about 1 ms, but completion callbacks arrive with enough skew to fragment an eight-request cohort. Batched Qwen prefill/decode measured about 536-563 audio-seconds/s on H100; fragmented admission left much of that throughput unused.

## Validation
- Modal: tests/test_autoregressive_executor.py (15 passed)
- ruff, py_compile, and git diff --check