### PR TITLE
Add synthesis streaming interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ extends precompiled execution across speech, Qwen, and Gemma workloads.
 - Added Gemma 4 26B-A4B base and instruction-tuned checkpoint support.
 - Added the model-bound `synthesize` capability and append-only streaming
   payloads for generated media such as PCM audio, including lossless compound
-  capability streams.
+  capability streams and explicit cancellation of generated streams.
 - Added Qwen3-ASR 0.6B and 1.7B and Parakeet TDT 0.6B v3 transcription for
   files and live PCM, with long-form chunking, progressive results, language
   and prompt controls, forced alignment, and word or character timestamps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ extends precompiled execution across speech, Qwen, and Gemma workloads.
 
 - Added Gemma 4 26B-A4B base and instruction-tuned checkpoint support.
 - Added the model-bound `synthesize` capability and append-only streaming
-  payloads for generated media such as PCM audio.
+  payloads for generated media such as PCM audio, including lossless compound
+  capability streams.
 - Added Qwen3-ASR 0.6B and 1.7B and Parakeet TDT 0.6B v3 transcription for
   files and live PCM, with long-form chunking, progressive results, language
   and prompt controls, forced alignment, and word or character timestamps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ extends precompiled execution across speech, Qwen, and Gemma workloads.
 ### More model families
 
 - Added Gemma 4 26B-A4B base and instruction-tuned checkpoint support.
+- Added the model-bound `synthesize` capability and append-only streaming
+  payloads for generated media such as PCM audio.
 - Added Qwen3-ASR 0.6B and 1.7B and Parakeet TDT 0.6B v3 transcription for
   files and live PCM, with long-form chunking, progressive results, language
   and prompt controls, forced alignment, and word or character timestamps

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -189,6 +189,8 @@ class CapabilityStream(AsyncIterator[CapabilityUpdate]):
             raise StopAsyncIteration
         item = await self._queue.get()
         if item is None:
+            if self._closed:
+                raise StopAsyncIteration
             self._closed = True
             await self._producer
             raise StopAsyncIteration
@@ -198,15 +200,19 @@ class CapabilityStream(AsyncIterator[CapabilityUpdate]):
         return await self._producer
 
     async def aclose(self) -> None:
-        if self._closed:
+        if self._closed and self._producer.done():
             return
         self._closed = True
         if not self._producer.done():
             self._producer.cancel()
         try:
-            await self._producer
-        except asyncio.CancelledError:
-            pass
+            outcome, = await asyncio.gather(
+                self._producer, return_exceptions=True
+            )
+            if isinstance(outcome, BaseException) and not isinstance(
+                outcome, asyncio.CancelledError
+            ):
+                raise outcome
         finally:
             while not self._queue.empty():
                 self._queue.get_nowait()

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import threading
 from dataclasses import dataclass, field
 from typing import (
     Any,
@@ -72,6 +73,8 @@ class EngineStream(AsyncIterator[StreamUpdate]):
         "request_id",
         "_queue",
         "_result_future",
+        "_cancel",
+        "_closed",
         "_final_result",
         "_error",
     )
@@ -81,10 +84,14 @@ class EngineStream(AsyncIterator[StreamUpdate]):
         request_id: int,
         queue: _StreamQueue,
         result_future: asyncio.Future[EngineResult],
+        *,
+        cancel: Optional[Callable[[], None]] = None,
     ) -> None:
         self.request_id = request_id
         self._queue = queue
         self._result_future = result_future
+        self._cancel = cancel
+        self._closed = False
         self._final_result: Optional[EngineResult] = None
         self._error: Optional[BaseException] = None
 
@@ -92,9 +99,14 @@ class EngineStream(AsyncIterator[StreamUpdate]):
         return self
 
     async def __anext__(self) -> StreamUpdate:
+        if self._closed:
+            raise StopAsyncIteration
         while True:
             item = await self._queue.get()
+            if self._closed:
+                raise StopAsyncIteration
             if isinstance(item, _StreamCompletion):
+                self._closed = True
                 if item.error is not None:
                     self._error = item.error
                     raise item.error
@@ -108,9 +120,24 @@ class EngineStream(AsyncIterator[StreamUpdate]):
             return self._final_result
         if self._error is not None:
             raise self._error
-        result = await self._result_future
+        result = await asyncio.shield(self._result_future)
         self._final_result = result
         return result
+
+    async def aclose(self) -> None:
+        """Stop generation and wait for the scheduler to settle the request."""
+
+        if self._closed and self._result_future.done():
+            return
+        self._closed = True
+        if self._cancel is not None:
+            self._cancel()
+        try:
+            self._final_result = await asyncio.shield(self._result_future)
+        finally:
+            while not self._queue.empty():
+                self._queue.get_nowait()
+            self._queue.put_nowait(_StreamCompletion(result=self._final_result))
 
 
 @dataclass(slots=True)
@@ -409,6 +436,7 @@ class _AutoregressiveRequest:
     return_logprobs: Optional[bool] = None
     generated_prefix: GeneratedPrefix = field(default_factory=GeneratedPrefix)
     suppress_next_token_ids: Optional[tuple[int, ...]] = None
+    cancel_event: threading.Event = field(default_factory=threading.Event, repr=False)
 
 
 @dataclass(slots=True)

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-from concurrent.futures import Future
 from dataclasses import dataclass, field
 from typing import (
     Any,
@@ -29,7 +28,7 @@ import numpy as np
 
 from kestrel.runtime import Token
 from kestrel.scheduler import GeneratedPrefix, StreamUpdate
-from kestrel.skills import SkillSpec, SkillState
+from kestrel.skills import SkillSpec
 
 
 @dataclass(slots=True)
@@ -116,7 +115,7 @@ class EngineStream(AsyncIterator[StreamUpdate]):
 
 @dataclass(slots=True)
 class CapabilityUpdate:
-    """One coalescible progress snapshot from compound capability work."""
+    """One model-defined update from compound capability work."""
 
     task: str
     index: int
@@ -135,21 +134,27 @@ _CapabilityProducer = Callable[[_EmitCapabilityUpdate], Awaitable[EngineResult]]
 
 
 class CapabilityStream(AsyncIterator[CapabilityUpdate]):
-    """Bounded progress stream for a multi-request capability operation.
+    """Progress or output stream for a compound capability operation.
 
-    Updates are snapshots rather than an append-only event log. If a consumer
-    is slower than the producer, the pending snapshot is replaced by the most
-    recent one. This keeps memory bounded while ``result()`` remains usable by
-    callers that do not iterate progress.
+    By default, updates are replaceable snapshots: if a consumer is slower
+    than the producer, only the latest pending snapshot is retained. Pass
+    ``coalesce=False`` for lossless, append-only payloads such as PCM chunks.
+    That mode has the same queueing semantics as autoregressive streams.
     """
 
     __slots__ = ("task", "_queue", "_producer", "_index", "_closed")
 
-    def __init__(self, task: str, producer: _CapabilityProducer) -> None:
+    def __init__(
+        self,
+        task: str,
+        producer: _CapabilityProducer,
+        *,
+        coalesce: bool = True,
+    ) -> None:
         if not isinstance(task, str) or not task:
             raise ValueError("CapabilityStream task must be a non-empty string")
         self.task = task
-        self._queue: asyncio.Queue[CapabilityUpdate] = asyncio.Queue(maxsize=1)
+        self._queue: asyncio.Queue[CapabilityUpdate | None] = asyncio.Queue()
         self._index = 0
         self._closed = False
 
@@ -164,49 +169,30 @@ class CapabilityStream(AsyncIterator[CapabilityUpdate]):
                 output=dict(output),
             )
             self._index += 1
-            if self._queue.full():
+            if coalesce and not self._queue.empty():
                 self._queue.get_nowait()
             self._queue.put_nowait(update)
 
-        self._producer = asyncio.create_task(producer(emit))
+        async def produce() -> EngineResult:
+            try:
+                return await producer(emit)
+            finally:
+                self._queue.put_nowait(None)
+
+        self._producer = asyncio.create_task(produce())
 
     def __aiter__(self) -> "CapabilityStream":
         return self
 
     async def __anext__(self) -> CapabilityUpdate:
-        if not self._queue.empty():
-            return self._queue.get_nowait()
-        if self._producer.done():
+        if self._closed:
+            raise StopAsyncIteration
+        item = await self._queue.get()
+        if item is None:
+            self._closed = True
             await self._producer
             raise StopAsyncIteration
-        next_update = asyncio.create_task(self._queue.get())
-        try:
-            done, _ = await asyncio.wait(
-                (next_update, self._producer),
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-        except asyncio.CancelledError:
-            if next_update.cancel():
-                try:
-                    await next_update
-                except asyncio.CancelledError:
-                    pass
-            elif not self._queue.full():
-                # Cancellation may arrive after queue.get() has consumed the
-                # snapshot but before asyncio.wait() returns it. Restore that
-                # snapshot unless the producer has already published a newer
-                # one, which supersedes it under the coalescing contract.
-                self._queue.put_nowait(next_update.result())
-            raise
-        if next_update in done:
-            return next_update.result()
-        next_update.cancel()
-        try:
-            await next_update
-        except asyncio.CancelledError:
-            pass
-        await self._producer
-        raise StopAsyncIteration
+        return item
 
     async def result(self) -> EngineResult:
         return await self._producer
@@ -221,6 +207,10 @@ class CapabilityStream(AsyncIterator[CapabilityUpdate]):
             await self._producer
         except asyncio.CancelledError:
             pass
+        finally:
+            while not self._queue.empty():
+                self._queue.get_nowait()
+            self._queue.put_nowait(None)
 
     async def __aenter__(self) -> "CapabilityStream":
         return self

--- a/kestrel/engine/_types.py
+++ b/kestrel/engine/_types.py
@@ -216,10 +216,11 @@ class CapabilityStream(AsyncIterator[CapabilityUpdate]):
         return self
 
     async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
-        if exc_type is not None:
+        try:
+            if exc_type is None:
+                await self.result()
+        finally:
             await self.aclose()
-        else:
-            await self.result()
 
 
 @dataclass(slots=True)

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1636,6 +1636,22 @@ class InferenceEngine:
             for update in updates:
                 self._deliver_model_stream_update(update)
 
+        def route_single_pass_ingress() -> bool:
+            progressed = False
+            while True:
+                try:
+                    model, req = self._single_pass_queue.get_nowait()
+                except queue.Empty:
+                    return progressed
+                lane = single_pass.get(model)
+                if lane is None:  # pragma: no cover - guarded in run()
+                    self._fail_request(
+                        req, ValueError(f"No single-pass lane for {model!r}")
+                    )
+                else:
+                    lane.submit(req)
+                progressed = True
+
         def any_work() -> bool:
             return (ar_executor is not None and ar_executor.has_work) or any(
                 sp.has_work for sp in single_pass.values()
@@ -1675,6 +1691,10 @@ class InferenceEngine:
                         for item in deferred:
                             self._scheduler_queue.put(item)
 
+                        # Route without launching; ``drain`` below settles only
+                        # cancelled requests and already-completed forwards.
+                        route_single_pass_ingress()
+
                         # Drain in-flight work before pause — callers may
                         # mutate runtime state while paused (e.g. rebuild
                         # CUDA graphs). Only the AR lane has graph state;
@@ -1688,6 +1708,8 @@ class InferenceEngine:
                                 synchronize(runtime.device)
                         else:
                             synchronize(runtime.device)
+                        for lane in single_pass.values():
+                            deliver(lane.drain())
                         paused_event.set()
                         if shutdown_requested:
                             break
@@ -1720,19 +1742,7 @@ class InferenceEngine:
                         ar_executor.submit(item)
                         progressed = True
                     # Single-pass ingress (model-tagged).
-                    while True:
-                        try:
-                            model, req = self._single_pass_queue.get_nowait()
-                        except queue.Empty:
-                            break
-                        lane = single_pass.get(model)
-                        if lane is None:  # pragma: no cover - guarded in run()
-                            self._fail_request(
-                                req, ValueError(f"No single-pass lane for {model!r}")
-                            )
-                        else:
-                            lane.submit(req)
-                        progressed = True
+                    progressed |= route_single_pass_ingress()
                     # Streaming session starts (model-tagged).
                     while True:
                         try:

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -788,6 +788,7 @@ class InferenceEngine:
         _suppress_next_token_ids: Optional[Sequence[int]] = None,
     ) -> EngineStream:
         queue: _StreamQueue = asyncio.Queue()
+        cancel_event = threading.Event()
         generated_prefix = self._normalize_generated_prefix(
             _generated_prefix,
             "_generated_prefix",
@@ -809,8 +810,20 @@ class InferenceEngine:
             suppress_next_token_ids=suppress_next_token_ids,
             stream_queue=queue,
             skill=skill,
+            cancel_event=cancel_event,
         )
-        return EngineStream(request_id=request_id, queue=queue, result_future=future)
+        wake_event = self._scheduler_event
+
+        def cancel() -> None:
+            cancel_event.set()
+            wake_event.set()
+
+        return EngineStream(
+            request_id=request_id,
+            queue=queue,
+            result_future=future,
+            cancel=cancel,
+        )
 
     # ------------------------------------------------------------------
     # Control APIs
@@ -1050,6 +1063,7 @@ class InferenceEngine:
         suppress_next_token_ids: Optional[tuple[int, ...]],
         stream_queue: Optional[_StreamQueue],
         skill: str,
+        cancel_event: threading.Event | None = None,
     ) -> Tuple[asyncio.Future[EngineResult], int]:
         if self._shutdown:
             raise RuntimeError("InferenceEngine is shut down")
@@ -1058,6 +1072,7 @@ class InferenceEngine:
         loop = asyncio.get_running_loop()
         req_id = next(self._request_ids)
         future: asyncio.Future[EngineResult] = loop.create_future()
+        cancel_event = cancel_event or threading.Event()
 
         skill_spec = self._skill_registry().resolve(skill)
         adapter_id = self._normalize_adapter_id(adapter)
@@ -1128,6 +1143,7 @@ class InferenceEngine:
             return_logprobs=return_logprobs,
             generated_prefix=generated_prefix,
             suppress_next_token_ids=suppress_next_token_ids,
+            cancel_event=cancel_event,
         )
         del prepared_prompt
         await self._queue.put(payload)
@@ -1833,6 +1849,7 @@ class InferenceEngine:
             return_logprobs=req.return_logprobs,
             generated_prefix=req.generated_prefix,
             suppress_next_token_ids=req.suppress_next_token_ids,
+            cancel_event=req.cancel_event,
         )
         limit = runtime.max_seq_length
         target_total = request_obj.target_length

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -1635,6 +1635,14 @@ class InferenceEngine:
                 while True:
                     # If paused, wait until resumed or shutdown completes.
                     if paused_flag.is_set():
+                        if paused_event.is_set() and not wake_event.is_set():
+                            run_gate.wait(timeout=0.1)
+                            continue
+
+                        # Clear before scanning so work arriving during the
+                        # scan leaves the event set for another pass.
+                        wake_event.clear()
+
                         # A stream can be closed after its request entered the
                         # thread queue but before admission. Settle only those
                         # canceled requests; leave every other request queued.

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -894,12 +894,14 @@ class InferenceEngine:
 
         loop = asyncio.get_running_loop()
         future: asyncio.Future[EngineResult] = loop.create_future()
+        cancel_event = threading.Event()
         req = _SinglePassRequest(
             request_id=next(self._request_ids),
             future=future,
             task=task,
             inputs=inputs,
             submitted_at=time.perf_counter(),
+            cancel_event=cancel_event,
         )
         self._raise_if_scheduler_failed()
         self._single_pass_queue.put((model, req))
@@ -907,7 +909,16 @@ class InferenceEngine:
         if self._scheduler_error is not None:
             self._fail_all_pending(self._scheduler_failed_error())
         del inputs, req
-        return await future
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            cancel_event.set()
+            self._scheduler_event.set()
+            try:
+                await asyncio.shield(future)
+            except Exception:
+                pass
+            raise
 
     async def stream(
         self,

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -576,6 +576,7 @@ class InferenceEngine:
         _generated_prefix: Optional[object] = None,
         _suppress_next_token_ids: Optional[Sequence[int]] = None,
     ) -> EngineResult:
+        cancel_event = threading.Event()
         generated_prefix = self._normalize_generated_prefix(
             _generated_prefix,
             "_generated_prefix",
@@ -597,12 +598,22 @@ class InferenceEngine:
             suppress_next_token_ids=suppress_next_token_ids,
             stream_queue=None,
             skill=skill,
+            cancel_event=cancel_event,
         )
         # Ingress owns the request payload; the remainder of this frame only
         # needs the result future, which may stay pending for a full decode.
         del request_context, image, encoder_input
         del generated_prefix, suppress_next_token_ids
-        return await future
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            cancel_event.set()
+            self._scheduler_event.set()
+            try:
+                await asyncio.shield(future)
+            except Exception:
+                pass
+            raise
 
     @overload
     async def query(
@@ -1624,6 +1635,27 @@ class InferenceEngine:
                 while True:
                     # If paused, wait until resumed or shutdown completes.
                     if paused_flag.is_set():
+                        # A stream can be closed after its request entered the
+                        # thread queue but before admission. Settle only those
+                        # canceled requests; leave every other request queued.
+                        deferred = []
+                        for _ in range(self._scheduler_queue.qsize()):
+                            try:
+                                item = self._scheduler_queue.get_nowait()
+                            except queue.Empty:
+                                break
+                            if item is None:
+                                shutdown_requested = True
+                            elif (
+                                ar_executor is not None
+                                and item.cancel_event.is_set()
+                            ):
+                                ar_executor.submit(item)
+                            else:
+                                deferred.append(item)
+                        for item in deferred:
+                            self._scheduler_queue.put(item)
+
                         # Drain in-flight work before pause — callers may
                         # mutate runtime state while paused (e.g. rebuild
                         # CUDA graphs). Only the AR lane has graph state;
@@ -1638,7 +1670,7 @@ class InferenceEngine:
                         else:
                             synchronize(runtime.device)
                         paused_event.set()
-                        if shutdown_requested and not any_work():
+                        if shutdown_requested:
                             break
                         run_gate.wait(timeout=0.1)
                         continue

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -29,6 +29,7 @@ from kestrel.models.moondream.lora import AdapterProvider
 
 from kestrel.engine._types import (
     Completion,
+    EngineMetrics,
     EngineResult,
     TickResult,
     _AutoregressiveRequest,
@@ -190,6 +191,20 @@ class _AdmissionCoordinator:
                 prefix_cache_hit=pending.prefix_cache_hit,
             )
 
+    def pop_cancelled(self) -> list[_AutoregressiveRequest]:
+        """Cancel preprocessing owned by streams their callers closed."""
+
+        cancelled: list[_AutoregressiveRequest] = []
+        for request_id, pending in list(self._pending.items()):
+            if not pending.req.cancel_event.is_set():
+                continue
+            self._pending.pop(request_id)
+            for future in (pending.crops_future, pending.encoder_input_future):
+                if future is not None and not future.done():
+                    future.cancel()
+            cancelled.append(pending.req)
+        return cancelled
+
     def fail_all(self, error: Optional[BaseException] = None) -> None:
         exc = error or RuntimeError("Engine shut down")
         for pending in list(self._pending.values()):
@@ -275,12 +290,15 @@ class AutoregressiveExecutor:
             runtime.max_batch_slots,
             runtime.max_batch_size * 4,
         )
-        # Admission-time failures surface as completions the kernel delivers.
-        self._admission_failures: List[Completion] = []
+        # Admission can finish a request before it reaches the scheduler.
+        self._admission_completions: List[Completion] = []
 
     # -- ingress (event-loop thread) ----------------------------------
 
     def submit(self, request: _AutoregressiveRequest) -> None:
+        if request.cancel_event.is_set():
+            self._complete_cancelled(request)
+            return
         if (
             request.max_new_tokens > 0
             and self._runtime.sampling_hooks.sample_greedy is not None
@@ -308,7 +326,7 @@ class AutoregressiveExecutor:
             self._scheduler.has_pending_work()
             or self._admission.has_pending()
             or bool(self._active)
-            or bool(self._admission_failures)
+            or bool(self._admission_completions)
         )
 
     @property
@@ -320,21 +338,24 @@ class AutoregressiveExecutor:
 
     def advance(self) -> TickResult:
         scheduler = self._scheduler
-        progressed = self._promote_ready()
+        cancelled = self._admission.pop_cancelled()
+        for request in cancelled:
+            self._complete_cancelled(request)
+        progressed = bool(cancelled) or self._promote_ready()
 
         if scheduler.has_pending_work():
             progressed = scheduler.advance() or progressed
 
         new = self._collect()
 
-        # Drain the admission-failure buffer LAST. _admission_failures is
-        # the durable home for not-yet-delivered failures; clearing it
+        # Drain admission completions LAST. The list is their durable home;
+        # clearing it
         # only here (after the work above that can raise) means that if
         # scheduler.advance() raises, the buffer stays intact and the
         # kernel's shutdown(exc) path still delivers those callers'
         # completions instead of leaving their futures unresolved.
-        completed = self._admission_failures + new
-        self._admission_failures = []
+        completed = self._admission_completions + new
+        self._admission_completions = []
         progressed = progressed or bool(completed)
 
         return TickResult(
@@ -352,15 +373,15 @@ class AutoregressiveExecutor:
         exc = error or RuntimeError("Engine shut down")
         # Fail in-flight admission first: fail_all() synchronously routes
         # any request still in async preprocessing through
-        # _fail_via_admission, which appends to _admission_failures — so
+        # _fail_via_admission, which appends to _admission_completions — so
         # collect that list *after*, or those requests' futures never get
         # resolved and callers hang.
         self._admission.fail_all(exc)
         for req in self._active.values():
-            self._admission_failures.append(Completion(request=req, error=exc))
+            self._admission_completions.append(Completion(request=req, error=exc))
         self._active.clear()
-        completions = self._admission_failures
-        self._admission_failures = []
+        completions = self._admission_completions
+        self._admission_completions = []
         self._release_active_sequences()
         return tuple(completions)
 
@@ -369,16 +390,39 @@ class AutoregressiveExecutor:
     def _fail_via_admission(
         self, req: _AutoregressiveRequest, error: BaseException
     ) -> None:
-        self._admission_failures.append(Completion(request=req, error=error))
+        self._admission_completions.append(Completion(request=req, error=error))
+
+    def _complete_cancelled(self, req: _AutoregressiveRequest) -> None:
+        self._admission_completions.append(
+            Completion(
+                request=req,
+                result=EngineResult(
+                    request_id=req.request_id,
+                    tokens=[],
+                    finish_reason="cancelled",
+                    metrics=EngineMetrics(
+                        input_tokens=0,
+                        output_tokens=0,
+                        prefill_time_ms=0.0,
+                        decode_time_ms=0.0,
+                        ttft_ms=0.0,
+                    ),
+                    output={},
+                ),
+            )
+        )
 
     def _admit_ready(self, ready: _ReadyAdmission) -> None:
         req = ready.req
+        if req.cancel_event.is_set():
+            self._complete_cancelled(req)
+            return
         try:
             generation_req, skill_state = self._build_generation_request(
                 self._runtime, req, ready.crops, ready.encoder_input
             )
         except Exception as exc:
-            self._admission_failures.append(Completion(request=req, error=exc))
+            self._admission_completions.append(Completion(request=req, error=exc))
             return
         crops_ready = (
             req.image is None

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -365,9 +365,13 @@ class AutoregressiveExecutor:
         )
 
     def drain(self) -> tuple[Completion, ...]:
-        """Complete in-flight pipeline work (used before a pause)."""
+        """Complete in-flight work and settle cancellations while paused."""
         self._scheduler._drain_pipeline()
-        return tuple(self._collect())
+        for request in self._admission.pop_cancelled():
+            self._complete_cancelled(request)
+        completed = self._admission_completions + self._collect()
+        self._admission_completions = []
+        return tuple(completed)
 
     def shutdown(self, error: Optional[BaseException] = None) -> tuple[Completion, ...]:
         exc = error or RuntimeError("Engine shut down")

--- a/kestrel/engine/executor.py
+++ b/kestrel/engine/executor.py
@@ -142,6 +142,11 @@ class _AdmissionCoordinator:
             pending = self._pending.get(req_id)
             if pending is None:
                 continue
+            # Cancellation owns terminal delivery once requested. A sibling
+            # future may have been cancelled while another is still running;
+            # leave that admission for ``pop_cancelled`` to settle as a unit.
+            if pending.req.cancel_event.is_set():
+                continue
             futures = (pending.crops_future, pending.encoder_input_future)
             failed: BaseException | None = None
             for future in futures:
@@ -192,16 +197,22 @@ class _AdmissionCoordinator:
             )
 
     def pop_cancelled(self) -> list[_AutoregressiveRequest]:
-        """Cancel preprocessing owned by streams their callers closed."""
+        """Settle preprocessing owned by streams their callers closed."""
 
         cancelled: list[_AutoregressiveRequest] = []
         for request_id, pending in list(self._pending.items()):
             if not pending.req.cancel_event.is_set():
                 continue
-            self._pending.pop(request_id)
-            for future in (pending.crops_future, pending.encoder_input_future):
+            futures = (pending.crops_future, pending.encoder_input_future)
+            for future in futures:
                 if future is not None and not future.done():
                     future.cancel()
+            # ``Future.cancel()`` cannot stop preprocessing that is already
+            # running. Retain ownership until its done callback wakes us again;
+            # only then may EngineStream.aclose() report scheduler settlement.
+            if any(future is not None and not future.done() for future in futures):
+                continue
+            self._pending.pop(request_id)
             cancelled.append(pending.req)
         return cancelled
 

--- a/kestrel/engine/handle.py
+++ b/kestrel/engine/handle.py
@@ -288,6 +288,13 @@ class ModelHandle:
     ) -> "EngineResult | EngineStream | ModelStream | CapabilityStream":
         return await self._capability("align", prompt)
 
+    async def synthesize(
+        self, **prompt: Any
+    ) -> "EngineResult | EngineStream | ModelStream | CapabilityStream":
+        """Synthesize model-defined media, such as speech, from a prompt."""
+
+        return await self._capability("synthesize", prompt)
+
     def __repr__(self) -> str:
         return f"ModelHandle(model_id={self._model!r}, tasks={self.tasks})"
 

--- a/kestrel/engine/single_pass.py
+++ b/kestrel/engine/single_pass.py
@@ -170,6 +170,28 @@ class SinglePassExecutor:
             has_work=self.has_work,
         )
 
+    def drain(self) -> tuple[Completion, ...]:
+        """Settle terminal work while leaving ordinary queued work paused."""
+
+        completed: List[Completion] = []
+        if self._deferred is not None and self._deferred.cancel_event.is_set():
+            completed.append(_cancelled_completion(self._deferred))
+            self._deferred = None
+        deferred = []
+        for _ in range(self._queue.qsize()):
+            try:
+                request = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if request.cancel_event.is_set():
+                completed.append(_cancelled_completion(request))
+            else:
+                deferred.append(request)
+        for request in deferred:
+            self._queue.put(request)
+        completed.extend(self._collect())
+        return tuple(completed)
+
     def shutdown(self, error: Optional[BaseException] = None) -> tuple[Completion, ...]:
         exc = error or RuntimeError("Engine shut down")
         completions: List[Completion] = [

--- a/kestrel/engine/single_pass.py
+++ b/kestrel/engine/single_pass.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import queue
-from dataclasses import dataclass
+import threading
+from dataclasses import dataclass, field
 from typing import Any, List, Optional, Sequence
 
 from kestrel.device import make_event, stream_context
@@ -54,9 +55,12 @@ class _SinglePassRequest:
     submitted_at: float
     adapter: Optional[str] = None
     stream_queue: "Optional[_StreamQueue]" = None
+    cancel_event: threading.Event = field(default_factory=threading.Event, repr=False)
 
 
-def _single_pass_result(request_id: int, output: Any) -> EngineResult:
+def _single_pass_result(
+    request_id: int, output: Any, finish_reason: str = "stop"
+) -> EngineResult:
     """Wrap a driver forward's output as an EngineResult.
 
     Single-pass tasks produce structured output (e.g. masks + scores),
@@ -75,7 +79,7 @@ def _single_pass_result(request_id: int, output: Any) -> EngineResult:
     return EngineResult(
         request_id=request_id,
         tokens=[],
-        finish_reason="stop",
+        finish_reason=finish_reason,
         metrics=EngineMetrics(
             input_tokens=0,
             output_tokens=0,
@@ -84,6 +88,13 @@ def _single_pass_result(request_id: int, output: Any) -> EngineResult:
             ttft_ms=0.0,
         ),
         output=output if isinstance(output, dict) else {"result": output},
+    )
+
+
+def _cancelled_completion(request: _SinglePassRequest) -> Completion:
+    return Completion(
+        request=request,
+        result=_single_pass_result(request.request_id, {}, "cancelled"),
     )
 
 
@@ -150,8 +161,8 @@ class SinglePassExecutor:
         return bool(self._in_flight)
 
     def advance(self) -> TickResult:
-        progressed = self._launch()
-        completed = self._collect()
+        progressed, completed = self._launch()
+        completed.extend(self._collect())
         progressed = progressed or bool(completed)
         return TickResult(
             progressed=progressed,
@@ -180,16 +191,25 @@ class SinglePassExecutor:
 
     # -- internals ----------------------------------------------------
 
-    def _launch(self) -> bool:
+    def _launch(self) -> tuple[bool, List[Completion]]:
         """Start forwards until the in-flight pool is full or the queue drains."""
-        launched = False
+        progressed = False
+        completed: List[Completion] = []
         while len(self._in_flight) < self._max_in_flight:
             try:
                 requests = self._take_batch()
             except queue.Empty:
                 break
-            launched = self._launch_batch(requests) or launched
-        return launched
+            pending = []
+            for request in requests:
+                if request.cancel_event.is_set():
+                    completed.append(_cancelled_completion(request))
+                    progressed = True
+                else:
+                    pending.append(request)
+            if pending:
+                progressed = self._launch_batch(pending) or progressed
+        return progressed, completed
 
     def _take_batch(self) -> tuple[_SinglePassRequest, ...]:
         if self._deferred is None:
@@ -258,7 +278,9 @@ class SinglePassExecutor:
             elif f.done_event.query():
                 completed.extend(
                     (
-                        Completion(request=request, error=output)
+                        _cancelled_completion(request)
+                        if request.cancel_event.is_set()
+                        else Completion(request=request, error=output)
                         if isinstance(output, BaseException)
                         else Completion(
                             request=request,

--- a/kestrel/models/whisper/longform.py
+++ b/kestrel/models/whisper/longform.py
@@ -1130,10 +1130,7 @@ async def _close_candidate_streams(values: Sequence[object]) -> None:
         if callable(close):
             await close()
             return
-        # EngineStream does not currently expose scheduler cancellation. Do
-        # not return ownership while its request is still consuming the GPU;
-        # settle it instead. A future engine cancellation hook can replace
-        # this fallback without changing the orchestrator contract.
+        # Custom stream implementations may expose only terminal settlement.
         result = getattr(value, "result", None)
         if callable(result):
             await result()

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -118,6 +118,7 @@ class GeneratedDecodeSpec:
     preparation_callbacks: Mapping[str, Callable[[Any, int], None]] = field(
         default_factory=dict
     )
+    program_names: frozenset[str] | None = None
 
 
 @dataclass(frozen=True)
@@ -522,6 +523,8 @@ class GeneratedDecode:
 
         properties = torch.cuda.get_device_properties(runtime.device)
         resolution_options = {}
+        if spec.program_names is not None:
+            resolution_options["program_names"] = spec.program_names
         weight_sources = getattr(spec, "weight_sources", None)
         if weight_sources is not None:
             resolution_options["weight_sources"] = weight_sources
@@ -675,19 +678,28 @@ class GeneratedDecode:
                     **materialization_options,
                 )
             else:
-                expected_contract = repr(self._programs[0].descriptor["weights"])
-                actual_contract = getattr(
-                    spec.weight_storage, "weight_contract", None
-                )
-                if actual_contract != expected_contract:
-                    raise RuntimeError(
-                        "preloaded generated weights do not match the selected program"
-                    )
                 if getattr(spec.weight_storage, "finalized", None) is not True:
                     raise RuntimeError(
                         "preloaded generated weights were not finalized after loading"
                     )
-                self.weight_storage = spec.weight_storage
+                expected_contract = repr(self._programs[0].descriptor["weights"])
+                actual_contract = getattr(
+                    spec.weight_storage, "weight_contract", None
+                )
+                if actual_contract == expected_contract:
+                    self.weight_storage = spec.weight_storage
+                else:
+                    from kestrel_kernels.generated_decode import (
+                        extend_weight_storage,
+                    )
+
+                    self.weight_storage = extend_weight_storage(
+                        spec.weight_storage,
+                        spec.weight_root,
+                        self._programs[0].descriptor,
+                        layer_prefix=spec.weight_layer_prefix,
+                        **materialization_options,
+                    )
             shared_inputs = dict(spec.bindings.runtime_inputs(runtime))
             weights_ready.record(runtime.compute_stream)
         ambient_stream.wait_event(weights_ready)

--- a/kestrel/runtime/sampling.py
+++ b/kestrel/runtime/sampling.py
@@ -98,6 +98,11 @@ class SamplingHooks:
     # fallback; source-only development runtimes leave it false.
     require_packed_greedy_logprobs: bool = False
 
+    # Require ordinary temperature/top-p sampling to resolve both CUDA
+    # operations from the packed kernel bundle. Production generated runtimes
+    # use this to prevent silent JIT or torch fallbacks.
+    require_packed_sampling: bool = False
+
     # post_sample(slot, *, sampled_ids, hidden_last, sequences,
     #             batch_idx, temperatures, top_ps, token_logprobs,
     #             ready_event) -> Any

--- a/kestrel/runtime/sampling.py
+++ b/kestrel/runtime/sampling.py
@@ -98,11 +98,6 @@ class SamplingHooks:
     # fallback; source-only development runtimes leave it false.
     require_packed_greedy_logprobs: bool = False
 
-    # Require ordinary temperature/top-p sampling to resolve both CUDA
-    # operations from the packed kernel bundle. Production generated runtimes
-    # use this to prevent silent JIT or torch fallbacks.
-    require_packed_sampling: bool = False
-
     # post_sample(slot, *, sampled_ids, hidden_last, sequences,
     #             batch_idx, temperatures, top_ps, token_logprobs,
     #             ready_event) -> Any
@@ -146,6 +141,11 @@ class SamplingHooks:
     # prepare_decode_inputs(slot, batch_idx, batch_size) -> None
     # Default: no-op. Runtime gathers any aux decode inputs into slot.
     prepare_decode_inputs: Callable[..., None] | None = None
+
+    # Require ordinary temperature/top-p sampling to resolve both CUDA
+    # operations from the packed kernel bundle. Production generated runtimes
+    # use this to prevent silent JIT or torch fallbacks.
+    require_packed_sampling: bool = False
 
 
 __all__ = ["SamplingHooks"]

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -502,6 +502,7 @@ class GenerationScheduler:
         progressed = False
         pipeline = self._pipeline
         with stream_context(self._compute_stream):
+            progressed |= self._cancel_requests()
             has_launch = pipeline.has_launch_in_flight()
             has_queued = pipeline.queue_depth() > 0
 
@@ -578,6 +579,31 @@ class GenerationScheduler:
                 progressed = True
         return progressed
 
+    def _cancel_requests(self) -> bool:
+        """Finish closed streams through the scheduler's existing release paths."""
+
+        progressed = False
+        for request in list(self.waiting):
+            if not request.cancel_event.is_set():
+                continue
+            self.waiting.remove(request)
+            self._finish_request_early(request, reason="cancelled")
+            progressed = True
+
+        for seq in list(self.running):
+            if (
+                not seq.request.cancel_event.is_set()
+                # The row is not safe to release until prefill commits it.
+                or seq.uncommitted_prefill_token
+            ):
+                continue
+            self.running.remove(seq)
+            self._finalize_sequence(seq, "cancelled")
+            if self.runtime.spec is not None and seq.inflight_refs == 0:
+                self._retire_spec_row(seq.state)
+            progressed = True
+        return progressed
+
     def _drain_pipeline(self) -> None:
         """Drain in-flight work before prefill / before an engine pause.
 
@@ -639,6 +665,7 @@ class GenerationScheduler:
     def _advance_spec(self) -> bool:
         progressed = False
         with stream_context(self._compute_stream):
+            progressed |= self._cancel_requests()
             progressed |= self._spec_admit()
             progressed |= self._spec_decode_step()
         return progressed
@@ -1225,7 +1252,11 @@ class GenerationScheduler:
         active = [
             seq
             for seq in self.running
-            if not seq.finished and seq.sequence_state is not None
+            if (
+                not seq.finished
+                and seq.sequence_state is not None
+                and not seq.request.cancel_event.is_set()
+            )
         ]
         # Reserve this launch's ref before the commit (see docstring): protects
         # continuing sequences from a premature retire when the commit drops
@@ -1274,6 +1305,7 @@ class GenerationScheduler:
                     seq.inflight_refs -= 1
                     if seq.inflight_refs == 0:
                         seq.transition(RequestPhase.COMPLETED)
+                        self._complete_deferred_cancellation(seq)
                         self._retire_spec_row(seq.state)
                 else:
                     launchable.append(seq)
@@ -1538,6 +1570,13 @@ class GenerationScheduler:
                 # stuck in FINALIZING forever after its row is retired.
                 if seq.inflight_refs == 0:
                     seq.transition(RequestPhase.COMPLETED)
+                    self._complete_deferred_cancellation(seq)
+                    self._retire_spec_row(seq.state)
+                continue
+            if seq.request.cancel_event.is_set():
+                self.running.remove(seq)
+                self._finalize_sequence(seq, "cancelled")
+                if seq.inflight_refs == 0:
                     self._retire_spec_row(seq.state)
                 continue
             seq_logprobs = logprobs[i] if logprobs is not None else None
@@ -1591,6 +1630,21 @@ class GenerationScheduler:
             exc,
             exc_info=exc,
         )
+        self._finish_request_early(
+            request,
+            reason="error",
+            error=exc,
+        )
+
+    def _finish_request_early(
+        self,
+        request: GenerationRequest,
+        *,
+        reason: str,
+        error: Exception | None = None,
+    ) -> None:
+        """Finish a request that has not installed a runtime sequence."""
+
         lifecycle = request.lifecycle
         if lifecycle.lora_slot_ready and request.lora_slot:
             # A request can carry a scheduler-owned adapter reference from an
@@ -1604,8 +1658,8 @@ class GenerationScheduler:
             finally:
                 request.lora_slot = 0
                 lifecycle.lora_slot_ready = False
-        lifecycle.finish_reason = "error"
-        lifecycle.error = exc
+        lifecycle.finish_reason = reason
+        lifecycle.error = error
         lifecycle.finished = True
         lifecycle.finalized = True
         # Terminal requests no longer need their prepared host-side encoder
@@ -1616,13 +1670,15 @@ class GenerationScheduler:
         result = SchedulerResult(
             request_id=request.request_id,
             tokens=[],
-            finish_reason="error",
+            finish_reason=reason,
             metrics=metrics,
-            output={"error": str(exc)},
+            output={"error": str(error)} if error is not None else {},
         )
         self._completed.append(result)
 
     def _is_launchable_request(self, request: GenerationRequest) -> bool:
+        if request.cancel_event.is_set():
+            return False
         lifecycle = request.lifecycle
         if lifecycle.phase not in (
             RequestPhase.WAITING_RESOURCES,
@@ -2203,6 +2259,8 @@ class GenerationScheduler:
         """
         if seq.finalized:
             return False
+        if seq.request.cancel_event.is_set():
+            return False
         if seq.inflight_refs >= 2:
             return False
         # Absolute max length (includes prompt)
@@ -2522,8 +2580,12 @@ class GenerationScheduler:
                 )
             logprobs = self._logprobs_for_sequences(step.sequences, logprobs_cpu)
             for seq, token, logprob in zip(step.sequences, tokens, logprobs):
-                seq.stage_token(self.runtime, token, logprob=logprob)
                 seq.uncommitted_prefill_token = False
+                if seq.request.cancel_event.is_set():
+                    self.running.remove(seq)
+                    self._finalize_sequence(seq, "cancelled")
+                    continue
+                seq.stage_token(self.runtime, token, logprob=logprob)
                 if self._mark_finished_if_needed(seq):
                     seq.finalized = True
                     # Prefill sequences are enqueued into `running` immediately
@@ -2567,6 +2629,12 @@ class GenerationScheduler:
                 if seq.inflight_refs == 0:
                     seq.transition(RequestPhase.COMPLETED)
                     self._release_sequence(seq)
+                    self._complete_deferred_cancellation(seq)
+                continue
+
+            if seq.request.cancel_event.is_set():
+                self.running.remove(seq)
+                self._finalize_sequence(seq, "cancelled")
                 continue
 
             # Stage token (calls consume_step, emits streaming)
@@ -3170,7 +3238,12 @@ class GenerationScheduler:
         else:
             seq.transition(RequestPhase.FINALIZING)
 
-        self._completed.append(self._build_result(seq))
+        if reason != "cancelled" or seq.inflight_refs == 0:
+            self._completed.append(self._build_result(seq))
+
+    def _complete_deferred_cancellation(self, seq: RequestLifecycle) -> None:
+        if seq.finish_reason == "cancelled":
+            self._completed.append(self._build_result(seq))
 
     def _build_result(self, seq: RequestLifecycle) -> SchedulerResult:
         finish_reason = seq.finish_reason or "unknown"

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1934,8 +1934,11 @@ class GenerationScheduler:
             ),
         )
 
-    def _commit_prefill(self, step: PendingCommit) -> tuple[list[Token], Tensor | None]:
-        """Commit a prefill PendingCommit and return first tokens/logprobs."""
+    def _commit_prefill(
+        self,
+        step: PendingCommit,
+    ) -> tuple[list[Token], Tensor | None, tuple[bool, ...]]:
+        """Commit prefill and return tokens, logprobs, and cancellation snapshot."""
         if step.kind != "prefill":
             raise AssertionError("prefill commit requires a prefill pending commit")
         payload = step.payload
@@ -1957,6 +1960,16 @@ class GenerationScheduler:
             # host ownership, so the original host payload can now be dropped.
             for sequence in step.sequences:
                 sequence.request.encoder_input = None
+            cancelled = tuple(
+                not sequence.finalized
+                and sequence.request.cancel_event.is_set()
+                for sequence in step.sequences
+            )
+            for sequence, is_cancelled in zip(
+                step.sequences, cancelled, strict=True
+            ):
+                if is_cancelled:
+                    sequence.finalized = True
             tokens = self._materialize_tokens(
                 token_ids_cpu,
                 step.sequences,
@@ -1974,7 +1987,7 @@ class GenerationScheduler:
                 )
             self._release_prefill_staging(staging)
             self.runtime.release_prefill_slot(prefill_slot)
-        return tokens, logprobs_cpu
+        return tokens, logprobs_cpu, cancelled
 
     def _launch_prefill_step(self, pipeline: PipelineState) -> bool:
         """Launch a prefill forward and enqueue it into the shared pipeline.
@@ -2577,16 +2590,18 @@ class GenerationScheduler:
         at commit time and released when their last step completes.
         """
         if step.kind == "prefill":
-            tokens, logprobs_cpu = self._commit_prefill(step)
+            tokens, logprobs_cpu, cancelled = self._commit_prefill(step)
             if len(tokens) != len(step.sequences):
                 raise RuntimeError(
                     "Prefill token count mismatch: "
                     f"{len(tokens)} token(s) for {len(step.sequences)} sequence(s)"
                 )
             logprobs = self._logprobs_for_sequences(step.sequences, logprobs_cpu)
-            for seq, token, logprob in zip(step.sequences, tokens, logprobs):
+            for seq, token, logprob, is_cancelled in zip(
+                step.sequences, tokens, logprobs, cancelled, strict=True
+            ):
                 seq.uncommitted_prefill_token = False
-                if seq.request.cancel_event.is_set():
+                if is_cancelled:
                     self.running.remove(seq)
                     self._finalize_sequence(seq, "cancelled")
                     continue
@@ -2617,6 +2632,14 @@ class GenerationScheduler:
         # ``runtime_step`` (e.g. CPU-side aux values, if it owns them).
         payload: DecodePendingCommit = step.payload
         batch_idx_cpu = slot.meta.batch_idx.cpu[: len(step.sequences)]
+        cancelled = tuple(
+            not seq.finalized and seq.request.cancel_event.is_set()
+            for seq in step.sequences
+        )
+        for seq, is_cancelled in zip(step.sequences, cancelled, strict=True):
+            if is_cancelled:
+                self.running.remove(seq)
+                self._finalize_sequence(seq, "cancelled")
         tokens = self._materialize_tokens(
             token_ids_cpu,
             step.sequences,
@@ -2635,11 +2658,6 @@ class GenerationScheduler:
                     seq.transition(RequestPhase.COMPLETED)
                     self._release_sequence(seq)
                     self._complete_deferred_cancellation(seq)
-                continue
-
-            if seq.request.cancel_event.is_set():
-                self.running.remove(seq)
-                self._finalize_sequence(seq, "cancelled")
                 continue
 
             # Stage token (calls consume_step, emits streaming)

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -646,6 +646,11 @@ class GenerationScheduler:
                 self.commit_step(step)
                 pipeline.on_step_completed()
 
+        # Pause forbids new launches, but closing an already-owned request
+        # must still release its scheduler resources while the engine is idle.
+        with stream_context(self._compute_stream):
+            self._cancel_requests()
+
     # ------------------------------------------------------------------
     # Speculative decode path
     #

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -3046,6 +3046,8 @@ class GenerationScheduler:
         }
         if logprobs is not None:
             sample_kwargs["logprobs_out"] = logprobs
+        if self._hooks.require_packed_sampling:
+            sample_kwargs["require_packed"] = True
         sampled_raw = sample_step_from_logits(
             logits,
             temps,

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -1,10 +1,12 @@
 """Typed containers used by the scheduler."""
 
-import numpy as np
+import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Callable, Dict, List, Mapping, Optional, Sequence
+
+import numpy as np
 
 from kestrel.runtime import AutoregressiveRuntime, SequenceState, Token
 from kestrel.skills import SkillSpec, SkillState, DecodeStep
@@ -215,6 +217,7 @@ class GenerationRequest:
     return_logprobs: Optional[bool] = None
     generated_prefix: GeneratedPrefix = field(default_factory=GeneratedPrefix)
     suppress_next_token_ids: Optional[tuple[int, ...]] = None
+    cancel_event: threading.Event = field(default_factory=threading.Event, repr=False)
 
     prompt_length: int = field(init=False)
 

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -149,16 +149,20 @@ class RequestLifecycle:
             self.logprobs.append(float(logprob))
         callback = self.request.stream_callback
         if callback is not None:
-            text_delta = self.skill_state.pop_stream_delta(runtime)
-            reasoning_delta = self.skill_state.pop_reasoning_stream_delta(runtime)
-            if text_delta or reasoning_delta:
+            output = self.skill_state.pop_stream_output(runtime)
+            if output is not None:
+                text = output.get("text", "")
+                reasoning = output.get("reasoning")
                 callback(
                     StreamUpdate(
                         request_id=self.request.request_id,
                         token=token,
-                        text=text_delta or "",
+                        text=text if isinstance(text, str) else "",
                         token_index=self.skill_state.token_count - 1,
-                        reasoning=reasoning_delta,
+                        reasoning=(
+                            reasoning if isinstance(reasoning, str) else None
+                        ),
+                        output=dict(output),
                     )
                 )
 
@@ -278,13 +282,19 @@ class SchedulerResult:
 
 @dataclass
 class StreamUpdate:
-    """Incremental token update emitted while a request is decoding."""
+    """One append-only update emitted while a request is decoding.
+
+    ``text`` remains the convenient text-delta surface. ``output`` carries the
+    capability-defined payload for non-text streams and mirrors text deltas as
+    ``{"text": text}``.
+    """
 
     request_id: int
     token: Token
     text: str
     token_index: int
     reasoning: Optional[str] = None
+    output: Dict[str, object] = field(default_factory=dict)
 
 
 StreamCallback = Callable[[StreamUpdate], None]

--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -4,7 +4,7 @@ import numpy as np
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Sequence
+from typing import Callable, Dict, List, Mapping, Optional, Sequence
 
 from kestrel.runtime import AutoregressiveRuntime, SequenceState, Token
 from kestrel.skills import SkillSpec, SkillState, DecodeStep
@@ -162,7 +162,7 @@ class RequestLifecycle:
                         reasoning=(
                             reasoning if isinstance(reasoning, str) else None
                         ),
-                        output=dict(output),
+                        output=output,
                     )
                 )
 
@@ -294,7 +294,7 @@ class StreamUpdate:
     text: str
     token_index: int
     reasoning: Optional[str] = None
-    output: Dict[str, object] = field(default_factory=dict)
+    output: Mapping[str, object] = field(default_factory=dict)
 
 
 StreamCallback = Callable[[StreamUpdate], None]

--- a/kestrel/skills/base.py
+++ b/kestrel/skills/base.py
@@ -329,6 +329,26 @@ class SkillState:
 
         return None
 
+    def pop_stream_output(
+        self,
+        runtime: "AutoregressiveRuntime",
+    ) -> Optional[Mapping[str, object]]:
+        """Return one append-only streaming update.
+
+        Text skills inherit the existing ``pop_stream_delta`` behavior. A
+        capability that streams another payload, such as synthesized PCM, can
+        override this hook without teaching the scheduler about that modality.
+        """
+
+        text = self.pop_stream_delta(runtime)
+        reasoning = self.pop_reasoning_stream_delta(runtime)
+        output = {}
+        if text:
+            output["text"] = text
+        if reasoning:
+            output["reasoning"] = reasoning
+        return output or None
+
 
 class SkillRegistry:
     """Maps a model's capability names to their skills.

--- a/tests/scheduler/test_launch_prefill_step.py
+++ b/tests/scheduler/test_launch_prefill_step.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from collections import deque
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -97,6 +98,36 @@ def _make_scheduler(
         _make_candidate(request)
     ]
     return scheduler
+
+
+def test_cancelled_prefill_waits_for_commit_before_finalizing() -> None:
+    request = _make_request()
+    request.cancel_event = threading.Event()
+    request.cancel_event.set()
+    sequence = request.lifecycle
+    sequence.sequence_state = SequenceState(
+        batch_idx=1,
+        length=1,
+        max_length=9,
+        prompt_length=1,
+    )
+    sequence.uncommitted_prefill_token = True
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = FakeRuntime()
+    scheduler.waiting = RequestQueue()
+    scheduler.running = RunningQueue()
+    scheduler.running.push(sequence)
+    finalized: list[tuple[RequestLifecycle, str]] = []
+    scheduler._finalize_sequence = lambda seq, reason: finalized.append((seq, reason))
+    scheduler._commit_prefill = lambda _step: ([TextToken(7)], None)
+    step = SimpleNamespace(kind="prefill", sequences=[sequence])
+
+    assert scheduler._cancel_requests() is False
+    scheduler.commit_step(step)
+
+    assert finalized == [(sequence, "cancelled")]
+    assert sequence.skill_state.tokens == []
+    assert len(scheduler.running) == 0
 
 
 def test_scheduler_requires_uniform_sampling_hooks() -> None:

--- a/tests/scheduler/test_launch_prefill_step.py
+++ b/tests/scheduler/test_launch_prefill_step.py
@@ -119,7 +119,7 @@ def test_cancelled_prefill_waits_for_commit_before_finalizing() -> None:
     scheduler.running.push(sequence)
     finalized: list[tuple[RequestLifecycle, str]] = []
     scheduler._finalize_sequence = lambda seq, reason: finalized.append((seq, reason))
-    scheduler._commit_prefill = lambda _step: ([TextToken(7)], None)
+    scheduler._commit_prefill = lambda _step: ([TextToken(7)], None, (True,))
     step = SimpleNamespace(kind="prefill", sequences=[sequence])
 
     assert scheduler._cancel_requests() is False

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -55,6 +55,14 @@ class _ReasoningStreamSkillState(_SkillStateStub):
         return "think"
 
 
+class _AudioStreamState(_SkillStateStub):
+    def pop_stream_output(self, runtime: object) -> dict[str, object] | None:
+        return {
+            "audio": [0.25, -0.25],
+            "sample_rate": 24_000,
+        }
+
+
 def _make_lifecycle(*, return_logprobs: bool | None) -> RequestLifecycle:
     request = GenerationRequest(
         request_id=7,
@@ -204,6 +212,21 @@ def test_stage_token_emits_reasoning_without_answer_text() -> None:
     assert updates[0].token_index == 0
     assert updates[0].text == ""
     assert updates[0].reasoning == "think"
+
+
+def test_stream_update_preserves_capability_defined_output() -> None:
+    updates = []
+    seq = _make_lifecycle_with_state(_AudioStreamState, return_logprobs=None)
+    seq.request.stream_callback = updates.append
+
+    seq.stage_token(SimpleNamespace(), TextToken(10))
+
+    assert len(updates) == 1
+    assert updates[0].text == ""
+    assert updates[0].output == {
+        "audio": [0.25, -0.25],
+        "sample_rate": 24_000,
+    }
 
 
 def test_scheduler_result_keeps_generated_prefix_logprobs_aligned() -> None:

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -388,6 +389,28 @@ def test_sample_batch_omits_logprob_keyword_without_opt_in(
 
     assert sampled.tolist() == [3]
     assert logprobs is None
+
+
+def test_sample_batch_requests_packed_sampling_when_runtime_requires_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = _scheduler()
+    scheduler._hooks = SamplingHooks(require_packed_sampling=True)
+    sample = Mock(return_value=torch.tensor([3]))
+    monkeypatch.setattr(
+        "kestrel.scheduler.scheduler.sample_step_from_logits",
+        sample,
+    )
+
+    GenerationScheduler._sample_batch(
+        scheduler,
+        torch.zeros((1, 8), dtype=torch.float32),
+        [_sequence(temperature=0.7, return_logprobs=None)],  # type: ignore[list-item]
+        torch.empty((1,), dtype=torch.long),
+        batch_idx=torch.tensor([0], dtype=torch.long),
+    )
+
+    assert sample.call_args.kwargs["require_packed"] is True
 
 
 def test_scheduler_rejects_custom_greedy_with_speculative_decode() -> None:

--- a/tests/scheduler/test_release_sequence.py
+++ b/tests/scheduler/test_release_sequence.py
@@ -25,6 +25,7 @@ from kestrel.scheduler.types import (
     RequestLifecycle,
     RequestPhase,
 )
+from kestrel.skills import DecodeStep
 
 from tests.scheduler._fake_runtime import FakeRuntime
 
@@ -32,6 +33,9 @@ from tests.scheduler._fake_runtime import FakeRuntime
 @dataclass
 class _SkillStateStub:
     tokens: list[object] = field(default_factory=list)
+
+    def consume_step(self, _runtime: object, step: DecodeStep) -> None:
+        self.tokens.append(step.token)
 
     @property
     def token_count(self) -> int:
@@ -418,12 +422,53 @@ def test_prefill_commit_drops_prepared_encoder_input() -> None:
         ),
     )
 
-    tokens, logprobs = scheduler._commit_prefill(step)
+    tokens, logprobs, cancelled = scheduler._commit_prefill(step)
 
     assert tokens == [TextToken(9)]
     assert logprobs is None
+    assert cancelled == (False,)
     assert lifecycle.request.encoder_input is None
     assert lifecycle.request.has_encoder_input is True
     assert runtime.finalized_prepared == [prepared]
     assert released_staging == [staging]
     assert runtime.released_prefill_slots == [slot]
+
+
+def test_prefill_commit_linearizes_cancellation_before_materialization() -> None:
+    runtime = FakeRuntime()
+    lifecycle = _make_lifecycle(runtime)
+    lifecycle.skill_state.tokens.clear()
+    lifecycle.uncommitted_prefill_token = True
+    prepared = SimpleNamespace(state=lifecycle.state)
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = runtime
+    scheduler.running = RunningQueue()
+    scheduler.running.push(lifecycle)
+    scheduler._release_prefill_staging = lambda _staging: None
+    scheduler._mark_finished_if_needed = lambda _seq: False
+
+    def materialize(*_args: object) -> list[TextToken]:
+        assert lifecycle.finalized is False
+        lifecycle.request.cancel_event.set()
+        return [TextToken(9)]
+
+    scheduler._materialize_tokens = materialize
+    slot = runtime.prefill_slots[0]
+    step = PendingCommit(
+        kind="prefill",
+        sequences=[lifecycle],
+        transfer=SimpleNamespace(wait=lambda: (object(), None)),
+        payload=PrefillPendingCommit(
+            staging=object(),
+            slot_id=0,
+            prepared_sequences=[prepared],
+            prefill_slot=slot,
+        ),
+    )
+
+    scheduler.commit_step(step)
+
+    assert lifecycle.request.cancel_event.is_set()
+    assert lifecycle.skill_state.tokens == [TextToken(9)]
+    assert lifecycle.finished is False
+    assert lifecycle in scheduler.running

--- a/tests/scheduler/test_release_sequence.py
+++ b/tests/scheduler/test_release_sequence.py
@@ -18,8 +18,13 @@ from kestrel.scheduler.pipeline import (
 )
 from kestrel.scheduler.queues import RunningQueue
 from kestrel.scheduler.scheduler import GenerationScheduler
-from kestrel.scheduler.types import GeneratedPrefix, GenerationRequest, RequestLifecycle
 from kestrel.runtime.sampling import SamplingHooks
+from kestrel.scheduler.types import (
+    GeneratedPrefix,
+    GenerationRequest,
+    RequestLifecycle,
+    RequestPhase,
+)
 
 from tests.scheduler._fake_runtime import FakeRuntime
 
@@ -98,6 +103,29 @@ def test_finalize_sequence_retains_prefix_before_release() -> None:
     assert retain_call["adapter_id"] == "adapter-a"
     assert retain_call["image_hash"] == b"0123456789abcdef"
     assert runtime.released_sequences == [state]
+
+
+def test_cancel_completion_waits_for_inflight_release() -> None:
+    runtime = FakeRuntime()
+    lifecycle = _make_lifecycle(runtime)
+    lifecycle.inflight_refs = 1
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler.runtime = runtime
+    scheduler._completed = deque()
+    scheduler._build_result = lambda seq: seq.finish_reason
+
+    scheduler._finalize_sequence(lifecycle, "cancelled")
+
+    assert scheduler.pop_completed() == []
+    assert runtime.released_sequences == []
+
+    lifecycle.inflight_refs = 0
+    lifecycle.transition(RequestPhase.COMPLETED)
+    scheduler._release_sequence(lifecycle)
+    scheduler._complete_deferred_cancellation(lifecycle)
+
+    assert scheduler.pop_completed() == ["cancelled"]
+    assert runtime.released_sequences == [lifecycle.state]
 
 
 def test_release_sequence_retains_only_decoded_suffix_after_generated_prefix() -> None:

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -67,6 +67,7 @@ def _executor() -> AutoregressiveExecutor:
     ex._scheduler = SimpleNamespace(
         _completed=[],
         waiting=[],
+        _drain_pipeline=lambda: None,
         has_pending_work=lambda: bool(ex._scheduler._completed),
         advance=lambda: False,
         pop_completed=lambda: [
@@ -230,6 +231,20 @@ def test_admission_failure_surfaces_as_completion() -> None:
     assert len(tick.completed) == 1
     assert isinstance(tick.completed[0].error, ValueError)
     assert ex.has_work is False
+
+
+def test_pause_drain_settles_cancelled_admission() -> None:
+    ex = _executor()
+    request = _pending(5)
+    request.cancel_event.set()
+    ex._admission.pop_cancelled = lambda: [request]
+
+    (completion,) = ex.drain()
+
+    assert completion.request is request
+    assert completion.result is not None
+    assert completion.result.finish_reason == "cancelled"
+    assert ex._admission_completions == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_autoregressive_executor.py
+++ b/tests/test_autoregressive_executor.py
@@ -11,7 +11,6 @@ covered by tests/scheduler/.
 from __future__ import annotations
 
 import asyncio
-import threading
 from types import SimpleNamespace
 from typing import Any, Callable
 
@@ -19,7 +18,6 @@ import pytest
 
 from kestrel.engine import (
     AutoregressiveExecutor,
-    Completion,
     EngineResult,
     EngineMetrics,
     _AutoregressiveRequest,
@@ -65,7 +63,7 @@ def _executor() -> AutoregressiveExecutor:
     ex._admission_capacity = 4
     ex._to_engine_result = _fake_to_engine_result
     ex._active = {}
-    ex._admission_failures = []
+    ex._admission_completions = []
     ex._scheduler = SimpleNamespace(
         _completed=[],
         waiting=[],
@@ -79,6 +77,7 @@ def _executor() -> AutoregressiveExecutor:
     ex._admission = SimpleNamespace(
         has_pending=lambda: False,
         pending_count=0,
+        pop_cancelled=lambda: [],
         take_ready=lambda: None,
         fail_all=lambda exc: None,
     )
@@ -272,7 +271,7 @@ def test_unsupported_custom_greedy_request_fails_before_admission(
 def test_advance_raising_preserves_queued_admission_failures() -> None:
     """Regression: a buffered admission failure must survive advance() raising.
 
-    advance() must not move _admission_failures into a local that's lost
+    advance() must not move admission completions into a local that's lost
     if scheduler.advance() raises mid-tick. The kernel responds to the
     exception by calling shutdown(exc); that must still see the buffered
     failure and return it, or the failed-admission caller hangs.
@@ -305,7 +304,7 @@ def test_shutdown_returns_requests_failed_during_fail_all() -> None:
 
     The real admission coordinator's fail_all() synchronously routes
     in-flight preprocessing requests through _fail_via_admission, which
-    appends to _admission_failures. shutdown() must collect that list
+    appends to the admission completion buffer. shutdown() must collect that list
     *after* fail_all() runs, or those requests' completions are dropped
     and their callers hang forever.
     """
@@ -319,7 +318,7 @@ def test_shutdown_returns_requests_failed_during_fail_all() -> None:
 
     assert [c.request for c in completions] == [stuck]
     assert isinstance(completions[0].error, RuntimeError)
-    assert ex._admission_failures == []
+    assert ex._admission_completions == []
 
 
 def test_shutdown_retires_spec_rows_through_the_decoder() -> None:

--- a/tests/test_capability_stream.py
+++ b/tests/test_capability_stream.py
@@ -39,6 +39,23 @@ def test_progress_is_coalesced_and_result_does_not_require_iteration() -> None:
     asyncio.run(scenario())
 
 
+def test_append_only_stream_keeps_every_update() -> None:
+    async def scenario() -> None:
+        async def produce(emit):
+            emit({"audio": b"first"})
+            emit({"audio": b"second"})
+            return _result("done")
+
+        stream = CapabilityStream("synthesize", produce, coalesce=False)
+        assert (await stream.result()).output == {"text": "done"}
+        assert (await anext(stream)).output == {"audio": b"first"}
+        assert (await anext(stream)).output == {"audio": b"second"}
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+
+    asyncio.run(scenario())
+
+
 def test_close_cancels_compound_producer() -> None:
     async def scenario() -> None:
         cancelled = asyncio.Event()
@@ -53,6 +70,38 @@ def test_close_cancels_compound_producer() -> None:
         await asyncio.sleep(0)
         await stream.aclose()
         assert cancelled.is_set()
+
+    asyncio.run(scenario())
+
+
+def test_close_discards_append_only_backlog() -> None:
+    async def scenario() -> None:
+        async def produce(emit):
+            emit({"audio": b"first"})
+            emit({"audio": b"second"})
+            return _result("done")
+
+        stream = CapabilityStream("synthesize", produce, coalesce=False)
+        await stream.result()
+        await stream.aclose()
+
+        assert stream._queue.qsize() == 1
+
+    asyncio.run(scenario())
+
+
+def test_close_wakes_pending_next() -> None:
+    async def scenario() -> None:
+        async def produce(emit):
+            await asyncio.Future()
+
+        stream = CapabilityStream("synthesize", produce, coalesce=False)
+        pending = asyncio.create_task(anext(stream))
+        await asyncio.sleep(0)
+        await stream.aclose()
+
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(pending, timeout=1.0)
 
     asyncio.run(scenario())
 

--- a/tests/test_capability_stream.py
+++ b/tests/test_capability_stream.py
@@ -74,7 +74,7 @@ def test_close_cancels_compound_producer() -> None:
     asyncio.run(scenario())
 
 
-def test_close_discards_append_only_backlog() -> None:
+def test_context_exit_discards_append_only_backlog() -> None:
     async def scenario() -> None:
         async def produce(emit):
             emit({"audio": b"first"})
@@ -82,10 +82,12 @@ def test_close_discards_append_only_backlog() -> None:
             return _result("done")
 
         stream = CapabilityStream("synthesize", produce, coalesce=False)
-        await stream.result()
-        await stream.aclose()
+        async with stream:
+            pass
 
         assert stream._queue.qsize() == 1
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
 
     asyncio.run(scenario())
 

--- a/tests/test_capability_stream.py
+++ b/tests/test_capability_stream.py
@@ -108,6 +108,29 @@ def test_close_wakes_pending_next() -> None:
     asyncio.run(scenario())
 
 
+def test_close_does_not_swallow_caller_cancellation() -> None:
+    async def scenario() -> None:
+        cleaning = asyncio.Event()
+
+        async def produce(emit):
+            try:
+                await asyncio.Future()
+            finally:
+                cleaning.set()
+                await asyncio.Future()
+
+        stream = CapabilityStream("synthesize", produce, coalesce=False)
+        await asyncio.sleep(0)
+        closing = asyncio.create_task(stream.aclose())
+        await cleaning.wait()
+        closing.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await closing
+
+    asyncio.run(scenario())
+
+
 def test_producer_failure_reaches_iterator_and_result() -> None:
     async def scenario() -> None:
         async def produce(emit):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -76,6 +76,39 @@ def test_engine_stream_close_stops_a_waiter_and_settles() -> None:
     asyncio.run(run())
 
 
+def test_cancelled_submit_waits_for_scheduler_settlement() -> None:
+    async def run() -> None:
+        engine = object.__new__(InferenceEngine)
+        engine._scheduler_event = threading.Event()
+        result_future = asyncio.get_running_loop().create_future()
+        captured: dict[str, threading.Event] = {}
+
+        async def submit_request(**kwargs: object):
+            cancel_event = kwargs["cancel_event"]
+            assert isinstance(cancel_event, threading.Event)
+            captured["cancel_event"] = cancel_event
+            return result_future, 1
+
+        engine._submit_request = submit_request  # type: ignore[method-assign]
+        task = asyncio.create_task(
+            engine.submit(object(), max_new_tokens=8, skill="synthesize")
+        )
+        await asyncio.sleep(0)
+
+        task.cancel()
+        await asyncio.sleep(0)
+        assert captured["cancel_event"].is_set()
+        assert engine._scheduler_event.is_set()
+        assert not task.done()
+        assert not result_future.cancelled()
+
+        result_future.set_exception(RuntimeError("scheduler stopped"))
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run())
+
+
 def _make_request(
     *,
     request_id: int = 1,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -12,13 +12,16 @@ import numpy as np
 import pytest
 
 from kestrel.engine import (
+    EngineMetrics,
+    EngineResult,
+    EngineStream,
     InferenceEngine,
     _AdmissionCoordinator,
     _AutoregressiveRequest,
 )
 from kestrel.models.moondream.runtime import TextToken
 from kestrel.runtime import ExecutionShape
-from kestrel.scheduler import GeneratedPrefix
+from kestrel.scheduler import GeneratedPrefix, StreamUpdate
 from kestrel.skills import (
     DecodeStep,
     PreparedSkillPrompt,
@@ -40,6 +43,37 @@ def test_default_prepared_skill_prompt_preserves_tokens_context_and_budget() -> 
         tokens=(),
         max_new_tokens=7,
     )
+
+
+def test_engine_stream_close_stops_a_waiter_and_settles() -> None:
+    async def run() -> None:
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[EngineResult] = loop.create_future()
+        cancelled = threading.Event()
+        queue = asyncio.Queue()
+        stream = EngineStream(1, queue, future, cancel=cancelled.set)
+        waiting = asyncio.create_task(anext(stream))
+        await asyncio.sleep(0)
+
+        closing = asyncio.create_task(stream.aclose())
+        await asyncio.sleep(0)
+        assert cancelled.is_set()
+        queue.put_nowait(StreamUpdate(1, TextToken(2), "x", 0))
+        result = EngineResult(
+            request_id=1,
+            tokens=[],
+            finish_reason="cancelled",
+            metrics=EngineMetrics(0, 0, 0.0, 0.0, 0.0),
+            output={},
+        )
+        future.set_result(result)
+
+        await closing
+        with pytest.raises(StopAsyncIteration):
+            await waiting
+        assert await stream.result() is result
+
+    asyncio.run(run())
 
 
 def _make_request(
@@ -280,6 +314,34 @@ def test_encoder_input_failure_cancels_concurrent_image_preprocessing() -> None:
 
     assert crop_future.cancelled()
     assert failures == [(req, encoder_input_future.exception())]
+    assert not coordinator.has_pending()
+
+
+def test_admission_close_cancels_pending_preprocessing() -> None:
+    crop_future: Future[object] = Future()
+    encoder_future: Future[object] = Future()
+    coordinator = _AdmissionCoordinator(
+        runtime=_FakeRuntime(
+            prefix_cache=None,
+            prefix_hit=False,
+            image_preprocessor=_FakeImagePreprocessor([crop_future]),
+            encoder_input_preprocessor=_FakeImagePreprocessor([encoder_future]),
+        ),
+        wake_event=threading.Event(),
+        fail_request=lambda *_: None,
+    )
+    req = _make_request(
+        image=np.zeros((4, 4, 3), dtype=np.uint8),
+        encoder_input=object(),
+    )
+    req.cancel_event = threading.Event()
+
+    assert coordinator.submit(req) is None
+    req.cancel_event.set()
+
+    assert coordinator.pop_cancelled() == [req]
+    assert crop_future.cancelled()
+    assert encoder_future.cancelled()
     assert not coordinator.has_pending()
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -378,6 +378,40 @@ def test_admission_close_cancels_pending_preprocessing() -> None:
     assert not coordinator.has_pending()
 
 
+def test_admission_close_waits_for_running_preprocessing() -> None:
+    crop_future: Future[object] = Future()
+    encoder_future: Future[object] = Future()
+    assert crop_future.set_running_or_notify_cancel()
+    coordinator = _AdmissionCoordinator(
+        runtime=_FakeRuntime(
+            prefix_cache=None,
+            prefix_hit=False,
+            image_preprocessor=_FakeImagePreprocessor([crop_future]),
+            encoder_input_preprocessor=_FakeImagePreprocessor([encoder_future]),
+        ),
+        wake_event=threading.Event(),
+        fail_request=lambda *_: None,
+    )
+    req = _make_request(
+        image=np.zeros((4, 4, 3), dtype=np.uint8),
+        encoder_input=object(),
+    )
+
+    assert coordinator.submit(req) is None
+    req.cancel_event.set()
+
+    assert coordinator.pop_cancelled() == []
+    assert coordinator.has_pending()
+    assert encoder_future.cancelled()
+    assert coordinator.take_ready() is None
+    assert coordinator.has_pending()
+
+    crop_future.set_result(object())
+
+    assert coordinator.pop_cancelled() == [req]
+    assert not coordinator.has_pending()
+
+
 def test_admission_coordinator_skips_crop_work_on_prefix_hit() -> None:
     image = np.arange(12, dtype=np.uint8).reshape(3, 4)
     preprocessor = _FakeImagePreprocessor()

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -32,6 +32,7 @@ def test_try_create_binds_physical_sm_count_to_program_resolution():
         bindings=SimpleNamespace(is_eligible=lambda value: value is runtime),
         weight_root=Mock(),
         weight_layer_prefix="model.layers",
+        program_names=frozenset({"selected_b1"}),
     )
     properties = SimpleNamespace(major=10, minor=0, multi_processor_count=148)
 
@@ -49,6 +50,7 @@ def test_try_create_binds_physical_sm_count_to_program_resolution():
         layer_prefix="model.layers",
         arch="sm100",
         device_sms=148,
+        program_names=frozenset({"selected_b1"}),
     )
 
 

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -23,6 +23,17 @@ def _program(capacity, *, active_batch=None, minimum_batch=1):
     )
 
 
+def _load_time_weight_runtime(monkeypatch):
+    from kestrel_kernels import generated_decode
+
+    for capability in (
+        "allocate_weight_storage_for_loading",
+        "finalize_weight_storage_after_loading",
+    ):
+        monkeypatch.setattr(generated_decode, capability, Mock(), raising=False)
+    return generated_decode
+
+
 def test_try_create_binds_physical_sm_count_to_program_resolution():
     runtime = SimpleNamespace(
         device=torch.device("cuda", 0),
@@ -152,8 +163,7 @@ def test_load_time_weight_preparation_fails_soft_only_when_optional(
     monkeypatch: pytest.MonkeyPatch,
     missing_capability: str,
 ) -> None:
-    from kestrel_kernels import generated_decode as generated_runtime
-
+    generated_runtime = _load_time_weight_runtime(monkeypatch)
     runtime = SimpleNamespace(
         device=torch.device("cuda", 0),
         dtype=torch.bfloat16,
@@ -167,7 +177,7 @@ def test_load_time_weight_preparation_fails_soft_only_when_optional(
         "resolve_compatible_programs",
         lambda *_args, **_kwargs: (program,),
     )
-    monkeypatch.delattr(generated_runtime, missing_capability)
+    monkeypatch.delattr(generated_runtime, missing_capability, raising=False)
     monkeypatch.setattr(
         torch.cuda, "get_device_properties", lambda _device: properties
     )
@@ -189,8 +199,7 @@ def test_load_time_weight_preparation_fails_soft_only_when_optional(
 def test_binding_reservation_allocates_every_program_slot_pair(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from kestrel_kernels import generated_decode as generated_runtime
-
+    generated_runtime = _load_time_weight_runtime(monkeypatch)
     programs = tuple(
         SimpleNamespace(descriptor={"owned_bytes": owned_bytes})
         for owned_bytes in (10, 20)
@@ -257,8 +266,7 @@ def test_binding_reservation_allocates_every_program_slot_pair(
 def test_binding_reservation_fails_soft_only_when_optional(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from kestrel_kernels import generated_decode as generated_runtime
-
+    generated_runtime = _load_time_weight_runtime(monkeypatch)
     monkeypatch.delattr(
         generated_runtime,
         "reserve_binding_storage",

--- a/tests/test_generated_decode_static_extents.py
+++ b/tests/test_generated_decode_static_extents.py
@@ -113,6 +113,13 @@ def _build(
         return SimpleNamespace(buffers={})
 
     generated.materialize_weights = materialize_weights
+    generated.extend_weight_storage = lambda storage, _module, descriptor, **kwargs: (
+        storage
+        if getattr(storage, "matches", False)
+        else SimpleNamespace(
+            buffers={}, base=storage, descriptor=descriptor, options=kwargs
+        )
+    )
     monkeypatch.setitem(sys.modules, "kestrel_kernels", kernels)
     monkeypatch.setitem(sys.modules, "kestrel_kernels.generated_decode", generated)
     monkeypatch.setattr(
@@ -174,18 +181,20 @@ def test_generated_decode_reuses_matching_preloaded_weight_storage(monkeypatch):
     assert calls == []
 
 
-def test_generated_decode_rejects_mismatched_preloaded_weight_storage(monkeypatch):
+def test_generated_decode_extends_partial_preloaded_weight_storage(monkeypatch):
     storage = SimpleNamespace(
-        buffers={}, weight_contract="different", finalized=True
+        buffers={}, weight_contract="partial", finalized=True
     )
 
-    with pytest.raises(RuntimeError, match="preloaded generated weights"):
-        _build(
-            monkeypatch,
-            _programs("b1"),
-            max_batch_size=1,
-            weight_storage=storage,
-        )
+    generated, _launches = _build(
+        monkeypatch,
+        _programs("b1"),
+        max_batch_size=1,
+        weight_storage=storage,
+    )
+
+    assert generated.weight_storage.base is storage
+    assert generated.weight_storage.options == {"layer_prefix": "layers"}
 
 
 def test_generated_decode_rejects_unfinalized_preloaded_weight_storage(monkeypatch):

--- a/tests/test_generated_decode_static_extents.py
+++ b/tests/test_generated_decode_static_extents.py
@@ -98,6 +98,7 @@ def _build(
     weight_sources=None,
     weight_storage=None,
     materialize_calls=None,
+    extension_helper=True,
 ):
     launches = programs[0].launches
     kernels = ModuleType("kestrel_kernels")
@@ -113,13 +114,12 @@ def _build(
         return SimpleNamespace(buffers={})
 
     generated.materialize_weights = materialize_weights
-    generated.extend_weight_storage = lambda storage, _module, descriptor, **kwargs: (
-        storage
-        if getattr(storage, "matches", False)
-        else SimpleNamespace(
-            buffers={}, base=storage, descriptor=descriptor, options=kwargs
+    if extension_helper:
+        generated.extend_weight_storage = (
+            lambda storage, _module, descriptor, **kwargs: SimpleNamespace(
+                buffers={}, base=storage, descriptor=descriptor, options=kwargs
+            )
         )
-    )
     monkeypatch.setitem(sys.modules, "kestrel_kernels", kernels)
     monkeypatch.setitem(sys.modules, "kestrel_kernels.generated_decode", generated)
     monkeypatch.setattr(
@@ -175,6 +175,7 @@ def test_generated_decode_reuses_matching_preloaded_weight_storage(monkeypatch):
         max_batch_size=1,
         weight_storage=storage,
         materialize_calls=calls,
+        extension_helper=False,
     )
 
     assert generated.weight_storage is storage

--- a/tests/test_model_handle.py
+++ b/tests/test_model_handle.py
@@ -88,6 +88,24 @@ class _ConfidenceTranscribeSkill(_TranscribeSkill):
         )
 
 
+class _SynthesizeSkill(SkillSpec):
+    def __init__(self) -> None:
+        super().__init__("synthesize")
+
+    def build_request(
+        self,
+        image: Any,
+        prompt: Any,
+        settings: Any,
+    ) -> BuiltRequest:
+        return BuiltRequest(
+            request_context=SimpleNamespace(),
+            max_new_tokens=8,
+            temperature=0.0,
+            top_p=1.0,
+        )
+
+
 class _WindowOrchestrator(CapabilityOrchestrator):
     async def run(
         self,
@@ -117,7 +135,13 @@ class _CompoundTranscribeSkill(_TranscribeSkill):
 def _engine() -> InferenceEngine:
     """Minimal engine with an AR default + a single-pass model registered."""
     ar_skills = SkillRegistry(
-        [QuerySkill(), CaptionSkill(), SegmentSkill(), _TranscribeSkill()]
+        [
+            QuerySkill(),
+            CaptionSkill(),
+            SegmentSkill(),
+            _TranscribeSkill(),
+            _SynthesizeSkill(),
+        ]
     )
     eng = object.__new__(InferenceEngine)
     eng._default_model = "ar-model"
@@ -167,7 +191,7 @@ def test_model_rejects_unknown_id() -> None:
 def test_ar_handle_advertises_skill_vocabulary() -> None:
     eng = _engine()
     h = eng.model("ar-model")
-    assert h.tasks == ("query", "caption", "segment", "transcribe")
+    assert h.tasks == ("query", "caption", "segment", "transcribe", "synthesize")
     assert h.supports("query") is True
     assert h.supports("segment_masks") is False
 
@@ -349,6 +373,33 @@ def test_transcribe_verb_routes_audio_through_model_skill() -> None:
     assert captured["prompt"] == {"audio": b"RIFF..."}
 
 
+def test_synthesize_verb_routes_prompt_through_model_skill() -> None:
+    eng = _engine()
+    captured: dict[str, Any] = {}
+    eng._run_skill = _capture_run_skill(captured)  # type: ignore[method-assign]
+
+    out = asyncio.run(
+        eng.model("ar-model").synthesize(
+            text="Hello from Kestrel",
+            voice="ryan",
+            stream=True,
+        )
+    )
+
+    assert out == "RESULT"
+    assert captured == {
+        "task": "synthesize",
+        "image": None,
+        "prompt": {
+            "text": "Hello from Kestrel",
+            "voice": "ryan",
+            "stream": True,
+        },
+        "settings": None,
+        "stream": True,
+    }
+
+
 def test_capability_orchestrator_composes_ordinary_leaf_requests() -> None:
     eng = _engine()
     skills = SkillRegistry([_CompoundTranscribeSkill()])
@@ -491,6 +542,7 @@ def test_capability_verbs_are_uniform_kwargs() -> None:
         "segment",
         "transcribe",
         "align",
+        "synthesize",
     ):
         params = list(inspect.signature(getattr(ModelHandle, verb)).parameters.values())
         assert [p.name for p in params] == ["self", "prompt"], verb

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -441,6 +441,72 @@ def test_run_resolves_when_event_pending_with_no_other_traffic() -> None:
     asyncio.run(go())
 
 
+def test_run_cancellation_skips_queued_work_and_drains_launched_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.engine.single_pass as sp_mod
+
+    recorded = threading.Event()
+    ready = threading.Event()
+
+    class _ControlledEvent:
+        def record(self, *a: Any, **k: Any) -> None:
+            recorded.set()
+
+        def query(self) -> bool:
+            return ready.is_set()
+
+    monkeypatch.setattr(sp_mod, "make_event", lambda device: _ControlledEvent())
+
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        sp = _StubSinglePass()
+        engine = _engine_with(ar, sp)
+        engine._loop = asyncio.get_running_loop()
+        engine._initialized = True
+        engine._init_task = None
+        thread = threading.Thread(target=engine._scheduler_loop, daemon=True)
+        thread.start()
+        requests: list[asyncio.Task[Any]] = []
+        try:
+            launched = asyncio.create_task(
+                engine.run(sp.model_name, "segment", {"request": "launched"})
+            )
+            requests.append(launched)
+            assert await asyncio.to_thread(recorded.wait, 1.0)
+
+            queued = asyncio.create_task(
+                engine.run(sp.model_name, "segment", {"request": "queued"})
+            )
+            requests.append(queued)
+            await asyncio.sleep(0)
+            launched.cancel()
+            queued.cancel()
+            await asyncio.sleep(0)
+
+            assert not launched.done()
+            assert not queued.done()
+            ready.set()
+            outcomes = await asyncio.wait_for(
+                asyncio.gather(*requests, return_exceptions=True), timeout=5.0
+            )
+            assert all(
+                isinstance(outcome, asyncio.CancelledError) for outcome in outcomes
+            )
+            assert sp.calls == [
+                ("segment", ({"request": "launched"},)),
+            ]
+        finally:
+            ready.set()
+            await asyncio.gather(*requests, return_exceptions=True)
+            engine._shutdown = True
+            engine._scheduler_queue.put(None)
+            engine._scheduler_event.set()
+            thread.join(timeout=5.0)
+
+    asyncio.run(go())
+
+
 def test_engine_shutdown_tears_down_single_pass_runtime() -> None:
     """Regression (P2): engine.shutdown() must not AttributeError on a
     single-pass runtime.

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -20,6 +20,7 @@ import torch
 
 from kestrel.engine import InferenceEngine
 from kestrel.engine._types import _AutoregressiveRequest
+from kestrel.engine.single_pass import _SinglePassRequest
 from kestrel.runtime import ExecutionShape
 
 from tests.scheduler._fake_runtime import FakeRuntime
@@ -107,12 +108,14 @@ def test_run_routes_single_pass_through_kernel_loop() -> None:
 def test_paused_loop_settles_cancelled_ingress_and_shutdown() -> None:
     async def go() -> None:
         ar = FakeRuntime(model_name="ar-default", device="cpu")
-        engine = _engine_with(ar, _StubSinglePass())
+        single_pass = _StubSinglePass()
+        engine = _engine_with(ar, single_pass)
         engine._loop = asyncio.get_running_loop()
         engine._paused_flag.set()
         engine._run_gate.clear()
 
         future = engine._loop.create_future()
+        single_pass_future = engine._loop.create_future()
         cancelled = threading.Event()
         cancelled.set()
         engine._scheduler_queue.put(
@@ -133,10 +136,26 @@ def test_paused_loop_settles_cancelled_ingress_and_shutdown() -> None:
                 cancel_event=cancelled,
             )
         )
+        engine._single_pass_queue.put(
+            (
+                single_pass.model_name,
+                _SinglePassRequest(
+                    request_id=2,
+                    future=single_pass_future,
+                    task="segment",
+                    inputs={},
+                    submitted_at=0.0,
+                    cancel_event=cancelled,
+                ),
+            )
+        )
 
         thread = threading.Thread(target=engine._scheduler_loop, daemon=True)
         thread.start()
         assert (await asyncio.wait_for(future, timeout=5.0)).finish_reason == "cancelled"
+        assert (
+            await asyncio.wait_for(single_pass_future, timeout=5.0)
+        ).finish_reason == "cancelled"
 
         engine._scheduler_queue.put(None)
         engine._scheduler_event.set()

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -104,6 +104,85 @@ def test_run_routes_single_pass_through_kernel_loop() -> None:
     assert result.output == {"task": "segment", "inputs": {"points": [[1, 2]]}}
 
 
+def test_paused_loop_settles_cancelled_ingress_and_shutdown() -> None:
+    async def go() -> None:
+        ar = FakeRuntime(model_name="ar-default", device="cpu")
+        engine = _engine_with(ar, _StubSinglePass())
+        engine._loop = asyncio.get_running_loop()
+        engine._paused_flag.set()
+        engine._run_gate.clear()
+
+        future = engine._loop.create_future()
+        cancelled = threading.Event()
+        cancelled.set()
+        engine._scheduler_queue.put(
+            _AutoregressiveRequest(
+                request_id=1,
+                prompt="",
+                prompt_tokens=(),
+                image=None,
+                image_hash=None,
+                max_new_tokens=1,
+                temperature=0.0,
+                top_p=1.0,
+                submitted_at=0.0,
+                future=future,
+                stream_queue=None,
+                skill=ar.skills().resolve("query"),
+                request_context=object(),
+                cancel_event=cancelled,
+            )
+        )
+
+        thread = threading.Thread(target=engine._scheduler_loop, daemon=True)
+        thread.start()
+        assert (await asyncio.wait_for(future, timeout=5.0)).finish_reason == "cancelled"
+
+        engine._scheduler_queue.put(None)
+        engine._scheduler_event.set()
+        thread.join(timeout=5.0)
+        assert not thread.is_alive()
+
+    asyncio.run(go())
+
+
+def test_paused_shutdown_does_not_wait_for_executor_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class BusyExecutor:
+        has_work = True
+
+        def drain(self):  # type: ignore[no-untyped-def]
+            return ()
+
+        def shutdown(self):  # type: ignore[no-untyped-def]
+            return ()
+
+    ar = FakeRuntime(model_name="ar-default", device="cpu")
+    engine = _engine_with(ar, _StubSinglePass())
+    engine._loop = asyncio.new_event_loop()
+    engine._paused_flag.set()
+    engine._run_gate.clear()
+    monkeypatch.setattr(
+        "kestrel.engine.core.AutoregressiveExecutor",
+        lambda *args, **kwargs: BusyExecutor(),
+    )
+
+    engine._scheduler_queue.put(None)
+    thread = threading.Thread(target=engine._scheduler_loop, daemon=True)
+    thread.start()
+    thread.join(timeout=1.0)
+    stopped = not thread.is_alive()
+    if not stopped:
+        engine._paused_flag.clear()
+        engine._run_gate.set()
+        engine._scheduler_event.set()
+        thread.join(timeout=5.0)
+
+    engine._loop.close()
+    assert stopped
+
+
 def test_default_model_can_be_single_pass() -> None:
     async def go() -> None:
         ar = FakeRuntime(model_name="unused-ar", device="cpu")

--- a/tests/test_single_pass_engine.py
+++ b/tests/test_single_pass_engine.py
@@ -152,7 +152,11 @@ def test_paused_shutdown_does_not_wait_for_executor_work(
     class BusyExecutor:
         has_work = True
 
+        def __init__(self) -> None:
+            self.drains = 0
+
         def drain(self):  # type: ignore[no-untyped-def]
+            self.drains += 1
             return ()
 
         def shutdown(self):  # type: ignore[no-untyped-def]
@@ -163,12 +167,23 @@ def test_paused_shutdown_does_not_wait_for_executor_work(
     engine._loop = asyncio.new_event_loop()
     engine._paused_flag.set()
     engine._run_gate.clear()
+    executor = BusyExecutor()
     monkeypatch.setattr(
         "kestrel.engine.core.AutoregressiveExecutor",
-        lambda *args, **kwargs: BusyExecutor(),
+        lambda *args, **kwargs: executor,
     )
 
-    engine._scheduler_queue.put(None)
+    class ShutdownAfterIdleWait(threading.Event):
+        waits = 0
+
+        def wait(self, timeout: float | None = None) -> bool:
+            self.waits += 1
+            if self.waits == 2:
+                engine._scheduler_queue.put(None)
+                engine._scheduler_event.set()
+            return False
+
+    engine._run_gate = ShutdownAfterIdleWait()
     thread = threading.Thread(target=engine._scheduler_loop, daemon=True)
     thread.start()
     thread.join(timeout=1.0)
@@ -181,6 +196,7 @@ def test_paused_shutdown_does_not_wait_for_executor_work(
 
     engine._loop.close()
     assert stopped
+    assert executor.drains == 2  # initial pause and shutdown, not the idle poll
 
 
 def test_default_model_can_be_single_pass() -> None:


### PR DESCRIPTION
## Summary

- add `ModelHandle.synthesize(...)` as a peer model capability
- let skills publish structured streaming output while preserving the existing text-delta contract
- support lossless compound streams for media such as incremental PCM
- let callers close generated streams or cancel single-pass runs without returning until admission preprocessing or in-flight GPU ownership is released
- add generic generated-runtime program selection, finalized weight-storage extension, and a fail-closed packed-sampling requirement

## Boundary

This PR contains the public synthesis/streaming interfaces and the generic engine, scheduler, and runtime support they require. It adds no model implementation and no TTS-specific admission, chunking, batching, codec, or media scheduling policy.

Autoregressive cancellation carries one generic event with the existing request, wakes the existing scheduler loop, and finishes through the existing admission, finalization, zombie-commit, release, and speculative-retire paths. Single-pass cancellation uses the same per-request signal and existing single-pass completion path: queued work is skipped, while launched work settles only after its device event completes. This adds no queue, registry, scheduler phase, model branch, or second lifecycle.

## Verification

- 191 focused engine, admission, scheduler, single-pass, capability-stream, and generated-runtime tests pass against the paired private runtime head
- the complete public suite passes on Modal: 1006 passed, 50 skipped; the four warnings are existing CPU-fallback warnings
- coverage includes closing a blocked iterator, cancelling and waiting for running admission preprocessing, prefill cancellation ordering, pause/shutdown settlement, and skipping queued or draining launched single-pass work
- the two legacy engine fixtures previously deselected from the H100 run now model the required runtime shape and pass without adding defensive production branches
- Ruff and `git diff --check` pass
- repeated adversarial API, stream-lifecycle, cancellation, speculative-decode, codec-cleanup, and scheduler-boundary review found no remaining user-facing issue or material simplification

This remains a draft and must not be merged before the paired private implementation receives final review.
