### PR TITLE
Bind Qwen packed prefill topology and generated state transport

### DIFF
--- a/kestrel/models/qwen35/cache.py
+++ b/kestrel/models/qwen35/cache.py
@@ -43,6 +43,7 @@ class Qwen35InferenceCache:
         config: Any,
         paged_kv: Sequence[PagedKVCache | None],
         replay_capacity: int,
+        prepare_gdn_replay_state: bool = True,
     ) -> None:
         layer_types = tuple(config.layer_types)
         if len(paged_kv) != len(layer_types):
@@ -62,6 +63,7 @@ class Qwen35InferenceCache:
             layers.append(layer)
         self.layers = tuple(layers)
         self.seq_length = 0
+        self.prepare_gdn_replay_state = bool(prepare_gdn_replay_state)
 
     def has_previous_state(self, layer_idx: int | None = None) -> bool:
         if layer_idx is None:
@@ -204,13 +206,25 @@ class Qwen35LinearStatePool:
 
     def capture_batch_from_cache(
         self,
-        batch_idx: torch.Tensor,
+        batch_indices: Sequence[int],
         cache: Qwen35InferenceCache,
         *,
         batch_size: int,
         copy_replay_payload: bool = True,
-    ) -> None:
-        indices = batch_idx[:batch_size].to(device=self.device, dtype=torch.long)
+    ) -> torch.Tensor:
+        rows = tuple(batch_indices)
+        if any(type(row) is not int for row in rows):
+            raise ValueError("Qwen GDN state rows must be host integers")
+        if len(rows) != batch_size:
+            raise ValueError("Qwen GDN state rows must match packed batch size")
+        if len(set(rows)) != len(rows):
+            raise ValueError("Qwen GDN state rows must be unique")
+        if any(row < 0 or row >= self.max_batch_slots for row in rows):
+            raise ValueError("Qwen GDN state row is outside the runtime pool")
+        indices = torch.tensor(rows, device=self.device, dtype=torch.long)
+        if self._recurrent_mode not in ("generated", "native"):
+            raise RuntimeError("Qwen recurrent decode representation is not selected")
+        captures: list[tuple[LinearAttentionState, LinearAttentionState]] = []
         for layer_idx, storage in enumerate(self.layers):
             if storage is None:
                 continue
@@ -219,35 +233,25 @@ class Qwen35LinearStatePool:
                 raise ValueError("Cannot capture mismatched Qwen linear state")
             if not src_layer.has_previous_state:
                 raise RuntimeError("Cannot capture uninitialized Qwen GDN state")
-            self._capture_conv_rows(
-                storage, src_layer, indices, batch_size=batch_size)
+            self._validate_conv_rows(storage, src_layer, batch_size=batch_size)
             if self._recurrent_mode == "generated":
-                target = storage.recurrent_states
-                if target is None or src_layer.recurrent_states is not target:
-                    raise RuntimeError(
-                        "Qwen prefill did not write the generated recurrent pool")
-                continue
-            if self._recurrent_mode != "native":
-                raise RuntimeError("Qwen recurrent decode representation is not selected")
-            self._validate_prefill_recurrent(src_layer, batch_size=batch_size)
-            storage.copy_rows_from(
-                src_layer, indices, copy_replay_payload=copy_replay_payload)
+                self._validate_generated_recurrent_rows(
+                    storage, src_layer, batch_size=batch_size)
+            else:
+                self._validate_prefill_recurrent(src_layer, batch_size=batch_size)
+            captures.append((storage, src_layer))
 
-    def bind_generated_prefill_state(self, cache: Qwen35InferenceCache) -> None:
-        """Expose the authoritative BF16 pool as packed-prefill final state."""
-
-        if self._recurrent_mode != "generated":
-            raise RuntimeError("Qwen generated recurrent state is not initialized")
-        for layer_idx, storage in enumerate(self.layers):
-            if storage is None:
-                continue
-            target = storage.recurrent_states
-            if target is None:
-                raise RuntimeError("Qwen generated recurrent state is incomplete")
-            layer = cache.layers[layer_idx]
-            if not isinstance(layer, LinearAttentionState):
-                raise ValueError("Cannot bind mismatched Qwen linear state")
-            layer.recurrent_states = target
+        # Validate every layer before the first persistent state write so a
+        # malformed later layer cannot leave a partially committed batch.
+        for storage, src_layer in captures:
+            if self._recurrent_mode == "generated":
+                self._capture_conv_rows(storage, src_layer, indices)
+                self._capture_generated_recurrent_rows(
+                    storage, src_layer, indices)
+            else:
+                storage.copy_rows_from(
+                    src_layer, indices, copy_replay_payload=copy_replay_payload)
+        return indices
 
     def bind_to_cache(self, cache: Qwen35InferenceCache) -> None:
         """Bind cache linear layers directly to runtime-owned persistent state."""
@@ -305,17 +309,84 @@ class Qwen35LinearStatePool:
         storage: LinearAttentionState,
         src_layer: LinearAttentionState,
         indices: torch.Tensor,
-        *,
-        batch_size: int = 1,
     ) -> None:
-        conv_states = src_layer.conv_states
-        if conv_states is None or conv_states.shape[0] != batch_size:
+        assert storage.conv_states is not None
+        assert src_layer.conv_states is not None
+        storage.conv_states.index_copy_(0, indices, src_layer.conv_states)
+
+    def _validate_conv_rows(
+        self,
+        storage: LinearAttentionState,
+        src_layer: LinearAttentionState,
+        *,
+        batch_size: int,
+    ) -> None:
+        source = src_layer.conv_states
+        target = storage.conv_states
+        expected_source = (batch_size, *self._conv_shape[1:])
+        if (
+            source is None
+            or tuple(source.shape) != expected_source
+            or source.device != self.device
+            or not source.is_contiguous()
+        ):
             raise RuntimeError(
                 "Qwen GDN prefill convolution batch must match capture batch"
             )
-        if storage.conv_states is None:
-            raise RuntimeError("Qwen GDN convolution pool is not initialized")
-        storage.conv_states.index_copy_(0, indices, conv_states)
+        if (
+            target is None
+            or tuple(target.shape) != self._conv_shape
+            or target.dtype != source.dtype
+            or target.device != self.device
+            or not target.is_contiguous()
+        ):
+            raise RuntimeError("Qwen GDN convolution pool is incomplete")
+
+    def _capture_generated_recurrent_rows(
+        self,
+        storage: LinearAttentionState,
+        src_layer: LinearAttentionState,
+        indices: torch.Tensor,
+    ) -> None:
+        assert src_layer.recurrent_states is not None
+        assert storage.recurrent_states is not None
+        value_major = (
+            src_layer.recurrent_states.transpose(-1, -2)
+            .to(
+                dtype=torch.bfloat16,
+                memory_format=torch.contiguous_format,
+            )
+        )
+        storage.recurrent_states.index_copy_(0, indices, value_major)
+
+    def _validate_generated_recurrent_rows(
+        self,
+        storage: LinearAttentionState,
+        src_layer: LinearAttentionState,
+        *,
+        batch_size: int,
+    ) -> None:
+        source = src_layer.recurrent_states
+        target = storage.recurrent_states
+        expected_source = (batch_size, *self._key_major_recurrent_shape[1:])
+        if (
+            source is None
+            or tuple(source.shape) != expected_source
+            or source.dtype != torch.float32
+            or source.device != self.device
+            or not source.is_contiguous()
+        ):
+            raise RuntimeError(
+                "Qwen generated prefill requires contiguous sequence-major FP32 state"
+            )
+        if (
+            target is None
+            or tuple(target.shape) != self._value_major_recurrent_shape
+            or target.dtype != torch.bfloat16
+            or target.device != self.device
+            or not target.is_contiguous()
+        ):
+            raise RuntimeError("Qwen generated recurrent state pool is incomplete")
 
     @staticmethod
     def _validate_prefill_recurrent(

--- a/kestrel/models/qwen35/generated_decode.py
+++ b/kestrel/models/qwen35/generated_decode.py
@@ -19,9 +19,7 @@ def _state_tensors(state_pool: Any, field: str) -> list[torch.Tensor | None]:
     ]
 
 
-def create_generated_decode(
-    runtime: Any, *, required: bool = False,
-) -> GeneratedDecode | None:
+def _generated_decode_spec(runtime: Any) -> GeneratedDecodeSpec:
     bindings = PagedDecodeBindings(
         runtime._paged_kv,
         extra_runtime_inputs=lambda bound_runtime: {
@@ -60,7 +58,7 @@ def create_generated_decode(
             "gdn_recurrent_state": recurrent,
         }
 
-    spec = GeneratedDecodeSpec(
+    return GeneratedDecodeSpec(
         label="Qwen",
         weight_root=runtime.model,
         weight_layer_prefix="model.language_model.layers",
@@ -81,6 +79,28 @@ def create_generated_decode(
             "prepare_position_ids": runtime._prepare_decode_position_ids,
         },
     )
+
+
+def generated_decode_slot_capacity(
+    runtime: Any, *, required: bool = False,
+) -> int | None:
+    required_batch_sizes = range(1, runtime.max_batch_size + 1)
+    capacity = GeneratedDecode.resolve_slot_capacity(
+        runtime,
+        _generated_decode_spec(runtime),
+        required_batch_sizes=required_batch_sizes,
+    )
+    if required and capacity is None:
+        raise RuntimeError(
+            "Qwen requires a compatible bundled generated-decode program"
+        )
+    return capacity
+
+
+def create_generated_decode(
+    runtime: Any, *, required: bool = False,
+) -> GeneratedDecode | None:
+    spec = _generated_decode_spec(runtime)
     if required:
         return GeneratedDecode.require(
             runtime, spec, batch_sizes=range(1, runtime.max_batch_size + 1)
@@ -92,4 +112,4 @@ def create_generated_decode(
     )
 
 
-__all__ = ["create_generated_decode"]
+__all__ = ["create_generated_decode", "generated_decode_slot_capacity"]

--- a/kestrel/models/qwen35/prefill_slot.py
+++ b/kestrel/models/qwen35/prefill_slot.py
@@ -25,7 +25,7 @@ class Qwen35PrefillScratch:
     # surface the fill code uses. Field set:
     #   input_ids, cache_position_ids, seq_idx, mm_token_type_ids, position_ids,
     #   slot_mapping, batch_indices, last_positions, last_token_offsets,
-    #   cu_seq_lens_q, rope_deltas
+    #   rope_deltas
     text_meta: PackedBuffer
     paged_kv_page_table: Tensor
     paged_kv_seqlens_k: Tensor
@@ -65,7 +65,6 @@ class Qwen35PrefillScratch:
                 ("batch_indices", (batch_capacity,), torch.int64),
                 ("last_positions", (batch_capacity,), torch.int32),
                 ("last_token_offsets", (batch_capacity,), torch.long),
-                ("cu_seq_lens_q", (batch_capacity + 1,), torch.int32),
                 ("rope_deltas", (batch_capacity, 1), torch.long),
             ],
             device=device,

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -292,6 +293,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         attention_mask: torch.Tensor | None = None,
         *,
         cu_seq_lens_q: torch.Tensor | None = None,
+        sequence_lengths: Sequence[int] | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
     ):
@@ -480,6 +482,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 recurrence_cu_seqlens,
                 workspace=workspace,
                 output_final_state=True,
+                sequence_lengths=sequence_lengths,
                 final_state=packed_recurrent_state,
                 final_state_indices=state_indices,
             )
@@ -880,6 +883,7 @@ class Qwen3_5DecoderLayer(nn.Module):
         paged_kv_seqlens_q: torch.Tensor | None = None,
         paged_kv_seqlens_k: torch.Tensor | None = None,
         cu_seq_lens_q: torch.Tensor | None = None,
+        sequence_lengths: Sequence[int] | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
@@ -892,6 +896,7 @@ class Qwen3_5DecoderLayer(nn.Module):
                 cache_params=past_key_values,
                 attention_mask=attention_mask,
                 cu_seq_lens_q=cu_seq_lens_q,
+                sequence_lengths=sequence_lengths,
                 seq_idx=seq_idx,
                 gdn_state_indices=gdn_state_indices,
             )
@@ -1216,6 +1221,7 @@ class Qwen3_5TextModel(nn.Module):
         paged_kv_seqlens_q: torch.Tensor | None = None,
         paged_kv_seqlens_k: torch.Tensor | None = None,
         cu_seq_lens_q: torch.Tensor | None = None,
+        sequence_lengths: Sequence[int] | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
     ) -> _TextModelOutput:
@@ -1273,6 +1279,7 @@ class Qwen3_5TextModel(nn.Module):
                 paged_kv_seqlens_q=paged_kv_seqlens_q,
                 paged_kv_seqlens_k=paged_kv_seqlens_k,
                 cu_seq_lens_q=cu_seq_lens_q,
+                sequence_lengths=sequence_lengths,
                 seq_idx=seq_idx,
                 gdn_state_indices=gdn_state_indices,
             )
@@ -1363,6 +1370,7 @@ class Qwen3_5Model(nn.Module):
         paged_kv_seqlens_q: torch.Tensor | None = None,
         paged_kv_seqlens_k: torch.Tensor | None = None,
         cu_seq_lens_q: torch.Tensor | None = None,
+        sequence_lengths: Sequence[int] | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
         vision_bilinear_indices: torch.Tensor | None = None,
@@ -1406,6 +1414,7 @@ class Qwen3_5Model(nn.Module):
             paged_kv_seqlens_q=paged_kv_seqlens_q,
             paged_kv_seqlens_k=paged_kv_seqlens_k,
             cu_seq_lens_q=cu_seq_lens_q,
+            sequence_lengths=sequence_lengths,
             seq_idx=seq_idx,
             gdn_state_indices=gdn_state_indices,
         )

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -337,14 +337,11 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                     dtype=torch.long,
                 ).view(-1).contiguous()
         else:
-            state_indices = (
-                None
-                if gdn_state_indices is None
-                else gdn_state_indices.to(
-                    device=hidden_states.device,
-                    dtype=torch.long,
-                ).view(-1).contiguous()
-            )
+            if gdn_state_indices is not None:
+                raise RuntimeError(
+                    "Qwen packed prefill state rows are committed after recurrence"
+                )
+            state_indices = None
 
         in_proj = self.in_proj(hidden_states)
         mixed_qkv, z, b, a = torch.split(
@@ -415,39 +412,17 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 self.head_k_dim,
                 self.head_v_dim,
             )
-            if state_indices is None:
-                if (
-                    layer.recurrent_states is None
-                    or tuple(layer.recurrent_states.shape) != recurrent_shape
-                ):
-                    layer.recurrent_states = torch.empty(
-                        recurrent_shape,
-                        device=mixed_qkv.device,
-                        dtype=torch.float32,
-                    )
-                packed_recurrent_state = layer.recurrent_states
-            else:
-                expected_tail = (
-                    self.num_v_heads,
-                    self.head_v_dim,
-                    self.head_k_dim,
+            if (
+                layer.recurrent_states is None
+                or tuple(layer.recurrent_states.shape) != recurrent_shape
+                or layer.recurrent_states.dtype != torch.float32
+            ):
+                layer.recurrent_states = torch.empty(
+                    recurrent_shape,
+                    device=mixed_qkv.device,
+                    dtype=torch.float32,
                 )
-                if (
-                    layer.recurrent_states is None
-                    or layer.recurrent_states.dtype != torch.bfloat16
-                    or tuple(layer.recurrent_states.shape[1:]) != expected_tail
-                    or not layer.recurrent_states.is_contiguous()
-                ):
-                    raise RuntimeError(
-                        "Qwen generated prefill requires contiguous BF16 "
-                        "value-major recurrent state"
-                    )
-                if int(state_indices.numel()) != num_sequences:
-                    raise RuntimeError(
-                        "Qwen generated prefill requires one recurrent-state "
-                        "index per packed sequence"
-                    )
-                packed_recurrent_state = layer.recurrent_states
+            packed_recurrent_state = layer.recurrent_states
             layer.has_previous_state = True
             if seq_idx is None:
                 seq_idx = _packed_seq_idx_from_cu_seqlens(
@@ -486,9 +461,9 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 sequence_lengths=sequence_lengths,
                 topology_token=topology_token,
                 final_state=packed_recurrent_state,
-                final_state_indices=state_indices,
+                final_state_indices=None,
             )
-            if state_indices is None:
+            if cache_params.prepare_gdn_replay_state:
                 # Native decode consumes ReplaySSM state seeded from the packed
                 # prefill's committed FP32 recurrence.
                 layer._reset_replay_rows(layer.recurrent_states, None)

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -294,6 +294,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         *,
         cu_seq_lens_q: torch.Tensor | None = None,
         sequence_lengths: Sequence[int] | None = None,
+        topology_token: object | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
     ):
@@ -483,6 +484,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 workspace=workspace,
                 output_final_state=True,
                 sequence_lengths=sequence_lengths,
+                topology_token=topology_token,
                 final_state=packed_recurrent_state,
                 final_state_indices=state_indices,
             )
@@ -884,6 +886,7 @@ class Qwen3_5DecoderLayer(nn.Module):
         paged_kv_seqlens_k: torch.Tensor | None = None,
         cu_seq_lens_q: torch.Tensor | None = None,
         sequence_lengths: Sequence[int] | None = None,
+        topology_token: object | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
@@ -897,6 +900,7 @@ class Qwen3_5DecoderLayer(nn.Module):
                 attention_mask=attention_mask,
                 cu_seq_lens_q=cu_seq_lens_q,
                 sequence_lengths=sequence_lengths,
+                topology_token=topology_token,
                 seq_idx=seq_idx,
                 gdn_state_indices=gdn_state_indices,
             )
@@ -1222,6 +1226,7 @@ class Qwen3_5TextModel(nn.Module):
         paged_kv_seqlens_k: torch.Tensor | None = None,
         cu_seq_lens_q: torch.Tensor | None = None,
         sequence_lengths: Sequence[int] | None = None,
+        topology_token: object | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
     ) -> _TextModelOutput:
@@ -1280,6 +1285,7 @@ class Qwen3_5TextModel(nn.Module):
                 paged_kv_seqlens_k=paged_kv_seqlens_k,
                 cu_seq_lens_q=cu_seq_lens_q,
                 sequence_lengths=sequence_lengths,
+                topology_token=topology_token,
                 seq_idx=seq_idx,
                 gdn_state_indices=gdn_state_indices,
             )
@@ -1371,6 +1377,7 @@ class Qwen3_5Model(nn.Module):
         paged_kv_seqlens_k: torch.Tensor | None = None,
         cu_seq_lens_q: torch.Tensor | None = None,
         sequence_lengths: Sequence[int] | None = None,
+        topology_token: object | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
         vision_bilinear_indices: torch.Tensor | None = None,
@@ -1415,6 +1422,7 @@ class Qwen3_5Model(nn.Module):
             paged_kv_seqlens_k=paged_kv_seqlens_k,
             cu_seq_lens_q=cu_seq_lens_q,
             sequence_lengths=sequence_lengths,
+            topology_token=topology_token,
             seq_idx=seq_idx,
             gdn_state_indices=gdn_state_indices,
         )

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -13,8 +13,9 @@ from typing import Any, Optional, Sequence
 
 import numpy as np
 import torch
-from kestrel_kernels import get_runtime
 from torch import nn
+
+from kestrel_kernels import get_runtime
 
 from kestrel.kv_cache import KVMemoryPool, PageTable, allocate_paged_kv_layers
 from kestrel.runtime.decode_graph import DecodeGraphManager
@@ -1053,8 +1054,8 @@ class Qwen35Runtime(UncachedPagedRuntime):
         image_grid_rows: int,
         vision_sequence_count: int,
     ) -> None:
-        # One H2D for every text-metadata field (input ids, positions, slot
-        # mapping, seq idx, batch indices, cu-seqlens, rope deltas, …) instead
+        # One H2D for every staged text-metadata field (input ids, positions,
+        # slot mapping, seq idx, batch indices, rope deltas, …) instead
         # of a dozen separate cudaMemcpyAsync launches. Consumers slice each
         # field to its live length, so shipping the whole packed buffer
         # (including unused tails) is safe.
@@ -1178,8 +1179,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
         offset = 0
         pixel_offset = 0
         grid_offset = 0
-        scratch.text_meta.cu_seq_lens_q.np[0] = 0
-
         for row, (token_ids, crops, grid_np, batch_idx) in enumerate(
             zip(token_rows, image_crops_list, crop_grid_rows, batch_indices)
         ):
@@ -1194,7 +1193,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
             scratch.text_meta.batch_indices.np[row] = int(batch_idx)
             scratch.text_meta.last_positions.np[row] = length - 1
             scratch.text_meta.last_token_offsets.np[row] = end - 1
-            scratch.text_meta.cu_seq_lens_q.np[row + 1] = end
             self._fill_prefill_slot_mapping(
                 scratch.text_meta.slot_mapping.np,
                 start=offset,
@@ -1272,11 +1270,10 @@ class Qwen35Runtime(UncachedPagedRuntime):
             input_ids=scratch.text_meta.input_ids.gpu[:, :total_tokens],
             cache_position_ids=scratch.text_meta.cache_position_ids.gpu[:, :total_tokens],
             position_ids=scratch.text_meta.position_ids.gpu[:, :, :total_tokens],
-            # Always pass packed metadata, even for a single sequence: text_meta
-            # is staged to the GPU unconditionally, so cu_seq_lens_q ([0, total])
-            # and seq_idx are valid for batch_size == 1. This lets a single
-            # sequence take the same packed_prefill path as batched prefill
-            # instead of the separate uniform_native_prefill branch.
+            # Always pass packed metadata, even for a single sequence. The
+            # topology factory derives cu_seq_lens_q ([0, total]) from the same
+            # ordered host lengths used to pack seq_idx, so a single sequence
+            # takes the same packed-prefill path as a batch.
             cu_seq_lens_q=cu_seq_lens_q,
             sequence_lengths=sequence_lengths,
             topology_token=topology_token,

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -13,6 +13,7 @@ from typing import Any, Optional, Sequence
 
 import numpy as np
 import torch
+from kestrel_kernels import get_runtime
 from torch import nn
 
 from kestrel.kv_cache import KVMemoryPool, PageTable, allocate_paged_kv_layers
@@ -63,6 +64,7 @@ class _PackedPrefillBatch:
     position_ids: torch.Tensor
     cu_seq_lens_q: Optional[torch.Tensor]
     sequence_lengths: tuple[int, ...]
+    topology_token: object
     seq_idx: Optional[torch.Tensor]
     batch_indices: torch.Tensor
     max_length: int
@@ -1258,6 +1260,13 @@ class Qwen35Runtime(UncachedPagedRuntime):
         )
 
         batch_size = len(prepared_sequences)
+        sequence_lengths = tuple(lengths)
+        cu_seq_lens_q, topology_token = (
+            get_runtime().gated_delta.bind_packed_prefill_topology(
+                sequence_lengths=sequence_lengths,
+                device=self.device,
+            )
+        )
 
         return _PackedPrefillBatch(
             input_ids=scratch.text_meta.input_ids.gpu[:, :total_tokens],
@@ -1268,8 +1277,9 @@ class Qwen35Runtime(UncachedPagedRuntime):
             # and seq_idx are valid for batch_size == 1. This lets a single
             # sequence take the same packed_prefill path as batched prefill
             # instead of the separate uniform_native_prefill branch.
-            cu_seq_lens_q=scratch.text_meta.cu_seq_lens_q.gpu[: batch_size + 1],
-            sequence_lengths=tuple(lengths),
+            cu_seq_lens_q=cu_seq_lens_q,
+            sequence_lengths=sequence_lengths,
+            topology_token=topology_token,
             seq_idx=scratch.text_meta.seq_idx.gpu[:, :total_tokens],
             batch_indices=scratch.text_meta.batch_indices.gpu[:batch_size],
             max_length=max(lengths),
@@ -1333,6 +1343,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
             paged_kv_seqlens_k=packed.paged_kv_seqlens_k,
             cu_seq_lens_q=packed.cu_seq_lens_q,
             sequence_lengths=packed.sequence_lengths,
+            topology_token=packed.topology_token,
             seq_idx=packed.seq_idx,
             gdn_state_indices=(
                 packed.batch_indices if self.generated_decode is not None else None),

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -67,7 +67,6 @@ class _PackedPrefillBatch:
     sequence_lengths: tuple[int, ...]
     topology_token: object
     seq_idx: Optional[torch.Tensor]
-    batch_indices: torch.Tensor
     max_length: int
     last_token_offsets: torch.Tensor
     paged_kv_page_table: torch.Tensor
@@ -704,7 +703,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
             last_hidden, cache = self._forward_packed_prefill(packed)
             hidden_rows = last_hidden[0].index_select(0, packed.last_token_offsets)
             self._store_packed_sequence_caches(
-                packed.batch_indices,
                 cache,
                 rope_deltas=packed.rope_deltas,
                 host_batch_indices=batch_indices,
@@ -1291,7 +1289,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
             sequence_lengths=sequence_lengths,
             topology_token=topology_token,
             seq_idx=scratch.text_meta.seq_idx.gpu[:, :total_tokens],
-            batch_indices=scratch.text_meta.batch_indices.gpu[:batch_size],
             max_length=max(lengths),
             last_token_offsets=scratch.text_meta.last_token_offsets.gpu[:batch_size],
             paged_kv_page_table=scratch.paged_kv_page_table[:batch_size],
@@ -1334,9 +1331,9 @@ class Qwen35Runtime(UncachedPagedRuntime):
         self,
         packed: _PackedPrefillBatch,
     ) -> tuple[torch.Tensor, Qwen35InferenceCache]:
-        cache = self._new_cache()
-        if self.generated_decode is not None:
-            self._linear_state_pool.bind_generated_prefill_state(cache)
+        cache = self._new_cache(
+            prepare_gdn_replay_state=self.generated_decode is None
+        )
         outputs = self.model.model(
             input_ids=packed.input_ids,
             past_key_values=cache,
@@ -1355,22 +1352,24 @@ class Qwen35Runtime(UncachedPagedRuntime):
             sequence_lengths=packed.sequence_lengths,
             topology_token=packed.topology_token,
             seq_idx=packed.seq_idx,
-            gdn_state_indices=(
-                packed.batch_indices if self.generated_decode is not None else None),
         )
         outputs.past_key_values.advance_to(packed.max_length)
         return outputs.last_hidden_state, outputs.past_key_values
 
-    def _new_cache(self) -> Qwen35InferenceCache:
+    def _new_cache(
+        self,
+        *,
+        prepare_gdn_replay_state: bool = True,
+    ) -> Qwen35InferenceCache:
         return Qwen35InferenceCache(
             config=self.architecture.text_config,
             paged_kv=self._paged_kv,
             replay_capacity=self._linear_state_pool.replay_capacity,
+            prepare_gdn_replay_state=prepare_gdn_replay_state,
         )
 
     def _store_packed_sequence_caches(
         self,
-        batch_idx: torch.Tensor,
         cache: Qwen35InferenceCache,
         *,
         rope_deltas: torch.Tensor,
@@ -1378,18 +1377,16 @@ class Qwen35Runtime(UncachedPagedRuntime):
     ) -> None:
         if not isinstance(cache, Qwen35InferenceCache):
             raise RuntimeError("Qwen engine decode requires paged hybrid caches")
-        indices = batch_idx.to(device=self.device, dtype=torch.long).view(-1)
-        batch_size = int(indices.shape[0])
-        if len(host_batch_indices) != batch_size:
-            raise ValueError("host batch indices must match packed batch size")
-        self._linear_state_pool.capture_batch_from_cache(
-            indices,
+        rows = tuple(host_batch_indices)
+        batch_size = len(rows)
+        indices = self._linear_state_pool.capture_batch_from_cache(
+            rows,
             cache,
             batch_size=batch_size,
-            # Packed prefill starts from a fresh cache. Each GDN layer has just
-            # checkpointed its final recurrent state and reset every replay
-            # cursor, so K/U/G payload bytes are unreachable and need not be
-            # copied into the persistent decode pool.
+            # Native GDN prefill has just checkpointed its final recurrence and
+            # reset every replay cursor, so K/U/G payload bytes are unreachable.
+            # Generated decode transports materialized state and owns no replay
+            # payload at all.
             copy_replay_payload=False,
         )
         rope_deltas = rope_deltas.to(device=self.device, dtype=torch.long)

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -398,19 +398,32 @@ class Qwen35Runtime(UncachedPagedRuntime):
         self._prefill_slot_free = list(self._prefill_slots)
         self.prefill_slots: Sequence[Any] = self._prefill_slots
 
+        generated_decode_capacity = None
+        if self.decode_path != "native":
+            from .generated_decode import generated_decode_slot_capacity
+
+            generated_decode_capacity = generated_decode_slot_capacity(
+                self,
+                required=self.decode_path == "generated",
+            )
+        self._decode_row_capacity = max(
+            self.max_batch_slots,
+            generated_decode_capacity or 0,
+        )
+
         self._decode_slots = tuple(
             create_decode_slot(
                 slot_id=i,
                 device=self.device,
                 dtype=self.dtype,
-                max_batch_slots=self.max_batch_slots,
+                max_batch_slots=self._decode_row_capacity,
                 kv_cache_pages=self._kv_cache_pages,
                 vocab_size=int(text_cfg.vocab_size),
                 hidden_dim=int(text_cfg.hidden_size),
-                position_shape=(4, self.max_batch_slots, 1),
+                position_shape=(4, self._decode_row_capacity, 1),
                 scratch_specs={
                     "rope_deltas": (
-                        (self.max_batch_slots, 1),
+                        (self._decode_row_capacity, 1),
                         torch.long,
                     ),
                 },

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -62,6 +62,7 @@ class _PackedPrefillBatch:
     cache_position_ids: torch.Tensor
     position_ids: torch.Tensor
     cu_seq_lens_q: Optional[torch.Tensor]
+    sequence_lengths: tuple[int, ...]
     seq_idx: Optional[torch.Tensor]
     batch_indices: torch.Tensor
     max_length: int
@@ -1268,6 +1269,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
             # sequence take the same packed_prefill path as batched prefill
             # instead of the separate uniform_native_prefill branch.
             cu_seq_lens_q=scratch.text_meta.cu_seq_lens_q.gpu[: batch_size + 1],
+            sequence_lengths=tuple(lengths),
             seq_idx=scratch.text_meta.seq_idx.gpu[:, :total_tokens],
             batch_indices=scratch.text_meta.batch_indices.gpu[:batch_size],
             max_length=max(lengths),
@@ -1330,6 +1332,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
             page_table=packed.paged_kv_page_table,
             paged_kv_seqlens_k=packed.paged_kv_seqlens_k,
             cu_seq_lens_q=packed.cu_seq_lens_q,
+            sequence_lengths=packed.sequence_lengths,
             seq_idx=packed.seq_idx,
             gdn_state_indices=(
                 packed.batch_indices if self.generated_decode is not None else None),

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -293,6 +293,27 @@ class GeneratedDecode:
         )
 
     @classmethod
+    def resolve_slot_capacity(
+        cls,
+        runtime: Any,
+        spec: GeneratedDecodeSpec,
+        *,
+        required_batch_sizes: Sequence[int] = (),
+    ) -> int | None:
+        """Return the physical row capacity needed by selectable programs."""
+
+        programs = cls._resolve_programs(runtime, spec)
+        if any(
+            _select_program(programs, int(batch_size)) is None
+            for batch_size in required_batch_sizes
+        ):
+            return None
+        selected = _selectable_programs(programs, runtime.max_batch_size)
+        if not selected:
+            return None
+        return max(int(program.capacity) for program in selected)
+
+    @classmethod
     def require(
         cls,
         runtime: Any,

--- a/tests/qwen35/test_generated_decode.py
+++ b/tests/qwen35/test_generated_decode.py
@@ -127,30 +127,37 @@ def test_generated_state_pool_rejects_incompatible_physical_forms(form):
         _state_pool().recurrent_tensors_for_form(form)
 
 
-def test_generated_prefill_writes_pool_rows_directly_and_reset_is_row_scoped():
+def test_generated_prefill_commits_fp32_state_to_bf16_pool_rows():
     config = _linear_config()
     pool = _state_pool(config)
     recurrent = pool.recurrent_tensors_for_form(_generated_form())
     cache = _inference_cache(config)
-    pool.bind_generated_prefill_state(cache)
-    indices = torch.tensor([3, 1], dtype=torch.long)
 
     for layer_idx in (0, 2):
         target = recurrent[layer_idx]
         layer = cache.layers[layer_idx]
         assert target is not None
-        assert layer.recurrent_states is target
-        target[3].fill_(layer_idx + 1)
-        target[1].fill_(layer_idx + 2)
+        source = torch.arange(24, dtype=torch.float32).reshape(2, 2, 2, 3)
+        layer.recurrent_states = source.add(layer_idx * 100)
         layer.conv_states = torch.full(
             (2, 10, 4), layer_idx + 3, dtype=torch.bfloat16)
         layer.has_previous_state = True
 
-    pool.capture_batch_from_cache(indices, cache, batch_size=2)
+    pool.capture_batch_from_cache((3, 1), cache, batch_size=2)
 
     for layer_idx in (0, 2):
         storage = pool.layers[layer_idx]
+        source = cache.layers[layer_idx].recurrent_states
         assert storage is not None and storage.conv_states is not None
+        assert source is not None
+        assert torch.equal(
+            storage.recurrent_states[3],
+            source[0].transpose(-1, -2).to(torch.bfloat16),
+        )
+        assert torch.equal(
+            storage.recurrent_states[1],
+            source[1].transpose(-1, -2).to(torch.bfloat16),
+        )
         assert torch.all(storage.conv_states[3] == layer_idx + 3)
         assert torch.all(storage.conv_states[1] == layer_idx + 3)
         assert storage.replay_checkpoint_states is None
@@ -164,7 +171,51 @@ def test_generated_prefill_writes_pool_rows_directly_and_reset_is_row_scoped():
         assert torch.count_nonzero(state[3]) > 0
 
 
-def test_indexed_prefill_passes_authoritative_bf16_pool_to_combined_kernel():
+@pytest.mark.parametrize(
+    ("rows", "batch_size"),
+    (((1, 1), 2), ((-1,), 1), ((4,), 1), ((1,), 2), ((1.0,), 1)),
+)
+def test_generated_prefill_rejects_invalid_host_rows_before_writes(rows, batch_size):
+    pool = _state_pool()
+    recurrent = pool.recurrent_tensors_for_form(_generated_form())
+    cache = _inference_cache()
+
+    with pytest.raises(ValueError, match="state rows|state row"):
+        pool.capture_batch_from_cache(rows, cache, batch_size=batch_size)
+
+    for layer_idx in (0, 2):
+        state = recurrent[layer_idx]
+        assert state is not None
+        assert torch.count_nonzero(state) == 0
+
+
+def test_generated_prefill_validates_all_layers_before_first_write():
+    config = _linear_config()
+    pool = _state_pool(config)
+    recurrent = pool.recurrent_tensors_for_form(_generated_form())
+    cache = _inference_cache(config)
+
+    for layer_idx in (0, 2):
+        layer = cache.layers[layer_idx]
+        layer.conv_states = torch.ones((1, 10, 4), dtype=torch.bfloat16)
+        layer.recurrent_states = torch.ones((1, 2, 2, 3), dtype=torch.float32)
+        layer.has_previous_state = True
+    cache.layers[2].recurrent_states = cache.layers[2].recurrent_states.to(
+        torch.bfloat16
+    )
+
+    with pytest.raises(RuntimeError, match="sequence-major FP32"):
+        pool.capture_batch_from_cache((3,), cache, batch_size=1)
+
+    for layer_idx in (0, 2):
+        state = recurrent[layer_idx]
+        storage = pool.layers[layer_idx]
+        assert state is not None and storage is not None
+        assert torch.count_nonzero(state) == 0
+        assert torch.count_nonzero(storage.conv_states) == 0
+
+
+def test_generated_prefill_uses_fast_fp32_recurrence_without_replay_state():
     config = SimpleNamespace(
         hidden_size=4,
         linear_num_key_heads=1,
@@ -187,6 +238,7 @@ def test_indexed_prefill_passes_authoritative_bf16_pool_to_combined_kernel():
     module.allocate_packed_gdn_prefill_workspace = (
         lambda *_args, **_kwargs: workspace
     )
+    module.norm.forward = lambda value, _gate: value
     captured = {}
 
     def combined(mixed_qkv, _a, _b, _A_log, _dt_bias, _cu, **kwargs):
@@ -198,37 +250,65 @@ def test_indexed_prefill_passes_authoritative_bf16_pool_to_combined_kernel():
             indices=indices,
             workspace=kwargs["workspace"],
         )
-        state[indices[0]].fill_(1)
-        state[indices[1]].fill_(2)
+        state[0].fill_(1)
+        state[1].fill_(2)
         return torch.zeros_like(workspace.out), state
 
     module.packed_gated_delta_rule_prefill = combined
-    pool = _state_pool(config)
-    recurrent_states = pool.recurrent_tensors_for_form(_generated_form())
     cache = Qwen35InferenceCache(
         config=config,
         paged_kv=(None,),
         replay_capacity=2,
+        prepare_gdn_replay_state=False,
     )
-    pool.bind_generated_prefill_state(cache)
-    indices = torch.tensor([3, 1], dtype=torch.long)
+    cache.layers[0]._reset_replay_rows = lambda *_args: pytest.fail(
+        "generated prefill must not allocate replay state"
+    )
 
     module(
         torch.zeros((1, 3, 4), dtype=torch.bfloat16),
         cache_params=cache,
         cu_seq_lens_q=torch.tensor([0, 1, 3], dtype=torch.int32),
-        gdn_state_indices=indices,
     )
 
-    state = recurrent_states[0]
+    state = cache.layers[0].recurrent_states
     assert state is not None
+    assert state.shape == (2, 2, 2, 2)
+    assert state.dtype == torch.float32
     assert captured["state"] is state
-    assert torch.equal(captured["indices"], indices)
+    assert captured["indices"] is None
     assert captured["workspace"] is workspace
-    assert torch.all(state[3] == 1)
+    assert torch.all(state[0] == 1)
     assert torch.all(state[1] == 2)
-    assert torch.count_nonzero(state[0]) == 0
     assert cache.layers[0].replay_checkpoint_states is None
+
+
+def test_packed_prefill_rejects_direct_state_indices():
+    config = SimpleNamespace(
+        hidden_size=4,
+        linear_num_key_heads=1,
+        linear_num_value_heads=2,
+        linear_key_head_dim=2,
+        linear_value_head_dim=2,
+        linear_conv_kernel_dim=2,
+        rms_norm_eps=1e-6,
+        layer_types=("linear_attention",),
+    )
+    module = Qwen3_5GatedDeltaNet(config, layer_idx=0).to(torch.bfloat16)
+    module.supports_packed_gdn = lambda *_args: True
+    cache = Qwen35InferenceCache(
+        config=config,
+        paged_kv=(None,),
+        replay_capacity=2,
+    )
+
+    with pytest.raises(RuntimeError, match="committed after recurrence"):
+        module(
+            torch.zeros((1, 3, 4), dtype=torch.bfloat16),
+            cache_params=cache,
+            cu_seq_lens_q=torch.tensor([0, 1, 3], dtype=torch.int32),
+            gdn_state_indices=torch.tensor([3, 1], dtype=torch.long),
+        )
 
 
 def test_packed_gdn_prefill_workspace_cache_reuses_capacity():

--- a/tests/qwen35/test_generated_decode.py
+++ b/tests/qwen35/test_generated_decode.py
@@ -361,6 +361,43 @@ def test_generated_decode_binds_rope_offsets_without_dropping_old_bundle_prep(
     )
 
 
+def test_generated_decode_reports_compiled_slot_capacity(monkeypatch):
+    runtime = SimpleNamespace(
+        max_batch_size=1,
+        _decode_rope_deltas=object(),
+        _gather_decode_rope_deltas=lambda *_args: None,
+        _prepare_decode_position_ids=lambda *_args: None,
+        _paged_kv=(),
+        _linear_state_pool=object(),
+        model=SimpleNamespace(
+            model=SimpleNamespace(
+                language_model=SimpleNamespace(
+                    rotary_emb=SimpleNamespace(inv_freq=object())
+                )
+            )
+        ),
+        page_table=SimpleNamespace(page_table=object()),
+    )
+    captured = {}
+
+    def resolve(_cls, bound_runtime, spec, *, required_batch_sizes=()):
+        captured["runtime"] = bound_runtime
+        captured["spec"] = spec
+        captured["required_batch_sizes"] = tuple(required_batch_sizes)
+        return 8
+
+    monkeypatch.setattr(
+        qwen_generated.GeneratedDecode,
+        "resolve_slot_capacity",
+        classmethod(resolve),
+    )
+
+    assert qwen_generated.generated_decode_slot_capacity(runtime) == 8
+    assert captured["runtime"] is runtime
+    assert captured["required_batch_sizes"] == (1,)
+    assert captured["spec"].label == "Qwen"
+
+
 def test_generated_capacity_inputs_resolve_state_after_cached_field_snapshot(
     monkeypatch,
 ):

--- a/tests/qwen35/test_prefill_topology.py
+++ b/tests/qwen35/test_prefill_topology.py
@@ -68,9 +68,12 @@ def test_packed_prefill_batch_forwards_host_sequence_lengths() -> None:
     model = SimpleNamespace(model=lambda **kwargs: observed.update(kwargs) or output)
     runtime = object.__new__(Qwen35Runtime)
     runtime.model = model
-    runtime._new_cache = lambda: cache
+    runtime._new_cache = lambda **kwargs: (
+        observed.update(new_cache=kwargs) or cache
+    )
 
     marker = object()
+    runtime.generated_decode = marker
     packed = _PackedPrefillBatch(
         input_ids=marker,
         cache_position_ids=marker,
@@ -79,7 +82,6 @@ def test_packed_prefill_batch_forwards_host_sequence_lengths() -> None:
         sequence_lengths=(544, 137),
         topology_token=marker,
         seq_idx=marker,
-        batch_indices=marker,
         max_length=544,
         last_token_offsets=marker,
         paged_kv_page_table=marker,
@@ -94,6 +96,7 @@ def test_packed_prefill_batch_forwards_host_sequence_lengths() -> None:
     assert returned_cache is cache
     assert observed["sequence_lengths"] == (544, 137)
     assert observed["topology_token"] is marker
+    assert observed["new_cache"] == {"prepare_gdn_replay_state": False}
     assert observed["max"] == 544
 
 
@@ -103,16 +106,22 @@ def test_gdn_prefill_forwards_host_sequence_lengths_to_recurrence() -> None:
         conv_states=None,
         recurrent_states=None,
         has_previous_state=False,
-        _reset_replay_rows=lambda state, indices: None,
+        _reset_replay_rows=lambda state, indices: observed.update(
+            replay_reset_state=state,
+            replay_reset_indices=indices,
+        ),
     )
     cache = SimpleNamespace(
         layers=[layer],
         has_previous_state=lambda layer_idx: False,
+        prepare_gdn_replay_state=True,
     )
     conv1d = SimpleNamespace(
         weight=torch.ones((1, 1, 1)),
         bias=None,
     )
+
+    workspace = SimpleNamespace()
 
     def recurrent(*args, **kwargs):
         observed.update(kwargs)
@@ -134,14 +143,11 @@ def test_gdn_prefill_forwards_host_sequence_lengths_to_recurrence() -> None:
         in_proj=lambda hidden: torch.zeros((1, 3, 4)),
         supports_packed_gdn=lambda *args: True,
         causal_conv1d_packed=lambda **kwargs: kwargs["x"],
-        packed_prefill_prepare=lambda *args: (
-            torch.zeros((1, 3, 1, 1)),
-            torch.zeros((1, 3, 1, 1)),
-            torch.zeros((1, 3, 1, 1)),
-            torch.zeros((1, 3, 1)),
-            torch.zeros((1, 3, 1)),
+        _prefill_workspace_cache=SimpleNamespace(
+            get=lambda *_args, **_kwargs: workspace,
         ),
-        packed_recurrent_prefill=recurrent,
+        allocate_packed_gdn_prefill_workspace=lambda *_args, **_kwargs: workspace,
+        packed_gated_delta_rule_prefill=recurrent,
         norm=lambda value, gate: value,
         out_proj=lambda value: value,
     )
@@ -159,3 +165,6 @@ def test_gdn_prefill_forwards_host_sequence_lengths_to_recurrence() -> None:
     assert result.shape == (1, 3, 1)
     assert observed["sequence_lengths"] == (3,)
     assert observed["topology_token"] is fake
+    assert observed["final_state_indices"] is None
+    assert observed["replay_reset_state"] is layer.recurrent_states
+    assert observed["replay_reset_indices"] is None

--- a/tests/qwen35/test_prefill_topology.py
+++ b/tests/qwen35/test_prefill_topology.py
@@ -1,0 +1,102 @@
+from types import SimpleNamespace
+
+import torch
+
+from kestrel.models.qwen35.qwen_model import Qwen3_5GatedDeltaNet
+from kestrel.models.qwen35.runtime import Qwen35Runtime, _PackedPrefillBatch
+
+
+def test_packed_prefill_batch_forwards_host_sequence_lengths() -> None:
+    observed: dict[str, object] = {}
+    cache = SimpleNamespace(advance_to=lambda length: observed.setdefault("max", length))
+    output = SimpleNamespace(last_hidden_state=object(), past_key_values=cache)
+    model = SimpleNamespace(model=lambda **kwargs: observed.update(kwargs) or output)
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.model = model
+    runtime._new_cache = lambda: cache
+
+    marker = object()
+    packed = _PackedPrefillBatch(
+        input_ids=marker,
+        cache_position_ids=marker,
+        position_ids=marker,
+        cu_seq_lens_q=marker,
+        sequence_lengths=(544, 137),
+        seq_idx=marker,
+        batch_indices=marker,
+        max_length=544,
+        last_token_offsets=marker,
+        paged_kv_page_table=marker,
+        paged_kv_seqlens_k=marker,
+        slot_mapping=marker,
+        rope_deltas=marker,
+    )
+
+    hidden, returned_cache = runtime._forward_packed_prefill(packed)
+
+    assert hidden is output.last_hidden_state
+    assert returned_cache is cache
+    assert observed["sequence_lengths"] == (544, 137)
+    assert observed["max"] == 544
+
+
+def test_gdn_prefill_forwards_host_sequence_lengths_to_recurrence() -> None:
+    observed: dict[str, object] = {}
+    layer = SimpleNamespace(
+        conv_states=None,
+        recurrent_states=None,
+        has_previous_state=False,
+        _reset_replay_rows=lambda state, indices: None,
+    )
+    cache = SimpleNamespace(
+        layers=[layer],
+        has_previous_state=lambda layer_idx: False,
+    )
+    conv1d = SimpleNamespace(
+        weight=torch.ones((1, 1, 1)),
+        bias=None,
+    )
+
+    def recurrent(*args, **kwargs):
+        observed.update(kwargs)
+        return torch.zeros((1, 3, 1)), None
+
+    fake = SimpleNamespace(
+        layer_idx=0,
+        num_k_heads=1,
+        num_v_heads=1,
+        head_k_dim=1,
+        head_v_dim=1,
+        conv_dim=1,
+        conv_kernel_size=1,
+        value_dim=1,
+        activation="silu",
+        A_log=torch.zeros((1,)),
+        dt_bias=torch.zeros((1,)),
+        conv1d=conv1d,
+        in_proj=lambda hidden: torch.zeros((1, 3, 4)),
+        supports_packed_gdn=lambda *args: True,
+        causal_conv1d_packed=lambda **kwargs: kwargs["x"],
+        packed_prefill_prepare=lambda *args: (
+            torch.zeros((1, 3, 1, 1)),
+            torch.zeros((1, 3, 1, 1)),
+            torch.zeros((1, 3, 1, 1)),
+            torch.zeros((1, 3, 1)),
+            torch.zeros((1, 3, 1)),
+        ),
+        packed_recurrent_prefill=recurrent,
+        norm=lambda value, gate: value,
+        out_proj=lambda value: value,
+    )
+
+    result = Qwen3_5GatedDeltaNet.forward(
+        fake,
+        torch.zeros((1, 3, 1)),
+        cache_params=cache,
+        cu_seq_lens_q=torch.tensor([0, 3], dtype=torch.int32),
+        sequence_lengths=(3,),
+        seq_idx=torch.zeros((1, 3), dtype=torch.int32),
+    )
+
+    assert result.shape == (1, 3, 1)
+    assert observed["sequence_lengths"] == (3,)

--- a/tests/qwen35/test_prefill_topology.py
+++ b/tests/qwen35/test_prefill_topology.py
@@ -2,8 +2,63 @@ from types import SimpleNamespace
 
 import torch
 
+from kestrel.models.qwen35 import runtime as qwen_runtime
 from kestrel.models.qwen35.qwen_model import Qwen3_5GatedDeltaNet
 from kestrel.models.qwen35.runtime import Qwen35Runtime, _PackedPrefillBatch
+from kestrel.runtime.tokens import TextToken
+
+
+def test_builder_binds_topology_from_ordered_host_lengths(monkeypatch) -> None:
+    observed: dict[str, object] = {}
+    topology_token = object()
+    bound_cu_seqlens = torch.tensor([0, 2, 5], dtype=torch.int32)
+
+    def bind_packed_prefill_topology(*, sequence_lengths, device):
+        observed["sequence_lengths"] = sequence_lengths
+        observed["device"] = device
+        return bound_cu_seqlens, topology_token
+
+    monkeypatch.setattr(
+        qwen_runtime,
+        "get_runtime",
+        lambda: SimpleNamespace(
+            gated_delta=SimpleNamespace(
+                bind_packed_prefill_topology=bind_packed_prefill_topology
+            )
+        ),
+    )
+
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.device = torch.device("cpu")
+    runtime.dtype = torch.float32
+    runtime.page_table = SimpleNamespace(
+        n_pages=8,
+        page_size=1,
+        page_table_cpu=(tuple(range(8)), tuple(range(8, 16))),
+        page_table=torch.tensor(
+            (tuple(range(8)), tuple(range(8, 16))), dtype=torch.int32
+        ),
+    )
+    prefill_slot = SimpleNamespace(batch_idx=torch.zeros(2, dtype=torch.int64))
+    prepared = (
+        SimpleNamespace(tokens_list=(TextToken(11), TextToken(12))),
+        SimpleNamespace(tokens_list=(TextToken(21), TextToken(22), TextToken(23))),
+    )
+
+    packed = runtime._build_packed_prefill_batch(
+        prepared,
+        prefill_slot=prefill_slot,
+        image_crops_list=(None, None),
+        batch_indices=(0, 1),
+    )
+
+    assert observed == {
+        "sequence_lengths": (2, 3),
+        "device": torch.device("cpu"),
+    }
+    assert packed.cu_seq_lens_q is bound_cu_seqlens
+    assert packed.sequence_lengths == (2, 3)
+    assert packed.topology_token is topology_token
 
 
 def test_packed_prefill_batch_forwards_host_sequence_lengths() -> None:
@@ -22,6 +77,7 @@ def test_packed_prefill_batch_forwards_host_sequence_lengths() -> None:
         position_ids=marker,
         cu_seq_lens_q=marker,
         sequence_lengths=(544, 137),
+        topology_token=marker,
         seq_idx=marker,
         batch_indices=marker,
         max_length=544,
@@ -37,6 +93,7 @@ def test_packed_prefill_batch_forwards_host_sequence_lengths() -> None:
     assert hidden is output.last_hidden_state
     assert returned_cache is cache
     assert observed["sequence_lengths"] == (544, 137)
+    assert observed["topology_token"] is marker
     assert observed["max"] == 544
 
 
@@ -95,8 +152,10 @@ def test_gdn_prefill_forwards_host_sequence_lengths_to_recurrence() -> None:
         cache_params=cache,
         cu_seq_lens_q=torch.tensor([0, 3], dtype=torch.int32),
         sequence_lengths=(3,),
+        topology_token=fake,
         seq_idx=torch.zeros((1, 3), dtype=torch.int32),
     )
 
     assert result.shape == (1, 3, 1)
     assert observed["sequence_lengths"] == (3,)
+    assert observed["topology_token"] is fake

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -97,3 +97,38 @@ def test_program_selection_rejects_invalid_runtime_interval():
 
     with pytest.raises(RuntimeError, match="invalid active-batch interval"):
         generated._program_for(4)
+
+
+def test_slot_capacity_uses_selected_program_physical_capacity(monkeypatch):
+    runtime = SimpleNamespace(max_batch_size=1)
+    b8 = _program(8)
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "_resolve_programs",
+        classmethod(lambda _cls, _runtime, _spec: (b8,)),
+    )
+
+    assert GeneratedDecode.resolve_slot_capacity(
+        runtime,
+        object(),
+        required_batch_sizes=(1,),
+    ) == 8
+
+
+def test_slot_capacity_refuses_incomplete_required_domain(monkeypatch):
+    runtime = SimpleNamespace(max_batch_size=4)
+    programs = tuple(
+        _program(batch_size, active_batch=batch_size)
+        for batch_size in (1, 2, 4)
+    )
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "_resolve_programs",
+        classmethod(lambda _cls, _runtime, _spec: programs),
+    )
+
+    assert GeneratedDecode.resolve_slot_capacity(
+        runtime,
+        object(),
+        required_batch_sizes=range(1, 5),
+    ) is None

--- a/tests/test_kernels_generated_decode_api.py
+++ b/tests/test_kernels_generated_decode_api.py
@@ -1,0 +1,29 @@
+import inspect
+
+from kestrel_kernels import generated_decode, get_runtime
+
+
+def test_pinned_kernels_exposes_generated_decode_weight_binding_api() -> None:
+    resolve_parameters = inspect.signature(
+        generated_decode.resolve_compatible_programs
+    ).parameters
+    assert {"device_sms", "weight_sources"} <= set(resolve_parameters), (
+        "the pinned kestrel-kernels wheel predates generated-decode device and "
+        "logical-weight binding"
+    )
+
+    materialize_parameters = inspect.signature(
+        generated_decode.materialize_weights
+    ).parameters
+    assert {"engine_buffers", "weight_sources"} <= set(materialize_parameters), (
+        "the pinned kestrel-kernels wheel predates generated-decode engine and "
+        "logical-weight materialization"
+    )
+
+
+def test_pinned_kernels_exposes_packed_prefill_topology_factory() -> None:
+    gated_delta = get_runtime().gated_delta
+    assert callable(getattr(gated_delta, "bind_packed_prefill_topology", None)), (
+        "the pinned kestrel-kernels wheel predates authoritative packed-prefill "
+        "topology binding"
+    )


### PR DESCRIPTION
## Summary
- bind packed Qwen GDN prefill to host-derived topology metadata
- enforce generated decode capacity and program contracts
- run fast sequence-major FP32 recurrence, then atomically commit validated rows into the BF16 value-major generated decoder pool
- keep native ReplaySSM seeding intact while generated prefill allocates no replay payload

## Validation
- focused Modal suite: 41 passed
- adversarial self-review: no remaining issues
- public main rebased at b943e051b6c253147c66cfcba68320a3fe1ff0b9