### PR TITLE
Support capability orchestration across execution shapes

### DIFF
--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -51,6 +51,7 @@ from kestrel.scheduler import (
     StreamUpdate,
 )
 from kestrel.skills import (
+    CapabilityOrchestrator,
     DecodeStep,
     PreparedSkillPrompt,
     SkillRegistry,
@@ -999,6 +1000,22 @@ class InferenceEngine:
         if runtime is not None:
             return tuple(runtime.tasks())
         raise ValueError(f"Unknown model {model_id!r}")
+
+    def _orchestrator_for(
+        self, model_id: str, task: str
+    ) -> Optional[CapabilityOrchestrator]:
+        """Return model-owned composition for a capability, if any."""
+
+        if model_id == self._default_model:
+            return self._skill_registry().resolve(task).orchestrator()
+        from kestrel.models.registry import get_spec
+
+        try:
+            spec = get_spec(model_id)
+        except ValueError:
+            # Injected runtimes need not have global registry metadata.
+            return None
+        return spec.orchestrators().get(task)
 
     async def _submit_request(
         self,

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -170,6 +170,35 @@ class ModelHandle:
         if runtime is not None and (
             runtime.execution_shape is ExecutionShape.SINGLE_PASS
         ):
+            orchestrator = self._engine._orchestrator_for(self._model, task)
+            if orchestrator is not None:
+                self._require(task)
+                settings = owned_prompt.pop("settings", None)
+                image = owned_prompt.pop("image", None)
+
+                async def invoke(
+                    leaf_prompt: Mapping[str, object],
+                    *,
+                    image: Optional[Any] = None,
+                    settings: Optional[Mapping[str, object]] = None,
+                ) -> object:
+                    inputs = dict(leaf_prompt)
+                    if image is not None:
+                        inputs["image"] = image
+                    if settings is not None:
+                        inputs["settings"] = settings
+                    submission = self._engine.run(self._model, task, inputs)
+                    del inputs, image, settings
+                    return await submission
+
+                submission = orchestrator.run(
+                    invoke,
+                    image=image,
+                    prompt=owned_prompt,
+                    settings=settings,
+                )
+                del orchestrator, owned_prompt, settings, image
+                return await submission
             submission = self.run(task, owned_prompt)
             del owned_prompt
             return await submission

--- a/kestrel/models/registry.py
+++ b/kestrel/models/registry.py
@@ -12,11 +12,11 @@ package's ``__init__.py`` (see ``kestrel/models/moondream/__init__.py``).
 """
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional
 
 if TYPE_CHECKING:
     from kestrel.runtime import Runtime
-    from kestrel.skills import SkillRegistry
+    from kestrel.skills import CapabilityOrchestrator, SkillRegistry
 
 
 @dataclass(frozen=True)
@@ -49,6 +49,12 @@ class ModelSpec:
     # Immutable revision for artifacts hosted by ``repo_id``. Runtimes also
     # apply it to the tokenizer when ``tokenizer_id`` names that same repo.
     revision: Optional[str] = None
+    # Optional model-owned composition around ordinary capability requests.
+    # This is execution-shape independent: each leaf still runs through the
+    # model's normal autoregressive or single-pass lane.
+    orchestrators: Callable[
+        [], "Mapping[str, CapabilityOrchestrator]"
+    ] = lambda: _empty_orchestrators()
 
 
 def _empty_skill_registry() -> "SkillRegistry":
@@ -60,6 +66,10 @@ def _empty_skill_registry() -> "SkillRegistry":
     from kestrel.skills import SkillRegistry
 
     return SkillRegistry([])
+
+
+def _empty_orchestrators() -> "Mapping[str, CapabilityOrchestrator]":
+    return {}
 
 
 _REGISTRY: Dict[str, ModelSpec] = {}

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -400,6 +400,39 @@ def test_capability_orchestrator_composes_ordinary_leaf_requests() -> None:
     ]
 
 
+def test_single_pass_capability_orchestrator_uses_single_pass_leaves() -> None:
+    eng = _engine()
+    eng._runtimes["sp-model"] = _StubSinglePass("sp-model", ("transcribe",))
+    eng._orchestrator_for = lambda _model, _task: _WindowOrchestrator()
+    calls = []
+
+    async def run(model: str, task: str, inputs: Any) -> str:
+        calls.append((model, task, inputs))
+        return f"leaf-{inputs['window']}"
+
+    eng.run = run  # type: ignore[method-assign]
+    result = asyncio.run(
+        eng.model("sp-model").transcribe(
+            windows=[b"first", b"second"],
+            settings={"max_tokens": 32},
+        )
+    )
+
+    assert result == ("leaf-0", "leaf-1")
+    assert calls == [
+        (
+            "sp-model",
+            "transcribe",
+            {"audio": b"first", "window": 0, "settings": {"max_tokens": 32}},
+        ),
+        (
+            "sp-model",
+            "transcribe",
+            {"audio": b"second", "window": 1, "settings": {"max_tokens": 32}},
+        ),
+    ]
+
+
 def test_capability_lifts_settings_and_mirrors_stream() -> None:
     """settings (sampling) is lifted out of the model prompt as its own arg.
     stream is passed to the engine to select streaming delivery AND left in

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -59,6 +59,12 @@ def test_modelspec_skills_factory_is_honored() -> None:
     assert spec.skills() is sentinel
 
 
+def test_modelspec_orchestrator_factory_is_honored() -> None:
+    sentinel = object()
+    spec = _spec(orchestrators=lambda: {"transcribe": sentinel})
+    assert spec.orchestrators()["transcribe"] is sentinel
+
+
 def test_modelspec_revision_does_not_shift_existing_positional_metadata() -> None:
     runtime = lambda *args, **kwargs: None
     skills = lambda: SkillRegistry([])


### PR DESCRIPTION
## Summary
- let ModelSpec declare optional capability orchestrators for any execution shape
- route single-pass orchestrator leaves through the ordinary single-pass lane
- preserve the existing skill-owned autoregressive orchestration path

This is the model-agnostic seam needed for progressive long-file transcription in single-pass ASR models such as Parakeet.

## Validation
- Modal: tests/test_model_handle.py and tests/test_model_registry.py (37 passed)
- ruff, py_compile, and git diff --check