### PR TITLE
Remove idle admission coalescing

### DIFF
--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import logging
 import queue
 import threading
-import time
 from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Protocol
@@ -38,9 +37,6 @@ from kestrel.engine._types import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-# Qwen3-ASR preprocessing measured about 1 ms warm on the H100 host; a 5 ms
-# idle-only window absorbed sibling completion skew without delaying lone requests.
-_IDLE_ADMISSION_BATCH_WAIT_S = 0.005
 
 
 @dataclass(slots=True)
@@ -135,16 +131,10 @@ class _AdmissionCoordinator:
                 )
         return None
 
-    def take_ready(self, timeout: float = 0.0) -> Optional[_ReadyAdmission]:
-        deadline = time.perf_counter() + timeout
+    def take_ready(self) -> Optional[_ReadyAdmission]:
         while True:
             try:
-                remaining = deadline - time.perf_counter()
-                req_id = (
-                    self._ready.get_nowait()
-                    if remaining <= 0
-                    else self._ready.get(timeout=remaining)
-                )
+                req_id = self._ready.get_nowait()
             except queue.Empty:
                 return None
 
@@ -330,9 +320,7 @@ class AutoregressiveExecutor:
 
     def advance(self) -> TickResult:
         scheduler = self._scheduler
-        progressed = self._promote_ready(
-            coalesce=not scheduler.has_pending_work(),
-        )
+        progressed = self._promote_ready()
 
         if scheduler.has_pending_work():
             progressed = scheduler.advance() or progressed
@@ -419,27 +407,14 @@ class AutoregressiveExecutor:
         self._scheduler.enqueue_request(generation_req, skill_state)
         self._active[req.request_id] = req
 
-    def _promote_ready(self, *, coalesce: bool = False) -> bool:
+    def _promote_ready(self) -> bool:
         promoted = False
-        deadline: float | None = None
-        promoted_count = 0
         while len(self._scheduler.waiting) < self._admission_capacity:
-            timeout = None
-            if (
-                coalesce
-                and promoted
-                and promoted_count < self._runtime.max_batch_size
-                and self._admission.pending_count
-            ):
-                if deadline is None:
-                    deadline = time.perf_counter() + _IDLE_ADMISSION_BATCH_WAIT_S
-                timeout = max(0.0, deadline - time.perf_counter())
-            ready = self._admission.take_ready(0.0 if timeout is None else timeout)
+            ready = self._admission.take_ready()
             if ready is None:
                 break
             self._admit_ready(ready)
             promoted = True
-            promoted_count += 1
         return promoted
 
     def _collect(self) -> List[Completion]:

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -79,7 +79,7 @@ def _executor() -> AutoregressiveExecutor:
     ex._admission = SimpleNamespace(
         has_pending=lambda: False,
         pending_count=0,
-        take_ready=lambda _timeout=0.0: None,
+        take_ready=lambda: None,
         fail_all=lambda exc: None,
     )
     return ex
@@ -177,21 +177,23 @@ def test_ingress_capacity_counts_active_and_preprocessing_requests() -> None:
     assert ex.has_ingress_capacity is False
 
 
-def test_idle_executor_collects_a_ready_preprocessing_cohort() -> None:
+def test_ready_request_does_not_wait_for_preprocessing_siblings() -> None:
     ex = _executor()
     ex._runtime.max_batch_size = 4
     waiting = ex._scheduler.waiting
-    ready = [object(), object()]
-    timeouts = []
+    ready = [object()]
+    calls = 0
 
-    def take_ready(timeout=0.0):
-        timeouts.append(timeout)
+    def take_ready():
+        nonlocal calls
+        calls += 1
         if not ready:
             return None
-        ex._admission.pending_count -= 1
         return ready.pop(0)
 
-    ex._admission.pending_count = len(ready)
+    # One sibling is still preprocessing. Its completion must not delay the
+    # request that is already ready.
+    ex._admission.pending_count = 1
     ex._admission.take_ready = take_ready
     ex._admit_ready = waiting.append
     launched = []
@@ -200,9 +202,8 @@ def test_idle_executor_collects_a_ready_preprocessing_cohort() -> None:
 
     ex.advance()
 
-    assert launched == [2]
-    assert timeouts[0] == 0.0
-    assert 0 < timeouts[1] <= 0.005
+    assert launched == [1]
+    assert calls == 2
 
 
 def test_shutdown_fails_in_flight_requests() -> None:


### PR DESCRIPTION
## Summary

- remove the 5 ms idle admission wait from the autoregressive executor
- restore non-blocking draining of completed preprocessing work
- assert that a ready request launches while a sibling is still preprocessing

## Rationale

The wait was a host-timing batching heuristic in the device-agnostic executor. Its original evidence reported batched throughput but no immediate-admission A/B baseline. Independent requests should not acquire an implicit timing contract; callers that require one batch should express that intent explicitly.

## Validation

- Modal CPU: executor plus all affected admission-coordinator tests, 23 passed
- `py_compile`
- `git diff --check`

An expanded current-main `tests/test_engine.py` run also exposed two unrelated fixture failures in tests that do not touch admission (`_runtimes` and `execution_shape` are absent from their test doubles).
