### PR TITLE
Use canonical Qwen3-ASR checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Kestrel supports these model families:
 | Qwen 3.6 | [Qwen 3.6 collection](https://huggingface.co/collections/Qwen/qwen36) | 27B and 35B-A3B; BF16 and FP8 checkpoints |
 | Gemma 4 | [Gemma 4 collection](https://huggingface.co/collections/google/gemma-4) | E2B, E4B, and 31B base/instruction variants |
 | Whisper large-v3-turbo | [openai/whisper-large-v3-turbo](https://huggingface.co/openai/whisper-large-v3-turbo) | Transcription, translation, long-form audio, and word timestamps |
-| Qwen3-ASR | [Qwen/Qwen3-ASR-0.6B-hf](https://huggingface.co/Qwen/Qwen3-ASR-0.6B-hf), [1.7B-hf](https://huggingface.co/Qwen/Qwen3-ASR-1.7B-hf) | Transcription, long-form/live audio, language hints, prompting, and forced-aligned word timestamps |
+| Qwen3-ASR | [Qwen/Qwen3-ASR-0.6B](https://huggingface.co/Qwen/Qwen3-ASR-0.6B), [1.7B](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) | Transcription, long-form/live audio, language hints, prompting, and forced-aligned word timestamps |
 | Parakeet TDT 0.6B v3 | [nvidia/parakeet-tdt-0.6b-v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) | Multilingual transcription, long-form/live audio, and native word/character timestamps |
 
 ## Quick Start
@@ -101,7 +101,7 @@ from pathlib import Path
 from kestrel.config import RuntimeConfig
 from kestrel.engine import InferenceEngine
 
-MODEL = "Qwen/Qwen3-ASR-0.6B-hf"
+MODEL = "Qwen/Qwen3-ASR-0.6B"
 
 
 async def main():

--- a/docs/asr.md
+++ b/docs/asr.md
@@ -4,8 +4,8 @@ Kestrel serves four speech-to-text checkpoints through the same model-bound
 `transcribe` capability:
 
 - `openai/whisper-large-v3-turbo`
-- `Qwen/Qwen3-ASR-0.6B-hf`
-- `Qwen/Qwen3-ASR-1.7B-hf`
+- `Qwen/Qwen3-ASR-0.6B`
+- `Qwen/Qwen3-ASR-1.7B`
 - `nvidia/parakeet-tdt-0.6b-v3`
 
 ## Basic usage
@@ -16,7 +16,7 @@ from pathlib import Path
 from kestrel.config import RuntimeConfig
 from kestrel.engine import InferenceEngine
 
-MODEL = "Qwen/Qwen3-ASR-0.6B-hf"
+MODEL = "Qwen/Qwen3-ASR-0.6B"
 
 engine = await InferenceEngine.create(RuntimeConfig(model=MODEL))
 model = engine.model(MODEL)

--- a/kestrel/models/asr/checkpoint.py
+++ b/kestrel/models/asr/checkpoint.py
@@ -28,7 +28,7 @@ def resolve_checkpoint(
                 local_files_only=local_files_only,
             )
         )
-    missing = [name for name in filenames if not (root / name).is_file()]
+    missing = [pattern for pattern in filenames if not any(root.glob(pattern))]
     if missing:
         raise FileNotFoundError(f"checkpoint is missing files: {missing}")
     return root.resolve()

--- a/kestrel/models/qwen3_asr/config.py
+++ b/kestrel/models/qwen3_asr/config.py
@@ -60,7 +60,7 @@ def _audio_config(raw: dict[str, Any]) -> AudioEncoderConfig:
         encoder_layers=raw["encoder_layers"],
         downsample_hidden_size=raw["downsample_hidden_size"],
         num_mel_bins=raw["num_mel_bins"],
-        max_position_embeddings=raw["max_position_embeddings"],
+        max_position_embeddings=raw.get("max_position_embeddings", 13),
         n_window=raw["n_window"],
         n_window_infer=raw["n_window_infer"],
         output_dim=raw["output_dim"],
@@ -91,19 +91,21 @@ class Qwen3AsrConfig:
     audio_token_id: int
     eos_token_ids: tuple[int, ...]
     pad_token_id: int
-    timestamp_token_id: int
 
     @classmethod
-    def from_json_file(cls, path: str | Path) -> "Qwen3AsrConfig":
-        with Path(path).open(encoding="utf-8") as file:
+    def from_checkpoint(cls, path: str | Path) -> "Qwen3AsrConfig":
+        root = Path(path)
+        with (root / "config.json").open(encoding="utf-8") as file:
             raw = json.load(file)
+        with (root / "generation_config.json").open(encoding="utf-8") as file:
+            generation = json.load(file)
+        thinker = raw["thinker_config"]
         config = cls(
-            audio=_audio_config(raw["audio_config"]),
-            text=_text_config(raw["text_config"]),
-            audio_token_id=raw["audio_token_id"],
-            eos_token_ids=tuple(raw["eos_token_id"]),
-            pad_token_id=raw["pad_token_id"],
-            timestamp_token_id=raw["timestamp_token_id"],
+            audio=_audio_config(thinker["audio_config"]),
+            text=_text_config(thinker["text_config"]),
+            audio_token_id=thinker["audio_token_id"],
+            eos_token_ids=tuple(generation["eos_token_id"]),
+            pad_token_id=generation["pad_token_id"],
         )
         config.validate()
         return config
@@ -154,7 +156,6 @@ class ForcedAlignerConfig:
             config.audio_token_id,
             (),
             0,
-            config.timestamp_token_id,
         ).validate()
         return config
 

--- a/kestrel/models/qwen3_asr/tokenizer.py
+++ b/kestrel/models/qwen3_asr/tokenizer.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from tokenizers import Tokenizer
+from tokenizers import AddedToken, Regex, Tokenizer, decoders, normalizers, pre_tokenizers
+from tokenizers.models import BPE
 
 
 LANGUAGES = {
@@ -61,7 +63,37 @@ def language_code(language: str) -> str:
 
 class Qwen3AsrTokenizer:
     def __init__(self, path: str | Path) -> None:
-        self.backend = Tokenizer.from_file(str(path))
+        root = Path(path)
+        with (root / "tokenizer_config.json").open(encoding="utf-8") as file:
+            config = json.load(file)
+        backend = Tokenizer(
+            BPE.from_file(str(root / "vocab.json"), str(root / "merges.txt"))
+        )
+        backend.normalizer = normalizers.NFC()
+        backend.pre_tokenizer = pre_tokenizers.Sequence(
+            [
+                pre_tokenizers.Split(
+                    Regex(
+                        r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|"
+                        r"\p{N}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|"
+                        r"\s+(?!\S)|\s+"
+                    ),
+                    behavior="isolated",
+                ),
+                pre_tokenizers.ByteLevel(
+                    add_prefix_space=False,
+                    trim_offsets=True,
+                    use_regex=False,
+                ),
+            ]
+        )
+        backend.decoder = decoders.ByteLevel()
+        for raw_id, raw_token in config["added_tokens_decoder"].items():
+            token = AddedToken(**raw_token)
+            backend.add_tokens([token])
+            if backend.token_to_id(token.content) != int(raw_id):
+                raise ValueError("Qwen3-ASR tokenizer token IDs are not contiguous")
+        self.backend = backend
         self.audio_token_id = self._token_id("<|audio_pad|>")
 
     def _token_id(self, token: str) -> int:

--- a/kestrel/models/qwen3_asr/weights.py
+++ b/kestrel/models/qwen3_asr/weights.py
@@ -15,10 +15,17 @@ from .tokenizer import Qwen3AsrTokenizer
 
 
 QWEN3_ASR_MODELS = {
-    "Qwen/Qwen3-ASR-0.6B-hf": "7f1569a48a89f3e3f4dc3a5c9d28bddd903bc76c",
-    "Qwen/Qwen3-ASR-1.7B-hf": "bcd2b5b7f32b480ab5790554cfa8347f246a14f3",
+    "Qwen/Qwen3-ASR-0.6B": "5eb144179a02acc5e5ba31e748d22b0cf3e303b0",
+    "Qwen/Qwen3-ASR-1.7B": "7278e1e70fe206f11671096ffdd38061171dd6e5",
 }
-_FILES = ("config.json", "tokenizer.json", "model.safetensors")
+_FILES = (
+    "config.json",
+    "generation_config.json",
+    "tokenizer_config.json",
+    "vocab.json",
+    "merges.txt",
+    "model*.safetensors",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,21 +50,42 @@ def load_qwen3_asr(
         filenames=_FILES,
         local_files_only=local_files_only,
     )
-    config = Qwen3AsrConfig.from_json_file(root / "config.json")
-    tokenizer = Qwen3AsrTokenizer(root / "tokenizer.json")
+    config = Qwen3AsrConfig.from_checkpoint(root)
+    tokenizer = Qwen3AsrTokenizer(root)
     if tokenizer.audio_token_id != config.audio_token_id:
         raise ValueError("Qwen3-ASR tokenizer and model audio tokens disagree")
     with torch.device("meta"):
         model = Qwen3AsrForConditionalGeneration(config)
-    from safetensors.torch import load_file
+    from safetensors import safe_open
 
-    state = load_file(str(root / "model.safetensors"), device="cpu")
+    state: dict[str, torch.Tensor] = {}
+    for shard_path in sorted(root.glob("model*.safetensors")):
+        with safe_open(str(shard_path), framework="pt", device="cpu") as shard:
+            for source_name in shard.keys():
+                target_name = _weight_name(source_name)
+                if target_name is not None:
+                    state[target_name] = shard.get_tensor(source_name)
     state["lm_head.weight"] = state["model.language_model.embed_tokens.weight"]
     model.load_state_dict(state, strict=True, assign=True)
     model.lm_head.weight = model.model.language_model.embed_tokens.weight
     model.reset_nonpersistent_buffers()
     model.to(device=device, dtype=dtype).eval()
     return LoadedQwen3Asr(model, tokenizer)
+
+
+def _weight_name(name: str) -> str | None:
+    if name == "thinker.lm_head.weight":
+        return None
+    prefixes = (
+        ("thinker.audio_tower.proj1.", "model.multi_modal_projector.linear_1."),
+        ("thinker.audio_tower.proj2.", "model.multi_modal_projector.linear_2."),
+        ("thinker.audio_tower.", "model.audio_tower."),
+        ("thinker.model.", "model.language_model."),
+    )
+    for source, target in prefixes:
+        if name.startswith(source):
+            return target + name.removeprefix(source)
+    raise KeyError(f"unsupported Qwen3-ASR checkpoint tensor {name!r}")
 
 
 __all__ = ["LoadedQwen3Asr", "QWEN3_ASR_MODELS", "load_qwen3_asr"]

--- a/tests/asr/test_reference_models.py
+++ b/tests/asr/test_reference_models.py
@@ -244,7 +244,6 @@ def test_qwen_prefill_and_decode_match_transformers() -> None:
                 499,
                 (2, 3),
                 0,
-                500,
             )
         )
     model.load_state_dict(reference.state_dict(), assign=True)


### PR DESCRIPTION
## Summary

- register the canonical `Qwen/Qwen3-ASR-0.6B` and `Qwen/Qwen3-ASR-1.7B` repositories instead of the Transformers-specific `-hf` conversions
- load Qwen's nested config, vocab/merges tokenizer assets, and single-file or sharded safetensors directly
- map the canonical tensor names onto Kestrel's inference-only module and skip the duplicated tied output head
- update the public examples and ASR documentation to use the canonical model IDs

## Validation

- H100 engine/transcription smoke: canonical 0.6B passed
- H100 engine/transcription smoke: canonical 1.7B sharded checkpoint passed
- Modal: `tests/asr` plus `tests/test_model_download.py`: 23 passed
- reconstructed tokenizer vocabulary and representative multilingual/prompt encodings exactly match Qwen's Transformers-native tokenizer
- canonical tensor coverage exactly matches the previous inference checkpoint for both sizes; sampled encoder, projector, decoder, and embedding bytes match
- `ruff check`, `py_compile`, and `git diff --check`
