### PR TITLE
Pass Qwen decode row information to prefill

### DIFF
--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -294,6 +294,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         cu_seq_lens_q: torch.Tensor | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
+        gdn_state_indices_allocator_owned: bool = False,
     ):
         if attention_mask is not None:
             raise RuntimeError("Qwen GDN requires packed sequence metadata")
@@ -482,6 +483,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 output_final_state=True,
                 final_state=packed_recurrent_state,
                 final_state_indices=state_indices,
+                final_state_indices_allocator_owned=gdn_state_indices_allocator_owned,
             )
             if state_indices is None:
                 # Native decode consumes ReplaySSM state seeded from the packed
@@ -882,6 +884,7 @@ class Qwen3_5DecoderLayer(nn.Module):
         cu_seq_lens_q: torch.Tensor | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
+        gdn_state_indices_allocator_owned: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         hidden_states = normalized_hidden_states
 
@@ -894,6 +897,7 @@ class Qwen3_5DecoderLayer(nn.Module):
                 cu_seq_lens_q=cu_seq_lens_q,
                 seq_idx=seq_idx,
                 gdn_state_indices=gdn_state_indices,
+                gdn_state_indices_allocator_owned=gdn_state_indices_allocator_owned,
             )
         elif self.layer_type == "full_attention":
             # Self Attention
@@ -1218,6 +1222,7 @@ class Qwen3_5TextModel(nn.Module):
         cu_seq_lens_q: torch.Tensor | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
+        gdn_state_indices_allocator_owned: bool = False,
     ) -> _TextModelOutput:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -1275,6 +1280,7 @@ class Qwen3_5TextModel(nn.Module):
                 cu_seq_lens_q=cu_seq_lens_q,
                 seq_idx=seq_idx,
                 gdn_state_indices=gdn_state_indices,
+                gdn_state_indices_allocator_owned=gdn_state_indices_allocator_owned,
             )
 
         hidden_states = (
@@ -1365,6 +1371,7 @@ class Qwen3_5Model(nn.Module):
         cu_seq_lens_q: torch.Tensor | None = None,
         seq_idx: torch.Tensor | None = None,
         gdn_state_indices: torch.Tensor | None = None,
+        gdn_state_indices_allocator_owned: bool = False,
         vision_bilinear_indices: torch.Tensor | None = None,
         vision_bilinear_weights: torch.Tensor | None = None,
         vision_position_ids: torch.Tensor | None = None,
@@ -1408,6 +1415,7 @@ class Qwen3_5Model(nn.Module):
             cu_seq_lens_q=cu_seq_lens_q,
             seq_idx=seq_idx,
             gdn_state_indices=gdn_state_indices,
+            gdn_state_indices_allocator_owned=gdn_state_indices_allocator_owned,
         )
 
         return _TextModelOutput(

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -1333,6 +1333,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
             seq_idx=packed.seq_idx,
             gdn_state_indices=(
                 packed.batch_indices if self.generated_decode is not None else None),
+            gdn_state_indices_allocator_owned=self.generated_decode is not None,
         )
         outputs.past_key_values.advance_to(packed.max_length)
         return outputs.last_hidden_state, outputs.past_key_values

--- a/tests/qwen35/test_generated_decode.py
+++ b/tests/qwen35/test_generated_decode.py
@@ -196,6 +196,7 @@ def test_indexed_prefill_passes_authoritative_bf16_pool_to_combined_kernel():
             mixed_qkv=mixed_qkv,
             state=state,
             indices=indices,
+            indices_allocator_owned=kwargs["final_state_indices_allocator_owned"],
             workspace=kwargs["workspace"],
         )
         state[indices[0]].fill_(1)
@@ -218,12 +219,14 @@ def test_indexed_prefill_passes_authoritative_bf16_pool_to_combined_kernel():
         cache_params=cache,
         cu_seq_lens_q=torch.tensor([0, 1, 3], dtype=torch.int32),
         gdn_state_indices=indices,
+        gdn_state_indices_allocator_owned=True,
     )
 
     state = recurrent_states[0]
     assert state is not None
     assert captured["state"] is state
     assert torch.equal(captured["indices"], indices)
+    assert captured["indices_allocator_owned"] is True
     assert captured["workspace"] is workspace
     assert torch.all(state[3] == 1)
     assert torch.all(state[1] == 2)


### PR DESCRIPTION
Qwen generated decode keeps recurrent state in rows allocated by the scheduler's page table.
Pass that information to prefill so the SM90 kernel can write each sequence's final GDN state directly into the correct decode row. Other prefill paths remain unchanged.