### PR TITLE
Reduce Gemma 4 inference memory and startup work

### DIFF
--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -1,8 +1,9 @@
 
+import gc
 import threading
 import weakref
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import Callable, Optional, Sequence, TypeVar
 
 import numpy as np
 import torch
@@ -99,19 +100,7 @@ class KVMemoryPool:
         per_tensor_bytes = n_pages * n_heads * page_size * head_dim * element_size
         layer_bytes = 2 * per_tensor_bytes
 
-        # Reserve the bytes atomically so concurrent callers can't both
-        # pass the precheck against the same counter value.
-        with self._lock:
-            if (
-                self.budget_bytes is not None
-                and self.allocated_bytes + layer_bytes > self.budget_bytes
-            ):
-                raise MemoryError(
-                    f"KVMemoryPool budget exceeded: requested {layer_bytes} "
-                    f"bytes, already used {self.allocated_bytes} of "
-                    f"{self.budget_bytes}"
-                )
-            self.allocated_bytes += layer_bytes
+        self._reserve_bytes(layer_bytes)
 
         try:
             k = torch.zeros(cache_shape, dtype=dtype, device=self.device)
@@ -135,6 +124,27 @@ class KVMemoryPool:
         with self._lock:
             self.allocated_bytes = max(0, self.allocated_bytes - n)
 
+    def _reserve_bytes(self, n: int) -> None:
+        # Reserve atomically so concurrent callers cannot both pass the budget
+        # check against the same counter value.
+        with self._lock:
+            if (
+                self.budget_bytes is not None
+                and self.allocated_bytes + n > self.budget_bytes
+            ):
+                raise MemoryError(
+                    f"KVMemoryPool budget exceeded: requested {n} bytes, "
+                    f"already used {self.allocated_bytes} of {self.budget_bytes}"
+                )
+            self.allocated_bytes += n
+
+    def budget_available_bytes(self) -> int | None:
+        """Return unallocated bytes from the explicit pool budget."""
+
+        with self._lock:
+            if self.budget_bytes is None:
+                return None
+            return max(0, self.budget_bytes - self.allocated_bytes)
 
 class PagedKVCache(torch.nn.Module):
     def __init__(
@@ -147,15 +157,40 @@ class PagedKVCache(torch.nn.Module):
         *,
         k_scale: float | None = None,
         v_scale: float | None = None,
+        storage: "PagedKVLayerStorage | None" = None,
     ):
         super().__init__()
-        k_cache, v_cache = pool.allocate_layer_kv(
-            n_pages=page_table.n_pages,
-            n_heads=n_heads,
-            page_size=page_table.page_size,
-            head_dim=head_dim,
-            dtype=dtype,
+        expected_shape = (
+            int(page_table.n_pages),
+            int(n_heads),
+            int(page_table.page_size),
+            int(head_dim),
         )
+        if storage is None:
+            k_cache, v_cache = pool.allocate_layer_kv(
+                n_pages=page_table.n_pages,
+                n_heads=n_heads,
+                page_size=page_table.page_size,
+                head_dim=head_dim,
+                dtype=dtype,
+            )
+            k_scale_tensor = None
+            v_scale_tensor = None
+        else:
+            k_cache, v_cache = storage.k_cache, storage.v_cache
+            for name, tensor in (("K", k_cache), ("V", v_cache)):
+                if (
+                    tuple(tensor.shape) != expected_shape
+                    or tensor.dtype is not dtype
+                    or tensor.device != pool.device
+                    or not tensor.is_contiguous()
+                ):
+                    raise ValueError(
+                        f"preallocated {name} cache does not match "
+                        f"{expected_shape}/{dtype}/{pool.device}"
+                    )
+            k_scale_tensor = storage.k_scale_tensor
+            v_scale_tensor = storage.v_scale_tensor
         self.register_buffer("k_cache", k_cache)
         self.register_buffer("v_cache", v_cache)
 
@@ -170,14 +205,25 @@ class PagedKVCache(torch.nn.Module):
         else:
             self.k_scale = 1.0
             self.v_scale = 1.0
-        self.register_buffer(
-            "k_scale_tensor",
-            torch.tensor(self.k_scale, dtype=torch.float32, device=pool.device),
-        )
-        self.register_buffer(
-            "v_scale_tensor",
-            torch.tensor(self.v_scale, dtype=torch.float32, device=pool.device),
-        )
+        if k_scale_tensor is None:
+            k_scale_tensor = torch.tensor(
+                self.k_scale, dtype=torch.float32, device=pool.device
+            )
+        if v_scale_tensor is None:
+            v_scale_tensor = torch.tensor(
+                self.v_scale, dtype=torch.float32, device=pool.device
+            )
+        for name, tensor in (
+            ("k_scale_tensor", k_scale_tensor),
+            ("v_scale_tensor", v_scale_tensor),
+        ):
+            if (
+                tensor.shape != torch.Size([])
+                or tensor.dtype is not torch.float32
+                or tensor.device != pool.device
+            ):
+                raise ValueError(f"preallocated {name} must be a device FP32 scalar")
+            self.register_buffer(name, tensor)
 
     def update(
         self,
@@ -243,14 +289,368 @@ class PagedKVLayerSpec:
     v_scale: float | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class PagedKVLayerStorage:
+    """Views owned by one physical K/V producer layer."""
+
+    k_cache: torch.Tensor
+    v_cache: torch.Tensor
+    k_scale_tensor: torch.Tensor
+    v_scale_tensor: torch.Tensor
+
+
+@dataclass(frozen=True, slots=True)
+class PagedKVStorage:
+    """One allocation-backed set of sparse physical K/V layers."""
+
+    n_pages: int
+    page_size: int
+    dtype: torch.dtype
+    layer_specs: tuple[PagedKVLayerSpec | None, ...]
+    layers: tuple[PagedKVLayerStorage | None, ...]
+    _kv_backing: torch.Tensor
+    _scale_backing: torch.Tensor
+
+
+_KV_TENSOR_ALIGNMENT_BYTES = 256
+_AdditionalStorage = TypeVar("_AdditionalStorage")
+
+
+def paged_kv_bytes_per_page(
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    *,
+    page_size: int,
+    dtype: torch.dtype,
+) -> int:
+    """Return aggregate K+V storage consumed by one physical page."""
+
+    page_size = int(page_size)
+    if page_size < 1:
+        raise ValueError("page_size must be positive")
+    element_size = torch.empty((), dtype=dtype).element_size()
+    total = sum(
+        2 * int(spec.n_heads) * page_size * int(spec.head_dim) * element_size
+        for spec in layer_specs
+        if spec is not None
+    )
+    if total <= 0:
+        raise ValueError("layer_specs must contain at least one physical K/V layer")
+    return total
+
+
+def _paged_kv_layout(
+    n_pages: int,
+    *,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    page_size: int,
+    dtype: torch.dtype,
+) -> tuple[int, tuple[tuple[int, int, tuple[int, ...]] | None, ...]]:
+    """Return one aligned backing layout in dtype elements."""
+
+    n_pages = int(n_pages)
+    page_size = int(page_size)
+    if n_pages < 1 or page_size < 1:
+        raise ValueError("n_pages and page_size must be positive")
+    element_size = torch.empty((), dtype=dtype).element_size()
+    alignment = max(1, _KV_TENSOR_ALIGNMENT_BYTES // element_size)
+
+    def aligned(value: int) -> int:
+        return ((value + alignment - 1) // alignment) * alignment
+
+    offset = 0
+    layout = []
+    for spec in layer_specs:
+        if spec is None:
+            layout.append(None)
+            continue
+        shape = (
+            n_pages,
+            int(spec.n_heads),
+            page_size,
+            int(spec.head_dim),
+        )
+        elements = int(np.prod(shape))
+        k_start = aligned(offset)
+        v_start = aligned(k_start + elements)
+        offset = v_start + elements
+        layout.append((k_start, v_start, shape))
+    if not layout or all(entry is None for entry in layout):
+        raise ValueError("layer_specs must contain at least one physical K/V layer")
+    return offset, tuple(layout)
+
+
+def paged_kv_storage_bytes(
+    n_pages: int,
+    *,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    page_size: int,
+    dtype: torch.dtype,
+) -> int:
+    """Return exact bytes in the aligned grouped K/V backing allocation."""
+
+    elements, _layout = _paged_kv_layout(
+        n_pages,
+        layer_specs=layer_specs,
+        page_size=page_size,
+        dtype=dtype,
+    )
+    element_size = torch.empty((), dtype=dtype).element_size()
+    alignment_elements = max(1, _KV_TENSOR_ALIGNMENT_BYTES // element_size)
+    return (elements + alignment_elements - 1) * element_size
+
+
+def allocate_paged_kv_storage(
+    n_pages: int,
+    *,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    page_size: int,
+    dtype: torch.dtype,
+    pool: KVMemoryPool,
+) -> PagedKVStorage:
+    """Allocate aligned K/V views with one pool-accounted backing owner."""
+
+    elements, layout = _paged_kv_layout(
+        n_pages,
+        layer_specs=layer_specs,
+        page_size=page_size,
+        dtype=dtype,
+    )
+    element_size = torch.empty((), dtype=dtype).element_size()
+    alignment_elements = max(1, _KV_TENSOR_ALIGNMENT_BYTES // element_size)
+    backing_elements = elements + alignment_elements - 1
+    storage_bytes = backing_elements * element_size
+    pool._reserve_bytes(storage_bytes)
+    try:
+        scale_values = []
+        for spec in layer_specs:
+            if spec is None:
+                continue
+            if dtype == torch.float8_e4m3fn:
+                if spec.k_scale is None or spec.v_scale is None:
+                    raise ValueError("FP8 KV cache requires per-layer k/v scales")
+                scale_values.extend((float(spec.k_scale), float(spec.v_scale)))
+            else:
+                scale_values.extend((1.0, 1.0))
+        scale_backing = torch.tensor(
+            scale_values,
+            dtype=torch.float32,
+            device=pool.device,
+        )
+        kv_backing = torch.empty(backing_elements, dtype=dtype, device=pool.device)
+        prefix_bytes = (-int(kv_backing.data_ptr())) % _KV_TENSOR_ALIGNMENT_BYTES
+        if prefix_bytes % element_size:
+            raise RuntimeError(
+                "K/V backing cannot satisfy dtype-aligned pointer padding"
+            )
+        aligned_backing = kv_backing.narrow(
+            0,
+            prefix_bytes // element_size,
+            elements,
+        )
+
+        layers = []
+        scale_index = 0
+        for entry in layout:
+            if entry is None:
+                layers.append(None)
+                continue
+            k_start, v_start, shape = entry
+            count = int(np.prod(shape))
+            k_cache = aligned_backing.narrow(0, k_start, count).view(shape)
+            v_cache = aligned_backing.narrow(0, v_start, count).view(shape)
+            if (
+                int(k_cache.data_ptr()) % _KV_TENSOR_ALIGNMENT_BYTES
+                or int(v_cache.data_ptr()) % _KV_TENSOR_ALIGNMENT_BYTES
+            ):
+                raise RuntimeError(
+                    "grouped K/V view does not satisfy pointer alignment"
+                )
+            # Page zero is the no-op physical page and may be read by padded rows.
+            # Live pages are written before being mapped, so zeroing the full cache
+            # would add a model-startup memset proportional to context capacity.
+            k_cache[0].zero_()
+            v_cache[0].zero_()
+            layers.append(
+                PagedKVLayerStorage(
+                    k_cache=k_cache,
+                    v_cache=v_cache,
+                    k_scale_tensor=scale_backing[scale_index],
+                    v_scale_tensor=scale_backing[scale_index + 1],
+                )
+            )
+            scale_index += 2
+    except Exception:
+        pool._release_bytes(storage_bytes)
+        raise
+
+    # Views retain ``kv_backing``. It is the sole accounting owner; cache views
+    # must never install independent pool finalizers.
+    weakref.finalize(kv_backing, pool._release_bytes, storage_bytes)
+    return PagedKVStorage(
+        n_pages=int(n_pages),
+        page_size=int(page_size),
+        dtype=dtype,
+        layer_specs=tuple(layer_specs),
+        layers=tuple(layers),
+        _kv_backing=kv_backing,
+        _scale_backing=scale_backing,
+    )
+
+
+def _largest_storage_pages(
+    upper: int,
+    available_bytes: int,
+    *,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    page_size: int,
+    dtype: torch.dtype,
+) -> int:
+    """Bound a probe by bytes; successful allocation remains authoritative."""
+
+    low, high = 0, max(0, int(upper))
+    while low < high:
+        middle = (low + high + 1) // 2
+        if paged_kv_storage_bytes(
+            middle,
+            layer_specs=layer_specs,
+            page_size=page_size,
+            dtype=dtype,
+        ) <= int(available_bytes):
+            low = middle
+        else:
+            high = middle - 1
+    return low
+
+
+def fit_and_allocate_paged_kv_storage(
+    requested_pages: int,
+    *,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    page_size: int,
+    dtype: torch.dtype,
+    pool: KVMemoryPool,
+    allocate_additional: Callable[[int], _AdditionalStorage] | None = None,
+) -> tuple[PagedKVStorage, _AdditionalStorage | None]:
+    """Allocate the largest exact fixed K/V cache that the device can retain.
+
+    Page-dependent caller resources are allocated first for each probe. The
+    accepted grouped K/V allocation and those resources are returned without
+    being freed or recreated, so pointer stability does not depend on allocator
+    estimates or cache reuse.
+    """
+
+    requested_pages = int(requested_pages)
+    if requested_pages < 3:
+        raise ValueError(
+            "requested_pages must include reserved, padding, and serving pages"
+        )
+
+    candidate = requested_pages
+    budget_available = pool.budget_available_bytes()
+    if budget_available is not None:
+        candidate = _largest_storage_pages(
+            candidate,
+            budget_available,
+            layer_specs=layer_specs,
+            page_size=page_size,
+            dtype=dtype,
+        )
+    if pool.device.type == "cuda":
+        with torch.cuda.device(pool.device):
+            torch.cuda.empty_cache()
+            driver_free, _driver_total = torch.cuda.mem_get_info(pool.device)
+        candidate = _largest_storage_pages(
+            candidate,
+            int(driver_free),
+            layer_specs=layer_specs,
+            page_size=page_size,
+            dtype=dtype,
+        )
+
+    last_failure: Exception | None = None
+    while candidate >= 3:
+        additional = None
+        try:
+            if allocate_additional is not None:
+                additional = allocate_additional(candidate)
+
+            # Flush only unowned allocator slack after the exact additional
+            # resources are resident. Driver free is an upper-bound hint; the
+            # retained allocation below is the acceptance criterion.
+            if pool.device.type == "cuda":
+                with torch.cuda.device(pool.device):
+                    torch.cuda.empty_cache()
+                    driver_free, _driver_total = torch.cuda.mem_get_info(pool.device)
+                bounded = _largest_storage_pages(
+                    candidate,
+                    int(driver_free),
+                    layer_specs=layer_specs,
+                    page_size=page_size,
+                    dtype=dtype,
+                )
+                if bounded < candidate:
+                    del additional
+                    gc.collect()
+                    candidate = bounded
+                    continue
+
+            budget_available = pool.budget_available_bytes()
+            if budget_available is not None:
+                bounded = _largest_storage_pages(
+                    candidate,
+                    budget_available,
+                    layer_specs=layer_specs,
+                    page_size=page_size,
+                    dtype=dtype,
+                )
+                if bounded < candidate:
+                    del additional
+                    gc.collect()
+                    candidate = bounded
+                    continue
+
+            storage = allocate_paged_kv_storage(
+                candidate,
+                layer_specs=layer_specs,
+                page_size=page_size,
+                dtype=dtype,
+                pool=pool,
+            )
+        except (MemoryError, torch.OutOfMemoryError) as exc:
+            last_failure = exc
+            del additional
+            gc.collect()
+            if pool.device.type == "cuda":
+                with torch.cuda.device(pool.device):
+                    torch.cuda.empty_cache()
+            candidate -= 1
+            continue
+        return storage, additional
+
+    detail = "" if last_failure is None else f": {last_failure}"
+    raise MemoryError(
+        f"insufficient memory for reserved, padding, and serving K/V pages{detail}"
+    )
+
+
 def allocate_paged_kv_layers(
     *,
     layer_specs: Sequence[PagedKVLayerSpec | None],
     page_table: "PageTable",
     pool: KVMemoryPool,
     dtype: torch.dtype,
+    storage: PagedKVStorage | None = None,
 ) -> tuple[PagedKVCache | None, ...]:
     """Allocate the sparse physical K/V layers described by ``layer_specs``."""
+
+    if storage is not None and (
+        storage.n_pages != int(page_table.n_pages)
+        or storage.page_size != int(page_table.page_size)
+        or storage.dtype is not dtype
+        or storage.layer_specs != tuple(layer_specs)
+        or len(storage.layers) != len(layer_specs)
+    ):
+        raise ValueError("preallocated K/V storage does not match the page table")
 
     return tuple(
         None
@@ -263,8 +663,9 @@ def allocate_paged_kv_layers(
             pool=pool,
             k_scale=spec.k_scale,
             v_scale=spec.v_scale,
+            storage=None if storage is None else storage.layers[index],
         )
-        for spec in layer_specs
+        for index, spec in enumerate(layer_specs)
     )
 
 

--- a/kestrel/models/gemma4/generated_decode.py
+++ b/kestrel/models/gemma4/generated_decode.py
@@ -14,19 +14,33 @@ from kestrel.runtime.generated_decode import (
 _WEIGHT_LAYER_PREFIX = "model.language_model.layers"
 
 
-def _rope_tables(runtime: Any) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
+def _rope_tables(runtime: Any, length: int) -> dict[str, torch.Tensor]:
+    length = int(length)
+    if length < 1 or length > runtime.max_seq_length:
+        raise ValueError(
+            f"Gemma RoPE table length must lie in [1, {runtime.max_seq_length}]"
+        )
     positions = torch.arange(
-        runtime.max_seq_length,
+        length,
         dtype=torch.int64,
         device=runtime.device,
     ).view(1, -1)
     probe = torch.empty((1, 1, 1), dtype=runtime.dtype, device=runtime.device)
     rotary = runtime.model.model.language_model.rotary_emb
-    return {
+    tables = {
         kind: tuple(
-            table[0].float().contiguous() for table in rotary(probe, positions, kind)
+            table[0].float().contiguous()
+            for table in rotary(probe, positions, kind)
         )
         for kind in ("sliding_attention", "full_attention")
+    }
+    local_cos, local_sin = tables["sliding_attention"]
+    global_cos, global_sin = tables["full_attention"]
+    return {
+        "rope_cos_local": local_cos,
+        "rope_sin_local": local_sin,
+        "rope_cos_global": global_cos,
+        "rope_sin_global": global_sin,
     }
 
 
@@ -41,15 +55,10 @@ def create_generated_decode(
     config = runtime.model.model.language_model.config
 
     def rope_inputs(bound_runtime: Any) -> dict[str, torch.Tensor]:
-        ropes = _rope_tables(bound_runtime)
-        local_cos, local_sin = ropes["sliding_attention"]
-        global_cos, global_sin = ropes["full_attention"]
-        return {
-            "rope_cos_local": local_cos,
-            "rope_sin_local": local_sin,
-            "rope_cos_global": global_cos,
-            "rope_sin_global": global_sin,
-        }
+        ropes = bound_runtime._generated_rope_inputs
+        if ropes is None:
+            raise RuntimeError("Gemma generated decode requires prepared RoPE tables")
+        return ropes
 
     bindings = PagedDecodeBindings(
         layers,
@@ -65,7 +74,7 @@ def create_generated_decode(
         weight_root=runtime.model,
         weight_layer_prefix=_WEIGHT_LAYER_PREFIX,
         bindings=bindings,
-        weight_storage=getattr(runtime, "_generated_weight_storage", None),
+        weight_storage=runtime._generated_weight_storage,
     )
     if required:
         return GeneratedDecode.require(

--- a/kestrel/models/gemma4/generated_decode.py
+++ b/kestrel/models/gemma4/generated_decode.py
@@ -11,6 +11,9 @@ from kestrel.runtime.generated_decode import (
 )
 
 
+_WEIGHT_LAYER_PREFIX = "model.language_model.layers"
+
+
 def _rope_tables(runtime: Any) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
     positions = torch.arange(
         runtime.max_seq_length,
@@ -60,8 +63,9 @@ def create_generated_decode(
     spec = GeneratedDecodeSpec(
         label="Gemma",
         weight_root=runtime.model,
-        weight_layer_prefix="model.language_model.layers",
+        weight_layer_prefix=_WEIGHT_LAYER_PREFIX,
         bindings=bindings,
+        weight_storage=getattr(runtime, "_generated_weight_storage", None),
     )
     if required:
         return GeneratedDecode.require(

--- a/kestrel/models/gemma4/loader.py
+++ b/kestrel/models/gemma4/loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Callable
 
 import torch
 from huggingface_hub import snapshot_download
@@ -13,6 +14,7 @@ from kestrel.runtime.bounded_projection import (
     bind_declared_packed_projections,
     declared_packed_projection_source_keys,
 )
+from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 
 from .config import Gemma4Config
 from .model import Gemma4InferenceModel
@@ -159,12 +161,77 @@ def load_weights(source: str | Path, model: torch.nn.Module) -> None:
         raise RuntimeError(f"Gemma checkpoint is missing tensors: {missing[:10]}")
 
 
+def _fill_derived_buffer(
+    module: torch.nn.Module,
+    name: str,
+    value: float,
+    *,
+    device: torch.device,
+) -> None:
+    buffer = module._buffers[name]
+    if buffer.device.type == "meta":
+        module._buffers[name] = torch.full(
+            tuple(buffer.shape), value, dtype=buffer.dtype, device=device
+        )
+    else:
+        with torch.no_grad():
+            buffer.fill_(value)
+
+
+def _restore_checkpoint_independent_state(
+    model: Gemma4InferenceModel,
+    config: Gemma4Config,
+    *,
+    device: torch.device,
+) -> None:
+    """Restore constants intentionally omitted from Gemma checkpoints."""
+
+    for module in model.modules():
+        if (
+            hasattr(module, "eps")
+            and "weight" in module._non_persistent_buffers_set
+            and module._buffers.get("weight") is not None
+        ):
+            _fill_derived_buffer(module, "weight", 1.0, device=device)
+
+    text = model.model.language_model
+    _fill_derived_buffer(
+        text.embed_tokens,
+        "embed_scale",
+        config.text_config.hidden_size**0.5,
+        device=device,
+    )
+    if config.text_config.hidden_size_per_layer_input:
+        _fill_derived_buffer(
+            text.embed_tokens_per_layer,
+            "embed_scale",
+            config.text_config.hidden_size_per_layer_input**0.5,
+            device=device,
+        )
+        _fill_derived_buffer(
+            text,
+            "per_layer_input_scale",
+            2.0**-0.5,
+            device=device,
+        )
+    text.rotary_emb = type(text.rotary_emb)(config.text_config, device=device)
+    vision = model.model.vision_tower
+    vision.encoder.rotary_emb = type(vision.encoder.rotary_emb)(
+        config.vision_config.head_dim,
+        config.vision_config.rope.theta,
+        dimensions=2,
+        device=device,
+    )
+
+
 def load_model(
     source: str | Path,
     *,
     device: torch.device,
     dtype: torch.dtype,
     revision: str | None = None,
+    prepare_model: Callable[[torch.nn.Module], None] | None = None,
+    finalize_model: Callable[[torch.nn.Module], None] | None = None,
 ) -> Gemma4InferenceModel:
     snapshot = _snapshot(source, revision=revision)
     config_path = snapshot / "config.json"
@@ -174,13 +241,20 @@ def load_model(
     old_dtype = torch.get_default_dtype()
     torch.set_default_dtype(dtype)
     try:
-        with torch.device(device):
+        construction_device = torch.device("meta") if prepare_model else device
+        with torch.device(construction_device):
             model = Gemma4InferenceModel(config)
     finally:
         torch.set_default_dtype(old_dtype)
+    if prepare_model is not None:
+        prepare_model(model)
+        _restore_checkpoint_independent_state(model, config, device=device)
+        materialize_remaining_meta_tensors(model, device=device)
 
     load_weights(snapshot, model)
     model.lm_head.weight = model.model.language_model.embed_tokens.weight
+    if finalize_model is not None:
+        finalize_model(model)
     return model.to(device=device).eval()
 
 

--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -139,22 +139,28 @@ class Gemma4TextAttention(nn.Module):
         use_alternative_attention = config.attention_k_eq_v and not self.is_sliding
         num_kv_heads = attention_kv_heads(config, is_sliding=self.is_sliding)
 
-        self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=False
-        )
+        query_out_features = config.num_attention_heads * self.head_dim
         self.q_norm = _rmsnorm_state(self.head_dim, config.rms_norm_eps)
 
         if self.owns_kv:
             self.k_norm = _rmsnorm_state(self.head_dim, config.rms_norm_eps)
             self.v_norm = _rmsnorm_state(
                 self.head_dim, config.rms_norm_eps, with_scale=False)
-            self.k_proj = nn.Linear(
-                config.hidden_size, num_kv_heads * self.head_dim, bias=False
+            kv_out_features = num_kv_heads * self.head_dim
+            self.qkv_proj = PackedLinear(
+                config.hidden_size,
+                (query_out_features, kv_out_features, kv_out_features),
+                source_names=(
+                    "q_proj",
+                    "k_proj",
+                    "k_proj" if use_alternative_attention else "v_proj",
+                ),
             )
-            self.v_proj = (
-                nn.Linear(config.hidden_size, num_kv_heads * self.head_dim, bias=False)
-                if not use_alternative_attention
-                else None
+        else:
+            self.qkv_proj = PackedLinear(
+                config.hidden_size,
+                (query_out_features,),
+                source_names=("q_proj",),
             )
 
         self.o_proj = nn.Linear(
@@ -176,13 +182,12 @@ class Gemma4TextAttention(nn.Module):
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)
 
-        query_states = self.q_proj(hidden_states).view(hidden_shape)
-        query_states = _dense_runtime.rmsnorm(
-            query_states, self.q_norm.weight, self.q_norm.eps)
-
         key_states: Optional[torch.Tensor] = None
         value_states: Optional[torch.Tensor] = None
         if not self.owns_kv:
+            query_states = self.qkv_proj(hidden_states).view(hidden_shape)
+            query_states = _dense_runtime.rmsnorm(
+                query_states, self.q_norm.weight, self.q_norm.eps)
             query_states, _ = _apply_neox_rotary(
                 query_states, None, position_embeddings
             )
@@ -195,10 +200,17 @@ class Gemma4TextAttention(nn.Module):
                 )
             key_states, value_states = source
         else:
-            key_states = self.k_proj(hidden_states).view(hidden_shape)
-            value_states = (
-                self.v_proj(hidden_states).view(hidden_shape) if self.v_proj is not None else key_states
+            query_states, key_states, value_states = self.qkv_proj(
+                hidden_states
+            ).split(
+                self.qkv_proj.packed_out_features,
+                dim=-1,
             )
+            query_states = query_states.view(hidden_shape)
+            key_states = key_states.view(hidden_shape)
+            value_states = value_states.view(hidden_shape)
+            query_states = _dense_runtime.rmsnorm(
+                query_states, self.q_norm.weight, self.q_norm.eps)
             key_states = _dense_runtime.rmsnorm(
                 key_states, self.k_norm.weight, self.k_norm.eps)
             query_states, key_states = _apply_neox_rotary(

--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -268,6 +268,11 @@ class Gemma4TextMLP(nn.Module):
             config.hidden_size,
             (self.intermediate_size, self.intermediate_size),
             source_names=("gate_proj", "up_proj"),
+            output_layout=(
+                "interleaved_i8"
+                if self.intermediate_size % 8 == 0
+                else "contiguous"
+            ),
         )
         self.down_proj = nn.Linear(
             self.intermediate_size, config.hidden_size, bias=False
@@ -280,7 +285,7 @@ class Gemma4TextMLP(nn.Module):
             hidden,
             gate_up,
             activation="gelu_tanh",
-            layout="contiguous",
+            layout=self.gate_up_proj.output_layout,
         )
         return self.down_proj(hidden)
 

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import threading
+from dataclasses import dataclass
 from typing import Any, Sequence
 
 import torch
 
 from kestrel.device import make_event, make_stream
-from kestrel.kv_cache import KVMemoryPool, PageTable, allocate_paged_kv_layers
+from kestrel.kv_cache import (
+    KVMemoryPool,
+    PageTable,
+    allocate_paged_kv_layers,
+    fit_and_allocate_paged_kv_storage,
+)
 from kestrel.runtime import ExecutionShape, SequenceState, TextToken, Token
 from kestrel.runtime.compilation import (
     canonicalize_immutable_scalar_buffers,
@@ -37,6 +43,71 @@ from .prompt_template import (
     TURN_ID,
     USER_ROLE_ID,
 )
+
+
+@dataclass(frozen=True, slots=True)
+class _PagedRuntimeResources:
+    rope_inputs: dict[str, torch.Tensor] | None
+    decode_page_tables: tuple[torch.Tensor, ...]
+    page_table: PageTable
+
+
+def _generated_kv_binding_inputs(
+    layer_specs: Sequence[Any],
+    layer_kinds: Sequence[str],
+) -> dict[str, tuple[Any | None, ...]]:
+    """Describe the exact pre-allocation layer collections for estimation."""
+
+    if len(layer_specs) != len(layer_kinds):
+        raise ValueError("Gemma K/V specs and layer kinds must have equal length")
+    marker = object()
+    inputs = {}
+    for suffix, kind in (
+        ("local", "sliding_attention"),
+        ("global", "full_attention"),
+    ):
+        layers = tuple(
+            marker if spec is not None and actual_kind == kind else None
+            for spec, actual_kind in zip(layer_specs, layer_kinds, strict=True)
+        )
+        inputs[f"mK_{suffix}"] = layers
+        inputs[f"mV_{suffix}"] = layers
+    return inputs
+
+
+def _allocate_decode_page_tables(
+    *,
+    count: int,
+    rows: int,
+    pages: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, ...]:
+    """Allocate exact per-slot page tables without publishing their pointers."""
+
+    return tuple(
+        torch.empty(
+            (rows, pages),
+            dtype=torch.int32,
+            device=device,
+        )
+        for _index in range(int(count))
+    )
+
+
+def _install_decode_page_tables(
+    slots: Sequence[Any], tables: Sequence[torch.Tensor]
+) -> None:
+    """Publish fitted page tables once, before native or generated binding."""
+
+    if len(slots) != len(tables):
+        raise ValueError("decode slots and fitted page tables must have equal length")
+    if not tables:
+        return
+    expected = (int(tables[0].shape[0]), 1)
+    if any(tuple(slot.paged_kv_page_table.shape) != expected for slot in slots):
+        raise RuntimeError("decode page tables must be unbound one-column placeholders")
+    for slot, table in zip(slots, tables, strict=True):
+        slot.paged_kv_page_table = table
 
 
 class Gemma4Runtime(UncachedPagedRuntime):
@@ -134,10 +205,8 @@ class Gemma4Runtime(UncachedPagedRuntime):
         self.execution_shape = ExecutionShape.AUTOREGRESSIVE
         self.spec = None
         self.page_size = cfg.page_size
-        self.max_seq_length = int(
-            self._config.text_config.max_position_embeddings
-        )
-        self._kv_cache_pages = bound_kv_cache_pages(
+        self.max_seq_length = int(self._config.text_config.max_position_embeddings)
+        requested_kv_cache_pages = bound_kv_cache_pages(
             cfg.kv_cache_pages,
             page_size=self.page_size,
             max_batch_size=self.max_batch_size,
@@ -164,17 +233,6 @@ class Gemma4Runtime(UncachedPagedRuntime):
         )
         self._copy_stream = make_stream(self.device)
         self.graph_capture_lock = threading.RLock()
-        self.page_table = PageTable(
-            n_pages=self._kv_cache_pages,
-            page_size=self.page_size,
-            max_batch_size=self.max_batch_slots,
-            device=str(self.device),
-            prefix_cache=None,
-            h2d_stream=self._compute_stream,
-        )
-        self.page_table.free_batch_idx.remove(self._padding_batch_idx)
-        self.page_table.reserve(self._padding_batch_idx, 1)
-        self.page_table.commit_block_table([self._padding_batch_idx])
         self._prefill_slot = PrefillSlot(
             slot_id=0,
             batch_idx=torch.zeros(
@@ -197,7 +255,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
                 device=self.device,
                 dtype=self.dtype,
                 max_batch_slots=decode_rows,
-                kv_cache_pages=self._kv_cache_pages,
+                kv_cache_pages=1,
                 vocab_size=text_config.vocab_size,
                 hidden_dim=text_config.hidden_size,
                 position_shape=(decode_rows, 1),
@@ -208,17 +266,127 @@ class Gemma4Runtime(UncachedPagedRuntime):
         )
         self.active_sequences: dict[int, SequenceState] = {}
 
+        kv_layer_specs = paged_kv_specs(text_config)
+        self._generated_rope_inputs = None
+        has_generated_decode = (
+            self.decode_path != "native"
+            and self._generated_weight_storage is not None
+        )
+        if self.decode_path == "generated" and not has_generated_decode:
+            raise RuntimeError(
+                "generated Gemma decode has no finalized load-time weight storage"
+            )
+        self._generated_binding_reservation = None
+        if has_generated_decode:
+            from kestrel.runtime.generated_decode import (
+                generated_weight_programs_for_loading,
+                reserve_generated_binding_storage,
+            )
+            from .generated_decode import _WEIGHT_LAYER_PREFIX
+
+            programs = generated_weight_programs_for_loading(
+                self,
+                self.model,
+                label="Gemma",
+                layer_prefix=_WEIGHT_LAYER_PREFIX,
+                required_batch_sizes=range(1, self.max_batch_size + 1),
+                required=self.decode_path == "generated",
+            )
+            if programs:
+                for program in programs:
+                    program.preload(self.device)
+            sparse_inputs = _generated_kv_binding_inputs(
+                kv_layer_specs,
+                tuple(text_config.layer_types),
+            )
+            if programs:
+                self._generated_binding_reservation = (
+                    reserve_generated_binding_storage(
+                        programs,
+                        weight_storage=self._generated_weight_storage,
+                        runtime_inputs_by_slot=tuple(
+                            sparse_inputs for _slot in self.decode_slots
+                        ),
+                        device=self.device,
+                        label="Gemma",
+                        required=self.decode_path == "generated",
+                    )
+                )
+            if self._generated_binding_reservation is None:
+                has_generated_decode = False
+                self._generated_weight_storage = None
+        rope_builder = None
+        if has_generated_decode:
+            from .generated_decode import _rope_tables
+
+            rope_builder = _rope_tables
+
+        def allocate_paged_resources(pages: int) -> _PagedRuntimeResources:
+            reachable_tokens = min(
+                self.max_seq_length,
+                (int(pages) - 2) * self.page_size,
+            )
+            rope_inputs = (
+                None if rope_builder is None else rope_builder(self, reachable_tokens)
+            )
+            decode_page_tables = _allocate_decode_page_tables(
+                count=len(self.decode_slots),
+                rows=decode_rows,
+                pages=pages,
+                device=self.device,
+            )
+            page_table = PageTable(
+                n_pages=pages,
+                page_size=self.page_size,
+                max_batch_size=self.max_batch_slots,
+                device=str(self.device),
+                prefix_cache=None,
+                h2d_stream=self._compute_stream,
+            )
+            page_table.free_batch_idx.remove(self._padding_batch_idx)
+            page_table.reserve(self._padding_batch_idx, 1)
+            page_table.commit_block_table([self._padding_batch_idx])
+            return _PagedRuntimeResources(
+                rope_inputs=rope_inputs,
+                decode_page_tables=decode_page_tables,
+                page_table=page_table,
+            )
+
+        self._kv_storage, paged_resources = fit_and_allocate_paged_kv_storage(
+            requested_kv_cache_pages,
+            layer_specs=kv_layer_specs,
+            page_size=self.page_size,
+            dtype=self.dtype,
+            pool=self._kv_pool,
+            allocate_additional=allocate_paged_resources,
+        )
+        if paged_resources is None:
+            raise RuntimeError("Gemma paged resource allocation returned no resources")
+        self._kv_cache_pages = self._kv_storage.n_pages
+        self._generated_rope_inputs = paged_resources.rope_inputs
+        _install_decode_page_tables(
+            self.decode_slots,
+            paged_resources.decode_page_tables,
+        )
+        self.page_table = paged_resources.page_table
         self._kv_cache = allocate_paged_kv_layers(
-            layer_specs=paged_kv_specs(text_config),
+            layer_specs=kv_layer_specs,
             page_table=self.page_table,
             pool=self._kv_pool,
             dtype=self.dtype,
+            storage=self._kv_storage,
         )
         self._initialize_generated_decode()
 
     def _initialize_generated_decode(self) -> None:
         """Apply the runtime-wide decode policy after model state is ready."""
 
+        # Generated bindings own exactly the tensors represented by this
+        # reservation. Release it only after every other resident allocation,
+        # so binding assembly can reuse the reserved allocator block.
+        reservation = self._generated_binding_reservation
+        self._generated_binding_reservation = None
+        del reservation
         self.generated_decode = None
         if self.decode_path == "native":
             return

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -64,17 +64,57 @@ class Gemma4Runtime(UncachedPagedRuntime):
 
         self._model_name = cfg.model
         self.decode_path = getattr(cfg, "decode_path", "auto")
+        self.max_batch_size = cfg.max_batch_size
         from kestrel.models.registry import get_spec
 
         model_spec = get_spec(self._model_name)
         model_source = cfg.model_path if cfg.model_path is not None else model_spec.repo_id
         if model_source is None:
             raise ValueError("Gemma model spec must declare repo_id")
+        self._generated_weight_storage = None
+        prepare_model = None
+        finalize_model = None
+        if self.decode_path != "native":
+            from kestrel.runtime.generated_decode import (
+                finalize_generated_weight_storage_after_loading,
+                prepare_generated_weight_storage_for_loading,
+            )
+            from .generated_decode import _WEIGHT_LAYER_PREFIX
+
+            def prepare_model(model: torch.nn.Module) -> None:
+                self._generated_weight_storage = (
+                    prepare_generated_weight_storage_for_loading(
+                        self,
+                        model,
+                        label="Gemma",
+                        layer_prefix=_WEIGHT_LAYER_PREFIX,
+                        required_batch_sizes=range(1, self.max_batch_size + 1),
+                        required=self.decode_path == "generated",
+                    )
+                )
+
+            def finalize_model(model: torch.nn.Module) -> None:
+                if self._generated_weight_storage is not None:
+                    self._generated_weight_storage = (
+                        finalize_generated_weight_storage_after_loading(
+                            self,
+                            model,
+                            self._generated_weight_storage,
+                            label="Gemma",
+                            layer_prefix=_WEIGHT_LAYER_PREFIX,
+                            required_batch_sizes=range(
+                                1, self.max_batch_size + 1
+                            ),
+                        )
+                    )
+
         self.model = load_model(
             model_source,
             device=self.device,
             dtype=self.dtype,
             revision=model_spec.revision,
+            prepare_model=prepare_model,
+            finalize_model=finalize_model,
         )
         self._config = self.model.config
         self._configure_model(cfg)
@@ -93,7 +133,6 @@ class Gemma4Runtime(UncachedPagedRuntime):
 
         self.execution_shape = ExecutionShape.AUTOREGRESSIVE
         self.spec = None
-        self.max_batch_size = cfg.max_batch_size
         self.page_size = cfg.page_size
         self.max_seq_length = int(
             self._config.text_config.max_position_embeddings
@@ -182,6 +221,12 @@ class Gemma4Runtime(UncachedPagedRuntime):
 
         self.generated_decode = None
         if self.decode_path == "native":
+            return
+        if self._generated_weight_storage is None:
+            if self.decode_path == "generated":
+                raise RuntimeError(
+                    "generated Gemma decode has no finalized load-time weight storage"
+                )
             return
 
         from .generated_decode import create_generated_decode

--- a/kestrel/models/qwen35/generated_decode.py
+++ b/kestrel/models/qwen35/generated_decode.py
@@ -12,89 +12,14 @@ from kestrel.runtime.generated_decode import (
 )
 
 
+_WEIGHT_LAYER_PREFIX = "model.language_model.layers"
+
+
 def _state_tensors(state_pool: Any, field: str) -> list[torch.Tensor | None]:
     return [
         None if storage is None else getattr(storage, field)
         for storage in state_pool.layers
     ]
-
-
-def prepare_generated_weight_storage(
-    runtime: Any,
-    model: torch.nn.Module,
-    *,
-    required: bool,
-) -> Any | None:
-    """Bind checkpoint load targets directly into the final generated layout."""
-
-    if runtime.device.type != "cuda" or runtime.dtype is not torch.bfloat16:
-        if required:
-            raise RuntimeError(
-                "generated Qwen decode requires CUDA BF16 model storage"
-            )
-        return None
-    try:
-        from kestrel_kernels import generated_decode as generated_runtime
-    except ModuleNotFoundError as exc:
-        if exc.name not in {"kestrel_kernels", "kestrel_kernels.generated_decode"}:
-            raise
-        if required:
-            raise RuntimeError(
-                "generated Qwen decode requires load-time weight binding support"
-            )
-        return None
-    allocate_weight_storage_for_loading = getattr(
-        generated_runtime, "allocate_weight_storage_for_loading", None
-    )
-    resolve_compatible_programs = getattr(
-        generated_runtime, "resolve_compatible_programs", None
-    )
-    if not callable(allocate_weight_storage_for_loading) or not callable(
-        resolve_compatible_programs
-    ):
-        if required:
-            raise RuntimeError(
-                "generated Qwen decode requires load-time weight binding support"
-            )
-        return None
-
-    properties = torch.cuda.get_device_properties(runtime.device)
-    programs = tuple(resolve_compatible_programs(
-        model,
-        layer_prefix="model.language_model.layers",
-        arch=f"sm{properties.major}{properties.minor}",
-        device_sms=int(properties.multi_processor_count),
-    ))
-    missing_batches = []
-    for batch_size in range(1, runtime.max_batch_size + 1):
-        covered = False
-        for program in programs:
-            static = program.static_extent_bindings.get("active_batch")
-            minimum = int(
-                program.runtime_extent_minimums.get("active_batch", 1)
-            )
-            covered = covered or (
-                (static is None and minimum <= batch_size <= program.capacity)
-                or static == batch_size
-            )
-        if not covered:
-            missing_batches.append(batch_size)
-    if missing_batches:
-        if required:
-            raise RuntimeError(
-                "generated Qwen decode has no load-time artifact coverage for "
-                f"batch sizes {missing_batches}"
-            )
-        return None
-    contracts = {repr(program.descriptor["weights"]) for program in programs}
-    if len(contracts) != 1:
-        raise RuntimeError("generated Qwen artifacts disagree on weight storage")
-    return allocate_weight_storage_for_loading(
-        model,
-        programs[0].descriptor,
-        device=runtime.device,
-        layer_prefix="model.language_model.layers",
-    )
 
 
 def _generated_decode_spec(runtime: Any) -> GeneratedDecodeSpec:
@@ -139,7 +64,7 @@ def _generated_decode_spec(runtime: Any) -> GeneratedDecodeSpec:
     return GeneratedDecodeSpec(
         label="Qwen",
         weight_root=runtime.model,
-        weight_layer_prefix="model.language_model.layers",
+        weight_layer_prefix=_WEIGHT_LAYER_PREFIX,
         bindings=bindings,
         weight_storage=getattr(runtime, "_generated_weight_storage", None),
         capacity_inputs=state_inputs,
@@ -194,5 +119,4 @@ def create_generated_decode(
 __all__ = [
     "create_generated_decode",
     "generated_decode_slot_capacity",
-    "prepare_generated_weight_storage",
 ]

--- a/kestrel/models/qwen35/generated_decode.py
+++ b/kestrel/models/qwen35/generated_decode.py
@@ -66,7 +66,7 @@ def _generated_decode_spec(runtime: Any) -> GeneratedDecodeSpec:
         weight_root=runtime.model,
         weight_layer_prefix=_WEIGHT_LAYER_PREFIX,
         bindings=bindings,
-        weight_storage=getattr(runtime, "_generated_weight_storage", None),
+        weight_storage=runtime._generated_weight_storage,
         capacity_inputs=state_inputs,
         preparations=(
             DeviceInputPreparation(

--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -12,6 +12,7 @@ from huggingface_hub import hf_hub_download
 from safetensors import safe_open
 
 from kestrel.ops.rotary import default_inv_freq
+from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 
 from .qwen_config import Qwen3_5Config
 from .qwen_model import (
@@ -701,40 +702,6 @@ def _resolve_checkpoint_file(
     return hf_hub_download(source, filename, **kwargs)
 
 
-def _materialize_remaining_meta_tensors(
-    model: torch.nn.Module,
-    *,
-    device: torch.device,
-) -> None:
-    parameter_replacements: dict[int, torch.nn.Parameter] = {}
-    buffer_replacements: dict[int, torch.Tensor] = {}
-    for module in model.modules():
-        for name, parameter in tuple(module._parameters.items()):
-            if parameter is None or parameter.device.type != "meta":
-                continue
-            replacement = parameter_replacements.get(id(parameter))
-            if replacement is None:
-                replacement = torch.nn.Parameter(
-                    torch.empty_like(parameter, device=device),
-                    requires_grad=parameter.requires_grad,
-                )
-                parameter_replacements[id(parameter)] = replacement
-            module._parameters[name] = replacement
-        for name, buffer in tuple(module._buffers.items()):
-            if buffer is None or buffer.device.type != "meta":
-                continue
-            if name in module._non_persistent_buffers_set:
-                raise RuntimeError(
-                    "Qwen load-time preparation left derived buffer "
-                    f"{type(module).__name__}.{name} uninitialized"
-                )
-            replacement = buffer_replacements.get(id(buffer))
-            if replacement is None:
-                replacement = torch.empty_like(buffer, device=device)
-                buffer_replacements[id(buffer)] = replacement
-            module._buffers[name] = replacement
-
-
 def _restore_rotary_buffers(
     model: Qwen3_5ForConditionalGeneration,
     config: Qwen3_5Config,
@@ -783,7 +750,7 @@ def load_qwen35_model(
     if prepare_model is not None:
         prepare_model(model)
         _restore_rotary_buffers(model, config, device=device)
-        _materialize_remaining_meta_tensors(model, device=device)
+        materialize_remaining_meta_tensors(model, device=device)
 
     index_path = _resolve_checkpoint_file(
         source, "model.safetensors.index.json", revision=revision

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -468,13 +468,21 @@ class Qwen35Runtime(UncachedPagedRuntime):
     def _load_model(self, source: str | Path) -> nn.Module:
         from .qwen_loader import load_qwen35_model
 
-        from .generated_decode import prepare_generated_weight_storage
+        from kestrel.runtime.generated_decode import (
+            prepare_generated_weight_storage_for_loading,
+        )
+        from .generated_decode import _WEIGHT_LAYER_PREFIX
 
         def prepare_model(model: nn.Module) -> None:
-            self._generated_weight_storage = prepare_generated_weight_storage(
-                self,
-                model,
-                required=True,
+            self._generated_weight_storage = (
+                prepare_generated_weight_storage_for_loading(
+                    self,
+                    model,
+                    label="Qwen",
+                    layer_prefix=_WEIGHT_LAYER_PREFIX,
+                    required_batch_sizes=range(1, self.max_batch_size + 1),
+                    required=True,
+                )
             )
 
         return load_qwen35_model(

--- a/kestrel/runtime/bounded_projection.py
+++ b/kestrel/runtime/bounded_projection.py
@@ -329,12 +329,14 @@ def bind_declared_packed_projections(
                 ),
                 dim=1,
             ).reshape(sum(child.packed_out_features), child.in_features)
+        elif len(weights) == 1:
+            packed_weight = weights[0]
         else:
             packed_weight = torch.cat(weights, dim=0)
         state_dict[target_weight_key] = packed_weight
         for bound_name, value in packed_bounds.items():
             state_dict[target_prefix + bound_name] = value
-        for key in source_weight_keys:
+        for key in dict.fromkeys(source_weight_keys):
             state_dict.pop(key)
-        for key in source_bound_keys:
+        for key in dict.fromkeys(source_bound_keys):
             state_dict.pop(key)

--- a/kestrel/runtime/bounded_projection.py
+++ b/kestrel/runtime/bounded_projection.py
@@ -115,6 +115,7 @@ class PackedLinear(nn.Linear):
         *,
         source_names: Sequence[str],
         source_weight_leaf: str = "weight",
+        output_layout: str = "contiguous",
     ) -> None:
         packed_out_features = tuple(int(size) for size in out_features)
         source_names = tuple(source_names)
@@ -124,6 +125,19 @@ class PackedLinear(nn.Linear):
             or len(source_names) != len(packed_out_features)
         ):
             raise ValueError("packed linear sources and output sizes must align")
+        if output_layout not in ("contiguous", "interleaved_i8"):
+            raise ValueError(
+                f"unsupported packed linear output layout {output_layout!r}"
+            )
+        if output_layout == "interleaved_i8" and (
+            len(packed_out_features) != 2
+            or packed_out_features[0] != packed_out_features[1]
+            or packed_out_features[0] % 8
+        ):
+            raise ValueError(
+                "interleaved_i8 packed linear requires two equal output sizes "
+                "divisible by 8"
+            )
         super().__init__(
             int(in_features),
             sum(packed_out_features),
@@ -132,6 +146,7 @@ class PackedLinear(nn.Linear):
         self.packed_out_features = packed_out_features
         self.source_names = source_names
         self.source_weight_leaf = source_weight_leaf
+        self.output_layout = output_layout
 
 
 def declared_packed_projection_source_keys(module: nn.Module) -> set[str]:
@@ -305,7 +320,17 @@ def bind_declared_packed_projections(
                     ]
                 )
 
-        packed_weight = torch.cat(weights, dim=0)
+        if isinstance(child, PackedLinear) and child.output_layout == "interleaved_i8":
+            block_rows = child.packed_out_features[0] // 8
+            packed_weight = torch.stack(
+                tuple(
+                    weight.reshape(block_rows, 8, child.in_features)
+                    for weight in weights
+                ),
+                dim=1,
+            ).reshape(sum(child.packed_out_features), child.in_features)
+        else:
+            packed_weight = torch.cat(weights, dim=0)
         state_dict[target_weight_key] = packed_weight
         for bound_name, value in packed_bounds.items():
             state_dict[target_prefix + bound_name] = value

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -401,6 +401,60 @@ def finalize_generated_weight_storage_after_loading(
     )
 
 
+def reserve_generated_binding_storage(
+    programs: Sequence[Any],
+    *,
+    weight_storage: Any,
+    runtime_inputs_by_slot: Sequence[Mapping[str, Any]],
+    device: torch.device,
+    label: str,
+    required: bool,
+) -> tuple[torch.Tensor, ...] | None:
+    """Reserve exact allocator-owned storage for later binding assembly.
+
+    Callers keep the shape- and dtype-exact tensors alive while fitting and
+    allocating other resident tensors, then release them immediately before
+    constructing :class:`GeneratedDecode`. The caching allocator can reuse
+    those same size classes for the per-program binding tensors.
+    """
+
+    generated_runtime = _generated_weight_runtime(label=label, required=required)
+    if generated_runtime is None:
+        return None
+    reserve = getattr(generated_runtime, "reserve_binding_storage", None)
+    if not callable(reserve):
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode requires binding-storage reservation"
+            )
+        return None
+    if getattr(weight_storage, "finalized", None) is not True:
+        raise RuntimeError(
+            f"generated {label} binding reservation requires finalized weights"
+        )
+    weights = getattr(weight_storage, "buffers", None)
+    if not isinstance(weights, Mapping):
+        raise RuntimeError(
+            f"generated {label} binding reservation requires weight buffers"
+        )
+    if not programs or not runtime_inputs_by_slot:
+        raise ValueError(
+            "generated binding reservation needs programs and decode slots"
+        )
+
+    return tuple(
+        tensor
+        for runtime_inputs in runtime_inputs_by_slot
+        for program in programs
+        for tensor in reserve(
+            program.descriptor,
+            weights=weights,
+            runtime_inputs=runtime_inputs,
+            device=device,
+        )
+    )
+
+
 def materialize_remaining_meta_tensors(
     model: torch.nn.Module,
     *,
@@ -802,4 +856,5 @@ __all__ = [
     "generated_weight_programs_for_loading",
     "materialize_remaining_meta_tensors",
     "prepare_generated_weight_storage_for_loading",
+    "reserve_generated_binding_storage",
 ]

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -256,6 +256,187 @@ def _selectable_programs(
     )
 
 
+def _generated_weight_runtime(*, label: str, required: bool) -> Any | None:
+    try:
+        from kestrel_kernels import generated_decode as generated_runtime
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"kestrel_kernels", "kestrel_kernels.generated_decode"}:
+            raise
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode requires load-time weight support"
+            )
+        return None
+    capabilities = (
+        "resolve_compatible_programs",
+        "allocate_weight_storage_for_loading",
+        "finalize_weight_storage_after_loading",
+    )
+    if not all(
+        callable(getattr(generated_runtime, name, None)) for name in capabilities
+    ):
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode requires load-time weight binding "
+                "and finalization support"
+            )
+        return None
+    return generated_runtime
+
+
+def generated_weight_programs_for_loading(
+    runtime: Any,
+    model: torch.nn.Module,
+    *,
+    label: str,
+    layer_prefix: str,
+    required_batch_sizes: Sequence[int],
+    required: bool,
+) -> tuple[Any, ...]:
+    """Resolve the exact load-time program set or fail soft when optional."""
+
+    if runtime.device.type != "cuda" or runtime.dtype is not torch.bfloat16:
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode requires CUDA BF16 model storage"
+            )
+        return ()
+    generated_runtime = _generated_weight_runtime(label=label, required=required)
+    if generated_runtime is None:
+        return ()
+
+    properties = torch.cuda.get_device_properties(runtime.device)
+    programs = tuple(generated_runtime.resolve_compatible_programs(
+        model,
+        layer_prefix=layer_prefix,
+        arch=f"sm{properties.major}{properties.minor}",
+        device_sms=int(properties.multi_processor_count),
+    ))
+    missing = [
+        int(batch_size)
+        for batch_size in required_batch_sizes
+        if _select_program(programs, int(batch_size)) is None
+    ]
+    if missing:
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode has no load-time artifact coverage "
+                f"for batch sizes {missing}"
+            )
+        return ()
+    selected = _selectable_programs(programs, runtime.max_batch_size)
+    if not selected:
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode has no selectable load-time artifact"
+            )
+        return ()
+    contracts = {repr(program.descriptor["weights"]) for program in selected}
+    if len(contracts) != 1:
+        raise RuntimeError(
+            f"generated {label} artifacts disagree on weight storage"
+        )
+    return selected
+
+
+def prepare_generated_weight_storage_for_loading(
+    runtime: Any,
+    model: torch.nn.Module,
+    *,
+    label: str,
+    layer_prefix: str,
+    required_batch_sizes: Sequence[int],
+    required: bool,
+) -> Any | None:
+    """Bind checkpoint targets into the selected generated program's final slabs."""
+
+    selected = generated_weight_programs_for_loading(
+        runtime,
+        model,
+        label=label,
+        layer_prefix=layer_prefix,
+        required_batch_sizes=required_batch_sizes,
+        required=required,
+    )
+    if not selected:
+        return None
+    generated_runtime = _generated_weight_runtime(label=label, required=True)
+    assert generated_runtime is not None
+
+    return generated_runtime.allocate_weight_storage_for_loading(
+        model,
+        selected[0].descriptor,
+        device=runtime.device,
+        layer_prefix=layer_prefix,
+    )
+
+
+def finalize_generated_weight_storage_after_loading(
+    runtime: Any,
+    model: torch.nn.Module,
+    storage: Any,
+    *,
+    label: str,
+    layer_prefix: str,
+    required_batch_sizes: Sequence[int],
+) -> Any:
+    """Finalize retained recipes against the exact selected weight contract."""
+
+    selected = generated_weight_programs_for_loading(
+        runtime,
+        model,
+        label=label,
+        layer_prefix=layer_prefix,
+        required_batch_sizes=required_batch_sizes,
+        required=True,
+    )
+    generated_runtime = _generated_weight_runtime(label=label, required=True)
+    assert generated_runtime is not None
+
+    return generated_runtime.finalize_weight_storage_after_loading(
+        model,
+        selected[0].descriptor,
+        storage,
+        layer_prefix=layer_prefix,
+    )
+
+
+def materialize_remaining_meta_tensors(
+    model: torch.nn.Module,
+    *,
+    device: torch.device,
+) -> None:
+    """Materialize checkpoint-backed tensors not claimed by a load-time layout."""
+
+    parameter_replacements: dict[int, torch.nn.Parameter] = {}
+    buffer_replacements: dict[int, torch.Tensor] = {}
+    for module in model.modules():
+        for name, parameter in tuple(module._parameters.items()):
+            if parameter is None or parameter.device.type != "meta":
+                continue
+            replacement = parameter_replacements.get(id(parameter))
+            if replacement is None:
+                replacement = torch.nn.Parameter(
+                    torch.empty_like(parameter, device=device),
+                    requires_grad=parameter.requires_grad,
+                )
+                parameter_replacements[id(parameter)] = replacement
+            module._parameters[name] = replacement
+        for name, buffer in tuple(module._buffers.items()):
+            if buffer is None or buffer.device.type != "meta":
+                continue
+            if name in module._non_persistent_buffers_set:
+                raise RuntimeError(
+                    "load-time preparation left derived buffer "
+                    f"{type(module).__name__}.{name} uninitialized"
+                )
+            replacement = buffer_replacements.get(id(buffer))
+            if replacement is None:
+                replacement = torch.empty_like(buffer, device=device)
+                buffer_replacements[id(buffer)] = replacement
+            module._buffers[name] = replacement
+
+
 class GeneratedDecode:
     """Select bundled capacities and bind them to one serving runtime."""
 
@@ -441,6 +622,10 @@ class GeneratedDecode:
                     raise RuntimeError(
                         "preloaded generated weights do not match the selected program"
                     )
+                if getattr(spec.weight_storage, "finalized", None) is not True:
+                    raise RuntimeError(
+                        "preloaded generated weights were not finalized after loading"
+                    )
                 self.weight_storage = spec.weight_storage
             shared_inputs = dict(spec.bindings.runtime_inputs(runtime))
             weights_ready.record(runtime.compute_stream)
@@ -613,4 +798,8 @@ __all__ = [
     "GeneratedDecodeBindings",
     "GeneratedDecodeSpec",
     "PagedDecodeBindings",
+    "finalize_generated_weight_storage_after_loading",
+    "generated_weight_programs_for_loading",
+    "materialize_remaining_meta_tensors",
+    "prepare_generated_weight_storage_for_loading",
 ]

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -7,8 +7,24 @@ import torch
 from safetensors.torch import save_file
 from torch import nn
 
-from kestrel.models.gemma4.loader import load_weights
+from kestrel.models.gemma4.config import (
+    Gemma4Config,
+    Gemma4TextConfig,
+    Gemma4VisionConfig,
+    RopeSpec,
+)
+from kestrel.models.gemma4.loader import (
+    _restore_checkpoint_independent_state,
+    load_weights,
+)
+from kestrel.models.gemma4.model import Gemma4InferenceModel
 from kestrel.runtime.bounded_projection import PackedLinear
+from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
+from kestrel_kernels.generated_decode import (
+    allocate_weight_storage_for_loading,
+    finalize_weight_storage_after_loading,
+    materialize_weights,
+)
 
 
 class _ToyShardedModel(nn.Module):
@@ -20,6 +36,53 @@ class _ToyShardedModel(nn.Module):
             source_names=("gate", "up"),
         )
         self.exact = nn.Linear(2, 2, bias=False)
+
+
+def _tiny_gemma_config() -> Gemma4Config:
+    rope = RopeSpec(kind="default", theta=10_000.0)
+    return Gemma4Config(
+        text_config=Gemma4TextConfig(
+            vocab_size=16,
+            hidden_size=8,
+            intermediate_size=8,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=4,
+            max_position_embeddings=32,
+            rms_norm_eps=1e-6,
+            rope={
+                "sliding_attention": rope,
+                "full_attention": rope,
+            },
+            sliding_window=8,
+            layer_types=("sliding_attention", "full_attention"),
+            final_logit_softcapping=30.0,
+            vocab_size_per_layer_input=0,
+            hidden_size_per_layer_input=0,
+            num_global_key_value_heads=1,
+            global_head_dim=4,
+            attention_k_eq_v=True,
+            num_kv_shared_layers=0,
+            use_double_wide_mlp=False,
+        ),
+        vision_config=Gemma4VisionConfig(
+            hidden_size=8,
+            intermediate_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=4,
+            rms_norm_eps=1e-6,
+            rope=rope,
+            pooling_kernel_size=2,
+            patch_size=2,
+            position_embedding_size=4,
+            use_clipped_linears=False,
+            standardize=False,
+        ),
+        image_token_id=15,
+    )
 
 
 def test_load_weights_streams_packed_projection_parts_across_shards(tmp_path) -> None:
@@ -80,3 +143,90 @@ def test_load_weights_rejects_unexpected_checkpoint_tensor(tmp_path) -> None:
 
     with pytest.raises(RuntimeError, match="unexpected.weight"):
         load_weights(tmp_path, _ToyShardedModel())
+
+
+def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retained():
+    config = _tiny_gemma_config()
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        with torch.device("meta"):
+            model = Gemma4InferenceModel(config)
+    finally:
+        torch.set_default_dtype(old_dtype)
+    descriptor = {
+        "weight_layer_prefix": "model.language_model.layers",
+        "weights": [
+            {
+                "name": "text_embedding_table",
+                "source": "model.language_model.embed_tokens.weight",
+                "prep": "cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": False,
+                "physical_layers": [None],
+                "kind": "param",
+            },
+            {
+                "name": "w_qkv_local",
+                "sources": [
+                    "self_attn.q_proj.weight",
+                    "self_attn.k_proj.weight",
+                    "self_attn.v_proj.weight",
+                ],
+                "prep": "concat_rows|cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": True,
+                "physical_layers": [0],
+                "kind": "param",
+            },
+            {
+                "name": "w_gate_up_fresh",
+                "source": "mlp.gate_up_proj.weight",
+                "prep": "interleave_gate_up_rows8_axis0|cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": True,
+                "physical_layers": [0],
+                "kind": "param",
+            },
+        ],
+    }
+
+    storage = allocate_weight_storage_for_loading(
+        model,
+        descriptor,
+        device="cpu",
+    )
+    final_storages = {
+        int(value.untyped_storage()._cdata): int(value.untyped_storage().nbytes())
+        for value in storage.buffers.values()
+    }
+    final_bytes = sum(final_storages.values())
+    _restore_checkpoint_independent_state(model, config, device=torch.device("cpu"))
+    materialize_remaining_meta_tensors(model, device=torch.device("cpu"))
+    layer = model.model.language_model.layers[0]
+    layer.self_attn.q_proj.weight.data.fill_(1)
+    layer.self_attn.k_proj.weight.data.fill_(2)
+    layer.self_attn.v_proj.weight.data.fill_(3)
+    layer.mlp.gate_up_proj.weight.data.copy_(
+        torch.arange(16, dtype=torch.bfloat16).view(16, 1).expand(16, 8)
+    )
+
+    finalize_weight_storage_after_loading(model, descriptor, storage)
+
+    assert final_bytes == 3 * 16 * 8 * 2
+    assert storage.aliased_source_bytes == 16 * 8 * 2
+    assert storage.retained_source_bytes == (8 * 8 + 4 * 8 + 4 * 8 + 16 * 8) * 2
+    assert storage.finalized
+    assert model.lm_head.weight is model.model.language_model.embed_tokens.weight
+    assert not any(
+        tensor.device.type == "meta"
+        for tensor in (*model.parameters(), *model.buffers())
+    )
+    assert not any(
+        tensor.device.type == "meta"
+        for tensor in model.model.language_model.rotary_emb.inv_freq.values()
+    )
+    assert materialize_weights(model, descriptor) is storage

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import asdict
 import json
 
 import pytest
@@ -15,6 +16,7 @@ from kestrel.models.gemma4.config import (
 )
 from kestrel.models.gemma4.loader import (
     _restore_checkpoint_independent_state,
+    load_model,
     load_weights,
 )
 from kestrel.models.gemma4.model import Gemma4InferenceModel
@@ -83,6 +85,86 @@ def _tiny_gemma_config() -> Gemma4Config:
         ),
         image_token_id=15,
     )
+
+
+def _rope_config(spec: RopeSpec) -> dict[str, object]:
+    return {
+        "rope_type": spec.kind,
+        "rope_theta": spec.theta,
+        "partial_rotary_factor": spec.partial_rotary_factor,
+        "factor": spec.factor,
+    }
+
+
+def _tiny_gemma_config_data() -> dict[str, object]:
+    config = _tiny_gemma_config()
+    text = asdict(config.text_config)
+    text.pop("rope")
+    text.update(
+        rope_parameters={
+            name: _rope_config(spec)
+            for name, spec in config.text_config.rope.items()
+        },
+        hidden_activation="gelu_pytorch_tanh",
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+    vision = asdict(config.vision_config)
+    vision.pop("rope")
+    vision.update(
+        rope_parameters=_rope_config(config.vision_config.rope),
+        hidden_activation="gelu_pytorch_tanh",
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+    return {
+        "tie_word_embeddings": True,
+        "text_config": text,
+        "vision_config": vision,
+        "image_token_id": config.image_token_id,
+    }
+
+
+def _tiny_generated_weight_descriptor() -> dict[str, object]:
+    return {
+        "weight_layer_prefix": "model.language_model.layers",
+        "weights": [
+            {
+                "name": "text_embedding_table",
+                "source": "model.language_model.embed_tokens.weight",
+                "prep": "cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": False,
+                "physical_layers": [None],
+                "kind": "param",
+            },
+            {
+                "name": "w_qkv_local",
+                "sources": [
+                    "self_attn.q_proj.weight",
+                    "self_attn.k_proj.weight",
+                    "self_attn.v_proj.weight",
+                ],
+                "prep": "concat_rows|cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": True,
+                "physical_layers": [0],
+                "kind": "param",
+            },
+            {
+                "name": "w_gate_up_fresh",
+                "source": "mlp.gate_up_proj.weight",
+                "prep": "interleave_gate_up_rows8_axis0|cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": True,
+                "physical_layers": [0],
+                "kind": "param",
+            },
+        ],
+    }
 
 
 def test_load_weights_streams_packed_projection_parts_across_shards(tmp_path) -> None:
@@ -154,45 +236,7 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
             model = Gemma4InferenceModel(config)
     finally:
         torch.set_default_dtype(old_dtype)
-    descriptor = {
-        "weight_layer_prefix": "model.language_model.layers",
-        "weights": [
-            {
-                "name": "text_embedding_table",
-                "source": "model.language_model.embed_tokens.weight",
-                "prep": "cast_bf16",
-                "shape": [16, 8],
-                "dtype": "bf16",
-                "per_layer": False,
-                "physical_layers": [None],
-                "kind": "param",
-            },
-            {
-                "name": "w_qkv_local",
-                "sources": [
-                    "self_attn.q_proj.weight",
-                    "self_attn.k_proj.weight",
-                    "self_attn.v_proj.weight",
-                ],
-                "prep": "concat_rows|cast_bf16",
-                "shape": [16, 8],
-                "dtype": "bf16",
-                "per_layer": True,
-                "physical_layers": [0],
-                "kind": "param",
-            },
-            {
-                "name": "w_gate_up_fresh",
-                "source": "mlp.gate_up_proj.weight",
-                "prep": "interleave_gate_up_rows8_axis0|cast_bf16",
-                "shape": [16, 8],
-                "dtype": "bf16",
-                "per_layer": True,
-                "physical_layers": [0],
-                "kind": "param",
-            },
-        ],
-    }
+    descriptor = _tiny_generated_weight_descriptor()
 
     storage = allocate_weight_storage_for_loading(
         model,
@@ -228,5 +272,86 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
     assert not any(
         tensor.device.type == "meta"
         for tensor in model.model.language_model.rotary_emb.inv_freq.values()
+    )
+    assert materialize_weights(model, descriptor) is storage
+
+
+def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
+    tmp_path,
+) -> None:
+    config = _tiny_gemma_config()
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        reference = Gemma4InferenceModel(config)
+    finally:
+        torch.set_default_dtype(old_dtype)
+    checkpoint = {
+        name: value.detach().clone()
+        for name, value in reference.state_dict().items()
+        if name != "lm_head.weight"
+    }
+    expected_embedding = checkpoint[
+        "model.language_model.embed_tokens.weight"
+    ].clone()
+    (tmp_path / "config.json").write_text(
+        json.dumps(_tiny_gemma_config_data()),
+        encoding="utf-8",
+    )
+    save_file(checkpoint, tmp_path / "model.safetensors")
+
+    descriptor = _tiny_generated_weight_descriptor()
+    lifecycle: list[str] = []
+    storage_box = {}
+
+    def prepare_model(model: torch.nn.Module) -> None:
+        lifecycle.append("prepare")
+        storage = allocate_weight_storage_for_loading(
+            model,
+            descriptor,
+            device="cpu",
+        )
+        assert not storage.finalized
+        storage_box["storage"] = storage
+
+    def finalize_model(model: torch.nn.Module) -> None:
+        lifecycle.append("finalize")
+        storage = storage_box["storage"]
+        assert not any(tensor.device.type == "meta" for tensor in model.parameters())
+        finalize_weight_storage_after_loading(model, descriptor, storage)
+        assert storage.finalized
+
+    model = load_model(
+        tmp_path,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        prepare_model=prepare_model,
+        finalize_model=finalize_model,
+    )
+
+    storage = storage_box["storage"]
+    embedding = model.model.language_model.embed_tokens.weight
+    assert lifecycle == ["prepare", "finalize"]
+    assert storage.finalized
+    assert model.lm_head.weight is embedding
+    assert torch._C._is_alias_of(
+        embedding,
+        storage.buffers["text_embedding_table"],
+    )
+    torch.testing.assert_close(embedding, expected_embedding)
+    assert not any(
+        tensor.device.type == "meta"
+        for tensor in (*model.parameters(), *model.buffers())
+    )
+    assert not any(
+        tensor.device.type == "meta"
+        for tensor in model.model.language_model.rotary_emb.inv_freq.values()
+    )
+    torch.testing.assert_close(
+        model.model.language_model.embed_tokens.embed_scale,
+        torch.full_like(
+            model.model.language_model.embed_tokens.embed_scale,
+            config.text_config.hidden_size**0.5,
+        ),
     )
     assert materialize_weights(model, descriptor) is storage

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, replace
 import json
 
 import pytest
 import torch
 from safetensors.torch import save_file
 from torch import nn
+from torch.nn import functional as F
 
 from kestrel.models.gemma4.config import (
     Gemma4Config,
@@ -19,7 +20,11 @@ from kestrel.models.gemma4.loader import (
     load_model,
     load_weights,
 )
-from kestrel.models.gemma4.model import Gemma4InferenceModel, Gemma4TextMLP
+from kestrel.models.gemma4.model import (
+    Gemma4InferenceModel,
+    Gemma4TextAttention,
+    Gemma4TextMLP,
+)
 from kestrel.runtime.bounded_projection import (
     PackedLinear,
     bind_declared_packed_projections,
@@ -144,12 +149,8 @@ def _tiny_generated_weight_descriptor() -> dict[str, object]:
             },
             {
                 "name": "w_qkv_local",
-                "sources": [
-                    "self_attn.q_proj.weight",
-                    "self_attn.k_proj.weight",
-                    "self_attn.v_proj.weight",
-                ],
-                "prep": "concat_rows|cast_bf16",
+                "source": "self_attn.qkv_proj.weight",
+                "prep": "identity",
                 "shape": [16, 8],
                 "dtype": "bf16",
                 "per_layer": True,
@@ -278,6 +279,151 @@ def test_text_mlp_interleaved_checkpoint_layout_matches_gate_up_math(
     torch.testing.assert_close(actual, expected)
 
 
+def test_text_attention_owner_packs_qkv_and_matches_projection_math() -> None:
+    torch.manual_seed(8)
+    config = _tiny_gemma_config().text_config
+    attention = Gemma4TextAttention(
+        config,
+        layer_idx=0,
+        kv_source_layer_idx=0,
+        publishes_kv=True,
+    )
+    q = torch.randn((8, 8))
+    k = torch.randn((4, 8))
+    v = torch.randn((4, 8))
+    packed = {
+        "q_proj.weight": q,
+        "k_proj.weight": k,
+        "v_proj.weight": v,
+    }
+    bind_declared_packed_projections(attention, packed)
+    with torch.no_grad():
+        attention.qkv_proj.weight.copy_(packed["qkv_proj.weight"])
+    hidden = torch.randn((3, 8))
+
+    actual = attention.qkv_proj(hidden).split(
+        attention.qkv_proj.packed_out_features,
+        dim=-1,
+    )
+    expected = tuple(F.linear(hidden, weight) for weight in (q, k, v))
+
+    assert attention.qkv_proj.source_names == ("q_proj", "k_proj", "v_proj")
+    assert not any(
+        name.startswith(("q_proj.", "k_proj.", "v_proj."))
+        for name, _ in attention.named_parameters()
+    )
+    for actual_part, expected_part in zip(actual, expected):
+        torch.testing.assert_close(actual_part, expected_part)
+
+
+def test_text_attention_k_equals_v_still_normalizes_k_and_v_separately(
+    monkeypatch,
+) -> None:
+    import kestrel.models.gemma4.model as gemma_model
+
+    torch.manual_seed(9)
+    config = _tiny_gemma_config().text_config
+    attention = Gemma4TextAttention(
+        config,
+        layer_idx=1,
+        kv_source_layer_idx=1,
+        publishes_kv=True,
+    )
+    q = torch.randn((8, 8))
+    k = torch.randn((4, 8))
+    packed = {"q_proj.weight": q, "k_proj.weight": k}
+    bind_declared_packed_projections(attention, packed)
+    with torch.no_grad():
+        attention.qkv_proj.weight.copy_(packed["qkv_proj.weight"])
+
+    observed: dict[str, torch.Tensor] = {}
+
+    class DenseRuntime:
+        @staticmethod
+        def rmsnorm(value, weight, eps):
+            del eps
+            if weight is attention.k_norm.weight:
+                observed["raw_k"] = value.clone()
+                return value + 10
+            if weight is attention.v_norm.weight:
+                observed["raw_v"] = value.clone()
+                return value + 20
+            return value
+
+    class Cache:
+        @staticmethod
+        def update(**kwargs):
+            observed["normalized_k"] = kwargs["k_val"]
+            observed["normalized_v"] = kwargs["v_val"]
+
+    monkeypatch.setattr(gemma_model, "_dense_runtime", DenseRuntime())
+    monkeypatch.setattr(
+        gemma_model,
+        "_apply_neox_rotary",
+        lambda query, key, position: (query, key),
+    )
+    monkeypatch.setattr(
+        gemma_model.attention_ops,
+        "dense_attention",
+        lambda query, key, value, **kwargs: query,
+    )
+    hidden = torch.randn((1, 2, 8))
+
+    attention(
+        hidden,
+        (torch.empty(0), torch.empty(0)),
+        [None, None],
+        Cache(),
+        torch.arange(2),
+        torch.arange(2),
+        None,
+    )
+
+    assert attention.qkv_proj.source_names == ("q_proj", "k_proj", "k_proj")
+    torch.testing.assert_close(observed["raw_k"], observed["raw_v"])
+    torch.testing.assert_close(
+        observed["normalized_k"],
+        observed["raw_k"] + 10,
+    )
+    torch.testing.assert_close(
+        observed["normalized_v"],
+        observed["raw_v"] + 20,
+    )
+
+
+def test_text_attention_shared_kv_packs_only_query() -> None:
+    config = _tiny_gemma_config().text_config
+    config = replace(
+        config,
+        num_kv_shared_layers=1,
+        layer_types=("sliding_attention", "sliding_attention"),
+    )
+    attention = Gemma4TextAttention(
+        config,
+        layer_idx=1,
+        kv_source_layer_idx=0,
+        publishes_kv=False,
+    )
+    q = torch.randn((8, 8))
+    packed = {"q_proj.weight": q}
+
+    bind_declared_packed_projections(attention, packed)
+    with torch.no_grad():
+        attention.qkv_proj.weight.copy_(packed["qkv_proj.weight"])
+    hidden = torch.ones((1, 8))
+
+    assert attention.qkv_proj.source_names == ("q_proj",)
+    assert packed["qkv_proj.weight"] is q
+    torch.testing.assert_close(
+        attention.qkv_proj(hidden),
+        F.linear(hidden, q),
+    )
+    assert not any(
+        name.startswith(("q_proj.", "k_proj.", "v_proj."))
+        for name, _ in attention.named_parameters()
+    )
+
+
 def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retained():
     config = _tiny_gemma_config()
     old_dtype = torch.get_default_dtype()
@@ -302,9 +448,15 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
     _restore_checkpoint_independent_state(model, config, device=torch.device("cpu"))
     materialize_remaining_meta_tensors(model, device=torch.device("cpu"))
     layer = model.model.language_model.layers[0]
-    layer.self_attn.q_proj.weight.data.fill_(1)
-    layer.self_attn.k_proj.weight.data.fill_(2)
-    layer.self_attn.v_proj.weight.data.fill_(3)
+    layer.self_attn.qkv_proj.weight.data.copy_(
+        torch.cat(
+            (
+                torch.full((8, 8), 1, dtype=torch.bfloat16),
+                torch.full((4, 8), 2, dtype=torch.bfloat16),
+                torch.full((4, 8), 3, dtype=torch.bfloat16),
+            )
+        )
+    )
     layer.mlp.gate_up_proj.weight.data.copy_(
         torch.arange(16, dtype=torch.bfloat16).view(16, 1).expand(16, 8)
     )
@@ -312,10 +464,10 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
     finalize_weight_storage_after_loading(model, descriptor, storage)
 
     assert final_bytes == 3 * 16 * 8 * 2
-    assert storage.aliased_source_bytes == 2 * 16 * 8 * 2
-    assert storage.retained_source_bytes == (8 * 8 + 4 * 8 + 4 * 8) * 2
+    assert storage.aliased_source_bytes == 3 * 16 * 8 * 2
+    assert storage.retained_source_bytes == 0
     assert all(
-        retained.name != "w_gate_up_fresh"
+        retained.name not in {"w_gate_up_fresh", "w_qkv_local"}
         for retained in storage.retained_recipes
     )
     assert storage.finalized
@@ -323,6 +475,20 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
     assert torch._C._is_alias_of(
         layer.mlp.gate_up_proj.weight,
         storage.buffers["w_gate_up_fresh"][0],
+    )
+    assert torch._C._is_alias_of(
+        layer.self_attn.qkv_proj.weight,
+        storage.buffers["w_qkv_local"][0],
+    )
+    assert not any(
+        name.endswith(
+            (
+                "self_attn.q_proj.weight",
+                "self_attn.k_proj.weight",
+                "self_attn.v_proj.weight",
+            )
+        )
+        for name, _ in model.named_parameters()
     )
     assert not any(
         tensor.device.type == "meta"
@@ -333,6 +499,49 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
         for tensor in model.model.language_model.rotary_emb.inv_freq.values()
     )
     assert materialize_weights(model, descriptor) is storage
+
+
+def test_gemma_generated_shared_query_projection_aliases_direct_row() -> None:
+    text_config = replace(
+        _tiny_gemma_config().text_config,
+        num_kv_shared_layers=1,
+        layer_types=("sliding_attention", "sliding_attention"),
+    )
+    config = replace(_tiny_gemma_config(), text_config=text_config)
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        with torch.device("meta"):
+            model = Gemma4InferenceModel(config)
+    finally:
+        torch.set_default_dtype(old_dtype)
+    descriptor = {
+        "weight_layer_prefix": "model.language_model.layers",
+        "weights": [
+            {
+                "name": "w_q_local",
+                "source": "self_attn.qkv_proj.weight",
+                "prep": "identity",
+                "shape": [8, 8],
+                "dtype": "bf16",
+                "per_layer": True,
+                "physical_layers": [1],
+                "kind": "param",
+            },
+        ],
+    }
+
+    storage = allocate_weight_storage_for_loading(
+        model,
+        descriptor,
+        device="cpu",
+    )
+    query = model.model.language_model.layers[1].self_attn.qkv_proj.weight
+
+    assert storage.finalized
+    assert storage.retained_source_bytes == 0
+    assert torch._C._is_alias_of(query, storage.buffers["w_q_local"][0])
+    assert tuple(query.stride()) == tuple(storage.buffers["w_q_local"][0].stride())
 
 
 def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
@@ -371,15 +580,18 @@ def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
             descriptor,
             device="cpu",
         )
-        assert not storage.finalized
+        assert storage.finalized
         storage_box["storage"] = storage
 
     def finalize_model(model: torch.nn.Module) -> None:
         lifecycle.append("finalize")
         storage = storage_box["storage"]
         assert not any(tensor.device.type == "meta" for tensor in model.parameters())
-        finalize_weight_storage_after_loading(model, descriptor, storage)
         assert storage.finalized
+        assert (
+            finalize_weight_storage_after_loading(model, descriptor, storage)
+            is storage
+        )
 
     model = load_model(
         tmp_path,

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -19,8 +19,11 @@ from kestrel.models.gemma4.loader import (
     load_model,
     load_weights,
 )
-from kestrel.models.gemma4.model import Gemma4InferenceModel
-from kestrel.runtime.bounded_projection import PackedLinear
+from kestrel.models.gemma4.model import Gemma4InferenceModel, Gemma4TextMLP
+from kestrel.runtime.bounded_projection import (
+    PackedLinear,
+    bind_declared_packed_projections,
+)
 from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 from kestrel_kernels.generated_decode import (
     allocate_weight_storage_for_loading,
@@ -156,7 +159,7 @@ def _tiny_generated_weight_descriptor() -> dict[str, object]:
             {
                 "name": "w_gate_up_fresh",
                 "source": "mlp.gate_up_proj.weight",
-                "prep": "interleave_gate_up_rows8_axis0|cast_bf16",
+                "prep": "identity",
                 "shape": [16, 8],
                 "dtype": "bf16",
                 "per_layer": True,
@@ -227,6 +230,54 @@ def test_load_weights_rejects_unexpected_checkpoint_tensor(tmp_path) -> None:
         load_weights(tmp_path, _ToyShardedModel())
 
 
+def test_text_mlp_interleaved_checkpoint_layout_matches_gate_up_math(
+    monkeypatch,
+) -> None:
+    import kestrel.models.gemma4.model as gemma_model
+
+    torch.manual_seed(7)
+    config = _tiny_gemma_config().text_config
+    mlp = Gemma4TextMLP(config, layer_idx=0)
+    gate = torch.randn((config.intermediate_size, config.hidden_size))
+    up = torch.randn_like(gate)
+    down = torch.randn((config.hidden_size, config.intermediate_size))
+    packed = {"gate_proj.weight": gate, "up_proj.weight": up}
+    bind_declared_packed_projections(mlp, packed)
+    with torch.no_grad():
+        mlp.gate_up_proj.weight.copy_(packed["gate_up_proj.weight"])
+        mlp.down_proj.weight.copy_(down)
+
+    observed_layouts: list[str] = []
+
+    def gated_activation_into(out, gate_up, *, activation, layout) -> None:
+        observed_layouts.append(layout)
+        assert activation == "gelu_tanh"
+        blocks = gate_up.reshape(*gate_up.shape[:-1], config.intermediate_size // 8, 16)
+        gate_out = blocks[..., :8].reshape_as(out)
+        up_out = blocks[..., 8:].reshape_as(out)
+        out.copy_(torch.nn.functional.gelu(
+            gate_out, approximate="tanh"
+        ) * up_out)
+
+    monkeypatch.setattr(
+        gemma_model,
+        "_kestrel_gated_activation_into",
+        gated_activation_into,
+    )
+    hidden = torch.randn((3, config.hidden_size))
+
+    actual = mlp(hidden)
+    expected = torch.nn.functional.linear(
+        torch.nn.functional.gelu(
+            torch.nn.functional.linear(hidden, gate), approximate="tanh"
+        ) * torch.nn.functional.linear(hidden, up),
+        down,
+    )
+
+    assert observed_layouts == ["interleaved_i8"]
+    torch.testing.assert_close(actual, expected)
+
+
 def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retained():
     config = _tiny_gemma_config()
     old_dtype = torch.get_default_dtype()
@@ -261,10 +312,18 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
     finalize_weight_storage_after_loading(model, descriptor, storage)
 
     assert final_bytes == 3 * 16 * 8 * 2
-    assert storage.aliased_source_bytes == 16 * 8 * 2
-    assert storage.retained_source_bytes == (8 * 8 + 4 * 8 + 4 * 8 + 16 * 8) * 2
+    assert storage.aliased_source_bytes == 2 * 16 * 8 * 2
+    assert storage.retained_source_bytes == (8 * 8 + 4 * 8 + 4 * 8) * 2
+    assert all(
+        retained.name != "w_gate_up_fresh"
+        for retained in storage.retained_recipes
+    )
     assert storage.finalized
     assert model.lm_head.weight is model.model.language_model.embed_tokens.weight
+    assert torch._C._is_alias_of(
+        layer.mlp.gate_up_proj.weight,
+        storage.buffers["w_gate_up_fresh"][0],
+    )
     assert not any(
         tensor.device.type == "meta"
         for tensor in (*model.parameters(), *model.buffers())
@@ -338,6 +397,10 @@ def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
     assert torch._C._is_alias_of(
         embedding,
         storage.buffers["text_embedding_table"],
+    )
+    assert torch._C._is_alias_of(
+        model.model.language_model.layers[0].mlp.gate_up_proj.weight,
+        storage.buffers["w_gate_up_fresh"][0],
     )
     torch.testing.assert_close(embedding, expected_embedding)
     assert not any(

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -306,6 +306,7 @@ def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
 
     def prepare_model(model: torch.nn.Module) -> None:
         lifecycle.append("prepare")
+        assert all(tensor.device.type == "meta" for tensor in model.parameters())
         storage = allocate_weight_storage_for_loading(
             model,
             descriptor,

--- a/tests/gemma4/test_runtime_resources.py
+++ b/tests/gemma4/test_runtime_resources.py
@@ -1,0 +1,144 @@
+"""Resource sizing for Gemma generated decode."""
+
+import gc
+import weakref
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from kestrel.models.gemma4.generated_decode import _rope_tables
+from kestrel.models.gemma4.runtime import (
+    Gemma4Runtime,
+    _allocate_decode_page_tables,
+    _generated_kv_binding_inputs,
+    _install_decode_page_tables,
+)
+
+
+class _Rotary:
+    def __call__(self, _probe, positions, kind):
+        offset = 1 if kind == "sliding_attention" else 10
+        values = positions.unsqueeze(-1).expand(-1, -1, 3) + offset
+        values = values.to(torch.bfloat16)
+        return values, values + 1
+
+
+def _runtime(max_seq_length: int = 8):
+    language_model = SimpleNamespace(rotary_emb=_Rotary())
+    return SimpleNamespace(
+        max_seq_length=max_seq_length,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        model=SimpleNamespace(
+            model=SimpleNamespace(language_model=language_model),
+        ),
+    )
+
+
+def test_rope_tables_materialize_only_requested_reachable_positions() -> None:
+    tables = _rope_tables(_runtime(), 3)
+
+    assert set(tables) == {
+        "rope_cos_local",
+        "rope_sin_local",
+        "rope_cos_global",
+        "rope_sin_global",
+    }
+    assert all(tuple(table.shape) == (3, 3) for table in tables.values())
+    assert all(table.dtype is torch.float32 for table in tables.values())
+    assert all(table.is_contiguous() for table in tables.values())
+
+
+@pytest.mark.parametrize("length", [0, 9])
+def test_rope_tables_reject_lengths_outside_model_context(length: int) -> None:
+    with pytest.raises(ValueError, match="must lie"):
+        _rope_tables(_runtime(), length)
+
+
+def test_generated_binding_inputs_preserve_sparse_layer_topology() -> None:
+    inputs = _generated_kv_binding_inputs(
+        (object(), None, object(), object()),
+        (
+            "sliding_attention",
+            "full_attention",
+            "full_attention",
+            "sliding_attention",
+        ),
+    )
+
+    assert inputs["mK_local"] is inputs["mV_local"]
+    assert inputs["mK_global"] is inputs["mV_global"]
+    assert [value is not None for value in inputs["mK_local"]] == [
+        True,
+        False,
+        False,
+        True,
+    ]
+    assert [value is not None for value in inputs["mK_global"]] == [
+        False,
+        False,
+        True,
+        False,
+    ]
+
+
+def test_generated_binding_reservation_is_released_before_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.gemma4 import generated_decode
+
+    released = []
+
+    class _Reservation:
+        def __del__(self):
+            released.append(True)
+
+    runtime = object.__new__(Gemma4Runtime)
+    runtime.decode_path = "auto"
+    runtime._generated_weight_storage = object()
+    runtime._generated_binding_reservation = _Reservation()
+    expected = object()
+
+    def create(_runtime, *, required=False):
+        assert released == [True]
+        assert required is False
+        return expected
+
+    monkeypatch.setattr(generated_decode, "create_generated_decode", create)
+
+    runtime._initialize_generated_decode()
+
+    assert runtime._generated_binding_reservation is None
+    assert runtime.generated_decode is expected
+
+
+def test_decode_page_table_placeholders_are_replaced_before_binding() -> None:
+    slots = tuple(
+        SimpleNamespace(paged_kv_page_table=torch.empty((3, 1), dtype=torch.int32))
+        for _ in range(2)
+    )
+    old_tables = tuple(weakref.ref(slot.paged_kv_page_table) for slot in slots)
+    tables = _allocate_decode_page_tables(
+        count=2,
+        rows=3,
+        pages=11,
+        device=torch.device("cpu"),
+    )
+
+    _install_decode_page_tables(slots, tables)
+
+    assert all(tuple(slot.paged_kv_page_table.shape) == (3, 11) for slot in slots)
+    assert all(slot.paged_kv_page_table is table for slot, table in zip(slots, tables))
+    gc.collect()
+    assert all(reference() is None for reference in old_tables)
+    with pytest.raises(RuntimeError, match="unbound one-column placeholders"):
+        _install_decode_page_tables(
+            slots,
+            _allocate_decode_page_tables(
+                count=2,
+                rows=3,
+                pages=12,
+                device=torch.device("cpu"),
+            ),
+        )

--- a/tests/qwen35/test_loader.py
+++ b/tests/qwen35/test_loader.py
@@ -12,11 +12,11 @@ from kestrel.models.qwen35.qwen_loader import (
     _dequantize_fp8_weight,
     _interleave_gate_up_weight,
     _load_sharded_safetensors,
-    _materialize_remaining_meta_tensors,
     _restore_rotary_buffers,
 )
 import kestrel.models.qwen35.qwen_loader as loader_module
 from kestrel.ops.rotary import default_inv_freq
+from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 
 
 class _FusedExpertHolder(torch.nn.Module):
@@ -299,7 +299,7 @@ def test_remaining_meta_tensors_materialize_without_replacing_bound_storage() ->
         module.register_buffer("pending_buffer", torch.empty(2))
     bound = module.bound
 
-    _materialize_remaining_meta_tensors(module, device=torch.device("cpu"))
+    materialize_remaining_meta_tensors(module, device=torch.device("cpu"))
 
     assert module.bound is bound
     assert module.pending.device.type == "cpu"
@@ -313,7 +313,7 @@ def test_remaining_meta_tensors_reject_uninitialized_derived_buffers() -> None:
         module.register_buffer("derived", torch.empty(2), persistent=False)
 
     try:
-        _materialize_remaining_meta_tensors(module, device=torch.device("cpu"))
+        materialize_remaining_meta_tensors(module, device=torch.device("cpu"))
     except RuntimeError as exc:
         assert "derived buffer" in str(exc)
     else:

--- a/tests/test_bounded_projection.py
+++ b/tests/test_bounded_projection.py
@@ -38,6 +38,39 @@ def test_packed_linear_binding_waits_for_all_streamed_parts() -> None:
     torch.testing.assert_close(state["packed.weight"], torch.cat((q, k)))
 
 
+def test_packed_linear_single_source_reuses_source_tensor() -> None:
+    module = nn.Module()
+    module.packed = PackedLinear(
+        3,
+        (2,),
+        source_names=("q",),
+    )
+    q = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    state = {"q.weight": q}
+
+    bind_declared_packed_projections(module, state)
+
+    assert state == {"packed.weight": q}
+    assert state["packed.weight"] is q
+
+
+def test_packed_linear_repeated_source_packs_each_declared_partition() -> None:
+    module = nn.Module()
+    module.packed = PackedLinear(
+        3,
+        (2, 1, 1),
+        source_names=("q", "k", "k"),
+    )
+    q = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    k = torch.arange(3, dtype=torch.float32).reshape(1, 3) + 10
+    state = {"q.weight": q, "k.weight": k}
+
+    bind_declared_packed_projections(module, state)
+
+    assert set(state) == {"packed.weight"}
+    torch.testing.assert_close(state["packed.weight"], torch.cat((q, k, k)))
+
+
 def test_packed_linear_binding_honors_interleaved_output_layout() -> None:
     module = nn.Module()
     module.packed = PackedLinear(
@@ -109,6 +142,38 @@ def test_packed_bounded_binding_waits_for_streamed_bounds() -> None:
         "packed.output_max",
         "packed.output_min",
     }
+
+
+def test_packed_bounded_repeated_source_removes_each_bound_once() -> None:
+    module = nn.Module()
+    module.packed = PackedBoundedProjections(
+        2,
+        (1, 1),
+        source_names=("k", "k"),
+        use_bounds=True,
+    )
+    weight = torch.ones((1, 2))
+    state = {
+        "k.linear.weight": weight,
+        "k.input_min": torch.tensor(-1.0),
+        "k.input_max": torch.tensor(1.0),
+        "k.output_min": torch.tensor(-2.0),
+        "k.output_max": torch.tensor(2.0),
+    }
+
+    bind_declared_packed_projections(module, state)
+
+    assert set(state) == {
+        "packed.input_max",
+        "packed.input_min",
+        "packed.linear.weight",
+        "packed.output_max",
+        "packed.output_min",
+    }
+    torch.testing.assert_close(
+        state["packed.linear.weight"],
+        torch.cat((weight, weight)),
+    )
 
 
 def test_packed_binding_skips_already_loaded_target() -> None:

--- a/tests/test_bounded_projection.py
+++ b/tests/test_bounded_projection.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from torch import nn
 
@@ -35,6 +36,40 @@ def test_packed_linear_binding_waits_for_all_streamed_parts() -> None:
     )
     assert set(state) == {"packed.weight"}
     torch.testing.assert_close(state["packed.weight"], torch.cat((q, k)))
+
+
+def test_packed_linear_binding_honors_interleaved_output_layout() -> None:
+    module = nn.Module()
+    module.packed = PackedLinear(
+        3,
+        (16, 16),
+        source_names=("gate", "up"),
+        output_layout="interleaved_i8",
+    )
+    gate = torch.arange(48, dtype=torch.float32).reshape(16, 3)
+    up = torch.arange(48, 96, dtype=torch.float32).reshape(16, 3)
+    state = {"gate.weight": gate, "up.weight": up}
+
+    bind_declared_packed_projections(module, state)
+
+    expected = torch.stack(
+        (gate.reshape(2, 8, 3), up.reshape(2, 8, 3)), dim=1
+    ).reshape(32, 3)
+    torch.testing.assert_close(state["packed.weight"], expected)
+
+
+@pytest.mark.parametrize(
+    "out_features",
+    ((8, 8, 8), (8, 16), (10, 10)),
+)
+def test_packed_linear_rejects_invalid_interleaved_shape(out_features) -> None:
+    with pytest.raises(ValueError, match="two equal output sizes"):
+        PackedLinear(
+            3,
+            out_features,
+            source_names=tuple(f"source_{index}" for index in range(len(out_features))),
+            output_layout="interleaved_i8",
+        )
 
 
 def test_packed_bounded_binding_waits_for_streamed_bounds() -> None:

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -88,6 +88,27 @@ def test_gemma_native_does_not_construct_generated_decode(
     assert runtime.generated_decode is None
 
 
+def test_gemma_auto_without_finalized_load_time_storage_uses_native(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.gemma4 import generated_decode as gemma_generated
+
+    runtime = object.__new__(Gemma4Runtime)
+    runtime.decode_path = "auto"
+    runtime._generated_weight_storage = None
+    monkeypatch.setattr(
+        gemma_generated,
+        "create_generated_decode",
+        lambda *_args, **_kwargs: pytest.fail(
+            "auto mode cannot materialize a second generated-weight slab"
+        ),
+    )
+
+    runtime._initialize_generated_decode()
+
+    assert runtime.generated_decode is None
+
+
 def test_qwen_required_generated_unavailable_refuses_before_graph_capture(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -75,6 +75,7 @@ def test_gemma_native_does_not_construct_generated_decode(
 
     runtime = object.__new__(Gemma4Runtime)
     runtime.decode_path = "native"
+    runtime._generated_binding_reservation = None
     monkeypatch.setattr(
         gemma_generated,
         "create_generated_decode",
@@ -96,6 +97,7 @@ def test_gemma_auto_without_finalized_load_time_storage_uses_native(
     runtime = object.__new__(Gemma4Runtime)
     runtime.decode_path = "auto"
     runtime._generated_weight_storage = None
+    runtime._generated_binding_reservation = None
     monkeypatch.setattr(
         gemma_generated,
         "create_generated_decode",

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -7,6 +7,7 @@ import torch
 from kestrel.runtime.generated_decode import (
     GeneratedDecode,
     prepare_generated_weight_storage_for_loading,
+    reserve_generated_binding_storage,
 )
 
 
@@ -180,3 +181,77 @@ def test_load_time_weight_preparation_fails_soft_only_when_optional(
         prepare_generated_weight_storage_for_loading(
             runtime, Mock(), required=True, **options
         )
+
+
+def test_binding_reservation_allocates_every_program_slot_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel_kernels import generated_decode as generated_runtime
+
+    programs = tuple(
+        SimpleNamespace(descriptor={"owned_bytes": owned_bytes})
+        for owned_bytes in (10, 20)
+    )
+    storage = SimpleNamespace(finalized=True, buffers={"weight": torch.empty(1)})
+    first = {"slot": 1}
+    second = {"slot": 2}
+    calls = []
+
+    def reserve(descriptor, *, weights, runtime_inputs, device):
+        calls.append((descriptor, weights, runtime_inputs))
+        return (
+            torch.empty(
+                descriptor["owned_bytes"] + runtime_inputs["slot"],
+                dtype=torch.uint8,
+                device=device,
+            ),
+        )
+
+    monkeypatch.setattr(
+        generated_runtime,
+        "reserve_binding_storage",
+        reserve,
+        raising=False,
+    )
+
+    reservation = reserve_generated_binding_storage(
+        programs,
+        weight_storage=storage,
+        runtime_inputs_by_slot=(first, second),
+        device=torch.device("cpu"),
+        label="test",
+        required=True,
+    )
+
+    assert reservation is not None
+    assert [tensor.dtype for tensor in reservation] == [torch.uint8] * 4
+    assert [tensor.numel() for tensor in reservation] == [11, 21, 12, 22]
+    assert calls == [
+        (programs[0].descriptor, storage.buffers, first),
+        (programs[1].descriptor, storage.buffers, first),
+        (programs[0].descriptor, storage.buffers, second),
+        (programs[1].descriptor, storage.buffers, second),
+    ]
+
+
+def test_binding_reservation_fails_soft_only_when_optional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel_kernels import generated_decode as generated_runtime
+
+    monkeypatch.delattr(
+        generated_runtime,
+        "reserve_binding_storage",
+        raising=False,
+    )
+    options = dict(
+        programs=(SimpleNamespace(descriptor={}),),
+        weight_storage=SimpleNamespace(finalized=True, buffers={}),
+        runtime_inputs_by_slot=({},),
+        device=torch.device("cpu"),
+        label="test",
+    )
+
+    assert reserve_generated_binding_storage(required=False, **options) is None
+    with pytest.raises(RuntimeError, match="binding-storage reservation"):
+        reserve_generated_binding_storage(required=True, **options)

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -4,7 +4,10 @@ from unittest.mock import Mock, patch
 import pytest
 import torch
 
-from kestrel.runtime.generated_decode import GeneratedDecode
+from kestrel.runtime.generated_decode import (
+    GeneratedDecode,
+    prepare_generated_weight_storage_for_loading,
+)
 
 
 def _program(capacity, *, active_batch=None, minimum_batch=1):
@@ -132,3 +135,48 @@ def test_slot_capacity_refuses_incomplete_required_domain(monkeypatch):
         object(),
         required_batch_sizes=range(1, 5),
     ) is None
+
+
+@pytest.mark.parametrize(
+    "missing_capability",
+    (
+        "allocate_weight_storage_for_loading",
+        "finalize_weight_storage_after_loading",
+    ),
+)
+def test_load_time_weight_preparation_fails_soft_only_when_optional(
+    monkeypatch: pytest.MonkeyPatch,
+    missing_capability: str,
+) -> None:
+    from kestrel_kernels import generated_decode as generated_runtime
+
+    runtime = SimpleNamespace(
+        device=torch.device("cuda", 0),
+        dtype=torch.bfloat16,
+        max_batch_size=1,
+    )
+    program = _program(1, active_batch=1)
+    program.descriptor = {"weights": []}
+    properties = SimpleNamespace(major=9, minor=0, multi_processor_count=132)
+    monkeypatch.setattr(
+        generated_runtime,
+        "resolve_compatible_programs",
+        lambda *_args, **_kwargs: (program,),
+    )
+    monkeypatch.delattr(generated_runtime, missing_capability)
+    monkeypatch.setattr(
+        torch.cuda, "get_device_properties", lambda _device: properties
+    )
+
+    options = dict(
+        label="Gemma",
+        layer_prefix="model.language_model.layers",
+        required_batch_sizes=(1,),
+    )
+    assert prepare_generated_weight_storage_for_loading(
+        runtime, Mock(), required=False, **options
+    ) is None
+    with pytest.raises(RuntimeError, match="binding and finalization support"):
+        prepare_generated_weight_storage_for_loading(
+            runtime, Mock(), required=True, **options
+        )

--- a/tests/test_generated_decode_static_extents.py
+++ b/tests/test_generated_decode_static_extents.py
@@ -157,7 +157,9 @@ def test_generated_decode_materializes_explicit_weight_sources(monkeypatch):
 
 
 def test_generated_decode_reuses_matching_preloaded_weight_storage(monkeypatch):
-    storage = SimpleNamespace(buffers={}, weight_contract=repr([]))
+    storage = SimpleNamespace(
+        buffers={}, weight_contract=repr([]), finalized=True
+    )
     calls = []
 
     generated, _launches = _build(
@@ -173,9 +175,25 @@ def test_generated_decode_reuses_matching_preloaded_weight_storage(monkeypatch):
 
 
 def test_generated_decode_rejects_mismatched_preloaded_weight_storage(monkeypatch):
-    storage = SimpleNamespace(buffers={}, weight_contract="different")
+    storage = SimpleNamespace(
+        buffers={}, weight_contract="different", finalized=True
+    )
 
     with pytest.raises(RuntimeError, match="preloaded generated weights"):
+        _build(
+            monkeypatch,
+            _programs("b1"),
+            max_batch_size=1,
+            weight_storage=storage,
+        )
+
+
+def test_generated_decode_rejects_unfinalized_preloaded_weight_storage(monkeypatch):
+    storage = SimpleNamespace(
+        buffers={}, weight_contract=repr([]), finalized=False
+    )
+
+    with pytest.raises(RuntimeError, match="not finalized"):
         _build(
             monkeypatch,
             _programs("b1"),

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -10,7 +10,17 @@ from __future__ import annotations
 import pytest
 import torch
 
-from kestrel.kv_cache import KVMemoryPool, PageTable, PagedKVCache
+from kestrel.kv_cache import (
+    KVMemoryPool,
+    PageTable,
+    PagedKVCache,
+    PagedKVLayerSpec,
+    allocate_paged_kv_layers,
+    allocate_paged_kv_storage,
+    fit_and_allocate_paged_kv_storage,
+    paged_kv_bytes_per_page,
+    paged_kv_storage_bytes,
+)
 
 
 def _make_page_table(*, page_size: int = 1, n_pages: int = 4) -> PageTable:
@@ -72,6 +82,304 @@ def test_pool_rejects_negative_budget() -> None:
 def test_pool_normalizes_string_device() -> None:
     pool = KVMemoryPool(device="cpu")
     assert pool.device == torch.device("cpu")
+
+
+def test_paged_kv_bytes_per_page_counts_sparse_layers_and_page_size() -> None:
+    specs = (
+        PagedKVLayerSpec(n_heads=2, head_dim=8),
+        None,
+        PagedKVLayerSpec(n_heads=1, head_dim=16),
+    )
+
+    assert paged_kv_bytes_per_page(
+        specs,
+        page_size=4,
+        dtype=torch.bfloat16,
+    ) == 2 * (2 * 8 + 1 * 16) * 4 * 2
+
+
+def test_fitted_paged_kv_storage_respects_consumed_shared_pool_budget() -> None:
+    specs = (PagedKVLayerSpec(n_heads=2, head_dim=8), None)
+    bytes_per_page = paged_kv_bytes_per_page(
+        specs,
+        page_size=4,
+        dtype=torch.bfloat16,
+    )
+    storage_bytes = paged_kv_storage_bytes(
+        8,
+        layer_specs=specs,
+        page_size=4,
+        dtype=torch.bfloat16,
+    )
+    pool = KVMemoryPool(
+        device="cpu",
+        budget_bytes=2 * bytes_per_page + storage_bytes,
+    )
+    pool.allocated_bytes = 2 * bytes_per_page
+
+    storage, additional = fit_and_allocate_paged_kv_storage(
+        100,
+        layer_specs=specs,
+        page_size=4,
+        dtype=torch.bfloat16,
+        pool=pool,
+    )
+
+    assert storage.n_pages == 8
+    assert additional is None
+    assert pool.allocated_bytes == pool.budget_bytes
+
+
+def test_fitted_paged_kv_storage_retains_first_successful_fragmented_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.kv_cache as kv_cache
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cpu")
+    original_allocate = allocate_paged_kv_storage
+    attempts = []
+    resources = []
+
+    def allocate_storage(n_pages, **kwargs):
+        attempts.append(n_pages)
+        if n_pages > 5:
+            raise torch.OutOfMemoryError("synthetic fragmented allocator")
+        return original_allocate(n_pages, **kwargs)
+
+    def allocate_additional(n_pages):
+        value = torch.empty(n_pages, dtype=torch.int32)
+        resources.append(value)
+        return value
+
+    monkeypatch.setattr(kv_cache, "allocate_paged_kv_storage", allocate_storage)
+
+    storage, additional = fit_and_allocate_paged_kv_storage(
+        8,
+        layer_specs=specs,
+        page_size=2,
+        dtype=torch.bfloat16,
+        pool=pool,
+        allocate_additional=allocate_additional,
+    )
+
+    assert attempts == [8, 7, 6, 5]
+    assert storage.n_pages == 5
+    assert additional is resources[-1]
+    assert additional.numel() == 5
+
+
+def test_fitted_paged_kv_storage_rejects_capacity_without_serving_page() -> None:
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    two_page_bytes = paged_kv_storage_bytes(
+        2,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.float32,
+    )
+    pool = KVMemoryPool(device="cpu", budget_bytes=two_page_bytes)
+
+    with pytest.raises(MemoryError, match="serving K/V pages"):
+        fit_and_allocate_paged_kv_storage(
+            8,
+            layer_specs=specs,
+            page_size=1,
+            dtype=torch.float32,
+            pool=pool,
+        )
+
+
+def test_grouped_paged_kv_storage_alignment_zero_page_and_pointer_reuse() -> None:
+    specs = (
+        PagedKVLayerSpec(n_heads=3, head_dim=5),
+        None,
+        PagedKVLayerSpec(n_heads=1, head_dim=7),
+    )
+    pool = KVMemoryPool(device="cpu")
+    storage = allocate_paged_kv_storage(
+        5,
+        layer_specs=specs,
+        page_size=3,
+        dtype=torch.bfloat16,
+        pool=pool,
+    )
+    before = tuple(
+        None if layer is None else (layer.k_cache.data_ptr(), layer.v_cache.data_ptr())
+        for layer in storage.layers
+    )
+    page_table = _make_page_table(page_size=3, n_pages=5)
+    caches = allocate_paged_kv_layers(
+        layer_specs=specs,
+        page_table=page_table,
+        pool=pool,
+        dtype=torch.bfloat16,
+        storage=storage,
+    )
+
+    after = tuple(
+        None if cache is None else (cache.k_cache.data_ptr(), cache.v_cache.data_ptr())
+        for cache in caches
+    )
+    assert after == before
+    assert all(
+        pointer % 256 == 0 for pair in before if pair is not None for pointer in pair
+    )
+    for cache in caches:
+        if cache is not None:
+            torch.testing.assert_close(
+                cache.k_cache[0], torch.zeros_like(cache.k_cache[0])
+            )
+            torch.testing.assert_close(
+                cache.v_cache[0], torch.zeros_like(cache.v_cache[0])
+            )
+    assert pool.allocated_bytes == paged_kv_storage_bytes(
+        5,
+        layer_specs=specs,
+        page_size=3,
+        dtype=torch.bfloat16,
+    )
+
+
+@pytest.mark.parametrize(
+    "mismatched_specs",
+    [
+        (
+            PagedKVLayerSpec(
+                n_heads=1,
+                head_dim=8,
+                k_scale=0.75,
+                v_scale=0.25,
+            ),
+            None,
+        ),
+        (
+            None,
+            PagedKVLayerSpec(
+                n_heads=1,
+                head_dim=8,
+                k_scale=0.5,
+                v_scale=0.25,
+            ),
+        ),
+    ],
+)
+def test_grouped_paged_kv_storage_rejects_scale_or_topology_reuse(
+    mismatched_specs,
+) -> None:
+    specs = (
+        PagedKVLayerSpec(
+            n_heads=1,
+            head_dim=8,
+            k_scale=0.5,
+            v_scale=0.25,
+        ),
+        None,
+    )
+    pool = KVMemoryPool(device="cpu")
+    storage = allocate_paged_kv_storage(
+        4,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.float8_e4m3fn,
+        pool=pool,
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        allocate_paged_kv_layers(
+            layer_specs=mismatched_specs,
+            page_table=_make_page_table(n_pages=4),
+            pool=pool,
+            dtype=torch.float8_e4m3fn,
+            storage=storage,
+        )
+
+
+def test_grouped_paged_kv_storage_has_one_accounting_owner() -> None:
+    import gc
+    import weakref
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cpu")
+    storage = allocate_paged_kv_storage(
+        4,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.float32,
+        pool=pool,
+    )
+    backing = weakref.ref(storage._kv_backing)
+    caches = allocate_paged_kv_layers(
+        layer_specs=specs,
+        page_table=_make_page_table(n_pages=4),
+        pool=pool,
+        dtype=torch.float32,
+        storage=storage,
+    )
+    allocated = pool.allocated_bytes
+    del storage
+    gc.collect()
+    assert backing() is not None
+    assert pool.allocated_bytes == allocated
+
+    del caches
+    gc.collect()
+    assert backing() is None
+    assert pool.allocated_bytes == 0
+
+
+def test_grouped_paged_kv_storage_budget_failure_rolls_back() -> None:
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    required = paged_kv_storage_bytes(
+        3,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.float32,
+    )
+    pool = KVMemoryPool(device="cpu", budget_bytes=required - 1)
+
+    with pytest.raises(MemoryError, match="budget exceeded"):
+        allocate_paged_kv_storage(
+            3,
+            layer_specs=specs,
+            page_size=1,
+            dtype=torch.float32,
+            pool=pool,
+        )
+    assert pool.allocated_bytes == 0
+
+
+def test_paged_kv_storage_bytes_includes_alignment_padding() -> None:
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=1),)
+
+    assert paged_kv_storage_bytes(
+        3,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.float32,
+    ) == 520
+
+
+def test_fitted_storage_requires_three_requested_pages() -> None:
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+
+    with pytest.raises(ValueError, match="reserved, padding, and serving"):
+        fit_and_allocate_paged_kv_storage(
+            2,
+            layer_specs=specs,
+            page_size=1,
+            dtype=torch.float32,
+            pool=KVMemoryPool(device="cpu"),
+        )
+
+
+def test_paged_kv_bytes_per_page_excludes_fixed_alignment_padding() -> None:
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+
+    assert paged_kv_bytes_per_page(
+        specs,
+        page_size=1,
+        dtype=torch.float32,
+    ) == 64
 
 
 def test_paged_cache_update_accepts_fused_projection_value_slice() -> None:


### PR DESCRIPTION
## Summary

- stream Gemma checkpoint weights directly into compiler-ready storage
- share packed QKV and gate/up projections between native prefill and generated decode
- fit and retain the largest usable paged KV allocation after all fixed decode resources are resident
- avoid full-cache zeroing while preserving the reserved no-op page

## Validation

- 85 focused public tests passed, 4 skipped
- 9 Qwen loader regression tests passed
- grouped KV coverage includes alignment, sparse topology, FP8 scales, pointer reuse, fragmentation, and allocation rollback
- exact H100 and B200 model qualification is running before merge