### PR TITLE
Batch single-pass model requests

### DIFF
--- a/kestrel/engine/single_pass.py
+++ b/kestrel/engine/single_pass.py
@@ -1,21 +1,16 @@
 """The single-pass executor lane.
 
-A single-pass driver (:class:`~kestrel.runtime.SinglePassRuntime`) fulfils
-a request with one ``forward(task, inputs)`` that enqueues kernels and
-returns result tensors *without* a host sync. This executor owns the
-pipeline around that call — a slot pool, a completion event per in-flight
-forward, and result delivery — so a single-pass forward overlaps
-autoregressive decode on the shared stream (async launch + deferred
-collect, the autoregressive pipeline's trick generalized to a second
-lane).
+A single-pass driver (:class:`~kestrel.runtime.SinglePassRuntime`) fulfils a
+same-task request cohort with one ``forward(task, inputs)``. This executor owns
+cohort formation, completion events, and per-request result delivery.
 
 It presents the same uniform :class:`Executor` face the kernel folds over
 (``submit`` / ``advance`` -> :class:`TickResult` / ``shutdown``) and emits
 :class:`Completion` values; like the autoregressive lane, it never touches
 the event loop.
 
-First cut: one in-flight forward (``max_in_flight=1``). Adding slots or
-batching is a parameter change here, not a new abstraction.
+One forward is in flight by default; each forward may contain up to the
+runtime's declared ``batch_capacity``.
 """
 
 from __future__ import annotations
@@ -24,7 +19,7 @@ import asyncio
 import logging
 import queue
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Sequence
 
 from kestrel.device import make_event, stream_context
 from kestrel.runtime import SinglePassRuntime
@@ -96,14 +91,14 @@ def _single_pass_result(request_id: int, output: Any) -> EngineResult:
 class _InFlight:
     """A forward whose kernels are enqueued and whose result is pending.
 
-    ``error`` is set instead of ``output``/``done_event`` when the
+    ``error`` is set instead of ``outputs``/``done_event`` when the
     ``forward`` call raised at launch; it surfaces as an error completion
     on the next collect, keeping launch failures on the same path as
     results.
     """
 
-    request: _SinglePassRequest
-    output: Any
+    requests: tuple[_SinglePassRequest, ...]
+    outputs: tuple[Any, ...]
     done_event: Any  # torch.cuda.Event | NoopEvent | None
     error: Optional[BaseException] = None
 
@@ -122,7 +117,11 @@ class SinglePassExecutor:
         self._device = runtime.device
         self._stream = compute_stream
         self._max_in_flight = max_in_flight
+        if runtime.batch_capacity < 1:
+            raise ValueError("single-pass batch_capacity must be positive")
+        self._batch_capacity = runtime.batch_capacity
         self._queue: "queue.Queue[_SinglePassRequest]" = queue.Queue()
+        self._deferred: _SinglePassRequest | None = None
         self._in_flight: List[_InFlight] = []
 
     # -- ingress (event-loop thread) ----------------------------------
@@ -134,7 +133,11 @@ class SinglePassExecutor:
 
     @property
     def has_work(self) -> bool:
-        return bool(self._in_flight) or not self._queue.empty()
+        return (
+            bool(self._in_flight)
+            or self._deferred is not None
+            or not self._queue.empty()
+        )
 
     @property
     def has_in_flight(self) -> bool:
@@ -159,9 +162,14 @@ class SinglePassExecutor:
     def shutdown(self, error: Optional[BaseException] = None) -> tuple[Completion, ...]:
         exc = error or RuntimeError("Engine shut down")
         completions: List[Completion] = [
-            Completion(request=f.request, error=exc) for f in self._in_flight
+            Completion(request=request, error=exc)
+            for in_flight in self._in_flight
+            for request in in_flight.requests
         ]
         self._in_flight = []
+        if self._deferred is not None:
+            completions.append(Completion(request=self._deferred, error=exc))
+            self._deferred = None
         while True:
             try:
                 req = self._queue.get_nowait()
@@ -177,27 +185,62 @@ class SinglePassExecutor:
         launched = False
         while len(self._in_flight) < self._max_in_flight:
             try:
-                req = self._queue.get_nowait()
+                requests = self._take_batch()
             except queue.Empty:
                 break
-            launched = self._launch_one(req) or launched
+            launched = self._launch_batch(requests) or launched
         return launched
 
-    def _launch_one(self, req: _SinglePassRequest) -> bool:
+    def _take_batch(self) -> tuple[_SinglePassRequest, ...]:
+        if self._deferred is None:
+            first = self._queue.get_nowait()
+        else:
+            first, self._deferred = self._deferred, None
+        requests = [first]
+        while len(requests) < self._batch_capacity:
+            try:
+                request = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if request.task != first.task:
+                self._deferred = request
+                break
+            requests.append(request)
+        return tuple(requests)
+
+    def _launch_batch(self, requests: Sequence[_SinglePassRequest]) -> bool:
         try:
             with stream_context(self._stream):
-                output = self._runtime.forward(req.task, req.inputs)
+                outputs = tuple(
+                    self._runtime.forward(
+                        requests[0].task,
+                        tuple(request.inputs for request in requests),
+                    )
+                )
+                if len(outputs) != len(requests):
+                    raise ValueError(
+                        "single-pass forward returned "
+                        f"{len(outputs)} results for {len(requests)} requests"
+                    )
                 done_event = make_event(self._device)
                 done_event.record()
         except Exception as exc:
-            # Launch-time failure: hold the error so it surfaces as a
-            # completion on the next collect, uniform with normal results.
             self._in_flight.append(
-                _InFlight(request=req, output=None, done_event=None, error=exc)
+                _InFlight(
+                    requests=tuple(requests),
+                    outputs=(),
+                    done_event=None,
+                    error=exc,
+                )
             )
             return True
         self._in_flight.append(
-            _InFlight(request=req, output=output, done_event=done_event, error=None)
+            _InFlight(
+                requests=tuple(requests),
+                outputs=outputs,
+                done_event=done_event,
+                error=None,
+            )
         )
         return True
 
@@ -209,13 +252,20 @@ class SinglePassExecutor:
         completed: List[Completion] = []
         for f in self._in_flight:
             if f.error is not None:
-                completed.append(Completion(request=f.request, error=f.error))
+                completed.extend(
+                    Completion(request=request, error=f.error) for request in f.requests
+                )
             elif f.done_event.query():
-                completed.append(
-                    Completion(
-                        request=f.request,
-                        result=_single_pass_result(f.request.request_id, f.output),
+                completed.extend(
+                    (
+                        Completion(request=request, error=output)
+                        if isinstance(output, BaseException)
+                        else Completion(
+                            request=request,
+                            result=_single_pass_result(request.request_id, output),
+                        )
                     )
+                    for request, output in zip(f.requests, f.outputs, strict=True)
                 )
             else:
                 still.append(f)

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -147,9 +147,7 @@ class AutoregressiveRuntime(Runtime, Protocol):
     # Gemma's resize+normalize), so the dispatch lives here. Async so
     # the engine can hide preprocessing latency behind admission /
     # other work.
-    def preprocess_image_async(
-        self, image: np.ndarray | bytes
-    ) -> Future[Any]: ...
+    def preprocess_image_async(self, image: np.ndarray | bytes) -> Future[Any]: ...
 
     def preprocess_encoder_input_async(self, encoder_input: object) -> Future[Any]: ...
 
@@ -245,18 +243,15 @@ class AutoregressiveRuntime(Runtime, Protocol):
 class SinglePassRuntime(Runtime, Protocol):
     """Runtime that fulfills a request with a single forward.
 
-    No KV cache, no decode loop. The driver is pure compute: ``forward``
-    enqueues the kernels for one forward and returns the result tensors
-    *without* a host sync. The engine supplies the compute stream shared
-    with the autoregressive lane when it constructs the runtime. The
-    executor owns the completion event, slot, and result delivery (the
-    driver↔executor split mirrors the autoregressive path, where the
-    model computes and the scheduler owns the pipeline).
+    No KV cache. ``forward`` runs one same-task request cohort and returns one
+    result per input. The engine supplies the compute stream shared with the
+    autoregressive lane and owns cohort formation, completion events, and
+    result delivery.
 
-    A synchronous ``forward`` (one that blocks on its own result) would
-    stall the kernel loop and defeat interleaving — implementations must
-    not call ``.item()`` / ``.cpu()`` / ``torch.cuda.synchronize`` before
-    returning.
+    Runtimes should return after enqueueing device work when their algorithm
+    permits it. A runtime that needs host decisions may finish the forward
+    synchronously; that blocks interleaving with other engine lanes until it
+    returns.
     """
 
     # Capability names this runtime serves, e.g. ("segment_masks",). The
@@ -265,11 +260,17 @@ class SinglePassRuntime(Runtime, Protocol):
     # contract — declared here, not discovered via getattr.
     def tasks(self) -> Sequence[str]: ...
 
-    def preprocess_image_async(
-        self, image: np.ndarray | bytes
-    ) -> Future[Any]: ...
+    def preprocess_image_async(self, image: np.ndarray | bytes) -> Future[Any]: ...
 
-    def forward(self, task: str, inputs: Any) -> Any: ...
+    # Maximum number of same-task requests accepted by one forward.
+    batch_capacity: int
+
+    # Per-request validation failures are returned in their result position so
+    # one malformed input does not fail the rest of its cohort. Raising fails
+    # the whole forward and is reserved for batch-wide execution failures.
+    def forward(
+        self, task: str, inputs: Sequence[Any]
+    ) -> Sequence[Any | BaseException]: ...
 
 
 class StreamingRuntime(Runtime, Protocol):

--- a/tests/test_multi_model.py
+++ b/tests/test_multi_model.py
@@ -34,12 +34,15 @@ class _SPStub:
         self.model_name = model_name
         self.device = torch.device("cpu")
         self.execution_shape = ExecutionShape.SINGLE_PASS
+        self.batch_capacity = 1
 
     def tasks(self) -> tuple[str, ...]:
         return ("segment",)
 
-    def forward(self, task: str, inputs: Any) -> Any:  # pragma: no cover - unused here
-        return {"task": task, "inputs": inputs}
+    def forward(
+        self, task: str, inputs: tuple[Any, ...]
+    ) -> tuple[Any, ...]:  # pragma: no cover - unused here
+        return tuple({"task": task, "inputs": value} for value in inputs)
 
     def shutdown(self) -> None:
         pass

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -32,13 +32,14 @@ class _StubSinglePass:
         self.model_name = model_name
         self.device = torch.device("cpu")
         self.execution_shape = ExecutionShape.SINGLE_PASS
+        self.batch_capacity = 2
         self.calls: list[tuple[str, Any]] = []
 
-    def forward(self, task: str, inputs: Any) -> Any:
+    def forward(self, task: str, inputs: tuple[Any, ...]) -> tuple[Any, ...]:
         self.calls.append((task, inputs))
         if task == "boom":
             raise ValueError("forward failed")
-        return {"task": task, "inputs": inputs}
+        return tuple({"task": task, "inputs": value} for value in inputs)
 
     def tasks(self) -> tuple[str, ...]:
         return ("segment", "boom")
@@ -88,7 +89,9 @@ async def _run(task: str, inputs: Any) -> Any:
     thread = threading.Thread(target=engine._scheduler_loop, name="kernel", daemon=True)
     thread.start()
     try:
-        return await asyncio.wait_for(engine.run(sp.model_name, task, inputs), timeout=5.0)
+        return await asyncio.wait_for(
+            engine.run(sp.model_name, task, inputs), timeout=5.0
+        )
     finally:
         engine._shutdown = True
         engine._scheduler_queue.put(None)
@@ -390,7 +393,9 @@ def test_single_pass_lane_crash_does_not_kill_the_kernel() -> None:
             thread.start()
             try:
                 # The bad lane crashes on its request; the good lane still works.
-                with pytest.raises(RuntimeError, match="Engine shut down|lane exploded"):
+                with pytest.raises(
+                    RuntimeError, match="Engine shut down|lane exploded"
+                ):
                     await asyncio.wait_for(
                         engine.run("bad-sp", "segment", {}), timeout=5.0
                     )

--- a/tests/test_single_pass_executor.py
+++ b/tests/test_single_pass_executor.py
@@ -9,7 +9,6 @@ integration is covered separately by the engine e2e test.
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
 from typing import Any
 
 import torch
@@ -29,13 +28,19 @@ class _StubDriver:
         # reports done immediately, so collect() fires on the next tick.
         self.device = torch.device("cpu")
         self.execution_shape = ExecutionShape.SINGLE_PASS
+        self.batch_capacity = 2
         self.calls: list[tuple[str, Any]] = []
 
-    def forward(self, task: str, inputs: Any) -> Any:
+    def forward(self, task: str, inputs: tuple[Any, ...]) -> tuple[Any, ...]:
         self.calls.append((task, inputs))
         if task == "boom":
             raise ValueError("forward failed")
-        return {"task": task, "inputs": inputs}
+        return tuple(
+            ValueError("invalid input")
+            if value == "bad"
+            else {"task": task, "inputs": value}
+            for value in inputs
+        )
 
     def shutdown(self) -> None:
         pass
@@ -84,7 +89,7 @@ def test_forward_error_becomes_error_completion() -> None:
 
 
 def test_one_in_flight_at_a_time() -> None:
-    """Default max_in_flight=1: a second job waits until the first frees."""
+    """Default max_in_flight=1: a second task waits until the first frees."""
     driver = _StubDriver()
     ex = SinglePassExecutor(driver, compute_stream=None, max_in_flight=1)
     ex.submit(_req(3, "a", 1))
@@ -99,6 +104,33 @@ def test_one_in_flight_at_a_time() -> None:
     tick2 = ex.advance()
     assert [c.request.request_id for c in tick2.completed] == [4]
     assert ex.has_work is False
+
+
+def test_same_task_requests_share_one_forward() -> None:
+    driver = _StubDriver()
+    ex = SinglePassExecutor(driver, compute_stream=None)
+    ex.submit(_req(8, "segment", 1))
+    ex.submit(_req(9, "segment", 2))
+
+    tick = ex.advance()
+
+    assert driver.calls == [("segment", (1, 2))]
+    assert [completion.result.output for completion in tick.completed] == [
+        {"task": "segment", "inputs": 1},
+        {"task": "segment", "inputs": 2},
+    ]
+
+
+def test_one_invalid_input_does_not_fail_its_batch() -> None:
+    ex = SinglePassExecutor(_StubDriver(), compute_stream=None)
+    ex.submit(_req(10, "segment", "bad"))
+    ex.submit(_req(11, "segment", "valid"))
+
+    tick = ex.advance()
+
+    assert isinstance(tick.completed[0].error, ValueError)
+    assert tick.completed[1].error is None
+    assert tick.completed[1].result.output["inputs"] == "valid"
 
 
 def test_idle_executor_reports_no_work() -> None:


### PR DESCRIPTION
## Summary
- let every single-pass runtime declare one uniform same-task batch capacity
- form request cohorts in the shared executor and preserve per-request results, failures, and ordering
- keep batch-one runtimes on the same contract without backend-specific dispatch

## Validation
- Modal: public single-pass engine/executor/multi-model tests (21 passed)
- end-to-end H100 Parakeet smoke in the paired proprietary change formed one six-request heterogeneous cohort