### PR TITLE
Add sub-40B Qwen and Gemma model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes since `v0.1.2` are documented in this file.
 
 ## Unreleased
 
+- Added Gemma 4 26B-A4B base and instruction-tuned checkpoint support.
 - Added Qwen3-ASR 0.6B and 1.7B and Parakeet TDT 0.6B v3 transcription for
   files and live PCM, with long-form chunking, progressive results, language
   and prompt controls, forced alignment, and word or character timestamps

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Kestrel supports these model families:
 | Moondream 3.1 9B A2B | [moondream/moondream3.1-9B-A2B](https://huggingface.co/moondream/moondream3.1-9B-A2B) | Public, no approval needed |
 | Qwen 3.5 | [Qwen 3.5 collection](https://huggingface.co/collections/Qwen/qwen35) | 0.8B, 2B, 4B, 9B, 27B, and 35B-A3B; Base variants where published |
 | Qwen 3.6 | [Qwen 3.6 collection](https://huggingface.co/collections/Qwen/qwen36) | 27B and 35B-A3B; BF16 and FP8 checkpoints |
-| Gemma 4 | [Gemma 4 collection](https://huggingface.co/collections/google/gemma-4) | E2B, E4B, and 31B base/instruction variants |
+| Gemma 4 | [Gemma 4 collection](https://huggingface.co/collections/google/gemma-4) | E2B, E4B, 26B-A4B, and 31B base/instruction variants |
 | Whisper large-v3-turbo | [openai/whisper-large-v3-turbo](https://huggingface.co/openai/whisper-large-v3-turbo) | Transcription, translation, long-form audio, and word timestamps |
 | Qwen3-ASR | [Qwen/Qwen3-ASR-0.6B](https://huggingface.co/Qwen/Qwen3-ASR-0.6B), [1.7B](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) | Transcription, long-form/live audio, language hints, prompting, and forced-aligned word timestamps |
 | Parakeet TDT 0.6B v3 | [nvidia/parakeet-tdt-0.6b-v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) | Multilingual transcription, long-form/live audio, and native word/character timestamps |

--- a/kestrel/models/gemma4/__init__.py
+++ b/kestrel/models/gemma4/__init__.py
@@ -14,6 +14,8 @@ _VARIANTS = [
     "google/gemma-4-E4B",
     "google/gemma-4-31B-it",
     "google/gemma-4-31B",
+    "google/gemma-4-26B-A4B-it",
+    "google/gemma-4-26B-A4B",
 ]
 
 for _repo_id in _VARIANTS:

--- a/kestrel/models/gemma4/config.py
+++ b/kestrel/models/gemma4/config.py
@@ -62,6 +62,10 @@ class Gemma4TextConfig:
     attention_k_eq_v: bool
     num_kv_shared_layers: int
     use_double_wide_mlp: bool
+    enable_moe_block: bool = False
+    num_experts: int | None = None
+    top_k_experts: int | None = None
+    moe_intermediate_size: int | None = None
 
     def __post_init__(self) -> None:
         if len(self.layer_types) != self.num_hidden_layers:
@@ -83,12 +87,40 @@ class Gemma4TextConfig:
             raise ValueError(
                 "text attention heads must be divisible by global K/V heads"
             )
+        moe_values = (
+            self.num_experts,
+            self.top_k_experts,
+            self.moe_intermediate_size,
+        )
+        if self.enable_moe_block:
+            if any(value is None for value in moe_values):
+                raise ValueError(
+                    "Gemma 4 MoE requires num_experts, top_k_experts, and "
+                    "moe_intermediate_size"
+                )
+            assert self.num_experts is not None
+            assert self.top_k_experts is not None
+            assert self.moe_intermediate_size is not None
+            if min(
+                self.num_experts,
+                self.top_k_experts,
+                self.moe_intermediate_size,
+            ) <= 0:
+                raise ValueError("Gemma 4 MoE dimensions must be positive")
+            if self.top_k_experts > self.num_experts:
+                raise ValueError("top_k_experts cannot exceed num_experts")
+        elif any(value is not None for value in moe_values):
+            raise ValueError(
+                "dense Gemma 4 config cannot define MoE dimensions"
+            )
+
+    @property
+    def is_moe(self) -> bool:
+        return self.enable_moe_block
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "Gemma4TextConfig":
         _validate_dense_inference(data, "Gemma 4 text config")
-        if bool(data.get("enable_moe_block", False)):
-            raise ValueError("Gemma 4 MoE checkpoints are not supported")
         rope_data = required_config(data, "rope_parameters", "Gemma 4 text")
         num_kv_heads = int(
             required_config(data, "num_key_value_heads", "Gemma 4 text")
@@ -112,6 +144,22 @@ class Gemma4TextConfig:
             },
             num_global_key_value_heads=int(
                 data.get("num_global_key_value_heads") or num_kv_heads
+            ),
+            enable_moe_block=bool(data.get("enable_moe_block", False)),
+            num_experts=(
+                int(data["num_experts"])
+                if data.get("num_experts") is not None
+                else None
+            ),
+            top_k_experts=(
+                int(data["top_k_experts"])
+                if data.get("top_k_experts") is not None
+                else None
+            ),
+            moe_intermediate_size=(
+                int(data["moe_intermediate_size"])
+                if data.get("moe_intermediate_size") is not None
+                else None
             ),
         )
         return cls(**kwargs)

--- a/kestrel/models/gemma4/loader.py
+++ b/kestrel/models/gemma4/loader.py
@@ -11,6 +11,7 @@ from safetensors import safe_open
 
 from kestrel.runtime.bounded_projection import (
     bind_declared_packed_projections,
+    declared_packed_projection_source_keys,
 )
 
 from .config import Gemma4Config
@@ -52,34 +53,39 @@ def load_weights(source: str | Path, model: torch.nn.Module) -> None:
     else:
         shard_names = ["model.safetensors"]
 
-    state_dict: dict[str, torch.Tensor] = {}
-    for shard_name in shard_names:
-        shard_path = snapshot / shard_name
-        with safe_open(str(shard_path), framework="pt", device="cpu") as handle:
-            for name in handle.keys():
-                if name.startswith(_UNSUPPORTED_WEIGHT_PREFIXES):
-                    continue
-                state_dict[name] = handle.get_tensor(name)
+    expected_state = model.state_dict()
+    expected = set(expected_state)
+    packed_source_keys = declared_packed_projection_source_keys(model)
+    loaded: set[str] = set()
+    seen_checkpoint_names: set[str] = set()
+    pending_packed: dict[str, torch.Tensor] = {}
 
-    bind_declared_packed_projections(model, state_dict)
+    def copy_loaded_targets() -> None:
+        for name in tuple(pending_packed):
+            if name not in expected:
+                continue
+            source_tensor = pending_packed.pop(name)
+            target = expected_state[name]
+            if source_tensor.shape != target.shape:
+                raise ValueError(
+                    f"Gemma checkpoint tensor {name!r} has shape "
+                    f"{tuple(source_tensor.shape)}, expected {tuple(target.shape)}"
+                )
+            with torch.no_grad():
+                target.copy_(source_tensor)
+            loaded.add(name)
 
-    expected = set(model.state_dict())
-    embedding_key = "model.language_model.embed_tokens.weight"
-    if "lm_head.weight" in expected and "lm_head.weight" not in state_dict:
-        try:
-            state_dict["lm_head.weight"] = state_dict[embedding_key]
-        except KeyError as exc:
-            raise KeyError(
-                "tied Gemma checkpoint is missing its text embedding"
-            ) from exc
+    def bind_ready_packed(*, require_complete: bool) -> None:
+        bind_declared_packed_projections(
+            model,
+            pending_packed,
+            already_bound_targets=loaded,
+            require_complete=require_complete,
+        )
+        copy_loaded_targets()
 
-    # Published checkpoints retain K/V parameters for layers whose config
-    # explicitly reuses an earlier producer. The inference module omits those
-    # dead parameters; discard only that exact declared family.
-    shared_kv_members = ("k_proj", "v_proj", "k_norm", "v_norm")
-    for name in tuple(state_dict):
-        if name in expected:
-            continue
+    def is_omitted_shared_kv(name: str) -> bool:
+        shared_kv_members = ("k_proj", "v_proj", "k_norm", "v_norm")
         for member in shared_kv_members:
             marker = f".self_attn.{member}."
             if marker not in name:
@@ -88,12 +94,69 @@ def load_weights(source: str | Path, model: torch.nn.Module) -> None:
             try:
                 attention = model.get_submodule(attention_path)
             except AttributeError:
-                break
-            if not hasattr(attention, member):
-                state_dict.pop(name)
-            break
+                return False
+            return not hasattr(attention, member)
+        return False
 
-    model.load_state_dict(state_dict, strict=True)
+    for shard_name in shard_names:
+        shard_path = snapshot / shard_name
+        with safe_open(str(shard_path), framework="pt", device="cpu") as handle:
+            shard_keys = list(handle.keys())
+        # A shard-wide mmap retained every faulted page through the load. Opening
+        # per tensor cut Gemma 31B host high-water from 74.65 GB to 24.88 GB on
+        # B200 while leaving the 65.45 GB CUDA peak unchanged; warm load time was
+        # 9.81 s versus 9.27 s with the shard-wide mapping.
+        for name in shard_keys:
+            if name in seen_checkpoint_names:
+                raise ValueError(f"duplicate Gemma checkpoint tensor {name!r}")
+            seen_checkpoint_names.add(name)
+            if name.startswith(_UNSUPPORTED_WEIGHT_PREFIXES):
+                continue
+            if (
+                name not in expected
+                and name not in packed_source_keys
+                and is_omitted_shared_kv(name)
+            ):
+                continue
+            with safe_open(str(shard_path), framework="pt", device="cpu") as handle:
+                tensor = handle.get_tensor(name)
+            try:
+                if name in expected:
+                    target = expected_state[name]
+                    if tensor.shape != target.shape:
+                        raise ValueError(
+                            f"Gemma checkpoint tensor {name!r} has shape "
+                            f"{tuple(tensor.shape)}, expected {tuple(target.shape)}"
+                        )
+                    with torch.no_grad():
+                        target.copy_(tensor)
+                    loaded.add(name)
+                else:
+                    pending_packed[name] = tensor
+            finally:
+                del tensor
+        bind_ready_packed(require_complete=False)
+
+    bind_ready_packed(require_complete=True)
+
+    embedding_key = "model.language_model.embed_tokens.weight"
+    if "lm_head.weight" in expected and "lm_head.weight" not in loaded:
+        if embedding_key not in loaded:
+            raise KeyError(
+                "tied Gemma checkpoint is missing its text embedding"
+            )
+        with torch.no_grad():
+            expected_state["lm_head.weight"].copy_(expected_state[embedding_key])
+        loaded.add("lm_head.weight")
+
+    if pending_packed:
+        raise RuntimeError(
+            "Gemma checkpoint contains unexpected tensors: "
+            f"{sorted(pending_packed)[:10]}"
+        )
+    missing = sorted(expected - loaded)
+    if missing:
+        raise RuntimeError(f"Gemma checkpoint is missing tensors: {missing[:10]}")
 
 
 def load_model(

--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -6,6 +6,7 @@ from typing import Optional, Sequence
 
 import torch
 from kestrel_kernels import get_runtime
+from kestrel_kernels import moe as _MOE_API
 from kestrel.kv_cache import PagedKVCache
 from kestrel.ops import attention as attention_ops
 from kestrel.ops import rotary as rotary_ops
@@ -28,9 +29,24 @@ from .paged_cache import kv_source_layers
 _dense_runtime = get_runtime().dense
 _attention_runtime = get_runtime().attention
 _rotary_runtime = get_runtime().rotary
+_moe_runtime = get_runtime().moe
 _kestrel_gated_activation_into = _dense_runtime.gated_activation_into
 _prepare_neox_rotary = _rotary_runtime.prepare_neox
 _apply_neox_rotary = _rotary_runtime.apply_neox
+_MOE_DECODE_MAX_TOKENS = 16
+_MOE_MIN_PREFILL_BUCKET_TOKENS = 64
+
+
+def _moe_capacity_for_tokens(tokens: int) -> tuple[int, str]:
+    tokens = int(tokens)
+    if tokens <= 0:
+        raise ValueError("tokens must be positive")
+    if tokens <= _MOE_DECODE_MAX_TOKENS:
+        return tokens, "decode"
+    return (
+        max(_MOE_MIN_PREFILL_BUCKET_TOKENS, 1 << (tokens - 1).bit_length()),
+        "prefill",
+    )
 
 
 def _rmsnorm_state(
@@ -269,6 +285,140 @@ class Gemma4TextMLP(nn.Module):
         return self.down_proj(hidden)
 
 
+class Gemma4TextExperts(nn.Module):
+
+    def __init__(self, config: Gemma4TextConfig) -> None:
+        super().__init__()
+        if (
+            config.num_experts is None
+            or config.top_k_experts is None
+            or config.moe_intermediate_size is None
+        ):
+            raise ValueError("Gemma 4 MoE config is incomplete")
+        self.num_experts = config.num_experts
+        self.top_k = config.top_k_experts
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.moe_intermediate_size
+        self.gate_up_proj = nn.Parameter(
+            torch.empty(
+                self.num_experts,
+                2 * self.intermediate_size,
+                self.hidden_size,
+            ),
+            requires_grad=False,
+        )
+        self.down_proj = nn.Parameter(
+            torch.empty(
+                self.num_experts,
+                self.hidden_size,
+                self.intermediate_size,
+            ),
+            requires_grad=False,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        top_k_index: torch.Tensor,
+        top_k_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        input_shape = hidden_states.shape
+        flat_hidden = hidden_states.reshape(-1, self.hidden_size)
+        tokens = int(flat_hidden.shape[0])
+        capacity_tokens, capacity_mode = _moe_capacity_for_tokens(tokens)
+        if top_k_index.dtype != torch.int32:
+            top_k_index = top_k_index.to(torch.int32)
+        weight_formats = {
+            torch.bfloat16: "bf16",
+            torch.float16: "fp16",
+            torch.float32: "fp32",
+        }
+        try:
+            weight_format = weight_formats[self.gate_up_proj.dtype]
+        except KeyError as exc:
+            raise ValueError(
+                f"unsupported Gemma 4 expert dtype {self.gate_up_proj.dtype}"
+            ) from exc
+        spec = _MOE_API.MoeSpec(
+            num_experts=self.num_experts,
+            top_k=self.top_k,
+            hidden_size=self.hidden_size,
+            intermediate_size=self.intermediate_size,
+            activation="geglu",
+            weight_format=weight_format,
+            dtype=flat_hidden.dtype,
+            backend="auto",
+        )
+        handle = _moe_runtime.prepare(
+            spec,
+            _MOE_API.MoeCapacity(
+                max_tokens=capacity_tokens,
+                mode=capacity_mode,
+            ),
+            device=flat_hidden.device,
+        )
+        weights = _MOE_API.pack_weights(
+            handle.spec,
+            up=self.gate_up_proj,
+            down=self.down_proj,
+            weight_scale_layout="block128",
+        )
+        output = _moe_runtime.forward(
+            handle,
+            x=flat_hidden,
+            topk_ids=top_k_index,
+            topk_weights=top_k_weights,
+            weights=weights,
+        )
+        return output.reshape(input_shape)
+
+
+class Gemma4TextRouter(nn.Module):
+
+    def __init__(self, config: Gemma4TextConfig) -> None:
+        super().__init__()
+        if config.num_experts is None or config.top_k_experts is None:
+            raise ValueError("Gemma 4 MoE router config is incomplete")
+        self.hidden_size = config.hidden_size
+        self.top_k = config.top_k_experts
+        self.norm = _rmsnorm_state(
+            config.hidden_size,
+            config.rms_norm_eps,
+            with_scale=False,
+        )
+        self.scale = nn.Parameter(torch.ones(self.hidden_size))
+        self.proj = nn.Linear(config.hidden_size, config.num_experts, bias=False)
+        self.per_expert_scale = nn.Parameter(torch.ones(config.num_experts))
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = hidden_states.reshape(-1, self.hidden_size)
+        hidden_states = _dense_runtime.rmsnorm(
+            hidden_states,
+            self.norm.weight,
+            self.norm.eps,
+        )
+        hidden_states = hidden_states * self.scale * (self.hidden_size**-0.5)
+        router_logits = self.proj(hidden_states)
+        router_probabilities = F.softmax(
+            router_logits,
+            dim=-1,
+            dtype=torch.float32,
+        )
+        routing_weights, selected_experts = torch.topk(
+            router_probabilities,
+            k=self.top_k,
+            dim=-1,
+        )
+        routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+        routing_weights = (
+            routing_weights * self.per_expert_scale[selected_experts]
+        )
+        return routing_weights, selected_experts
+
+
 class Gemma4TextDecoderLayer(nn.Module):
 
     def __init__(
@@ -287,6 +437,19 @@ class Gemma4TextDecoderLayer(nn.Module):
             publishes_kv=publishes_kv,
         )
         self.mlp = Gemma4TextMLP(config, layer_idx)
+        self.enable_moe_block = config.is_moe
+        if self.enable_moe_block:
+            self.experts = Gemma4TextExperts(config)
+            self.router = Gemma4TextRouter(config)
+            self.post_feedforward_layernorm_1 = _rmsnorm_state(
+                config.hidden_size, config.rms_norm_eps
+            )
+            self.pre_feedforward_layernorm_2 = _rmsnorm_state(
+                config.hidden_size, config.rms_norm_eps
+            )
+            self.post_feedforward_layernorm_2 = _rmsnorm_state(
+                config.hidden_size, config.rms_norm_eps
+            )
         self.input_layernorm = _rmsnorm_state(
             config.hidden_size, config.rms_norm_eps)
         self.post_attention_layernorm = _rmsnorm_state(
@@ -352,6 +515,29 @@ class Gemma4TextDecoderLayer(nn.Module):
             self.pre_feedforward_layernorm.eps,
         )
         hidden_states = self.mlp(hidden_states)
+        if self.enable_moe_block:
+            dense_hidden_states = _dense_runtime.rmsnorm(
+                hidden_states,
+                self.post_feedforward_layernorm_1.weight,
+                self.post_feedforward_layernorm_1.eps,
+            )
+            routing_weights, selected_experts = self.router(residual)
+            expert_hidden_states = _dense_runtime.rmsnorm(
+                residual,
+                self.pre_feedforward_layernorm_2.weight,
+                self.pre_feedforward_layernorm_2.eps,
+            )
+            expert_hidden_states = self.experts(
+                expert_hidden_states,
+                selected_experts,
+                routing_weights,
+            )
+            expert_hidden_states = _dense_runtime.rmsnorm(
+                expert_hidden_states,
+                self.post_feedforward_layernorm_2.weight,
+                self.post_feedforward_layernorm_2.eps,
+            )
+            hidden_states = dense_hidden_states + expert_hidden_states
         hidden_states = _dense_runtime.rmsnorm(
             hidden_states,
             self.post_feedforward_layernorm.weight,

--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -344,7 +344,7 @@ class Gemma4TextExperts(nn.Module):
             top_k=self.top_k,
             hidden_size=self.hidden_size,
             intermediate_size=self.intermediate_size,
-            activation="geglu",
+            activation="gelu",
             weight_format=weight_format,
             dtype=flat_hidden.dtype,
             backend="auto",

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -15,7 +15,11 @@ from kestrel.runtime.compilation import (
     materialize_dynamic_batch_domain,
 )
 from kestrel.runtime.decode_slot import create_decode_slot
-from kestrel.runtime.paged_resources import PrefillSlot, decode_slot_rows
+from kestrel.runtime.paged_resources import (
+    PrefillSlot,
+    bound_kv_cache_pages,
+    decode_slot_rows,
+)
 from kestrel.runtime.preprocessing import derive_image_insertion_offset
 from kestrel.runtime.preprocessing import derive_preprocessing_workers
 from kestrel.runtime.staging import AsyncPreprocessor, BatchedTensorStager
@@ -91,10 +95,14 @@ class Gemma4Runtime(UncachedPagedRuntime):
         self.spec = None
         self.max_batch_size = cfg.max_batch_size
         self.page_size = cfg.page_size
-        self._kv_cache_pages = cfg.kv_cache_pages
-        self.max_seq_length = min(
-            self._config.text_config.max_position_embeddings,
-            2048,
+        self.max_seq_length = int(
+            self._config.text_config.max_position_embeddings
+        )
+        self._kv_cache_pages = bound_kv_cache_pages(
+            cfg.kv_cache_pages,
+            page_size=self.page_size,
+            max_batch_size=self.max_batch_size,
+            max_seq_length=self.max_seq_length,
         )
         self.image_prefix_length = MAX_IMAGE_TOKENS + 2
         self._vision_stager = BatchedTensorStager(

--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -581,21 +581,30 @@ class MoondreamRuntime:
         captured_k_scales: list[Optional[float]] = [None] * n_layers
         captured_v_scales: list[Optional[float]] = [None] * n_layers
 
-        def _capture_kv_scale(name: str, tensor: torch.Tensor) -> None:
+        def _kv_scale_location(name: str) -> tuple[int, str] | None:
             if not name.startswith("text_model.transformer.h."):
-                return
+                return None
             parts = name.split(".")
             if len(parts) < 6:
-                return
+                return None
             try:
                 layer_idx = int(parts[3])
             except ValueError:
-                return
+                return None
             if not (0 <= layer_idx < n_layers):
-                return
+                return None
             if parts[4] != "kv_quantizer":
-                return
+                return None
             target = parts[5]
+            if target not in {"k_scale", "v_scale"}:
+                return None
+            return layer_idx, target
+
+        def _capture_kv_scale(name: str, tensor: torch.Tensor) -> None:
+            location = _kv_scale_location(name)
+            if location is None:
+                return
+            layer_idx, target = location
             value_tensor = tensor.detach()
             if value_tensor.numel() != 1:
                 return
@@ -609,6 +618,7 @@ class MoondreamRuntime:
             str(cfg.model_path),
             self.model,
             tensor_hook=_capture_kv_scale,
+            tensor_hook_predicate=lambda name: _kv_scale_location(name) is not None,
             region=self.region,
             checkpoint_format=self._spec.checkpoint_format,
         )

--- a/kestrel/models/moondream/weights.py
+++ b/kestrel/models/moondream/weights.py
@@ -6,7 +6,7 @@ Adapted from the Moondream project (Apache-2.0).
 
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Collection, Dict, List, Optional
 
 import safetensors
 import torch
@@ -200,6 +200,7 @@ def _assign_md3_text_weights(
             f"text_model.transformer.h.{first_layer_idx}.mlp.experts.weight")
         E, two_inter, hidden = (
             int(first_up.shape[0]), int(first_up.shape[1]), int(first_up.shape[2]))
+        del first_up
         device = first_block["mlp"]["mlp"].up_experts.weight.device
         up_w_slab, up_scale_slab = build_md3_moe_up_slab(
             text, num_experts=E, two_inter=two_inter, hidden=hidden, device=device)
@@ -228,6 +229,7 @@ def _assign_md3_text_weights(
             fused_mlp.down_experts.weight = nn.Parameter(
                 down_weight_uint8.to(device), requires_grad=False)
             fused_mlp.down_experts.register_buffer("scale", down_scale.to(device))
+            del up_weight_uint8, down_weight_uint8
 
     # Tau weights (q/v scaling). Kestrel stores these fused as a single wqwv matrix
     # for performance, but older checkpoints store tau_wq and tau_wv separately.
@@ -467,13 +469,14 @@ def load_text_weights(
 
 
 def _capture_moe_scales(
-    tensors_raw: Dict[str, torch.Tensor],
+    tensor_names: Collection[str],
+    get_raw_tensor: Callable[[str], torch.Tensor],
     n_layers: int,
 ) -> MoEScales:
     """Extract MoE FP8 scales from raw checkpoint tensors."""
     moe_scales = MoEScales.empty(n_layers)
 
-    for name, tensor in tensors_raw.items():
+    for name in tensor_names:
         if not name.startswith("text_model.transformer.h."):
             continue
         parts = name.split(".")
@@ -488,9 +491,12 @@ def _capture_moe_scales(
         if parts[4] != "moe_quant":
             continue
         target = parts[5]
+        if target not in {"up_scale", "down_scale"}:
+            continue
+        tensor = get_raw_tensor(name)
         if target == "up_scale":
             moe_scales.up_scales[layer_idx] = tensor.detach().clone()
-        elif target == "down_scale":
+        else:
             moe_scales.down_scales[layer_idx] = tensor.detach().clone()
 
     return moe_scales
@@ -516,12 +522,12 @@ def load_moondream_weights(
         return tensor.to(target_dtype)
 
     def assign_weights(
-        all_tensors: dict[str, torch.Tensor],
+        tensor_names: Collection[str],
         getter: Callable[[str], torch.Tensor],
         raw_getter: Callable[[str], torch.Tensor],
     ) -> None:
-        fmt = checkpoint_format or _detect_checkpoint_format(list(all_tensors.keys()))
-        moe_scales = _capture_moe_scales(all_tensors, n_layers)
+        fmt = checkpoint_format or _detect_checkpoint_format(list(tensor_names))
+        moe_scales = _capture_moe_scales(tensor_names, raw_getter, n_layers)
 
         if fmt == "md2":
             _assign_md2_text_weights(getter, model)
@@ -540,20 +546,30 @@ def load_moondream_weights(
 
     if path.endswith(".safetensors"):
         with safetensors_open(path) as get_tensor:
-            all_tensors = {}
+            original_names: dict[str, str] = {}
             for orig_name in get_tensor.keys():
                 name = orig_name.replace("._orig_mod", "")
-                all_tensors[name] = get_tensor(orig_name)
+                previous = original_names.setdefault(name, orig_name)
+                if previous != orig_name:
+                    raise ValueError(
+                        "Checkpoint tensor names collide after removing "
+                        f"'._orig_mod': {previous!r} and {orig_name!r}"
+                    )
 
-            if tensor_hook is not None:
-                for name, tensor in all_tensors.items():
-                    tensor_hook(name, tensor)
+        def get_raw_tensor(name: str) -> torch.Tensor:
+            # Bound resident file-backed pages to the tensors still in use.
+            with safetensors_open(path) as get_tensor:
+                return get_tensor(original_names[name])
 
-            assign_weights(
-                all_tensors,
-                getter=lambda name: convert(all_tensors[name]),
-                raw_getter=lambda name: all_tensors[name],
-            )
+        if tensor_hook is not None:
+            for name in original_names:
+                tensor_hook(name, get_raw_tensor(name))
+
+        assign_weights(
+            original_names.keys(),
+            getter=lambda name: convert(get_raw_tensor(name)),
+            raw_getter=get_raw_tensor,
+        )
     else:
         # Load .pt checkpoints on CPU first to avoid transient GPU OOM during
         # deserialization. mmap keeps startup fast on repeated local loads.
@@ -570,7 +586,7 @@ def load_moondream_weights(
                 tensor_hook(name, value)
 
         assign_weights(
-            all_tensors,
+            all_tensors.keys(),
             getter=lambda name: convert(all_tensors[name]),
             raw_getter=lambda name: all_tensors[name],
         )

--- a/kestrel/models/moondream/weights.py
+++ b/kestrel/models/moondream/weights.py
@@ -456,6 +456,7 @@ def load_text_weights(
     model: nn.Module,
     *,
     tensor_hook: Callable[[str, torch.Tensor], None] | None = None,
+    tensor_hook_predicate: Callable[[str], bool] | None = None,
     checkpoint_format: Optional[str] = None,
 ) -> None:
     load_moondream_weights(
@@ -463,6 +464,7 @@ def load_text_weights(
         model,
         load_vision=False,
         tensor_hook=tensor_hook,
+        tensor_hook_predicate=tensor_hook_predicate,
         region=None,
         checkpoint_format=checkpoint_format,
     )
@@ -508,6 +510,7 @@ def load_moondream_weights(
     *,
     load_vision: bool = True,
     tensor_hook: Callable[[str, torch.Tensor], None] | None = None,
+    tensor_hook_predicate: Callable[[str], bool] | None = None,
     region: Optional[nn.Module] = None,
     checkpoint_format: Optional[str] = None,
 ) -> None:
@@ -563,6 +566,11 @@ def load_moondream_weights(
 
         if tensor_hook is not None:
             for name in original_names:
+                if (
+                    tensor_hook_predicate is not None
+                    and not tensor_hook_predicate(name)
+                ):
+                    continue
                 tensor_hook(name, get_raw_tensor(name))
 
         assign_weights(
@@ -583,6 +591,11 @@ def load_moondream_weights(
 
         if tensor_hook is not None:
             for name, value in all_tensors.items():
+                if (
+                    tensor_hook_predicate is not None
+                    and not tensor_hook_predicate(name)
+                ):
+                    continue
                 tensor_hook(name, value)
 
         assign_weights(

--- a/kestrel/models/qwen35/generated_decode.py
+++ b/kestrel/models/qwen35/generated_decode.py
@@ -19,6 +19,84 @@ def _state_tensors(state_pool: Any, field: str) -> list[torch.Tensor | None]:
     ]
 
 
+def prepare_generated_weight_storage(
+    runtime: Any,
+    model: torch.nn.Module,
+    *,
+    required: bool,
+) -> Any | None:
+    """Bind checkpoint load targets directly into the final generated layout."""
+
+    if runtime.device.type != "cuda" or runtime.dtype is not torch.bfloat16:
+        if required:
+            raise RuntimeError(
+                "generated Qwen decode requires CUDA BF16 model storage"
+            )
+        return None
+    try:
+        from kestrel_kernels import generated_decode as generated_runtime
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"kestrel_kernels", "kestrel_kernels.generated_decode"}:
+            raise
+        if required:
+            raise RuntimeError(
+                "generated Qwen decode requires load-time weight binding support"
+            )
+        return None
+    allocate_weight_storage_for_loading = getattr(
+        generated_runtime, "allocate_weight_storage_for_loading", None
+    )
+    resolve_compatible_programs = getattr(
+        generated_runtime, "resolve_compatible_programs", None
+    )
+    if not callable(allocate_weight_storage_for_loading) or not callable(
+        resolve_compatible_programs
+    ):
+        if required:
+            raise RuntimeError(
+                "generated Qwen decode requires load-time weight binding support"
+            )
+        return None
+
+    properties = torch.cuda.get_device_properties(runtime.device)
+    programs = tuple(resolve_compatible_programs(
+        model,
+        layer_prefix="model.language_model.layers",
+        arch=f"sm{properties.major}{properties.minor}",
+        device_sms=int(properties.multi_processor_count),
+    ))
+    missing_batches = []
+    for batch_size in range(1, runtime.max_batch_size + 1):
+        covered = False
+        for program in programs:
+            static = program.static_extent_bindings.get("active_batch")
+            minimum = int(
+                program.runtime_extent_minimums.get("active_batch", 1)
+            )
+            covered = covered or (
+                (static is None and minimum <= batch_size <= program.capacity)
+                or static == batch_size
+            )
+        if not covered:
+            missing_batches.append(batch_size)
+    if missing_batches:
+        if required:
+            raise RuntimeError(
+                "generated Qwen decode has no load-time artifact coverage for "
+                f"batch sizes {missing_batches}"
+            )
+        return None
+    contracts = {repr(program.descriptor["weights"]) for program in programs}
+    if len(contracts) != 1:
+        raise RuntimeError("generated Qwen artifacts disagree on weight storage")
+    return allocate_weight_storage_for_loading(
+        model,
+        programs[0].descriptor,
+        device=runtime.device,
+        layer_prefix="model.language_model.layers",
+    )
+
+
 def create_generated_decode(
     runtime: Any, *, required: bool = False,
 ) -> GeneratedDecode | None:
@@ -65,6 +143,7 @@ def create_generated_decode(
         weight_root=runtime.model,
         weight_layer_prefix="model.language_model.layers",
         bindings=bindings,
+        weight_storage=getattr(runtime, "_generated_weight_storage", None),
         capacity_inputs=state_inputs,
         preparations=(
             DeviceInputPreparation(
@@ -92,4 +171,4 @@ def create_generated_decode(
     )
 
 
-__all__ = ["create_generated_decode"]
+__all__ = ["create_generated_decode", "prepare_generated_weight_storage"]

--- a/kestrel/models/qwen35/generated_decode.py
+++ b/kestrel/models/qwen35/generated_decode.py
@@ -97,9 +97,7 @@ def prepare_generated_weight_storage(
     )
 
 
-def create_generated_decode(
-    runtime: Any, *, required: bool = False,
-) -> GeneratedDecode | None:
+def _generated_decode_spec(runtime: Any) -> GeneratedDecodeSpec:
     bindings = PagedDecodeBindings(
         runtime._paged_kv,
         extra_runtime_inputs=lambda bound_runtime: {
@@ -138,7 +136,7 @@ def create_generated_decode(
             "gdn_recurrent_state": recurrent,
         }
 
-    spec = GeneratedDecodeSpec(
+    return GeneratedDecodeSpec(
         label="Qwen",
         weight_root=runtime.model,
         weight_layer_prefix="model.language_model.layers",
@@ -160,6 +158,28 @@ def create_generated_decode(
             "prepare_position_ids": runtime._prepare_decode_position_ids,
         },
     )
+
+
+def generated_decode_slot_capacity(
+    runtime: Any, *, required: bool = False,
+) -> int | None:
+    required_batch_sizes = range(1, runtime.max_batch_size + 1)
+    capacity = GeneratedDecode.resolve_slot_capacity(
+        runtime,
+        _generated_decode_spec(runtime),
+        required_batch_sizes=required_batch_sizes,
+    )
+    if required and capacity is None:
+        raise RuntimeError(
+            "Qwen requires a compatible bundled generated-decode program"
+        )
+    return capacity
+
+
+def create_generated_decode(
+    runtime: Any, *, required: bool = False,
+) -> GeneratedDecode | None:
+    spec = _generated_decode_spec(runtime)
     if required:
         return GeneratedDecode.require(
             runtime, spec, batch_sizes=range(1, runtime.max_batch_size + 1)
@@ -171,4 +191,8 @@ def create_generated_decode(
     )
 
 
-__all__ = ["create_generated_decode", "prepare_generated_weight_storage"]
+__all__ = [
+    "create_generated_decode",
+    "generated_decode_slot_capacity",
+    "prepare_generated_weight_storage",
+]

--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -14,7 +14,11 @@ from safetensors import safe_open
 from kestrel.ops.rotary import default_inv_freq
 
 from .qwen_config import Qwen3_5Config
-from .qwen_model import Qwen3_5ForConditionalGeneration, Qwen3_5RMSNormGated
+from .qwen_model import (
+    _KESTREL_MOE_GATE_UP_LAYOUT,
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5RMSNormGated,
+)
 
 
 _GDN_IN_PROJ_PARTS = (
@@ -43,6 +47,11 @@ _FP8_TEXT_DENSE_WEIGHT_RE = re.compile(
     r".+\.weight$"
 )
 _DEQUANT_CHUNK_ROWS = 1024
+_DIRECT_CHECKPOINT_TENSOR_PREPS = (
+    # Qwen checkpoints store fused expert rows as [all gate, all up]. The
+    # native MoE ABI consumes alternating eight-row gate/up blocks.
+    (".mlp.experts.gate_up_proj", _KESTREL_MOE_GATE_UP_LAYOUT),
+)
 
 
 def _torch_device_arg(device: torch.device) -> str:
@@ -139,6 +148,51 @@ def _loadable_tensor(
     if key in qwen_rms_norm_weight_keys:
         return value.to(torch.float32) + 1.0
     return value
+
+
+def _direct_checkpoint_tensor_prep(key: str) -> str | None:
+    matches = tuple(
+        prep
+        for suffix, prep in _DIRECT_CHECKPOINT_TENSOR_PREPS
+        if key.endswith(suffix)
+    )
+    if len(matches) > 1:
+        raise ValueError(f"Qwen checkpoint tensor {key!r} has ambiguous preparation")
+    return matches[0] if matches else None
+
+
+def _copy_direct_checkpoint_tensor(
+    target: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    key: str,
+    prep: str | None,
+) -> None:
+    if prep is None:
+        target.copy_(value)
+        return
+    if prep != _KESTREL_MOE_GATE_UP_LAYOUT:
+        raise ValueError(
+            f"Qwen checkpoint tensor {key!r} has unsupported preparation {prep!r}"
+        )
+    if value.ndim < 2 or value.shape[-2] % 16 != 0:
+        raise ValueError(
+            f"Qwen fused expert tensor {key!r} cannot form interleaved-i8 "
+            f"gate/up rows from shape {tuple(value.shape)}"
+        )
+    intermediate = value.shape[-2] // 2
+    gate, up = value.split(intermediate, dim=-2)
+    target_blocks = target.reshape(
+        *target.shape[:-2], intermediate // 8, 2, 8, target.shape[-1]
+    )
+    gate_blocks = gate.reshape(
+        *gate.shape[:-2], intermediate // 8, 8, gate.shape[-1]
+    )
+    up_blocks = up.reshape(
+        *up.shape[:-2], intermediate // 8, 8, up.shape[-1]
+    )
+    target_blocks[..., 0, :, :].copy_(gate_blocks)
+    target_blocks[..., 1, :, :].copy_(up_blocks)
 
 
 def _stores_checkpoint_fp8_as_bf16(key: str) -> bool:
@@ -537,7 +591,12 @@ def _load_sharded_safetensors(
                     exact_fp32_weight_keys=qwen_gdn_norm_weight_keys,
                 )
                 with torch.no_grad():
-                    expected_state[key].copy_(loaded)
+                    _copy_direct_checkpoint_tensor(
+                        expected_state[key],
+                        loaded,
+                        key=key,
+                        prep=_direct_checkpoint_tensor_prep(key),
+                    )
                 loaded_keys.add(key)
                 continue
             fused_parts = _fused_projection_keys(key)

--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -10,7 +10,6 @@ from typing import Any
 import torch
 from huggingface_hub import hf_hub_download
 from safetensors import safe_open
-from safetensors.torch import load_file
 
 from .qwen_config import Qwen3_5Config
 from .qwen_model import Qwen3_5ForConditionalGeneration, Qwen3_5RMSNormGated
@@ -41,6 +40,7 @@ _FP8_TEXT_DENSE_WEIGHT_RE = re.compile(
     r"(?!experts\.)"
     r".+\.weight$"
 )
+_DEQUANT_CHUNK_ROWS = 1024
 
 
 def _torch_device_arg(device: torch.device) -> str:
@@ -129,11 +129,11 @@ def _loadable_tensor(
         value = _dequantize_fp8_weight(value, scale_inv, expected_shape, key=key)
     if key.endswith("visual.patch_embed.proj.weight") and value.ndim == 5:
         value = value.reshape(value.shape[0], -1)
-        if value.shape != expected_shape:
-            raise ValueError(
-                "Qwen vision patch projection weight has unexpected shape after "
-                f"flattening: got {tuple(value.shape)}, expected {tuple(expected_shape)}"
-            )
+    if value.shape != expected_shape:
+        raise ValueError(
+            f"Qwen weight {key!r} has shape {tuple(value.shape)}, "
+            f"expected {tuple(expected_shape)}"
+        )
     if key in qwen_rms_norm_weight_keys:
         return value.to(torch.float32) + 1.0
     return value
@@ -182,14 +182,23 @@ def _dequantize_fp8_weight(
             f"Qwen FP8 weight scale {_scale_inv_key(key)!r} has shape "
             f"{tuple(scale_inv.shape)}, expected {expected_scale_shape}"
         )
-    expanded_scale = scale_inv.repeat_interleave(block_m, dim=0).repeat_interleave(
-        block_n,
-        dim=1,
-    )
-    expanded_scale = expanded_scale[: value.shape[0], : value.shape[1]]
-    return (value.to(torch.float32) * expanded_scale.to(torch.float32)).to(
-        torch.bfloat16
-    )
+    output = torch.empty(value.shape, dtype=torch.bfloat16, device=value.device)
+    scale_fp32 = scale_inv.to(torch.float32)
+    for row_start in range(0, value.shape[0], _DEQUANT_CHUNK_ROWS):
+        row_end = min(row_start + _DEQUANT_CHUNK_ROWS, value.shape[0])
+        scale_row_start = row_start // block_m
+        scale_row_end = (row_end + block_m - 1) // block_m
+        expanded_scale = scale_fp32[
+            scale_row_start:scale_row_end
+        ].repeat_interleave(block_m, dim=0)
+        expanded_scale = expanded_scale[
+            : row_end - row_start
+        ].repeat_interleave(block_n, dim=1)
+        expanded_scale = expanded_scale[:, : value.shape[1]]
+        chunk = value[row_start:row_end].to(torch.float32)
+        chunk.mul_(expanded_scale)
+        output[row_start:row_end].copy_(chunk)
+    return output
 
 
 def _load_fp8_expert_weight_and_scale(
@@ -252,33 +261,68 @@ def _interleave_gate_up_weight(gate: torch.Tensor, up: torch.Tensor) -> torch.Te
     )
 
 
-def _load_ready_fused_projections(
-    model: torch.nn.Module,
-    pending: dict[str, dict[str, torch.Tensor]],
-    pending_parts: dict[str, tuple[str, ...]],
+def _copy_fused_projection_part(
+    expected_state: dict[str, torch.Tensor],
+    tensor_shapes: dict[str, torch.Size],
+    *,
+    checkpoint_key: str,
+    fused_key: str,
+    part: str,
+    parts: tuple[str, ...],
+    value: torch.Tensor,
+    loaded_parts: dict[str, set[str]],
     loaded_keys: set[str],
 ) -> None:
-    compatible_state = {}
-    for fused_key, part_tensors in list(pending.items()):
-        parts = pending_parts[fused_key]
-        if not all(part in part_tensors for part in parts):
-            continue
-        if parts == _MLP_GATE_UP_WEIGHT_PARTS:
-            compatible_state[fused_key] = _interleave_gate_up_weight(
-                part_tensors["gate_proj.weight"],
-                part_tensors["up_proj.weight"],
+    target = expected_state[fused_key]
+    if value.shape != tensor_shapes[checkpoint_key]:
+        raise ValueError(
+            f"checkpoint tensor {checkpoint_key!r} changed shape while loading"
+        )
+    seen = loaded_parts.setdefault(fused_key, set())
+    if part in seen:
+        raise ValueError(f"duplicate fused projection part {checkpoint_key!r}")
+    if parts == _MLP_GATE_UP_WEIGHT_PARTS:
+        expected_target_shape = (2 * value.shape[0], *value.shape[1:])
+        if target.shape != expected_target_shape:
+            raise ValueError(
+                f"fused target {fused_key!r} has shape {tuple(target.shape)}, "
+                f"expected {expected_target_shape}"
             )
-        else:
-            compatible_state[fused_key] = torch.cat(
-                [part_tensors[part] for part in parts],
-                dim=0,
+        slot = parts.index(part)
+        target_blocks = target.reshape(
+            target.shape[0] // 16,
+            2,
+            8,
+            *target.shape[1:],
+        )
+        source_blocks = value.reshape(
+            value.shape[0] // 8,
+            8,
+            *value.shape[1:],
+        )
+        with torch.no_grad():
+            target_blocks[:, slot].copy_(source_blocks)
+    else:
+        prefix = checkpoint_key[: -len(part)]
+        expected_target_shape = (
+            sum(tensor_shapes[f"{prefix}{item}"][0] for item in parts),
+            *value.shape[1:],
+        )
+        if target.shape != expected_target_shape:
+            raise ValueError(
+                f"fused target {fused_key!r} has shape {tuple(target.shape)}, "
+                f"expected {expected_target_shape}"
             )
-        loaded_keys.add(fused_key)
-        del pending[fused_key]
-        del pending_parts[fused_key]
+        offset = sum(
+            tensor_shapes[f"{prefix}{previous}"][0]
+            for previous in parts[: parts.index(part)]
+        )
+        with torch.no_grad():
+            target.narrow(0, offset, value.shape[0]).copy_(value)
 
-    if compatible_state:
-        model.load_state_dict(compatible_state, strict=False)
+    seen.add(part)
+    if seen == set(parts):
+        loaded_keys.add(fused_key)
 
 
 def _load_ready_packed_experts(
@@ -380,8 +424,7 @@ def _load_sharded_safetensors(
     expected_state = model.state_dict()
     expected_keys = set(expected_state)
     loaded_keys: set[str] = set()
-    pending_fused: dict[str, dict[str, torch.Tensor]] = {}
-    pending_fused_parts: dict[str, tuple[str, ...]] = {}
+    loaded_fused_parts: dict[str, set[str]] = {}
     pending_experts: dict[str, dict[int, dict[str, torch.Tensor]]] = {}
     qwen_rms_norm_weight_keys = _qwen_rms_norm_weight_keys(model)
     qwen_gdn_norm_weight_keys = _qwen_gdn_norm_weight_keys(model)
@@ -394,35 +437,43 @@ def _load_sharded_safetensors(
         )
         for shard_name in shard_names
     ]
+    tensor_shapes: dict[str, torch.Size] = {}
+    for _shard_name, shard_path in shard_paths:
+        with safe_open(shard_path, framework="pt", device="cpu") as handle:
+            for key in handle.keys():
+                if key in tensor_shapes:
+                    raise ValueError(f"duplicate Qwen checkpoint tensor {key!r}")
+                tensor_shapes[key] = torch.Size(handle.get_slice(key).get_shape())
     scale_inv_by_key = _load_scale_inv_tensors(shard_paths, device_arg=device_arg)
 
     for _shard_name, shard_path in shard_paths:
-        shard_state = load_file(shard_path, device=device_arg)
-        compatible_state = {}
-        for key, value in shard_state.items():
-            if key.startswith("mtp."):
-                continue
-            if key.endswith(".weight_scale_inv"):
-                continue
-            if key in expected_keys:
-                scale_key = _scale_inv_key(key)
-                compatible_state[key] = _loadable_tensor(
-                    key,
-                    value,
-                    qwen_rms_norm_weight_keys,
-                    expected_state[key].shape,
-                    scale_inv_by_key.get(scale_key),
-                    convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
-                    exact_fp32_weight_keys=qwen_gdn_norm_weight_keys,
-                )
-                loaded_keys.add(key)
-                continue
-            fused_parts = _fused_projection_keys(key)
-            fused_handled = False
-            for fused_key, part, parts in fused_parts:
-                if fused_key in expected_keys:
-                    pending_fused.setdefault(fused_key, {})[part] = (
-                        _loadable_tensor(
+        with safe_open(shard_path, framework="pt", device=device_arg) as handle:
+            for key in handle.keys():
+                if key.startswith("mtp."):
+                    continue
+                if key.endswith(".weight_scale_inv"):
+                    continue
+                value = handle.get_tensor(key)
+                if key in expected_keys:
+                    scale_key = _scale_inv_key(key)
+                    loaded = _loadable_tensor(
+                        key,
+                        value,
+                        qwen_rms_norm_weight_keys,
+                        expected_state[key].shape,
+                        scale_inv_by_key.get(scale_key),
+                        convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
+                        exact_fp32_weight_keys=qwen_gdn_norm_weight_keys,
+                    )
+                    with torch.no_grad():
+                        expected_state[key].copy_(loaded)
+                    loaded_keys.add(key)
+                    continue
+                fused_parts = _fused_projection_keys(key)
+                fused_handled = False
+                for fused_key, part, parts in fused_parts:
+                    if fused_key in expected_keys:
+                        loaded = _loadable_tensor(
                             key,
                             value,
                             set(),
@@ -430,65 +481,60 @@ def _load_sharded_safetensors(
                             scale_inv_by_key.get(_scale_inv_key(key)),
                             convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
                         )
-                    )
-                    pending_fused_parts[fused_key] = parts
-                    fused_handled = True
-                    break
-            if fused_handled:
-                continue
-            expert_part = _expert_projection_key(key)
-            if expert_part is not None:
-                target_key, expert_idx, part = expert_part
-                if target_key in expected_keys:
-                    if expected_state[target_key].dtype == torch.uint8:
-                        target_shape = expected_state[target_key].shape
-                        if target_key.endswith("gate_up_proj"):
-                            expected_part_shape = torch.Size(
-                                (target_shape[1] // 2, target_shape[2])
-                            )
-                        else:
-                            expected_part_shape = torch.Size(
-                                (target_shape[1], target_shape[2])
-                            )
-                        weight, scale = _load_fp8_expert_weight_and_scale(
-                            value,
-                            scale_inv_by_key.get(_scale_inv_key(key)),
-                            expected_part_shape,
-                            key=key,
+                        _copy_fused_projection_part(
+                            expected_state,
+                            tensor_shapes,
+                            checkpoint_key=key,
+                            fused_key=fused_key,
+                            part=part,
+                            parts=parts,
+                            value=loaded,
+                            loaded_parts=loaded_fused_parts,
+                            loaded_keys=loaded_keys,
                         )
-                        expert_entry = pending_experts.setdefault(
-                            target_key, {}
-                        ).setdefault(expert_idx, {})
-                        expert_entry[part] = weight
-                        expert_entry[f"{part}_scale_inv"] = scale
-                        continue
-                    pending_experts.setdefault(target_key, {}).setdefault(
-                        expert_idx, {}
-                    )[part] = _loadable_tensor(
-                        key,
-                        value,
-                        set(),
-                        value.shape,
-                        scale_inv_by_key.get(_scale_inv_key(key)),
-                        convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
-                    )
+                        fused_handled = True
+                        break
+                if fused_handled:
                     continue
-            unexpected.append(key)
-        model.load_state_dict(compatible_state, strict=False)
-        _load_ready_fused_projections(
-            model,
-            pending_fused,
-            pending_fused_parts,
-            loaded_keys,
-        )
+                expert_part = _expert_projection_key(key)
+                if expert_part is not None:
+                    target_key, expert_idx, part = expert_part
+                    if target_key in expected_keys:
+                        if expected_state[target_key].dtype == torch.uint8:
+                            target_shape = expected_state[target_key].shape
+                            if target_key.endswith("gate_up_proj"):
+                                expected_part_shape = torch.Size(
+                                    (target_shape[1] // 2, target_shape[2])
+                                )
+                            else:
+                                expected_part_shape = torch.Size(
+                                    (target_shape[1], target_shape[2])
+                                )
+                            weight, scale = _load_fp8_expert_weight_and_scale(
+                                value,
+                                scale_inv_by_key.get(_scale_inv_key(key)),
+                                expected_part_shape,
+                                key=key,
+                            )
+                            expert_entry = pending_experts.setdefault(
+                                target_key, {}
+                            ).setdefault(expert_idx, {})
+                            expert_entry[part] = weight
+                            expert_entry[f"{part}_scale_inv"] = scale
+                            continue
+                        pending_experts.setdefault(target_key, {}).setdefault(
+                            expert_idx, {}
+                        )[part] = _loadable_tensor(
+                            key,
+                            value,
+                            set(),
+                            value.shape,
+                            scale_inv_by_key.get(_scale_inv_key(key)),
+                            convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
+                        )
+                        continue
+                unexpected.append(key)
         _load_ready_packed_experts(model, pending_experts, loaded_keys)
-        del shard_state, compatible_state
-    _load_ready_fused_projections(
-        model,
-        pending_fused,
-        pending_fused_parts,
-        loaded_keys,
-    )
     _load_ready_packed_experts(model, pending_experts, loaded_keys)
 
     missing = [
@@ -559,7 +605,11 @@ def load_qwen35_model(
         )
     if config.text_config.tie_word_embeddings:
         model.lm_head.weight = model.model.language_model.embed_tokens.weight
-    return model.to(device=device).eval()
+    model = model.to(device=device).eval()
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+        torch.cuda.empty_cache()
+    return model
 
 
 __all__ = ["load_qwen35_model"]

--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -11,6 +11,8 @@ import torch
 from huggingface_hub import hf_hub_download
 from safetensors import safe_open
 
+from kestrel.ops.rotary import default_inv_freq
+
 from .qwen_config import Qwen3_5Config
 from .qwen_model import Qwen3_5ForConditionalGeneration, Qwen3_5RMSNormGated
 
@@ -657,11 +659,39 @@ def _materialize_remaining_meta_tensors(
         for name, buffer in tuple(module._buffers.items()):
             if buffer is None or buffer.device.type != "meta":
                 continue
+            if name in module._non_persistent_buffers_set:
+                raise RuntimeError(
+                    "Qwen load-time preparation left derived buffer "
+                    f"{type(module).__name__}.{name} uninitialized"
+                )
             replacement = buffer_replacements.get(id(buffer))
             if replacement is None:
                 replacement = torch.empty_like(buffer, device=device)
                 buffer_replacements[id(buffer)] = replacement
             module._buffers[name] = replacement
+
+
+def _restore_rotary_buffers(
+    model: Qwen3_5ForConditionalGeneration,
+    config: Qwen3_5Config,
+    *,
+    device: torch.device,
+) -> None:
+    """Materialize checkpoint-independent RoPE tables after meta construction."""
+
+    vision_rotary = model.model.visual.rotary_pos_emb
+    vision_rotary.inv_freq = default_inv_freq(
+        int(vision_rotary.inv_freq.numel()) * 2,
+        10_000.0,
+        device=device,
+    )
+    text_config = config.text_config
+    model.model.language_model.rotary_emb.inv_freq = default_inv_freq(
+        text_config.head_dim,
+        text_config.rope_theta,
+        partial_rotary_factor=text_config.partial_rotary_factor,
+        device=device,
+    )
 
 
 def load_qwen35_model(
@@ -688,6 +718,7 @@ def load_qwen35_model(
         torch.set_default_dtype(old_dtype)
     if prepare_model is not None:
         prepare_model(model)
+        _restore_rotary_buffers(model, config, device=device)
         _materialize_remaining_meta_tensors(model, device=device)
 
     index_path = _resolve_checkpoint_file(

--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -514,100 +514,105 @@ def _load_sharded_safetensors(
 
     for _shard_name, shard_path in shard_paths:
         with safe_open(shard_path, framework="pt", device=device_arg) as handle:
-            for key in handle.keys():
-                if key.startswith("mtp."):
-                    continue
-                if key.endswith(".weight_scale_inv"):
-                    continue
+            shard_keys = list(handle.keys())
+        # Keep only the tensor currently being copied backed by the shard mmap.
+        # A shard-wide handle retains every faulted page until the entire shard
+        # has loaded, which defeats the bounded-memory loader for large shards.
+        for key in shard_keys:
+            if key.startswith("mtp."):
+                continue
+            if key.endswith(".weight_scale_inv"):
+                continue
+            with safe_open(shard_path, framework="pt", device=device_arg) as handle:
                 value = handle.get_tensor(key)
-                if key in expected_keys:
-                    scale_key = _scale_inv_key(key)
+            if key in expected_keys:
+                scale_key = _scale_inv_key(key)
+                loaded = _loadable_tensor(
+                    key,
+                    value,
+                    qwen_rms_norm_weight_keys,
+                    expected_state[key].shape,
+                    scale_inv_by_key.get(scale_key),
+                    convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
+                    exact_fp32_weight_keys=qwen_gdn_norm_weight_keys,
+                )
+                with torch.no_grad():
+                    expected_state[key].copy_(loaded)
+                loaded_keys.add(key)
+                continue
+            fused_parts = _fused_projection_keys(key)
+            fused_handled = False
+            for fused_key, part, parts in fused_parts:
+                if fused_key in expected_keys:
                     loaded = _loadable_tensor(
                         key,
                         value,
-                        qwen_rms_norm_weight_keys,
-                        expected_state[key].shape,
-                        scale_inv_by_key.get(scale_key),
+                        set(),
+                        value.shape,
+                        scale_inv_by_key.get(_scale_inv_key(key)),
                         convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
-                        exact_fp32_weight_keys=qwen_gdn_norm_weight_keys,
                     )
-                    with torch.no_grad():
-                        expected_state[key].copy_(loaded)
-                    loaded_keys.add(key)
-                    continue
-                fused_parts = _fused_projection_keys(key)
-                fused_handled = False
-                for fused_key, part, parts in fused_parts:
-                    if fused_key in expected_keys:
-                        loaded = _loadable_tensor(
-                            key,
-                            value,
-                            set(),
-                            value.shape,
-                            scale_inv_by_key.get(_scale_inv_key(key)),
-                            convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
-                        )
-                        _copy_fused_projection_part(
-                            expected_state,
-                            tensor_shapes,
-                            checkpoint_key=key,
-                            fused_key=fused_key,
-                            part=part,
-                            parts=parts,
-                            value=loaded,
-                            loaded_parts=loaded_fused_parts,
-                            loaded_keys=loaded_keys,
-                        )
-                        fused_handled = True
-                        break
-                if fused_handled:
-                    continue
-                expert_part = _expert_projection_key(key)
-                if expert_part is not None:
-                    target_key, expert_idx, part = expert_part
-                    if target_key in expected_keys:
-                        if expected_state[target_key].dtype == torch.uint8:
-                            target_shape = expected_state[target_key].shape
-                            if target_key.endswith("gate_up_proj"):
-                                expected_part_shape = torch.Size(
-                                    (target_shape[1] // 2, target_shape[2])
-                                )
-                            else:
-                                expected_part_shape = torch.Size(
-                                    (target_shape[1], target_shape[2])
-                                )
-                            weight, scale = _load_fp8_expert_weight_and_scale(
-                                value,
-                                scale_inv_by_key.get(_scale_inv_key(key)),
-                                expected_part_shape,
-                                key=key,
+                    _copy_fused_projection_part(
+                        expected_state,
+                        tensor_shapes,
+                        checkpoint_key=key,
+                        fused_key=fused_key,
+                        part=part,
+                        parts=parts,
+                        value=loaded,
+                        loaded_parts=loaded_fused_parts,
+                        loaded_keys=loaded_keys,
+                    )
+                    fused_handled = True
+                    break
+            if fused_handled:
+                continue
+            expert_part = _expert_projection_key(key)
+            if expert_part is not None:
+                target_key, expert_idx, part = expert_part
+                if target_key in expected_keys:
+                    if expected_state[target_key].dtype == torch.uint8:
+                        target_shape = expected_state[target_key].shape
+                        if target_key.endswith("gate_up_proj"):
+                            expected_part_shape = torch.Size(
+                                (target_shape[1] // 2, target_shape[2])
                             )
-                            expert_entry = pending_experts.setdefault(
-                                target_key, {}
-                            ).setdefault(expert_idx, {})
-                            expert_entry[part] = weight
-                            expert_entry[f"{part}_scale_inv"] = scale
-                            continue
-                        loaded = _loadable_tensor(
-                            key,
+                        else:
+                            expected_part_shape = torch.Size(
+                                (target_shape[1], target_shape[2])
+                            )
+                        weight, scale = _load_fp8_expert_weight_and_scale(
                             value,
-                            set(),
-                            value.shape,
                             scale_inv_by_key.get(_scale_inv_key(key)),
-                            convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
+                            expected_part_shape,
+                            key=key,
                         )
-                        _copy_bf16_expert_part(
-                            expected_state,
-                            checkpoint_key=key,
-                            target_key=target_key,
-                            expert_idx=expert_idx,
-                            part=part,
-                            value=loaded,
-                            loaded_parts=loaded_expert_parts,
-                            loaded_keys=loaded_keys,
-                        )
+                        expert_entry = pending_experts.setdefault(
+                            target_key, {}
+                        ).setdefault(expert_idx, {})
+                        expert_entry[part] = weight
+                        expert_entry[f"{part}_scale_inv"] = scale
                         continue
-                unexpected.append(key)
+                    loaded = _loadable_tensor(
+                        key,
+                        value,
+                        set(),
+                        value.shape,
+                        scale_inv_by_key.get(_scale_inv_key(key)),
+                        convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
+                    )
+                    _copy_bf16_expert_part(
+                        expected_state,
+                        checkpoint_key=key,
+                        target_key=target_key,
+                        expert_idx=expert_idx,
+                        part=part,
+                        value=loaded,
+                        loaded_parts=loaded_expert_parts,
+                        loaded_keys=loaded_keys,
+                    )
+                    continue
+            unexpected.append(key)
         _load_ready_packed_experts(model, pending_experts, loaded_keys)
     _load_ready_packed_experts(model, pending_experts, loaded_keys)
 

--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import torch
 from huggingface_hub import hf_hub_download
@@ -325,6 +325,69 @@ def _copy_fused_projection_part(
         loaded_keys.add(fused_key)
 
 
+def _copy_bf16_expert_part(
+    expected_state: dict[str, torch.Tensor],
+    *,
+    checkpoint_key: str,
+    target_key: str,
+    expert_idx: int,
+    part: str,
+    value: torch.Tensor,
+    loaded_parts: dict[str, dict[int, set[str]]],
+    loaded_keys: set[str],
+) -> None:
+    target = expected_state[target_key]
+    if target.dtype != torch.bfloat16:
+        raise ValueError(f"expert target {target_key!r} is not BF16")
+    if not 0 <= expert_idx < target.shape[0]:
+        raise ValueError(f"expert index out of range in {checkpoint_key!r}")
+    seen = loaded_parts.setdefault(target_key, {}).setdefault(expert_idx, set())
+    if part in seen:
+        raise ValueError(f"duplicate expert projection part {checkpoint_key!r}")
+
+    expert_target = target[expert_idx]
+    if target_key.endswith(".gate_up_proj"):
+        parts = _MLP_GATE_UP_WEIGHT_PARTS
+        expected_shape = (
+            expert_target.shape[0] // 2,
+            *expert_target.shape[1:],
+        )
+        if value.shape != expected_shape:
+            raise ValueError(
+                f"expert projection {checkpoint_key!r} has shape {tuple(value.shape)}, "
+                f"expected {tuple(expected_shape)}"
+            )
+        slot = parts.index(part)
+        target_blocks = expert_target.reshape(
+            expert_target.shape[0] // 16,
+            2,
+            8,
+            *expert_target.shape[1:],
+        )
+        source_blocks = value.reshape(
+            value.shape[0] // 8,
+            8,
+            *value.shape[1:],
+        )
+        with torch.no_grad():
+            target_blocks[:, slot].copy_(source_blocks)
+    else:
+        parts = ("down_proj.weight",)
+        if value.shape != expert_target.shape:
+            raise ValueError(
+                f"expert projection {checkpoint_key!r} has shape {tuple(value.shape)}, "
+                f"expected {tuple(expert_target.shape)}"
+            )
+        with torch.no_grad():
+            expert_target.copy_(value)
+
+    seen.add(part)
+    if len(loaded_parts[target_key]) == target.shape[0] and all(
+        item == set(parts) for item in loaded_parts[target_key].values()
+    ):
+        loaded_keys.add(target_key)
+
+
 def _load_ready_packed_experts(
     model: torch.nn.Module,
     pending: dict[str, dict[int, dict[str, torch.Tensor]]],
@@ -425,6 +488,7 @@ def _load_sharded_safetensors(
     expected_keys = set(expected_state)
     loaded_keys: set[str] = set()
     loaded_fused_parts: dict[str, set[str]] = {}
+    loaded_expert_parts: dict[str, dict[int, set[str]]] = {}
     pending_experts: dict[str, dict[int, dict[str, torch.Tensor]]] = {}
     qwen_rms_norm_weight_keys = _qwen_rms_norm_weight_keys(model)
     qwen_gdn_norm_weight_keys = _qwen_gdn_norm_weight_keys(model)
@@ -522,15 +586,23 @@ def _load_sharded_safetensors(
                             expert_entry[part] = weight
                             expert_entry[f"{part}_scale_inv"] = scale
                             continue
-                        pending_experts.setdefault(target_key, {}).setdefault(
-                            expert_idx, {}
-                        )[part] = _loadable_tensor(
+                        loaded = _loadable_tensor(
                             key,
                             value,
                             set(),
                             value.shape,
                             scale_inv_by_key.get(_scale_inv_key(key)),
                             convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
+                        )
+                        _copy_bf16_expert_part(
+                            expected_state,
+                            checkpoint_key=key,
+                            target_key=target_key,
+                            expert_idx=expert_idx,
+                            part=part,
+                            value=loaded,
+                            loaded_parts=loaded_expert_parts,
+                            loaded_keys=loaded_keys,
                         )
                         continue
                 unexpected.append(key)
@@ -563,12 +635,42 @@ def _resolve_checkpoint_file(
     return hf_hub_download(source, filename, **kwargs)
 
 
+def _materialize_remaining_meta_tensors(
+    model: torch.nn.Module,
+    *,
+    device: torch.device,
+) -> None:
+    parameter_replacements: dict[int, torch.nn.Parameter] = {}
+    buffer_replacements: dict[int, torch.Tensor] = {}
+    for module in model.modules():
+        for name, parameter in tuple(module._parameters.items()):
+            if parameter is None or parameter.device.type != "meta":
+                continue
+            replacement = parameter_replacements.get(id(parameter))
+            if replacement is None:
+                replacement = torch.nn.Parameter(
+                    torch.empty_like(parameter, device=device),
+                    requires_grad=parameter.requires_grad,
+                )
+                parameter_replacements[id(parameter)] = replacement
+            module._parameters[name] = replacement
+        for name, buffer in tuple(module._buffers.items()):
+            if buffer is None or buffer.device.type != "meta":
+                continue
+            replacement = buffer_replacements.get(id(buffer))
+            if replacement is None:
+                replacement = torch.empty_like(buffer, device=device)
+                buffer_replacements[id(buffer)] = replacement
+            module._buffers[name] = replacement
+
+
 def load_qwen35_model(
     source: str | Path,
     *,
     device: torch.device,
     dtype: torch.dtype,
     revision: str | None = None,
+    prepare_model: Callable[[torch.nn.Module], None] | None = None,
 ) -> Qwen3_5ForConditionalGeneration:
     config_path = _resolve_checkpoint_file(
         source, "config.json", revision=revision
@@ -579,10 +681,14 @@ def load_qwen35_model(
     old_dtype = torch.get_default_dtype()
     torch.set_default_dtype(dtype)
     try:
-        with torch.device(device):
+        construction_device = torch.device("meta") if prepare_model else device
+        with torch.device(construction_device):
             model = Qwen3_5ForConditionalGeneration(config)
     finally:
         torch.set_default_dtype(old_dtype)
+    if prepare_model is not None:
+        prepare_model(model)
+        _materialize_remaining_meta_tensors(model, device=device)
 
     index_path = _resolve_checkpoint_file(
         source, "model.safetensors.index.json", revision=revision
@@ -604,8 +710,11 @@ def load_qwen35_model(
             f"missing={missing[:8]} unexpected={unexpected[:8]}"
         )
     if config.text_config.tie_word_embeddings:
-        model.lm_head.weight = model.model.language_model.embed_tokens.weight
-    model = model.to(device=device).eval()
+        embedding_weight = model.model.language_model.embed_tokens.weight
+        with torch.no_grad():
+            model.lm_head.weight.copy_(embedding_weight)
+        model.lm_head.weight = embedding_weight
+    model = model.eval()
     if device.type == "cuda":
         torch.cuda.synchronize(device)
         torch.cuda.empty_cache()

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -737,7 +737,7 @@ class Qwen3_5Experts(nn.Module):
             activation="swiglu",
             weight_format=self.expert_weight_format,
             dtype=hidden_states.dtype,
-            backend="auto" if self.expert_weight_format == "fp8_e4m3" else "triton",
+            backend="auto",
         )
         handle = _kestrel_moe_runtime.prepare(
             spec,

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -59,6 +59,7 @@ _kestrel_moe_runtime = _kestrel_runtime.moe
 _kestrel_moe_topk_fwd = _kestrel_moe_runtime.topk_fwd
 _KESTREL_MOE_DECODE_MAX_TOKENS = 16
 _KESTREL_MOE_MIN_PREFILL_BUCKET_TOKENS = 64
+_KESTREL_MOE_GATE_UP_LAYOUT = "interleaved_i8"
 _KESTREL_MOE_FP8_WEIGHT_SCALE_LAYOUT = "block128_interleaved8"
 
 
@@ -638,7 +639,7 @@ class Qwen3_5MLP(nn.Module):
             hidden,
             gate_up,
             activation="silu",
-            layout="interleaved_i8",
+            layout=_KESTREL_MOE_GATE_UP_LAYOUT,
         )
         return self.down_proj(hidden)
 

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -401,19 +401,32 @@ class Qwen35Runtime(UncachedPagedRuntime):
         self._prefill_slot_free = list(self._prefill_slots)
         self.prefill_slots: Sequence[Any] = self._prefill_slots
 
+        generated_decode_capacity = None
+        if self.decode_path != "native":
+            from .generated_decode import generated_decode_slot_capacity
+
+            generated_decode_capacity = generated_decode_slot_capacity(
+                self,
+                required=self.decode_path == "generated",
+            )
+        self._decode_row_capacity = max(
+            self.max_batch_slots,
+            generated_decode_capacity or 0,
+        )
+
         self._decode_slots = tuple(
             create_decode_slot(
                 slot_id=i,
                 device=self.device,
                 dtype=self.dtype,
-                max_batch_slots=self.max_batch_slots,
+                max_batch_slots=self._decode_row_capacity,
                 kv_cache_pages=self._kv_cache_pages,
                 vocab_size=int(text_cfg.vocab_size),
                 hidden_dim=int(text_cfg.hidden_size),
-                position_shape=(4, self.max_batch_slots, 1),
+                position_shape=(4, self._decode_row_capacity, 1),
                 scratch_specs={
                     "rope_deltas": (
-                        (self.max_batch_slots, 1),
+                        (self._decode_row_capacity, 1),
                         torch.long,
                     ),
                 },

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -293,6 +293,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
         )
         if model_source is None:
             raise ValueError("Qwen model spec must declare repo_id")
+        self._generated_weight_storage = None
         self.model = self._load_model(model_source).eval()
         self.architecture = self.model.config
         text_cfg = self.architecture.text_config
@@ -497,11 +498,23 @@ class Qwen35Runtime(UncachedPagedRuntime):
     def _load_model(self, source: str | Path) -> nn.Module:
         from .qwen_loader import load_qwen35_model
 
+        prepare_model = None
+        if self.decode_path != "native":
+            from .generated_decode import prepare_generated_weight_storage
+
+            def prepare_model(model: nn.Module) -> None:
+                self._generated_weight_storage = prepare_generated_weight_storage(
+                    self,
+                    model,
+                    required=self.decode_path == "generated",
+                )
+
         return load_qwen35_model(
             source,
             device=self.device,
             dtype=self.dtype,
             revision=self._spec.revision,
+            prepare_model=prepare_model,
         )
 
     def acquire_prefill_slot(self, slot_id: int) -> Any:

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -18,6 +18,7 @@ from torch import nn
 from kestrel.kv_cache import KVMemoryPool, PageTable, allocate_paged_kv_layers
 from kestrel.runtime.decode_graph import DecodeGraphManager
 from kestrel.runtime.decode_slot import DecodeSlot, create_decode_slot
+from kestrel.runtime.paged_resources import bound_kv_cache_pages
 from kestrel.runtime.tokenizer import load_tokenizer
 from kestrel.runtime.preprocessing import (
     derive_image_insertion_offset,
@@ -340,7 +341,12 @@ class Qwen35Runtime(UncachedPagedRuntime):
                 stacklevel=2,
             )
         self.page_size = int(getattr(cfg, "page_size", 1))
-        self._kv_cache_pages = int(getattr(cfg, "kv_cache_pages", 65536))
+        self._kv_cache_pages = bound_kv_cache_pages(
+            int(getattr(cfg, "kv_cache_pages", 65536)),
+            page_size=self.page_size,
+            max_batch_size=self.max_batch_size,
+            max_seq_length=self.max_seq_length,
+        )
         self.page_table = PageTable(
             n_pages=self._kv_cache_pages,
             page_size=self.page_size,

--- a/kestrel/runtime/bounded_projection.py
+++ b/kestrel/runtime/bounded_projection.py
@@ -244,6 +244,7 @@ def bind_declared_packed_projections(
         packed_bounds: dict[str, torch.Tensor] = {}
         source_bound_keys: list[str] = []
         bound_values: dict[str, list[torch.Tensor]] = {}
+        incomplete_bounds = False
         if is_bounded and child.use_bounds:
             for bound_name in (
                 "input_min",
@@ -257,10 +258,13 @@ def bind_declared_packed_projections(
                 ]
                 missing = [key for key in keys if key not in state_dict]
                 if missing:
-                    raise KeyError(
-                        f"packed projection {module_name!r} is missing bounds: "
-                        + ", ".join(repr(key) for key in missing)
-                    )
+                    if require_complete:
+                        raise KeyError(
+                            f"packed projection {module_name!r} is missing bounds: "
+                            + ", ".join(repr(key) for key in missing)
+                        )
+                    incomplete_bounds = True
+                    break
                 values = [state_dict[key] for key in keys]
                 if any(
                     value.ndim != 0
@@ -274,6 +278,9 @@ def bind_declared_packed_projections(
                     )
                 bound_values[bound_name] = values
                 source_bound_keys.extend(keys)
+
+            if incomplete_bounds:
+                continue
 
             for bound_name in ("input_min", "input_max"):
                 values = bound_values[bound_name]

--- a/kestrel/runtime/bounded_projection.py
+++ b/kestrel/runtime/bounded_projection.py
@@ -1,6 +1,6 @@
 """Dataflow helpers for bounded sibling projections."""
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 
 import torch
 from torch import nn
@@ -134,9 +134,39 @@ class PackedLinear(nn.Linear):
         self.source_weight_leaf = source_weight_leaf
 
 
+def declared_packed_projection_source_keys(module: nn.Module) -> set[str]:
+    """Return checkpoint keys consumed by declared packed projections."""
+
+    source_keys: set[str] = set()
+    for module_name, child in module.named_modules():
+        if not isinstance(child, (PackedBoundedProjections, PackedLinear)):
+            continue
+        parent_name, separator, _ = module_name.rpartition(".")
+        source_prefix = f"{parent_name}." if separator else ""
+        source_keys.update(
+            f"{source_prefix}{name}.{child.source_weight_leaf}"
+            for name in child.source_names
+        )
+        if isinstance(child, PackedBoundedProjections) and child.use_bounds:
+            source_keys.update(
+                f"{source_prefix}{name}.{bound_name}"
+                for name in child.source_names
+                for bound_name in (
+                    "input_min",
+                    "input_max",
+                    "output_min",
+                    "output_max",
+                )
+            )
+    return source_keys
+
+
 def bind_declared_packed_projections(
     module: nn.Module,
     state_dict: dict[str, torch.Tensor],
+    *,
+    already_bound_targets: Collection[str] = (),
+    require_complete: bool = True,
 ) -> None:
     """Pack declared sibling weights after proving compatible transforms."""
 
@@ -153,7 +183,7 @@ def bind_declared_packed_projections(
         target_weight_key = target_prefix + (
             "linear.weight" if is_bounded else "weight"
         )
-        if target_weight_key in state_dict:
+        if target_weight_key in state_dict or target_weight_key in already_bound_targets:
             continue
 
         source_weight_keys = [
@@ -162,10 +192,33 @@ def bind_declared_packed_projections(
         ]
         missing = [key for key in source_weight_keys if key not in state_dict]
         if missing:
+            if not require_complete:
+                continue
             raise KeyError(
                 f"packed projection {module_name!r} is missing source weights: "
                 + ", ".join(repr(key) for key in missing)
             )
+        if is_bounded and child.use_bounds:
+            required_bound_keys = [
+                f"{source_prefix}{name}.{bound_name}"
+                for bound_name in (
+                    "input_min",
+                    "input_max",
+                    "output_min",
+                    "output_max",
+                )
+                for name in child.source_names
+            ]
+            missing = [
+                key for key in required_bound_keys if key not in state_dict
+            ]
+            if missing:
+                if not require_complete:
+                    continue
+                raise KeyError(
+                    f"packed projection {module_name!r} is missing bounds: "
+                    + ", ".join(repr(key) for key in missing)
+                )
         weights = [state_dict[key] for key in source_weight_keys]
         first_weight = weights[0]
         for key, weight, output_size in zip(

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -106,6 +106,7 @@ class GeneratedDecodeSpec:
     weight_layer_prefix: str
     bindings: GeneratedDecodeBindings
     weight_sources: Mapping[str, torch.Tensor] | None = None
+    weight_storage: Any | None = None
     capacity_inputs: (
         Callable[[int, tuple[StateRepresentationRequirement, ...]], Mapping[str, Any]]
         | None
@@ -403,12 +404,23 @@ class GeneratedDecode:
             materialization_options = {}
             if spec.weight_sources is not None:
                 materialization_options["weight_sources"] = spec.weight_sources
-            self.weight_storage = materialize_weights(
-                spec.weight_root,
-                self._programs[0].descriptor,
-                layer_prefix=spec.weight_layer_prefix,
-                **materialization_options,
-            )
+            if spec.weight_storage is None:
+                self.weight_storage = materialize_weights(
+                    spec.weight_root,
+                    self._programs[0].descriptor,
+                    layer_prefix=spec.weight_layer_prefix,
+                    **materialization_options,
+                )
+            else:
+                expected_contract = repr(self._programs[0].descriptor["weights"])
+                actual_contract = getattr(
+                    spec.weight_storage, "weight_contract", None
+                )
+                if actual_contract != expected_contract:
+                    raise RuntimeError(
+                        "preloaded generated weights do not match the selected program"
+                    )
+                self.weight_storage = spec.weight_storage
             shared_inputs = dict(spec.bindings.runtime_inputs(runtime))
             weights_ready.record(runtime.compute_stream)
         ambient_stream.wait_event(weights_ready)

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -294,6 +294,27 @@ class GeneratedDecode:
         )
 
     @classmethod
+    def resolve_slot_capacity(
+        cls,
+        runtime: Any,
+        spec: GeneratedDecodeSpec,
+        *,
+        required_batch_sizes: Sequence[int] = (),
+    ) -> int | None:
+        """Return the physical row capacity required by selectable programs."""
+
+        programs = cls._resolve_programs(runtime, spec)
+        if any(
+            _select_program(programs, int(batch_size)) is None
+            for batch_size in required_batch_sizes
+        ):
+            return None
+        selected = _selectable_programs(programs, runtime.max_batch_size)
+        if not selected:
+            return None
+        return max(int(program.capacity) for program in selected)
+
+    @classmethod
     def require(
         cls,
         runtime: Any,

--- a/kestrel/runtime/paged_resources.py
+++ b/kestrel/runtime/paged_resources.py
@@ -21,8 +21,10 @@ def bound_kv_cache_pages(
     page_size = int(page_size)
     max_batch_size = int(max_batch_size)
     max_seq_length = int(max_seq_length)
-    if requested_pages < 1:
-        raise ValueError("requested_pages must be positive")
+    if requested_pages < 2:
+        raise ValueError(
+            "requested_pages must leave room for reserved and padding pages"
+        )
     if page_size < 1:
         raise ValueError("page_size must be positive")
     if max_batch_size < 1:

--- a/kestrel/runtime/paged_resources.py
+++ b/kestrel/runtime/paged_resources.py
@@ -8,6 +8,35 @@ from typing import Any
 import torch
 
 
+def bound_kv_cache_pages(
+    requested_pages: int,
+    *,
+    page_size: int,
+    max_batch_size: int,
+    max_seq_length: int,
+) -> int:
+    """Cap physical KV pages at the runtime's maximum reachable capacity."""
+
+    requested_pages = int(requested_pages)
+    page_size = int(page_size)
+    max_batch_size = int(max_batch_size)
+    max_seq_length = int(max_seq_length)
+    if requested_pages < 1:
+        raise ValueError("requested_pages must be positive")
+    if page_size < 1:
+        raise ValueError("page_size must be positive")
+    if max_batch_size < 1:
+        raise ValueError("max_batch_size must be positive")
+    if max_seq_length < 1:
+        raise ValueError("max_seq_length must be positive")
+
+    pages_per_sequence = (max_seq_length + page_size - 1) // page_size
+    # PageTable reserves physical page 0, and these runtimes reserve one
+    # additional page for their padding batch row.
+    reachable_pages = 2 + max_batch_size * pages_per_sequence
+    return min(requested_pages, reachable_pages)
+
+
 def decode_slot_rows(max_batch_size: int) -> int:
     max_batch_size = int(max_batch_size)
     if max_batch_size < 1:
@@ -29,5 +58,6 @@ class PrefillSlot:
 
 __all__ = [
     "PrefillSlot",
+    "bound_kv_cache_pages",
     "decode_slot_rows",
 ]

--- a/kestrel/skills/query.py
+++ b/kestrel/skills/query.py
@@ -238,8 +238,7 @@ class QuerySkillState(SkillState):
         runtime: "AutoregressiveRuntime",
         step: DecodeStep,
     ) -> None:
-        if self._reasoning_enabled:
-            self._ensure_token_ids(runtime)
+        self._ensure_token_ids(runtime)
         self.append_token(step.token)
 
         template = self._get_query_template(runtime)
@@ -258,7 +257,14 @@ class QuerySkillState(SkillState):
             # Don't collect injected tokens as answer tokens
             return None
 
-        if not self._reasoning_enabled:
+        if (
+            not self._reasoning_enabled
+            and not self._collecting_reasoning
+            and self._consume_optional_reasoning_start(step.token)
+        ):
+            return None
+
+        if not self._reasoning_enabled and not self._collecting_reasoning:
             if isinstance(step.token, TextToken):
                 self._answer_tokens.append(step.token.token_id)
             return None
@@ -337,9 +343,9 @@ class QuerySkillState(SkillState):
         *,
         reason: str,
     ) -> SkillFinalizeResult:
+        if self._reasoning_start_tokens and not self._reasoning_start_seen:
+            self._switch_to_direct_answer()
         if self._reasoning_enabled:
-            if self._reasoning_start_tokens and not self._reasoning_start_seen:
-                self._switch_to_direct_answer()
             self._flush_current_chunk()
 
         tokenizer = runtime.tokenizer
@@ -402,6 +408,28 @@ class QuerySkillState(SkillState):
         self._answer_tokens.extend(self._reasoning_start_tokens)
         self._reasoning_start_tokens.clear()
         self._answer_stream_offset = 0
+
+    def _consume_optional_reasoning_start(self, token: Token) -> bool:
+        """Hide a model-emitted reasoning channel in direct-answer mode."""
+
+        prefix = self._reasoning_start_prefix or ()
+        if (
+            not prefix
+            or self._reasoning_start_seen
+            or self._answer_tokens
+            or not isinstance(token, TextToken)
+        ):
+            return False
+        expected_id = prefix[len(self._reasoning_start_tokens)]
+        if token.token_id != expected_id:
+            self._switch_to_direct_answer()
+            return False
+        self._reasoning_start_tokens.append(token.token_id)
+        if len(self._reasoning_start_tokens) == len(prefix):
+            self._reasoning_start_seen = True
+            self._reasoning_start_tokens.clear()
+            self._collecting_reasoning = True
+        return True
 
     def _ensure_token_ids(self, runtime: "AutoregressiveRuntime") -> None:
         if self._answer_id is not None:

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from torch import nn
+
+from kestrel.models.gemma4.loader import load_weights
+from kestrel.runtime.bounded_projection import PackedLinear
+
+
+class _ToyShardedModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.packed = PackedLinear(
+            2,
+            (2, 2),
+            source_names=("gate", "up"),
+        )
+        self.exact = nn.Linear(2, 2, bias=False)
+
+
+def test_load_weights_streams_packed_projection_parts_across_shards(tmp_path) -> None:
+    gate = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    up = torch.tensor([[5.0, 6.0], [7.0, 8.0]])
+    exact = torch.tensor([[9.0, 10.0], [11.0, 12.0]])
+    save_file(
+        {"gate.weight": gate, "exact.weight": exact},
+        tmp_path / "model-00001-of-00002.safetensors",
+    )
+    save_file(
+        {"up.weight": up},
+        tmp_path / "model-00002-of-00002.safetensors",
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "gate.weight": "model-00001-of-00002.safetensors",
+                    "exact.weight": "model-00001-of-00002.safetensors",
+                    "up.weight": "model-00002-of-00002.safetensors",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    model = _ToyShardedModel()
+
+    load_weights(tmp_path, model)
+
+    torch.testing.assert_close(model.packed.weight, torch.cat((gate, up), dim=0))
+    torch.testing.assert_close(model.exact.weight, exact)
+
+
+def test_load_weights_rejects_incomplete_packed_projection(tmp_path) -> None:
+    save_file(
+        {
+            "gate.weight": torch.ones((2, 2)),
+            "exact.weight": torch.ones((2, 2)),
+        },
+        tmp_path / "model.safetensors",
+    )
+
+    with pytest.raises(KeyError, match="missing source weights"):
+        load_weights(tmp_path, _ToyShardedModel())
+
+
+def test_load_weights_rejects_unexpected_checkpoint_tensor(tmp_path) -> None:
+    save_file(
+        {
+            "gate.weight": torch.ones((2, 2)),
+            "up.weight": torch.ones((2, 2)),
+            "exact.weight": torch.ones((2, 2)),
+            "unexpected.weight": torch.ones((1,)),
+        },
+        tmp_path / "model.safetensors",
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected.weight"):
+        load_weights(tmp_path, _ToyShardedModel())

--- a/tests/gemma4/test_moe.py
+++ b/tests/gemma4/test_moe.py
@@ -152,7 +152,7 @@ def test_experts_use_shared_contiguous_geglu_runtime(monkeypatch) -> None:
 
     spec = calls["spec"]
     forward = calls["forward"]
-    assert spec.activation == "geglu"
+    assert spec.activation == "gelu"
     assert spec.backend == "auto"
     assert spec.intermediate_size == config.moe_intermediate_size
     assert forward["weights"].weight_scale_layout == "block128"

--- a/tests/gemma4/test_moe.py
+++ b/tests/gemma4/test_moe.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from kestrel.models.gemma4.config import Gemma4TextConfig, RopeSpec
+from kestrel.models.gemma4.model import (
+    Gemma4TextDecoderLayer,
+    Gemma4TextExperts,
+    Gemma4TextRouter,
+)
+from kestrel.models.registry import get_spec
+import kestrel.models.gemma4.model as model_module
+
+
+def _text_config(*, moe: bool = True) -> Gemma4TextConfig:
+    return Gemma4TextConfig(
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=12,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        rope={
+            "sliding_attention": RopeSpec(kind="default", theta=10_000.0),
+            "full_attention": RopeSpec(kind="default", theta=10_000.0),
+        },
+        sliding_window=16,
+        layer_types=("sliding_attention",),
+        final_logit_softcapping=30.0,
+        vocab_size_per_layer_input=32,
+        hidden_size_per_layer_input=0,
+        num_global_key_value_heads=1,
+        global_head_dim=4,
+        attention_k_eq_v=False,
+        num_kv_shared_layers=0,
+        use_double_wide_mlp=False,
+        enable_moe_block=moe,
+        num_experts=4 if moe else None,
+        top_k_experts=2 if moe else None,
+        moe_intermediate_size=6 if moe else None,
+    )
+
+
+def test_gemma4_26b_a4b_variants_are_registered() -> None:
+    for repo_id in (
+        "google/gemma-4-26B-A4B",
+        "google/gemma-4-26B-A4B-it",
+    ):
+        spec = get_spec(repo_id)
+        assert spec.repo_id == repo_id
+        assert spec.checkpoint_format == "gemma4"
+
+
+def test_moe_modules_match_checkpoint_parameter_shapes() -> None:
+    config = _text_config()
+    layer = Gemma4TextDecoderLayer(
+        config,
+        0,
+        kv_source_layer_idx=0,
+        publishes_kv=False,
+    )
+
+    assert layer.router.scale.shape == (config.hidden_size,)
+    assert layer.router.per_expert_scale.shape == (config.num_experts,)
+    assert layer.experts.gate_up_proj.shape == (4, 12, 8)
+    assert layer.experts.down_proj.shape == (4, 8, 6)
+    assert {
+        "router.scale",
+        "router.per_expert_scale",
+        "router.proj.weight",
+        "experts.gate_up_proj",
+        "experts.down_proj",
+        "post_feedforward_layernorm_1.weight",
+        "pre_feedforward_layernorm_2.weight",
+        "post_feedforward_layernorm_2.weight",
+    } <= set(layer.state_dict())
+
+
+def test_router_matches_full_softmax_then_topk_reference() -> None:
+    config = _text_config()
+    router = Gemma4TextRouter(config)
+    with torch.no_grad():
+        router.proj.weight.copy_(
+            torch.tensor(
+                [
+                    [0.2, -0.1, 0.3, 0.0, -0.2, 0.1, 0.4, -0.3],
+                    [-0.4, 0.2, 0.1, 0.3, 0.0, -0.1, 0.2, 0.1],
+                    [0.1, 0.3, -0.2, 0.4, -0.1, 0.2, 0.0, -0.3],
+                    [0.0, -0.2, 0.4, -0.1, 0.3, 0.1, -0.4, 0.2],
+                ]
+            )
+        )
+        router.scale.copy_(torch.linspace(0.8, 1.2, config.hidden_size))
+        router.per_expert_scale.copy_(torch.tensor([1.0, 0.5, 1.5, 0.75]))
+    hidden = torch.tensor(
+        [
+            [0.5, -0.4, 0.3, -0.2, 0.1, 0.0, 0.7, -0.6],
+            [-0.1, 0.2, 0.4, -0.3, 0.6, -0.5, 0.8, 0.1],
+        ]
+    )
+
+    actual_weights, actual_indices = router(hidden)
+
+    normalized = torch.nn.functional.rms_norm(
+        hidden.float(),
+        (config.hidden_size,),
+        eps=config.rms_norm_eps,
+    )
+    logits = torch.nn.functional.linear(
+        normalized * router.scale * (config.hidden_size**-0.5),
+        router.proj.weight,
+    )
+    probabilities = torch.softmax(logits, dim=-1, dtype=torch.float32)
+    expected_weights, expected_indices = torch.topk(
+        probabilities,
+        k=config.top_k_experts,
+        dim=-1,
+    )
+    expected_weights /= expected_weights.sum(dim=-1, keepdim=True)
+    expected_weights *= router.per_expert_scale[expected_indices]
+
+    torch.testing.assert_close(actual_weights, expected_weights)
+    torch.testing.assert_close(actual_indices.to(torch.long), expected_indices)
+    assert actual_weights.dtype == torch.float32
+
+
+def test_experts_use_shared_contiguous_geglu_runtime(monkeypatch) -> None:
+    config = _text_config()
+    experts = Gemma4TextExperts(config)
+    calls: dict[str, object] = {}
+
+    class FakeMoeRuntime:
+        def prepare(self, spec, capacity, *, device):
+            calls.update(spec=spec, capacity=capacity, device=device)
+            return SimpleNamespace(spec=spec)
+
+        def forward(self, handle, **kwargs):
+            calls.update(handle=handle, forward=kwargs)
+            return kwargs["x"] + 1
+
+    monkeypatch.setattr(model_module, "_moe_runtime", FakeMoeRuntime())
+    hidden = torch.zeros((1, 2, config.hidden_size))
+    indices = torch.tensor([[0, 1], [2, 3]], dtype=torch.int64)
+    weights = torch.full((2, 2), 0.5)
+
+    output = experts(hidden, indices, weights)
+
+    spec = calls["spec"]
+    forward = calls["forward"]
+    assert spec.activation == "geglu"
+    assert spec.backend == "auto"
+    assert spec.intermediate_size == config.moe_intermediate_size
+    assert forward["weights"].weight_scale_layout == "block128"
+    assert forward["topk_ids"].dtype == torch.int32
+    torch.testing.assert_close(output, hidden + 1)

--- a/tests/moondream/test_weight_streaming.py
+++ b/tests/moondream/test_weight_streaming.py
@@ -105,6 +105,39 @@ def test_safetensors_tensor_hook_still_visits_normalized_names(monkeypatch) -> N
     ]
 
 
+def test_safetensors_tensor_hook_predicate_avoids_unselected_reads(
+    monkeypatch,
+) -> None:
+    tensors = {
+        "wanted.a": torch.tensor([1.0]),
+        "unused.large": torch.empty(1024),
+        "metadata.scale": torch.tensor([3.0]),
+    }
+    calls: list[str] = []
+    hooked: list[tuple[str, float]] = []
+
+    monkeypatch.setattr(
+        weights, "safetensors_open", _fake_safetensors_open(tensors, calls)
+    )
+    monkeypatch.setattr(
+        weights,
+        "_assign_md2_text_weights",
+        lambda get_tensor, model: get_tensor("wanted.a"),
+    )
+
+    weights.load_moondream_weights(
+        "weights.safetensors",
+        _Model(),
+        load_vision=False,
+        checkpoint_format="md2",
+        tensor_hook=lambda name, tensor: hooked.append((name, tensor.item())),
+        tensor_hook_predicate=lambda name: name == "metadata.scale",
+    )
+
+    assert hooked == [("metadata.scale", 3.0)]
+    assert calls == ["metadata.scale", "wanted.a"]
+
+
 def test_safetensors_normalization_collision_fails_closed(monkeypatch) -> None:
     tensors = {
         "model._orig_mod.text.wte": torch.tensor([1.0]),

--- a/tests/moondream/test_weight_streaming.py
+++ b/tests/moondream/test_weight_streaming.py
@@ -1,0 +1,155 @@
+from contextlib import contextmanager
+
+import pytest
+import torch
+import torch.nn as nn
+from safetensors.torch import save_file
+
+from kestrel.models.moondream import weights
+
+
+class _Text(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.anchor = nn.Parameter(torch.empty(1))
+        self.blocks = nn.ModuleList()
+
+
+class _Model(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.text = _Text()
+
+
+def _fake_safetensors_open(
+    tensors: dict[str, torch.Tensor], calls: list[str]
+):
+    @contextmanager
+    def open_weights(path: str):
+        assert path.endswith(".safetensors")
+
+        def get_tensor(name: str) -> torch.Tensor:
+            calls.append(name)
+            return tensors[name]
+
+        get_tensor.keys = lambda: list(tensors)  # type: ignore[attr-defined]
+        yield get_tensor
+
+    return open_weights
+
+
+def test_safetensors_load_fetches_only_assigned_tensors(monkeypatch) -> None:
+    tensors = {
+        "wanted.a": torch.tensor([1.0]),
+        "wanted.b": torch.tensor([2.0]),
+        "unused.large": torch.empty(1024),
+    }
+    calls: list[str] = []
+    assigned: list[torch.Tensor] = []
+
+    monkeypatch.setattr(
+        weights, "safetensors_open", _fake_safetensors_open(tensors, calls)
+    )
+
+    def assign(get_tensor, model) -> None:
+        assigned.extend((get_tensor("wanted.a"), get_tensor("wanted.b")))
+
+    monkeypatch.setattr(weights, "_assign_md2_text_weights", assign)
+    weights.load_moondream_weights(
+        "weights.safetensors",
+        _Model(),
+        load_vision=False,
+        checkpoint_format="md2",
+    )
+
+    assert calls == ["wanted.a", "wanted.b"]
+    assert [tensor.item() for tensor in assigned] == [1.0, 2.0]
+
+
+def test_safetensors_tensor_hook_still_visits_normalized_names(monkeypatch) -> None:
+    tensors = {
+        "wanted._orig_mod.a": torch.tensor([1.0]),
+        "wanted.b": torch.tensor([2.0]),
+        "metadata.scale": torch.tensor([3.0]),
+    }
+    calls: list[str] = []
+    hooked: list[tuple[str, float]] = []
+
+    monkeypatch.setattr(
+        weights, "safetensors_open", _fake_safetensors_open(tensors, calls)
+    )
+    monkeypatch.setattr(
+        weights,
+        "_assign_md2_text_weights",
+        lambda get_tensor, model: get_tensor("wanted.a"),
+    )
+
+    weights.load_moondream_weights(
+        "weights.safetensors",
+        _Model(),
+        load_vision=False,
+        checkpoint_format="md2",
+        tensor_hook=lambda name, tensor: hooked.append((name, tensor.item())),
+    )
+
+    assert hooked == [
+        ("wanted.a", 1.0),
+        ("wanted.b", 2.0),
+        ("metadata.scale", 3.0),
+    ]
+    assert calls == [
+        "wanted._orig_mod.a",
+        "wanted.b",
+        "metadata.scale",
+        "wanted._orig_mod.a",
+    ]
+
+
+def test_safetensors_normalization_collision_fails_closed(monkeypatch) -> None:
+    tensors = {
+        "model._orig_mod.text.wte": torch.tensor([1.0]),
+        "model.text.wte": torch.tensor([2.0]),
+    }
+    calls: list[str] = []
+    monkeypatch.setattr(
+        weights, "safetensors_open", _fake_safetensors_open(tensors, calls)
+    )
+
+    with pytest.raises(ValueError, match="collide"):
+        weights.load_moondream_weights(
+            "weights.safetensors",
+            _Model(),
+            load_vision=False,
+            checkpoint_format="md2",
+        )
+
+    assert calls == []
+
+
+def test_real_safetensor_tensors_survive_per_read_handle_close(
+    monkeypatch, tmp_path
+) -> None:
+    path = tmp_path / "weights.safetensors"
+    save_file(
+        {
+            "wanted.a": torch.tensor([1.0]),
+            "wanted.b": torch.tensor([2.0]),
+        },
+        path,
+    )
+    assigned: list[torch.Tensor] = []
+
+    def assign(get_tensor, model) -> None:
+        assigned.extend(
+            (get_tensor("wanted.a").clone(), get_tensor("wanted.b").clone())
+        )
+
+    monkeypatch.setattr(weights, "_assign_md2_text_weights", assign)
+    weights.load_moondream_weights(
+        str(path),
+        _Model(),
+        load_vision=False,
+        checkpoint_format="md2",
+    )
+
+    assert [tensor.item() for tensor in assigned] == [1.0, 2.0]

--- a/tests/qwen35/test_generated_decode.py
+++ b/tests/qwen35/test_generated_decode.py
@@ -364,6 +364,43 @@ def test_generated_decode_binds_rope_offsets_without_dropping_old_bundle_prep(
     )
 
 
+def test_generated_decode_reports_compiled_slot_capacity(monkeypatch):
+    runtime = SimpleNamespace(
+        max_batch_size=1,
+        _decode_rope_deltas=object(),
+        _gather_decode_rope_deltas=lambda *_args: None,
+        _prepare_decode_position_ids=lambda *_args: None,
+        _paged_kv=(),
+        _linear_state_pool=object(),
+        model=SimpleNamespace(
+            model=SimpleNamespace(
+                language_model=SimpleNamespace(
+                    rotary_emb=SimpleNamespace(inv_freq=object())
+                )
+            )
+        ),
+        page_table=SimpleNamespace(page_table=object()),
+    )
+    captured = {}
+
+    def resolve(_cls, bound_runtime, spec, *, required_batch_sizes=()):
+        captured["runtime"] = bound_runtime
+        captured["spec"] = spec
+        captured["required_batch_sizes"] = tuple(required_batch_sizes)
+        return 8
+
+    monkeypatch.setattr(
+        qwen_generated.GeneratedDecode,
+        "resolve_slot_capacity",
+        classmethod(resolve),
+    )
+
+    assert qwen_generated.generated_decode_slot_capacity(runtime) == 8
+    assert captured["runtime"] is runtime
+    assert captured["required_batch_sizes"] == (1,)
+    assert captured["spec"].label == "Qwen"
+
+
 def test_generated_capacity_inputs_resolve_state_after_cached_field_snapshot(
     monkeypatch,
 ):

--- a/tests/qwen35/test_loader.py
+++ b/tests/qwen35/test_loader.py
@@ -3,9 +3,11 @@ import torch
 from kestrel.models.qwen35.qwen_loader import (
     _ATTN_QKV_WEIGHT_PARTS,
     _MLP_GATE_UP_WEIGHT_PARTS,
+    _copy_bf16_expert_part,
     _copy_fused_projection_part,
     _dequantize_fp8_weight,
     _interleave_gate_up_weight,
+    _materialize_remaining_meta_tensors,
 )
 
 
@@ -87,3 +89,70 @@ def test_gate_up_parts_copy_directly_into_interleaved_layout() -> None:
 
     torch.testing.assert_close(target, _interleave_gate_up_weight(gate, up))
     assert loaded_keys == {"layer.gate_up_proj.weight"}
+
+
+def test_bf16_experts_stream_into_final_interleaved_slices() -> None:
+    gate = torch.arange(48, dtype=torch.bfloat16).reshape(16, 3)
+    up = gate + 100
+    down = torch.arange(24, dtype=torch.bfloat16).reshape(3, 8)
+    expected_state = {
+        "layer.experts.gate_up_proj": torch.empty((2, 32, 3), dtype=torch.bfloat16),
+        "layer.experts.down_proj": torch.empty((2, 3, 8), dtype=torch.bfloat16),
+    }
+    loaded_parts: dict[str, dict[int, set[str]]] = {}
+    loaded_keys: set[str] = set()
+
+    for expert_idx in range(2):
+        for part, value in (("up_proj.weight", up), ("gate_proj.weight", gate)):
+            _copy_bf16_expert_part(
+                expected_state,
+                checkpoint_key=f"layer.experts.{expert_idx}.{part}",
+                target_key="layer.experts.gate_up_proj",
+                expert_idx=expert_idx,
+                part=part,
+                value=value,
+                loaded_parts=loaded_parts,
+                loaded_keys=loaded_keys,
+            )
+        _copy_bf16_expert_part(
+            expected_state,
+            checkpoint_key=f"layer.experts.{expert_idx}.down_proj.weight",
+            target_key="layer.experts.down_proj",
+            expert_idx=expert_idx,
+            part="down_proj.weight",
+            value=down,
+            loaded_parts=loaded_parts,
+            loaded_keys=loaded_keys,
+        )
+
+    interleaved = _interleave_gate_up_weight(gate, up)
+    torch.testing.assert_close(
+        expected_state["layer.experts.gate_up_proj"],
+        torch.stack((interleaved, interleaved)),
+    )
+    torch.testing.assert_close(
+        expected_state["layer.experts.down_proj"],
+        torch.stack((down, down)),
+    )
+    assert loaded_keys == {
+        "layer.experts.gate_up_proj",
+        "layer.experts.down_proj",
+    }
+
+
+def test_remaining_meta_tensors_materialize_without_replacing_bound_storage() -> None:
+    module = torch.nn.Module()
+    module.bound = torch.nn.Parameter(torch.empty(3))
+    with torch.device("meta"):
+        shared = torch.nn.Parameter(torch.empty(4))
+        module.pending = shared
+        module.pending_alias = shared
+        module.register_buffer("pending_buffer", torch.empty(2))
+    bound = module.bound
+
+    _materialize_remaining_meta_tensors(module, device=torch.device("cpu"))
+
+    assert module.bound is bound
+    assert module.pending.device.type == "cpu"
+    assert module.pending is module.pending_alias
+    assert module.pending_buffer.device.type == "cpu"

--- a/tests/qwen35/test_loader.py
+++ b/tests/qwen35/test_loader.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import torch
@@ -9,9 +10,11 @@ from kestrel.models.qwen35.qwen_loader import (
     _copy_fused_projection_part,
     _dequantize_fp8_weight,
     _interleave_gate_up_weight,
+    _load_sharded_safetensors,
     _materialize_remaining_meta_tensors,
     _restore_rotary_buffers,
 )
+import kestrel.models.qwen35.qwen_loader as loader_module
 from kestrel.ops.rotary import default_inv_freq
 
 
@@ -142,6 +145,76 @@ def test_bf16_experts_stream_into_final_interleaved_slices() -> None:
         "layer.experts.gate_up_proj",
         "layer.experts.down_proj",
     }
+
+
+def test_sharded_loader_closes_key_handle_before_per_tensor_read(
+    monkeypatch, tmp_path
+) -> None:
+    checkpoint = tmp_path / "model.safetensors"
+    checkpoint.write_bytes(b"fake")
+    source = torch.tensor([[1.0, 2.0]])
+    events: list[tuple[str, int, str | None]] = []
+    next_handle = 0
+
+    class Slice:
+        def get_shape(self):
+            return source.shape
+
+    @contextmanager
+    def fake_safe_open(path, *, framework, device):
+        nonlocal next_handle
+        assert path == str(checkpoint)
+        assert framework == "pt"
+        handle_id = next_handle
+        next_handle += 1
+        tensor_reads = 0
+        events.append(("open", handle_id, device))
+
+        class Handle:
+            def keys(self):
+                events.append(("keys", handle_id, None))
+                return ["weight"]
+
+            def get_slice(self, key):
+                assert key == "weight"
+                events.append(("slice", handle_id, key))
+                return Slice()
+
+            def get_tensor(self, key):
+                nonlocal tensor_reads
+                assert key == "weight"
+                tensor_reads += 1
+                assert tensor_reads == 1
+                events.append(("tensor", handle_id, key))
+                return source
+
+        try:
+            yield Handle()
+        finally:
+            events.append(("close", handle_id, device))
+
+    monkeypatch.setattr(loader_module, "safe_open", fake_safe_open)
+    model = torch.nn.Linear(2, 1, bias=False)
+
+    missing, unexpected = _load_sharded_safetensors(
+        model,
+        tmp_path,
+        [checkpoint.name],
+        device=torch.device("cpu"),
+    )
+
+    assert missing == []
+    assert unexpected == []
+    torch.testing.assert_close(model.weight, source)
+    tensor_handle = next(
+        handle_id for event, handle_id, _ in events if event == "tensor"
+    )
+    tensor_open_index = events.index(("open", tensor_handle, "cpu"))
+    close_event = events[tensor_open_index - 1]
+    assert close_event[0] == "close"
+    key_handle = close_event[1]
+    assert key_handle != tensor_handle
+    assert ("keys", key_handle, None) in events
 
 
 def test_remaining_meta_tensors_materialize_without_replacing_bound_storage() -> None:

--- a/tests/qwen35/test_loader.py
+++ b/tests/qwen35/test_loader.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import torch
 
 from kestrel.models.qwen35.qwen_loader import (
@@ -8,7 +10,9 @@ from kestrel.models.qwen35.qwen_loader import (
     _dequantize_fp8_weight,
     _interleave_gate_up_weight,
     _materialize_remaining_meta_tensors,
+    _restore_rotary_buffers,
 )
+from kestrel.ops.rotary import default_inv_freq
 
 
 def test_fp8_dequantization_chunks_without_changing_bf16_result() -> None:
@@ -156,3 +160,59 @@ def test_remaining_meta_tensors_materialize_without_replacing_bound_storage() ->
     assert module.pending.device.type == "cpu"
     assert module.pending is module.pending_alias
     assert module.pending_buffer.device.type == "cpu"
+
+
+def test_remaining_meta_tensors_reject_uninitialized_derived_buffers() -> None:
+    module = torch.nn.Module()
+    with torch.device("meta"):
+        module.register_buffer("derived", torch.empty(2), persistent=False)
+
+    try:
+        _materialize_remaining_meta_tensors(module, device=torch.device("cpu"))
+    except RuntimeError as exc:
+        assert "derived buffer" in str(exc)
+    else:
+        raise AssertionError("uninitialized derived buffer was accepted")
+
+
+def test_rotary_buffers_are_recomputed_after_meta_construction() -> None:
+    class Rotary(torch.nn.Module):
+        def __init__(self, size: int) -> None:
+            super().__init__()
+            with torch.device("meta"):
+                self.register_buffer(
+                    "inv_freq", torch.empty(size), persistent=False
+                )
+
+    model = SimpleNamespace(
+        model=SimpleNamespace(
+            visual=SimpleNamespace(rotary_pos_emb=Rotary(4)),
+            language_model=SimpleNamespace(rotary_emb=Rotary(3)),
+        )
+    )
+    config = SimpleNamespace(
+        text_config=SimpleNamespace(
+            head_dim=12,
+            rope_theta=1_000_000.0,
+            partial_rotary_factor=0.5,
+        )
+    )
+
+    _restore_rotary_buffers(model, config, device=torch.device("cpu"))
+
+    torch.testing.assert_close(
+        model.model.visual.rotary_pos_emb.inv_freq,
+        default_inv_freq(8, 10_000.0),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        model.model.language_model.rotary_emb.inv_freq,
+        default_inv_freq(
+            12,
+            1_000_000.0,
+            partial_rotary_factor=0.5,
+        ),
+        rtol=0,
+        atol=0,
+    )

--- a/tests/qwen35/test_loader.py
+++ b/tests/qwen35/test_loader.py
@@ -1,0 +1,89 @@
+import torch
+
+from kestrel.models.qwen35.qwen_loader import (
+    _ATTN_QKV_WEIGHT_PARTS,
+    _MLP_GATE_UP_WEIGHT_PARTS,
+    _copy_fused_projection_part,
+    _dequantize_fp8_weight,
+    _interleave_gate_up_weight,
+)
+
+
+def test_fp8_dequantization_chunks_without_changing_bf16_result() -> None:
+    torch.manual_seed(0)
+    value = torch.randn((1_153, 257), dtype=torch.float32).to(
+        torch.float8_e4m3fn
+    )
+    scale = torch.rand((10, 3), dtype=torch.float32)
+
+    actual = _dequantize_fp8_weight(
+        value,
+        scale,
+        value.shape,
+        key="model.language_model.layers.0.mlp.gate_proj.weight",
+    )
+    expanded_scale = scale.repeat_interleave(128, dim=0).repeat_interleave(
+        128,
+        dim=1,
+    )[: value.shape[0], : value.shape[1]]
+    expected = (value.float() * expanded_scale).to(torch.bfloat16)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_fused_projection_parts_copy_directly_into_final_slices() -> None:
+    values = {
+        "q_proj.weight": torch.full((4, 3), 1.0),
+        "k_proj.weight": torch.full((2, 3), 2.0),
+        "v_proj.weight": torch.full((2, 3), 3.0),
+    }
+    target = torch.zeros((8, 3))
+    shapes = {f"layer.{key}": value.shape for key, value in values.items()}
+    loaded_parts: dict[str, set[str]] = {}
+    loaded_keys: set[str] = set()
+
+    for part in ("v_proj.weight", "q_proj.weight", "k_proj.weight"):
+        _copy_fused_projection_part(
+            {"layer.qkv_proj.weight": target},
+            shapes,
+            checkpoint_key=f"layer.{part}",
+            fused_key="layer.qkv_proj.weight",
+            part=part,
+            parts=_ATTN_QKV_WEIGHT_PARTS,
+            value=values[part],
+            loaded_parts=loaded_parts,
+            loaded_keys=loaded_keys,
+        )
+
+    torch.testing.assert_close(
+        target,
+        torch.cat([values[part] for part in _ATTN_QKV_WEIGHT_PARTS]),
+    )
+    assert loaded_keys == {"layer.qkv_proj.weight"}
+
+
+def test_gate_up_parts_copy_directly_into_interleaved_layout() -> None:
+    gate = torch.arange(48, dtype=torch.float32).reshape(16, 3)
+    up = gate + 100
+    target = torch.zeros((32, 3))
+    loaded_parts: dict[str, set[str]] = {}
+    loaded_keys: set[str] = set()
+
+    for part, value in (("up_proj.weight", up), ("gate_proj.weight", gate)):
+        _copy_fused_projection_part(
+            {"layer.gate_up_proj.weight": target},
+            {
+                "layer.gate_proj.weight": gate.shape,
+                "layer.up_proj.weight": up.shape,
+            },
+            checkpoint_key=f"layer.{part}",
+            fused_key="layer.gate_up_proj.weight",
+            part=part,
+            parts=_MLP_GATE_UP_WEIGHT_PARTS,
+            value=value,
+            loaded_parts=loaded_parts,
+            loaded_keys=loaded_keys,
+        )
+
+    torch.testing.assert_close(target, _interleave_gate_up_weight(gate, up))
+    assert loaded_keys == {"layer.gate_up_proj.weight"}

--- a/tests/qwen35/test_loader.py
+++ b/tests/qwen35/test_loader.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 
 import torch
+from safetensors.torch import save_file
 
 from kestrel.models.qwen35.qwen_loader import (
     _ATTN_QKV_WEIGHT_PARTS,
@@ -16,6 +17,21 @@ from kestrel.models.qwen35.qwen_loader import (
 )
 import kestrel.models.qwen35.qwen_loader as loader_module
 from kestrel.ops.rotary import default_inv_freq
+
+
+class _FusedExpertHolder(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = torch.nn.Module()
+        self.model.language_model = torch.nn.Module()
+        self.model.language_model.layers = torch.nn.ModuleList([torch.nn.Module()])
+        layer = self.model.language_model.layers[0]
+        layer.mlp = torch.nn.Module()
+        layer.mlp.experts = torch.nn.Module()
+        layer.mlp.experts.gate_up_proj = torch.nn.Parameter(
+            torch.empty((2, 32, 3), dtype=torch.bfloat16),
+            requires_grad=False,
+        )
 
 
 def test_fp8_dequantization_chunks_without_changing_bf16_result() -> None:
@@ -145,6 +161,62 @@ def test_bf16_experts_stream_into_final_interleaved_slices() -> None:
         "layer.experts.gate_up_proj",
         "layer.experts.down_proj",
     }
+
+
+def test_fused_and_separate_expert_checkpoints_load_identical_physical_layout(
+    tmp_path,
+) -> None:
+    gate = torch.arange(2 * 16 * 3, dtype=torch.bfloat16).reshape(2, 16, 3)
+    up = gate + 1000
+    target_key = "model.language_model.layers.0.mlp.experts.gate_up_proj"
+    fused_dir = tmp_path / "fused"
+    separate_dir = tmp_path / "separate"
+    fused_dir.mkdir()
+    separate_dir.mkdir()
+    save_file(
+        {target_key: torch.cat((gate, up), dim=1)},
+        fused_dir / "model.safetensors",
+    )
+    save_file(
+        {
+            f"model.language_model.layers.0.mlp.experts.{expert}.gate_proj.weight": gate[expert]
+            for expert in range(2)
+        }
+        | {
+            f"model.language_model.layers.0.mlp.experts.{expert}.up_proj.weight": up[expert]
+            for expert in range(2)
+        },
+        separate_dir / "model.safetensors",
+    )
+    fused = _FusedExpertHolder()
+    separate = _FusedExpertHolder()
+
+    fused_result = _load_sharded_safetensors(
+        fused,
+        fused_dir,
+        ["model.safetensors"],
+        device=torch.device("cpu"),
+    )
+    separate_result = _load_sharded_safetensors(
+        separate,
+        separate_dir,
+        ["model.safetensors"],
+        device=torch.device("cpu"),
+    )
+
+    assert fused_result == ([], [])
+    assert separate_result == ([], [])
+    expected = torch.stack(
+        tuple(_interleave_gate_up_weight(gate[i], up[i]) for i in range(2))
+    )
+    torch.testing.assert_close(
+        fused.model.language_model.layers[0].mlp.experts.gate_up_proj,
+        expected,
+    )
+    torch.testing.assert_close(
+        separate.model.language_model.layers[0].mlp.experts.gate_up_proj,
+        expected,
+    )
 
 
 def test_sharded_loader_closes_key_handle_before_per_tensor_read(

--- a/tests/qwen35/test_moe.py
+++ b/tests/qwen35/test_moe.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+import torch
+
+from kestrel.models.qwen35.qwen_config import Qwen3_5TextConfig
+from kestrel.models.qwen35.qwen_model import Qwen3_5Experts
+import kestrel.models.qwen35.qwen_model as model_module
+
+
+def _moe_config() -> Qwen3_5TextConfig:
+    return Qwen3_5TextConfig(
+        vocab_size=32,
+        hidden_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        tie_word_embeddings=False,
+        rope_theta=10_000.0,
+        partial_rotary_factor=1.0,
+        mrope_section=(1, 1, 1),
+        head_dim=4,
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=2,
+        linear_value_head_dim=2,
+        linear_num_key_heads=1,
+        linear_num_value_heads=2,
+        layer_types=("linear_attention",),
+        intermediate_size=12,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        num_experts_per_tok=2,
+        num_experts=4,
+        expert_weight_format="bf16",
+    )
+
+
+def test_bf16_experts_use_device_selected_moe_backend(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    class FakeMoeRuntime:
+        def prepare(self, spec, capacity, *, device):
+            calls.update(spec=spec, capacity=capacity, device=device)
+            return SimpleNamespace(spec=spec)
+
+        def forward(self, handle, **kwargs):
+            calls.update(handle=handle, forward=kwargs)
+            return kwargs["x"] + 1
+
+    monkeypatch.setattr(model_module, "_kestrel_moe_runtime", FakeMoeRuntime())
+    experts = Qwen3_5Experts(_moe_config()).to(dtype=torch.bfloat16)
+    hidden = torch.zeros((2, 8), dtype=torch.bfloat16)
+    indices = torch.tensor([[0, 1], [2, 3]], dtype=torch.int64)
+    weights = torch.full((2, 2), 0.5, dtype=torch.bfloat16)
+
+    output = experts(hidden, indices, weights)
+
+    spec = calls["spec"]
+    assert spec.backend == "auto"
+    assert spec.weight_format == "bf16"
+    assert calls["forward"]["topk_ids"].dtype == torch.int32
+    torch.testing.assert_close(output, hidden + 1)

--- a/tests/test_bounded_projection.py
+++ b/tests/test_bounded_projection.py
@@ -1,0 +1,118 @@
+import torch
+from torch import nn
+
+from kestrel.runtime.bounded_projection import (
+    PackedBoundedProjections,
+    PackedLinear,
+    bind_declared_packed_projections,
+    declared_packed_projection_source_keys,
+)
+
+
+def test_packed_linear_binding_waits_for_all_streamed_parts() -> None:
+    module = nn.Module()
+    module.packed = PackedLinear(
+        3,
+        (2, 1),
+        source_names=("q", "k"),
+    )
+    q = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    state = {"q.weight": q}
+
+    bind_declared_packed_projections(
+        module,
+        state,
+        require_complete=False,
+    )
+    assert state == {"q.weight": q}
+
+    k = torch.arange(3, dtype=torch.float32).reshape(1, 3) + 10
+    state["k.weight"] = k
+    bind_declared_packed_projections(
+        module,
+        state,
+        require_complete=False,
+    )
+    assert set(state) == {"packed.weight"}
+    torch.testing.assert_close(state["packed.weight"], torch.cat((q, k)))
+
+
+def test_packed_bounded_binding_waits_for_streamed_bounds() -> None:
+    module = nn.Module()
+    module.packed = PackedBoundedProjections(
+        2,
+        (1, 1),
+        source_names=("left", "right"),
+        use_bounds=True,
+    )
+    state = {
+        "left.linear.weight": torch.ones((1, 2)),
+        "right.linear.weight": torch.full((1, 2), 2.0),
+    }
+
+    bind_declared_packed_projections(
+        module,
+        state,
+        require_complete=False,
+    )
+    assert "packed.linear.weight" not in state
+
+    for source in ("left", "right"):
+        state[f"{source}.input_min"] = torch.tensor(-1.0)
+        state[f"{source}.input_max"] = torch.tensor(1.0)
+        state[f"{source}.output_min"] = torch.tensor(-2.0)
+        state[f"{source}.output_max"] = torch.tensor(2.0)
+    bind_declared_packed_projections(
+        module,
+        state,
+        require_complete=False,
+    )
+    assert set(state) == {
+        "packed.input_max",
+        "packed.input_min",
+        "packed.linear.weight",
+        "packed.output_max",
+        "packed.output_min",
+    }
+
+
+def test_packed_binding_skips_already_loaded_target() -> None:
+    module = nn.Module()
+    module.packed = PackedLinear(
+        3,
+        (2, 1),
+        source_names=("q", "k"),
+    )
+    state: dict[str, torch.Tensor] = {}
+
+    bind_declared_packed_projections(
+        module,
+        state,
+        already_bound_targets={"packed.weight"},
+    )
+
+    assert state == {}
+
+
+def test_declared_source_keys_include_weights_and_bounds() -> None:
+    module = nn.Module()
+    module.attn = nn.Module()
+    module.attn.qkv = PackedBoundedProjections(
+        2,
+        (1, 1),
+        source_names=("q", "k"),
+        use_bounds=True,
+    )
+
+    assert declared_packed_projection_source_keys(module) == {
+        "attn.q.linear.weight",
+        "attn.k.linear.weight",
+        "attn.q.input_min",
+        "attn.q.input_max",
+        "attn.q.output_min",
+        "attn.q.output_max",
+        "attn.k.input_min",
+        "attn.k.input_max",
+        "attn.k.output_min",
+        "attn.k.output_max",
+    }

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -97,3 +97,38 @@ def test_program_selection_rejects_invalid_runtime_interval():
 
     with pytest.raises(RuntimeError, match="invalid active-batch interval"):
         generated._program_for(4)
+
+
+def test_slot_capacity_uses_selected_program_physical_capacity(monkeypatch):
+    runtime = SimpleNamespace(max_batch_size=1)
+    b8 = _program(8)
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "_resolve_programs",
+        classmethod(lambda _cls, _runtime, _spec: (b8,)),
+    )
+
+    assert GeneratedDecode.resolve_slot_capacity(
+        runtime,
+        object(),
+        required_batch_sizes=(1,),
+    ) == 8
+
+
+def test_slot_capacity_refuses_incomplete_required_domain(monkeypatch):
+    runtime = SimpleNamespace(max_batch_size=4)
+    programs = tuple(
+        _program(batch_size, active_batch=batch_size)
+        for batch_size in (1, 2, 4)
+    )
+    monkeypatch.setattr(
+        GeneratedDecode,
+        "_resolve_programs",
+        classmethod(lambda _cls, _runtime, _spec: programs),
+    )
+
+    assert GeneratedDecode.resolve_slot_capacity(
+        runtime,
+        object(),
+        required_batch_sizes=range(1, 5),
+    ) is None

--- a/tests/test_generated_decode_static_extents.py
+++ b/tests/test_generated_decode_static_extents.py
@@ -96,6 +96,7 @@ def _build(
     bindings=None,
     max_batch_size=8,
     weight_sources=None,
+    weight_storage=None,
     materialize_calls=None,
 ):
     launches = programs[0].launches
@@ -133,6 +134,7 @@ def _build(
         weight_layer_prefix="layers",
         bindings=bindings or _Bindings(),
         weight_sources=weight_sources,
+        weight_storage=weight_storage,
     )
     return runtime_decode.GeneratedDecode(
         runtime, spec=spec, programs=programs
@@ -152,6 +154,34 @@ def test_generated_decode_materializes_explicit_weight_sources(monkeypatch):
     )
 
     assert calls == [{"layer_prefix": "layers", "weight_sources": sources}]
+
+
+def test_generated_decode_reuses_matching_preloaded_weight_storage(monkeypatch):
+    storage = SimpleNamespace(buffers={}, weight_contract=repr([]))
+    calls = []
+
+    generated, _launches = _build(
+        monkeypatch,
+        _programs("b1"),
+        max_batch_size=1,
+        weight_storage=storage,
+        materialize_calls=calls,
+    )
+
+    assert generated.weight_storage is storage
+    assert calls == []
+
+
+def test_generated_decode_rejects_mismatched_preloaded_weight_storage(monkeypatch):
+    storage = SimpleNamespace(buffers={}, weight_contract="different")
+
+    with pytest.raises(RuntimeError, match="preloaded generated weights"):
+        _build(
+            monkeypatch,
+            _programs("b1"),
+            max_batch_size=1,
+            weight_storage=storage,
+        )
 
 
 def test_generated_decode_constructs_and_selects_dynamic_exact_siblings(monkeypatch):

--- a/tests/test_paged_resources.py
+++ b/tests/test_paged_resources.py
@@ -1,0 +1,54 @@
+import pytest
+
+from kestrel.runtime.paged_resources import bound_kv_cache_pages
+
+
+def test_bound_kv_cache_pages_caps_unreachable_capacity() -> None:
+    assert bound_kv_cache_pages(
+        65_536,
+        page_size=1,
+        max_batch_size=1,
+        max_seq_length=2_048,
+    ) == 2_050
+
+
+def test_bound_kv_cache_pages_accounts_for_batch_and_page_size() -> None:
+    assert bound_kv_cache_pages(
+        65_536,
+        page_size=16,
+        max_batch_size=4,
+        max_seq_length=2_049,
+    ) == 518
+
+
+def test_bound_kv_cache_pages_preserves_tighter_user_limit() -> None:
+    assert bound_kv_cache_pages(
+        1_024,
+        page_size=1,
+        max_batch_size=4,
+        max_seq_length=2_048,
+    ) == 1_024
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("requested_pages", 0),
+        ("page_size", 0),
+        ("max_batch_size", 0),
+        ("max_seq_length", 0),
+    ),
+)
+def test_bound_kv_cache_pages_rejects_non_positive_inputs(
+    field: str,
+    value: int,
+) -> None:
+    kwargs = {
+        "requested_pages": 64,
+        "page_size": 1,
+        "max_batch_size": 1,
+        "max_seq_length": 32,
+    }
+    kwargs[field] = value
+    with pytest.raises(ValueError, match="must be positive"):
+        bound_kv_cache_pages(**kwargs)

--- a/tests/test_paged_resources.py
+++ b/tests/test_paged_resources.py
@@ -33,7 +33,6 @@ def test_bound_kv_cache_pages_preserves_tighter_user_limit() -> None:
 @pytest.mark.parametrize(
     ("field", "value"),
     (
-        ("requested_pages", 0),
         ("page_size", 0),
         ("max_batch_size", 0),
         ("max_seq_length", 0),
@@ -52,3 +51,16 @@ def test_bound_kv_cache_pages_rejects_non_positive_inputs(
     kwargs[field] = value
     with pytest.raises(ValueError, match="must be positive"):
         bound_kv_cache_pages(**kwargs)
+
+
+@pytest.mark.parametrize("requested_pages", (0, 1))
+def test_bound_kv_cache_pages_requires_both_reserved_pages(
+    requested_pages: int,
+) -> None:
+    with pytest.raises(ValueError, match="reserved and padding pages"):
+        bound_kv_cache_pages(
+            requested_pages,
+            page_size=1,
+            max_batch_size=1,
+            max_seq_length=32,
+        )

--- a/tests/test_query_skill.py
+++ b/tests/test_query_skill.py
@@ -289,6 +289,55 @@ def test_gemma4_channel_marker_preserves_reasoning_answer_split(
     }
 
 
+@pytest.mark.parametrize(
+    "model_name", ("google/gemma-4-E2B-it", "google/gemma-4-26B-A4B-it")
+)
+def test_gemma4_direct_answer_hides_model_emitted_reasoning_channel(
+    model_name: str,
+) -> None:
+    runtime = SimpleNamespace(
+        prompt_template=Gemma4PromptTemplate(model_name),
+        tokenizer=_VisibleTokenizer(),
+    )
+    context = QueryRequest(question="hi", image=None, reasoning=False, stream=True)
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    for position, token_id in enumerate(
+        [
+            START_OF_CHANNEL_ID,
+            THOUGHT_ID,
+            NEWLINE_ID,
+            42,
+            END_OF_CHANNEL_ID,
+            43,
+            END_OF_TURN_ID,
+        ]
+    ):
+        state.consume_step(
+            runtime, DecodeStep(TextToken(token_id=token_id), position=position)
+        )
+
+    assert state.pop_stream_delta(runtime) == "<43>"
+    result = state.finalize(runtime, reason="stop")
+    assert result.output == {"answer": "<43>"}
+
+
+def test_direct_answer_preserves_partial_reasoning_prefix_mismatch() -> None:
+    runtime = _Runtime(reasoning_start_token_ids=[30, 31, 32])
+    runtime.tokenizer = _VisibleTokenizer()
+    context = QueryRequest(question="hi", image=None, reasoning=False, stream=True)
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=30), position=0))
+    assert state.pop_stream_delta(runtime) is None
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=42), position=1))
+
+    assert state.pop_stream_delta(runtime) == "<30><42>"
+    assert state.finalize(runtime, reason="stop").output == {
+        "answer": "<30><42>"
+    }
+
+
 def test_reasoning_start_partial_mismatch_restores_buffered_answer_tokens() -> None:
     runtime = _Runtime(reasoning_start_token_ids=[30, 31, 32])
     runtime.tokenizer = _VisibleTokenizer()


### PR DESCRIPTION
## Summary
- add Gemma 4 26B-A4B base and instruction-tuned model support
- stream Gemma, Qwen, and Moondream checkpoint loading to bound host memory
- load Qwen weights directly into generated decode storage
- validate paged-cache capacity and restore Qwen rotary buffers after meta construction
- route Qwen BF16 MoE through the device-selected native backend

## Validation
- focused high/medium suite: 34 passed
- full import-mode suite: 893 passed, 49 skipped
- two existing fixture failures reproduce on `main` (`test_transcribe_only_runtime_skips_legacy_query_warmup`, `test_validate_generated_prefix_rejects_unsupported_requests`)
- B200 model-board retake is in progress

## Merge status
Draft for the next major release. The matching proprietary kernel/runtime changes and final B200/H100 performance board must land before merge.