### PR TITLE
Batch concurrent Qwen ASR requests without delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ All notable changes since `v0.1.2` are documented in this file.
 
 - Added Qwen3-ASR 0.6B and 1.7B and Parakeet TDT 0.6B v3 transcription,
   including long-form files, live PCM, progressive results, language and prompt
-  controls, forced alignment, and word or character timestamps where supported.
-- Improved concurrent Qwen3-ASR throughput by batching submitted PCM requests
-  without adding an admission delay.
+  controls, forced alignment, and word or character timestamps where supported,
+  with batched concurrent Qwen3-ASR transcription for short 16 kHz PCM.
 
 ## 0.6.1 — 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes since `v0.1.2` are documented in this file.
 - Added Qwen3-ASR 0.6B and 1.7B and Parakeet TDT 0.6B v3 transcription,
   including long-form files, live PCM, progressive results, language and prompt
   controls, forced alignment, and word or character timestamps where supported.
+- Improved concurrent Qwen3-ASR throughput by batching submitted PCM requests
+  without adding an admission delay.
 
 ## 0.6.1 — 2026-08-26
 

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1183,9 +1183,24 @@ class InferenceEngine:
                 self._fail_request(request, self._scheduler_failed_error())
                 continue
             self._scheduler_queue.put(request)
+            shutdown = False
+            for _ in range(self.runtime.max_batch_size - 1):
+                try:
+                    queued = self._queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if queued is None:
+                    shutdown = True
+                    break
+                self._scheduler_queue.put(queued)
+
             self._scheduler_event.set()
             if self._scheduler_error is not None:
                 self._fail_all_pending(self._scheduler_failed_error())
+            if shutdown:
+                self._scheduler_queue.put(None)
+                self._scheduler_event.set()
+                break
 
         while not self._queue.empty():
             pending = self._queue.get_nowait()

--- a/kestrel/models/qwen3_asr/longform.py
+++ b/kestrel/models/qwen3_asr/longform.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Callable, Mapping
 
+import numpy as np
+from torch import Tensor
+
 from kestrel.engine import CapabilityStream, EngineResult
 from kestrel.skills.base import CapabilityInvoker, CapabilityOrchestrator
 
@@ -21,6 +24,17 @@ from kestrel.models.asr.longform import (
 
 _CHUNK_SECONDS = {"none": 1_200, "segment": 30, "word": 180}
 _NO_SPACE_LANGUAGES = frozenset({"ja", "th", "yue", "zh"})
+
+
+def _fits_one_chunk(request: TranscriptionRequest, seconds: int) -> bool:
+    audio = request.audio
+    rate = request.sample_rate
+    return (
+        isinstance(audio, (np.ndarray, Tensor))
+        and rate is not None
+        and audio.ndim == 1
+        and int(audio.shape[0]) <= seconds * rate
+    )
 
 
 def _join_text(parts: list[str], languages: list[str]) -> str:
@@ -335,6 +349,8 @@ class Qwen3AsrLongFormOrchestrator(CapabilityOrchestrator):
                 settings=settings,
             )
         timestamps = request.timestamps
+        if not request.stream and _fits_one_chunk(request, _CHUNK_SECONDS[timestamps]):
+            return await invoke(prompt, image=image, settings=settings)
         audio = await settled_to_thread(snapshot_file_like, request.audio)
         owned_prompt = {**prompt, "audio": audio}
         source = await settled_to_thread(open_audio_source, audio, request)

--- a/kestrel/models/qwen3_asr/runtime.py
+++ b/kestrel/models/qwen3_asr/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Any, Sequence
 
@@ -32,7 +33,7 @@ from kestrel.runtime.tokens import TextToken, Token
 from kestrel.runtime.uncached_paged import UncachedPagedRuntime
 from kestrel.utils import CpuGpuBuffer
 
-from kestrel.models.asr.audio import DecodedAudio, decode_audio
+from kestrel.models.asr.audio import MAX_SHORT_AUDIO_SECONDS, DecodedAudio, decode_audio
 from kestrel.models.asr.contract import TranscriptionRequest
 
 from .alignment import LoadedForcedAligner, align_transcript, load_forced_aligner
@@ -272,6 +273,25 @@ class Qwen3AsrRuntime(UncachedPagedRuntime):
         return features.to(self.dtype), masks
 
     def preprocess_encoder_input_async(self, encoder_input: object) -> Any:
+        if isinstance(encoder_input, TranscriptionRequest):
+            audio = encoder_input.audio
+            short_pcm = (
+                isinstance(audio, (np.ndarray, torch.Tensor))
+                and encoder_input.sample_rate == 16_000
+                and encoder_input.clip_start_seconds == 0
+                and encoder_input.clip_end_seconds is None
+                and audio.ndim == 1
+                and int(audio.shape[0]) <= MAX_SHORT_AUDIO_SECONDS * 16_000
+            )
+            if short_pcm:
+                # A completed future lets one already-decoded PCM burst reach
+                # admission together without delaying an individual request.
+                completed: Future[Any] = Future()
+                try:
+                    completed.set_result(self._prepare_audio(encoder_input))
+                except Exception as exc:
+                    completed.set_exception(exc)
+                return completed
         return self._audio_preprocessor.submit(encoder_input)
 
     def preprocess_image_async(self, image: object) -> None:

--- a/tests/asr/test_live_transcription.py
+++ b/tests/asr/test_live_transcription.py
@@ -92,6 +92,31 @@ def test_qwen_live_pcm_does_not_strand_a_tiny_final_tail() -> None:
     assert result.output["duration_seconds"] == 30.01
 
 
+def test_qwen_short_pcm_goes_directly_to_inference(monkeypatch) -> None:
+    def unexpected_open(*_args):
+        raise AssertionError("opened short PCM")
+
+    monkeypatch.setattr(
+        "kestrel.models.qwen3_asr.longform.open_audio_source",
+        unexpected_open,
+    )
+    audio = np.zeros(8 * 16_000, dtype=np.float32)
+
+    async def invoke(prompt, *, image=None, settings=None):
+        assert prompt["audio"] is audio
+        return _result(1, "short")
+
+    result = asyncio.run(
+        Qwen3AsrLongFormOrchestrator().run(
+            invoke,
+            image=None,
+            prompt={"audio": audio, "sample_rate": 16_000},
+            settings=None,
+        )
+    )
+    assert result.output["text"] == "short"
+
+
 def test_qwen_short_file_stream_uses_capability_updates(monkeypatch) -> None:
     class Source:
         duration_seconds = 10.0

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -230,6 +230,39 @@ def test_worker_fails_ar_if_scheduler_dies_after_forwarding() -> None:
     asyncio.run(go())
 
 
+def test_worker_forwards_one_queued_ar_batch_before_waking_scheduler() -> None:
+    async def go() -> None:
+        engine = _engine_with(
+            FakeRuntime(model_name="ar-default", device="cpu", max_batch_size=2),
+            _StubSinglePass(),
+        )
+        engine._queue = asyncio.Queue()
+        requests = [object(), object(), object()]
+        for request in requests:
+            engine._queue.put_nowait(request)
+        engine._queue.put_nowait(None)
+
+        class _WakeEvent:
+            queue_sizes = []
+
+            def set(self) -> None:
+                self.queue_sizes.append(engine._scheduler_queue.qsize())
+
+        wake_event = _WakeEvent()
+        engine._scheduler_event = wake_event
+
+        await asyncio.wait_for(engine._worker_loop(), timeout=1.0)
+
+        assert wake_event.queue_sizes == [2, 3, 4]
+        assert [engine._scheduler_queue.get_nowait() for _ in range(4)] == [
+            *requests,
+            None,
+        ]
+        assert engine._scheduler_queue.empty()
+
+    asyncio.run(go())
+
+
 def test_run_rejects_unknown_model() -> None:
     async def go() -> None:
         ar = FakeRuntime(model_name="ar-default", device="cpu")


### PR DESCRIPTION
## Summary
- forward each already-queued autoregressive request burst before waking the scheduler
- bypass redundant long-form inspection for short in-memory PCM
- prepare short 16 kHz PCM inline so the complete submitted burst reaches admission together
- retain asynchronous preprocessing for encoded, resampled, clipped, and long audio

No admission timeout, sleep, or coalescing window is introduced.

## Performance
8-second LibriSpeech clip, median end-to-end throughput in multiples of realtime:

| GPU / model | C1 | C2 | C4 | C8 |
| --- | ---: | ---: | ---: | ---: |
| H100 Qwen3-ASR 0.6B | 156x | 296x | 539x | 867x |
| H100 Qwen3-ASR 1.7B | 90x | 172x | 324x | 551x |
| B200 Qwen3-ASR 0.6B | 176x | 336x | 608x | 931x |
| B200 Qwen3-ASR 1.7B | 116x | 223x | 407x | 735x |

The corresponding vLLM 0.28.0 results were 99/186/314/528x, 74/140/253/439x, 103/193/340/576x, and 95/177/319/551x respectively. Kestrel leads by 1.22-1.79x across the matrix. vLLM used its normal compiled, CUDA-graph, FlashAttention/FlashInfer paths.

Every measured C1-C8 Kestrel iteration used one prefill batch. Transcripts and detected language remained unchanged in every benchmark sample.

## Validation
- 27 focused ASR and worker tests passed on Modal
- 269 broader engine, scheduler, and ASR tests passed on Modal; two unrelated fixture-drift tests on current main were deselected
- ruff and git diff checks pass
