### PR TITLE
Accelerate Parakeet TDT decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes since `v0.1.2` are documented in this file.
   including long-form files, live PCM, progressive results, language and prompt
   controls, forced alignment, and word or character timestamps where supported,
   with batched concurrent Qwen3-ASR transcription for short 16 kHz PCM and
-  faster batched Parakeet TDT decoding on NVIDIA GPUs.
+  C2-C8 Parakeet TDT decision decoding through one precompiled launch per step
+  on H100 and B200.
 
 ## 0.6.1 — 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes since `v0.1.2` are documented in this file.
 
 ## Unreleased
 
-- Added Qwen3-ASR 0.6B and 1.7B and Parakeet TDT 0.6B v3 transcription,
-  including long-form files, live PCM, progressive results, language and prompt
-  controls, forced alignment, and word or character timestamps where supported,
-  with batched concurrent Qwen3-ASR transcription for short 16 kHz PCM and
-  C2-C8 Parakeet TDT decision decoding through one precompiled launch per step
-  on H100 and B200.
+- Added Qwen3-ASR 0.6B and 1.7B and Parakeet TDT 0.6B v3 transcription for
+  files and live PCM, with long-form chunking, progressive results, language
+  and prompt controls, forced alignment, and word or character timestamps
+  where supported.
+- Added concurrent short-audio batching for Qwen3-ASR without an admission
+  delay. Parakeet decoding uses C1-C8 precompiled decision kernels on H100 and
+  B200, including a no-emission fast path.
+- Added single-pass models as a default-model option, batched single-pass
+  requests, and capability orchestration across execution shapes.
+- Corrected Qwen Gated DeltaNet prefill ownership so allocator-managed rows are
+  not redundantly copied.
 
 ## 0.6.1 — 2026-08-26
 

--- a/kestrel/models/parakeet_tdt/decode_graph.py
+++ b/kestrel/models/parakeet_tdt/decode_graph.py
@@ -26,6 +26,8 @@ class _TdtDecodeSlot:
 class _TdtBatchGraphDecoder:
     """Replay one exact TDT step while the host owns stopping and results."""
 
+    minimum_batch = 2
+
     def __init__(
         self,
         model: ParakeetTdt,

--- a/kestrel/models/parakeet_tdt/generated_decode.py
+++ b/kestrel/models/parakeet_tdt/generated_decode.py
@@ -74,7 +74,7 @@ class _TdtDecodeBindings:
 class _TdtBatchGeneratedDecoder:
     """Run one complete TDT decision per generated kernel launch."""
 
-    minimum_batch = 2
+    minimum_batch = 1
 
     @classmethod
     def create(

--- a/kestrel/models/parakeet_tdt/generated_decode.py
+++ b/kestrel/models/parakeet_tdt/generated_decode.py
@@ -1,0 +1,206 @@
+"""Generated one-decision execution for Parakeet TDT."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import torch
+from torch import Tensor
+
+from kestrel.runtime.generated_decode import GeneratedDecode, GeneratedDecodeSpec
+
+from .model import ParakeetTdt, TdtOutput, _decode_batch
+
+
+@dataclass(slots=True)
+class _TdtDecodeSlot:
+    slot_id: int
+    compute_stream: torch.cuda.Stream
+    encoded: Tensor
+    frame_indices: Tensor
+    active: Tensor
+    decoder_hidden: Tensor
+    hidden: tuple[Tensor, ...]
+    cell: tuple[Tensor, ...]
+    decisions: Tensor
+
+
+@dataclass(frozen=True, slots=True)
+class _TdtDecodeBindings:
+    def is_eligible(self, runtime: Any) -> bool:
+        config = runtime.model.config
+        return (
+            config.decoder_hidden_size == 640
+            and config.vocab_size == 8193
+            and config.blank_token_id == 8192
+            and len(config.durations) == 5
+            and config.num_decoder_layers == 2
+            and config.encoder.max_position_embeddings == 5000
+        )
+
+    def runtime_inputs(self, _runtime: Any) -> Mapping[str, Any]:
+        return {}
+
+    def slot_inputs(self, slot: _TdtDecodeSlot, capacity: int) -> Mapping[str, Any]:
+        state = {
+            "decoder_hidden": slot.decoder_hidden[:capacity],
+            **{
+                f"hidden_{layer}": value[:capacity]
+                for layer, value in enumerate(slot.hidden)
+            },
+            **{
+                f"cell_{layer}": value[:capacity]
+                for layer, value in enumerate(slot.cell)
+            },
+        }
+        return {
+            "encoded": slot.encoded[:capacity].flatten(0, 1),
+            "frame_indices": slot.frame_indices[:capacity],
+            "active": slot.active[:capacity],
+            "token": slot.decisions[0, :capacity],
+            "duration": slot.decisions[1, :capacity],
+            **state,
+            **{f"{name}_next": value for name, value in state.items()},
+        }
+
+    @staticmethod
+    def launch_extents(
+        _slot: _TdtDecodeSlot, batch_size: int
+    ) -> Mapping[str, int]:
+        return {"active_batch": int(batch_size)}
+
+
+class _TdtBatchGeneratedDecoder:
+    """Run one complete TDT decision per generated kernel launch."""
+
+    minimum_batch = 2
+
+    @classmethod
+    def create(
+        cls,
+        model: ParakeetTdt,
+        *,
+        max_batch: int,
+        compute_stream: torch.cuda.Stream,
+        required: bool,
+    ) -> _TdtBatchGeneratedDecoder | None:
+        decoder = cls(model, max_batch=max_batch, compute_stream=compute_stream)
+        spec = GeneratedDecodeSpec(
+            label="Parakeet TDT",
+            weight_root=model,
+            weight_layer_prefix="",
+            bindings=_TdtDecodeBindings(),
+        )
+        batch_sizes = range(cls.minimum_batch, max_batch + 1)
+        generated = (
+            GeneratedDecode.require(decoder, spec, batch_sizes=batch_sizes)
+            if required
+            else GeneratedDecode.try_create(
+                decoder, spec, required_batch_sizes=batch_sizes
+            )
+        )
+        if generated is None:
+            return None
+        decoder._generated = generated
+        return decoder
+
+    def __init__(
+        self,
+        model: ParakeetTdt,
+        *,
+        max_batch: int,
+        compute_stream: torch.cuda.Stream,
+    ) -> None:
+        self.model = model
+        self.device = model.encoder_projector.weight.device
+        self.dtype = model.encoder_projector.weight.dtype
+        self.max_batch_size = int(max_batch)
+        self.compute_stream = compute_stream
+        config = model.config
+        token = torch.full(
+            (max_batch, 1),
+            config.blank_token_id,
+            dtype=torch.long,
+            device=self.device,
+        )
+        with torch.inference_mode():
+            initial_decoder_hidden, initial_state = model.decoder(token, None)
+        initial_hidden, initial_cell = initial_state
+        self._initial_decoder_hidden = initial_decoder_hidden[:, 0]
+        self._initial_hidden = tuple(initial_hidden.unbind())
+        self._initial_cell = tuple(initial_cell.unbind())
+        self.slot = _TdtDecodeSlot(
+            slot_id=0,
+            compute_stream=compute_stream,
+            encoded=torch.empty(
+                (
+                    max_batch,
+                    config.encoder.max_position_embeddings,
+                    config.decoder_hidden_size,
+                ),
+                device=self.device,
+                dtype=self.dtype,
+            ),
+            frame_indices=torch.zeros(
+                max_batch, dtype=torch.long, device=self.device
+            ),
+            active=torch.zeros(max_batch, dtype=torch.bool, device=self.device),
+            decoder_hidden=torch.empty_like(self._initial_decoder_hidden),
+            hidden=tuple(torch.empty_like(value) for value in self._initial_hidden),
+            cell=tuple(torch.empty_like(value) for value in self._initial_cell),
+            decisions=torch.empty(
+                (2, max_batch), dtype=torch.int32, device=self.device
+            ),
+        )
+        self.decode_slots: Sequence[_TdtDecodeSlot] = (self.slot,)
+        self._generated: GeneratedDecode
+
+    def generate(
+        self,
+        encoded: Tensor,
+        valid: Tensor,
+        *,
+        max_tokens: int | None,
+    ) -> TdtOutput:
+        batch, width, _ = encoded.shape
+        if not self.minimum_batch <= batch <= self.max_batch_size:
+            raise ValueError("TDT generated decode requires a supported batch")
+        if width > self.slot.encoded.shape[1]:
+            return self.model._generate_batch(
+                encoded, valid, max_tokens=max_tokens
+            )
+
+        valid_lengths = valid.sum(-1).tolist()
+        slot = self.slot
+        slot.encoded[:batch, :width].copy_(encoded)
+        slot.decoder_hidden.copy_(self._initial_decoder_hidden)
+        for current, initial in zip(
+            (*slot.hidden, *slot.cell),
+            (*self._initial_hidden, *self._initial_cell),
+            strict=True,
+        ):
+            current.copy_(initial)
+        max_frames = slot.encoded.shape[1]
+        launch = self._generated.static_launcher(slot, batch)
+
+        def step(frames: list[int], active: list[bool]) -> list[list[int]]:
+            slot.frame_indices[:batch].copy_(torch.tensor(
+                [row * max_frames + min(frame, max_frames - 1)
+                 for row, frame in enumerate(frames)],
+                device=self.device,
+            ))
+            slot.active[:batch].copy_(torch.tensor(active, device=self.device))
+            launch()
+            return slot.decisions[:, :batch].T.tolist()
+
+        return _decode_batch(
+            self.model.config,
+            valid_lengths,
+            max_tokens,
+            self.device,
+            step,
+        )
+
+
+__all__ = ["_TdtBatchGeneratedDecoder"]

--- a/kestrel/models/parakeet_tdt/runtime.py
+++ b/kestrel/models/parakeet_tdt/runtime.py
@@ -25,6 +25,7 @@ from kestrel.models.asr.contract import (
 
 from .contract import parse_request
 from .decode_graph import _TdtBatchGraphDecoder
+from .generated_decode import _TdtBatchGeneratedDecoder
 from .features import parakeet_features
 from .model import ParakeetTdt, TdtState
 from .tokenizer import ParakeetTokenizer
@@ -124,9 +125,30 @@ class ParakeetTdtRuntime:
             model, tokenizer = loaded.model, loaded.tokenizer
         self.model = model.eval()
         self.tokenizer = tokenizer
+        self.decode_path = getattr(cfg, "decode_path", "auto")
+        if self.decode_path not in {"auto", "native", "generated"}:
+            raise ValueError("decode_path must be 'auto', 'native', or 'generated'")
         self._batch_decoder = None
+        generated_supported = (
+            self.device.type == "cuda"
+            and torch.cuda.is_available()
+            and self.dtype == torch.bfloat16
+        )
+        if self.decode_path == "generated" and not generated_supported:
+            raise RuntimeError(
+                "Parakeet generated decode requires CUDA with BF16 weights"
+            )
+        if self.decode_path != "native" and generated_supported:
+            stream = compute_stream or torch.cuda.current_stream(self.device)
+            self._batch_decoder = _TdtBatchGeneratedDecoder.create(
+                self.model,
+                max_batch=self.batch_capacity,
+                compute_stream=stream,
+                required=self.decode_path == "generated",
+            )
         if (
-            bool(getattr(cfg, "enable_cuda_graphs", True))
+            self._batch_decoder is None
+            and bool(getattr(cfg, "enable_cuda_graphs", True))
             and self.device.type == "cuda"
             and torch.cuda.is_available()
         ):
@@ -415,7 +437,10 @@ class ParakeetTdtRuntime:
                         ):
                             results[index] = value
                         continue
-                    if self._batch_decoder is None or features.shape[0] == 1:
+                    if (
+                        self._batch_decoder is None
+                        or features.shape[0] < self._batch_decoder.minimum_batch
+                    ):
                         output = self.model.generate(
                             features,
                             mask,

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -524,6 +524,32 @@ class GeneratedDecode:
         _index, program = selected
         return self.state_requirements_by_capacity[program.capacity]
 
+    def static_launcher(self, slot: Any, batch_size: int) -> Callable[[], None]:
+        """Bind a repeated launch whose inputs and extents stay fixed."""
+
+        if self._input_preparation_plan:
+            raise ValueError(
+                "static generated decode cannot run per-step input preparations"
+            )
+        selected = self._program_for(batch_size)
+        if selected is None:
+            raise ValueError(f"no generated decode capacity covers {batch_size}")
+        program_index, _program = selected
+        bound = self._slots[(int(slot.slot_id), program_index)]
+        extents = dict(self._spec.bindings.launch_extents(slot, int(batch_size)))
+        missing = bound.required_launch_extents - extents.keys()
+        if missing:
+            raise RuntimeError(
+                f"generated {self._spec.label} launch misses {sorted(missing)}"
+            )
+        return bound.invocation.prepare_launch(
+            **{
+                name: value
+                for name, value in extents.items()
+                if name in bound.scalar_names
+            }
+        )
+
     @torch.inference_mode()
     def run(self, slot: Any, batch_size: int = 1) -> None:
         selected = self._program_for(batch_size)

--- a/tests/test_generated_decode_static_extents.py
+++ b/tests/test_generated_decode_static_extents.py
@@ -26,6 +26,9 @@ class _Invocation:
     def launch(self, **extents) -> None:
         self.launches.append((self.name, dict(extents)))
 
+    def prepare_launch(self, **extents):
+        return lambda: self.launch(**extents)
+
 
 @dataclass(frozen=True)
 class _Program:
@@ -167,6 +170,22 @@ def test_generated_decode_constructs_and_selects_dynamic_exact_siblings(monkeypa
         ("b8", {"active_batch": 6}),
         ("b8", {"active_batch": 7}),
         ("b8_exact", {}),
+    ]
+
+
+def test_static_launcher_resolves_capacity_once(monkeypatch):
+    generated, launches = _build(
+        monkeypatch,
+        _programs("b1", "b2", "b4", "b8"),
+    )
+
+    launch = generated.static_launcher(SimpleNamespace(slot_id=0), 3)
+    launch()
+    launch()
+
+    assert launches == [
+        ("b4", {"active_batch": 3}),
+        ("b4", {"active_batch": 3}),
     ]
 
 


### PR DESCRIPTION
## Summary

- route Parakeet TDT 0.6B v3 C1-C8 decisions through the matching precompiled generated program
- retain CUDA graphs as the automatic fallback when a compatible generated bundle is unavailable
- use the shared prepared-launch hook so stable AOT arguments are packed once rather than on each decision

Depends on the generated kernels in https://github.com/m87-labs/kestrel-proprietary/pull/2066. It remains safe to merge first: automatic mode falls back until a wheel containing those bundles is released.

## End-to-end performance

Public Kestrel `InferenceEngine` versus NVIDIA NeMo 3.0.0 using NVIDIA's documented `ASRModel.from_pretrained(...).transcribe(...)` path and default decoding/precision. The workload is the same real eight-second LibriSpeech sample at C1/C2/C4/C8, with four warmups and twelve timed samples per cell; entries are medians and normalized transcripts match.

| GPU | Concurrent audio | NeMo | Kestrel | Speedup |
| --- | ---: | ---: | ---: | ---: |
| H100 | 1 | 35.97 ms | 22.71 ms | 1.58x |
| H100 | 2 | 37.09 ms | 24.25 ms | 1.53x |
| H100 | 4 | 40.62 ms | 26.12 ms | 1.56x |
| H100 | 8 | 52.46 ms | 26.84 ms | 1.96x |
| B200 | 1 | 31.10 ms | 18.39 ms | 1.69x |
| B200 | 2 | 32.93 ms | 19.24 ms | 1.71x |
| B200 | 4 | 38.06 ms | 19.73 ms | 1.93x |
| B200 | 8 | 49.59 ms | 20.99 ms | 2.36x |

## Validation

- exact sequence, duration, and length parity against native/CUDA-graph decoding on H100 and B200
- exact normalized transcript parity against NeMo on the real-speech benchmark
- packaged AOT discovery and all model-weight recipes verified on both architectures
- public focused suite: 23 passed on H100 and 23 passed on B200
- proprietary focused generated-region tests: 2 passed on H100 and 2 passed on B200
- proprietary H100 changed-surface suite: 342 passed
