### PR TITLE
Stream generated model weights into final layouts

### DIFF
--- a/kestrel/device.py
+++ b/kestrel/device.py
@@ -13,7 +13,8 @@ on ``runtime._use_cuda_graphs`` which evaluates to False on MPS.
 """
 
 import contextlib
-from typing import Optional
+import threading
+from typing import Callable, Optional
 
 import torch
 
@@ -89,6 +90,45 @@ def stream_context(stream: Optional[torch.cuda.Stream]):
             yield
 
 
+def materialize_blas_runtime(
+    device: torch.device,
+    stream: Optional[torch.cuda.Stream],
+    operation: Callable[[], None],
+) -> None:
+    """Materialize the BLAS handle used by a later scheduler thread.
+
+    PyTorch lends CUDA BLAS handles through a thread-local pool window. Running
+    the representative operation on a short-lived thread returns the live
+    handle to the process-wide pool before the scheduler starts and retains its
+    stream workspace, keeping both allocations visible to memory fitting.
+    """
+
+    if device.type != "cuda":
+        with torch.inference_mode():
+            operation()
+        return
+
+    failures: list[BaseException] = []
+
+    def prime() -> None:
+        try:
+            with torch.cuda.device(device), stream_context(stream):
+                with torch.inference_mode():
+                    operation()
+                if stream is None:
+                    torch.cuda.synchronize(device)
+                else:
+                    stream.synchronize()
+        except BaseException as exc:
+            failures.append(exc)
+
+    worker = threading.Thread(target=prime, name="kestrel-blas-prime")
+    worker.start()
+    worker.join()
+    if failures:
+        raise failures[0]
+
+
 class NoopEvent:
     """Stand-in for ``torch.cuda.Event`` on devices without async events."""
 
@@ -124,6 +164,7 @@ __all__ = [
     "NoopEvent",
     "empty_cache",
     "get_device_capability",
+    "materialize_blas_runtime",
     "make_event",
     "make_stream",
     "set_device",

--- a/kestrel/device.py
+++ b/kestrel/device.py
@@ -14,7 +14,7 @@ on ``runtime._use_cuda_graphs`` which evaluates to False on MPS.
 
 import contextlib
 import threading
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import torch
 
@@ -93,7 +93,7 @@ def stream_context(stream: Optional[torch.cuda.Stream]):
 def materialize_blas_runtime(
     device: torch.device,
     stream: Optional[torch.cuda.Stream],
-    operation: Callable[[], None],
+    operation: Callable[[], Any],
 ) -> None:
     """Materialize the BLAS handle used by a later scheduler thread.
 
@@ -105,7 +105,8 @@ def materialize_blas_runtime(
 
     if device.type != "cuda":
         with torch.inference_mode():
-            operation()
+            result = operation()
+        del result
         return
 
     failures: list[BaseException] = []
@@ -114,11 +115,12 @@ def materialize_blas_runtime(
         try:
             with torch.cuda.device(device), stream_context(stream):
                 with torch.inference_mode():
-                    operation()
+                    result = operation()
                 if stream is None:
                     torch.cuda.synchronize(device)
                 else:
                     stream.synchronize()
+                del result
         except BaseException as exc:
             failures.append(exc)
 

--- a/kestrel/device.py
+++ b/kestrel/device.py
@@ -52,7 +52,8 @@ def synchronize(device: torch.device) -> None:
 def empty_cache(device: torch.device) -> None:
     """Hint the allocator to release cached blocks; no-op when unsupported."""
     if device.type == "cuda":
-        torch.cuda.empty_cache()
+        with torch.cuda.device(device):
+            torch.cuda.empty_cache()
     elif device.type == "mps":
         torch.mps.empty_cache()
 

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -34,7 +34,7 @@ from dataclasses import replace
 
 from kestrel_kernels import get_runtime
 from kestrel.config import RuntimeConfig
-from kestrel.device import make_stream, set_device, synchronize
+from kestrel.device import empty_cache, make_stream, set_device, synchronize
 from kestrel.runtime import (
     AutoregressiveRuntime,
     CoordToken,
@@ -383,7 +383,7 @@ class InferenceEngine:
         # loops back through ``query()`` → ``_ensure_started``; the
         # ``_init_task is current_task`` check there keeps that
         # recursive call from re-entering this body.
-        await self._warmup_query_pipeline()
+        await self._warmup_and_reclaim_allocator()
         if reporter is not None:
             reporter.start()
             self._photon_reporter = reporter
@@ -490,6 +490,14 @@ class InferenceEngine:
         except Exception:
             _LOGGER.exception("Warmup query pipeline failed")
             raise
+
+    async def _warmup_and_reclaim_allocator(self) -> None:
+        """Finish startup warmup before releasing its inactive device blocks."""
+
+        await self._warmup_query_pipeline()
+        device = self._runtime_cfg.resolved_device()
+        synchronize(device)
+        empty_cache(device)
 
     async def shutdown(self) -> None:
         if self._shutdown:

--- a/kestrel/engine/core.py
+++ b/kestrel/engine/core.py
@@ -34,7 +34,7 @@ from dataclasses import replace
 
 from kestrel_kernels import get_runtime
 from kestrel.config import RuntimeConfig
-from kestrel.device import empty_cache, make_stream, set_device, synchronize
+from kestrel.device import make_stream, set_device, synchronize
 from kestrel.runtime import (
     AutoregressiveRuntime,
     CoordToken,
@@ -383,7 +383,7 @@ class InferenceEngine:
         # loops back through ``query()`` → ``_ensure_started``; the
         # ``_init_task is current_task`` check there keeps that
         # recursive call from re-entering this body.
-        await self._warmup_and_reclaim_allocator()
+        await self._warmup_query_pipeline()
         if reporter is not None:
             reporter.start()
             self._photon_reporter = reporter
@@ -490,14 +490,6 @@ class InferenceEngine:
         except Exception:
             _LOGGER.exception("Warmup query pipeline failed")
             raise
-
-    async def _warmup_and_reclaim_allocator(self) -> None:
-        """Finish startup warmup before releasing its inactive device blocks."""
-
-        await self._warmup_query_pipeline()
-        device = self._runtime_cfg.resolved_device()
-        synchronize(device)
-        empty_cache(device)
 
     async def shutdown(self) -> None:
         if self._shutdown:

--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -1,4 +1,3 @@
-
 import gc
 import threading
 import weakref
@@ -49,7 +48,6 @@ def _flatten_bshd_tokens(name: str, tensor: torch.Tensor) -> torch.Tensor:
     )
 
 
-
 class KVMemoryPool:
     """Allocator for paged KV cache storage.
 
@@ -74,9 +72,7 @@ class KVMemoryPool:
         budget_bytes: int | None = None,
     ):
         if budget_bytes is not None and budget_bytes < 0:
-            raise ValueError(
-                f"budget_bytes must be non-negative, got {budget_bytes}"
-            )
+            raise ValueError(f"budget_bytes must be non-negative, got {budget_bytes}")
         self.device = resolve_device(device)
         self.budget_bytes = budget_bytes
         self.allocated_bytes = 0
@@ -145,6 +141,7 @@ class KVMemoryPool:
             if self.budget_bytes is None:
                 return None
             return max(0, self.budget_bytes - self.allocated_bytes)
+
 
 class PagedKVCache(torch.nn.Module):
     def __init__(
@@ -533,7 +530,9 @@ def fit_and_allocate_paged_kv_storage(
     stream: Any,
     materialize_fixed: Callable[[], None] | None = None,
     allocate_additional: Callable[[int], _AdditionalStorage] | None = None,
-    validate_transient: Callable[[], _TransientProbe] | None = None,
+    validate_transient: (
+        Callable[[PagedKVStorage, _AdditionalStorage | None], _TransientProbe] | None
+    ) = None,
 ) -> tuple[PagedKVStorage, _AdditionalStorage | None]:
     """Allocate the largest exact fixed K/V cache that the device can retain.
 
@@ -637,7 +636,7 @@ def fit_and_allocate_paged_kv_storage(
                 )
                 if validate_transient is not None:
                     with torch.inference_mode():
-                        transient = validate_transient()
+                        transient = validate_transient(storage, additional)
                     # Keep the probe result alive until every operation that
                     # produced it has completed. This makes the live peak, not
                     # an allocator estimate, the candidate acceptance gate.
@@ -862,7 +861,9 @@ class PageTable:
         # find empty physical pages
         allocated_pages_list = self.free_pages[-num_pages_to_allocate:]
         # update page table on host first via numpy view (faster than torch.as_tensor)
-        self._page_table_cpu_np[batch_idx, start_page_idx:end_page_idx] = allocated_pages_list
+        self._page_table_cpu_np[batch_idx, start_page_idx:end_page_idx] = (
+            allocated_pages_list
+        )
 
         # update cpu side metadata
         self.page_table_cpu[batch_idx] += allocated_pages_list
@@ -943,9 +944,7 @@ class PageTable:
                 f"got {batch_idx.device}/{input_pos.device}"
             )
         if out_page_table.device != device or out_seqused_k.device != device:
-            raise ValueError(
-                f"out_page_table/out_seqused_k must live on {device}"
-            )
+            raise ValueError(f"out_page_table/out_seqused_k must live on {device}")
 
         batch_idx = batch_idx.to(device=device)
         input_pos = input_pos.to(device=device)

--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -530,14 +530,16 @@ def fit_and_allocate_paged_kv_storage(
     dtype: torch.dtype,
     pool: KVMemoryPool,
     stream: Any,
+    materialize_fixed: Callable[[], None] | None = None,
     allocate_additional: Callable[[int], _AdditionalStorage] | None = None,
 ) -> tuple[PagedKVStorage, _AdditionalStorage | None]:
     """Allocate the largest exact fixed K/V cache that the device can retain.
 
-    Page-dependent caller resources are allocated first for each probe. The
-    accepted grouped K/V allocation and those resources are returned without
-    being freed or recreated, so pointer stability does not depend on allocator
-    estimates or cache reuse.
+    Fixed runtime resources are materialized once before observing available
+    memory. Page-dependent caller resources are then allocated first for each
+    probe. The accepted grouped K/V allocation and those resources are returned
+    without being freed or recreated, so pointer stability does not depend on
+    allocator estimates or cache reuse.
     """
 
     requested_pages = int(requested_pages)
@@ -545,6 +547,9 @@ def fit_and_allocate_paged_kv_storage(
         raise ValueError(
             "requested_pages must include reserved, padding, and serving pages"
         )
+
+    if materialize_fixed is not None:
+        materialize_fixed()
 
     candidate = requested_pages
     budget_available = pool.budget_available_bytes()

--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -1,8 +1,9 @@
 
+import gc
 import threading
 import weakref
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import Any, Callable, Optional, Sequence, TypeVar
 
 import numpy as np
 import torch
@@ -99,19 +100,7 @@ class KVMemoryPool:
         per_tensor_bytes = n_pages * n_heads * page_size * head_dim * element_size
         layer_bytes = 2 * per_tensor_bytes
 
-        # Reserve the bytes atomically so concurrent callers can't both
-        # pass the precheck against the same counter value.
-        with self._lock:
-            if (
-                self.budget_bytes is not None
-                and self.allocated_bytes + layer_bytes > self.budget_bytes
-            ):
-                raise MemoryError(
-                    f"KVMemoryPool budget exceeded: requested {layer_bytes} "
-                    f"bytes, already used {self.allocated_bytes} of "
-                    f"{self.budget_bytes}"
-                )
-            self.allocated_bytes += layer_bytes
+        self._reserve_bytes(layer_bytes)
 
         try:
             k = torch.zeros(cache_shape, dtype=dtype, device=self.device)
@@ -135,6 +124,27 @@ class KVMemoryPool:
         with self._lock:
             self.allocated_bytes = max(0, self.allocated_bytes - n)
 
+    def _reserve_bytes(self, n: int) -> None:
+        # Reserve atomically so concurrent callers cannot both pass the budget
+        # check against the same counter value.
+        with self._lock:
+            if (
+                self.budget_bytes is not None
+                and self.allocated_bytes + n > self.budget_bytes
+            ):
+                raise MemoryError(
+                    f"KVMemoryPool budget exceeded: requested {n} bytes, "
+                    f"already used {self.allocated_bytes} of {self.budget_bytes}"
+                )
+            self.allocated_bytes += n
+
+    def budget_available_bytes(self) -> int | None:
+        """Return unallocated bytes from the explicit pool budget."""
+
+        with self._lock:
+            if self.budget_bytes is None:
+                return None
+            return max(0, self.budget_bytes - self.allocated_bytes)
 
 class PagedKVCache(torch.nn.Module):
     def __init__(
@@ -147,15 +157,40 @@ class PagedKVCache(torch.nn.Module):
         *,
         k_scale: float | None = None,
         v_scale: float | None = None,
+        storage: "PagedKVLayerStorage | None" = None,
     ):
         super().__init__()
-        k_cache, v_cache = pool.allocate_layer_kv(
-            n_pages=page_table.n_pages,
-            n_heads=n_heads,
-            page_size=page_table.page_size,
-            head_dim=head_dim,
-            dtype=dtype,
+        expected_shape = (
+            int(page_table.n_pages),
+            int(n_heads),
+            int(page_table.page_size),
+            int(head_dim),
         )
+        if storage is None:
+            k_cache, v_cache = pool.allocate_layer_kv(
+                n_pages=page_table.n_pages,
+                n_heads=n_heads,
+                page_size=page_table.page_size,
+                head_dim=head_dim,
+                dtype=dtype,
+            )
+            k_scale_tensor = None
+            v_scale_tensor = None
+        else:
+            k_cache, v_cache = storage.k_cache, storage.v_cache
+            for name, tensor in (("K", k_cache), ("V", v_cache)):
+                if (
+                    tuple(tensor.shape) != expected_shape
+                    or tensor.dtype is not dtype
+                    or tensor.device != pool.device
+                    or not tensor.is_contiguous()
+                ):
+                    raise ValueError(
+                        f"preallocated {name} cache does not match "
+                        f"{expected_shape}/{dtype}/{pool.device}"
+                    )
+            k_scale_tensor = storage.k_scale_tensor
+            v_scale_tensor = storage.v_scale_tensor
         self.register_buffer("k_cache", k_cache)
         self.register_buffer("v_cache", v_cache)
 
@@ -170,14 +205,25 @@ class PagedKVCache(torch.nn.Module):
         else:
             self.k_scale = 1.0
             self.v_scale = 1.0
-        self.register_buffer(
-            "k_scale_tensor",
-            torch.tensor(self.k_scale, dtype=torch.float32, device=pool.device),
-        )
-        self.register_buffer(
-            "v_scale_tensor",
-            torch.tensor(self.v_scale, dtype=torch.float32, device=pool.device),
-        )
+        if k_scale_tensor is None:
+            k_scale_tensor = torch.tensor(
+                self.k_scale, dtype=torch.float32, device=pool.device
+            )
+        if v_scale_tensor is None:
+            v_scale_tensor = torch.tensor(
+                self.v_scale, dtype=torch.float32, device=pool.device
+            )
+        for name, tensor in (
+            ("k_scale_tensor", k_scale_tensor),
+            ("v_scale_tensor", v_scale_tensor),
+        ):
+            if (
+                tensor.shape != torch.Size([])
+                or tensor.dtype is not torch.float32
+                or tensor.device != pool.device
+            ):
+                raise ValueError(f"preallocated {name} must be a device FP32 scalar")
+            self.register_buffer(name, tensor)
 
     def update(
         self,
@@ -243,14 +289,375 @@ class PagedKVLayerSpec:
     v_scale: float | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class PagedKVLayerStorage:
+    """Views owned by one physical K/V producer layer."""
+
+    k_cache: torch.Tensor
+    v_cache: torch.Tensor
+    k_scale_tensor: torch.Tensor
+    v_scale_tensor: torch.Tensor
+
+
+@dataclass(frozen=True, slots=True)
+class PagedKVStorage:
+    """One allocation-backed set of sparse physical K/V layers."""
+
+    n_pages: int
+    page_size: int
+    dtype: torch.dtype
+    layer_specs: tuple[PagedKVLayerSpec | None, ...]
+    layers: tuple[PagedKVLayerStorage | None, ...]
+    _kv_backing: torch.Tensor
+    _scale_backing: torch.Tensor
+
+
+_KV_TENSOR_ALIGNMENT_BYTES = 256
+_AdditionalStorage = TypeVar("_AdditionalStorage")
+
+
+def paged_kv_bytes_per_page(
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    *,
+    page_size: int,
+    dtype: torch.dtype,
+) -> int:
+    """Return aggregate K+V storage consumed by one physical page."""
+
+    page_size = int(page_size)
+    if page_size < 1:
+        raise ValueError("page_size must be positive")
+    element_size = torch.empty((), dtype=dtype).element_size()
+    total = sum(
+        2 * int(spec.n_heads) * page_size * int(spec.head_dim) * element_size
+        for spec in layer_specs
+        if spec is not None
+    )
+    if total <= 0:
+        raise ValueError("layer_specs must contain at least one physical K/V layer")
+    return total
+
+
+def _paged_kv_layout(
+    n_pages: int,
+    *,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    page_size: int,
+    dtype: torch.dtype,
+) -> tuple[int, tuple[tuple[int, int, tuple[int, ...]] | None, ...]]:
+    """Return one aligned backing layout in dtype elements."""
+
+    n_pages = int(n_pages)
+    page_size = int(page_size)
+    if n_pages < 1 or page_size < 1:
+        raise ValueError("n_pages and page_size must be positive")
+    element_size = torch.empty((), dtype=dtype).element_size()
+    alignment = max(1, _KV_TENSOR_ALIGNMENT_BYTES // element_size)
+
+    def aligned(value: int) -> int:
+        return ((value + alignment - 1) // alignment) * alignment
+
+    offset = 0
+    layout = []
+    for spec in layer_specs:
+        if spec is None:
+            layout.append(None)
+            continue
+        shape = (
+            n_pages,
+            int(spec.n_heads),
+            page_size,
+            int(spec.head_dim),
+        )
+        elements = int(np.prod(shape))
+        k_start = aligned(offset)
+        v_start = aligned(k_start + elements)
+        offset = v_start + elements
+        layout.append((k_start, v_start, shape))
+    if not layout or all(entry is None for entry in layout):
+        raise ValueError("layer_specs must contain at least one physical K/V layer")
+    return offset, tuple(layout)
+
+
+def paged_kv_storage_bytes(
+    n_pages: int,
+    *,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    page_size: int,
+    dtype: torch.dtype,
+) -> int:
+    """Return exact bytes in the aligned grouped K/V backing allocation."""
+
+    elements, _layout = _paged_kv_layout(
+        n_pages,
+        layer_specs=layer_specs,
+        page_size=page_size,
+        dtype=dtype,
+    )
+    element_size = torch.empty((), dtype=dtype).element_size()
+    alignment_elements = max(1, _KV_TENSOR_ALIGNMENT_BYTES // element_size)
+    return (elements + alignment_elements - 1) * element_size
+
+
+def allocate_paged_kv_storage(
+    n_pages: int,
+    *,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    page_size: int,
+    dtype: torch.dtype,
+    pool: KVMemoryPool,
+) -> PagedKVStorage:
+    """Allocate aligned K/V views with one pool-accounted backing owner."""
+
+    elements, layout = _paged_kv_layout(
+        n_pages,
+        layer_specs=layer_specs,
+        page_size=page_size,
+        dtype=dtype,
+    )
+    element_size = torch.empty((), dtype=dtype).element_size()
+    alignment_elements = max(1, _KV_TENSOR_ALIGNMENT_BYTES // element_size)
+    backing_elements = elements + alignment_elements - 1
+    storage_bytes = backing_elements * element_size
+    pool._reserve_bytes(storage_bytes)
+    try:
+        scale_values = []
+        for spec in layer_specs:
+            if spec is None:
+                continue
+            if dtype == torch.float8_e4m3fn:
+                if spec.k_scale is None or spec.v_scale is None:
+                    raise ValueError("FP8 KV cache requires per-layer k/v scales")
+                scale_values.extend((float(spec.k_scale), float(spec.v_scale)))
+            else:
+                scale_values.extend((1.0, 1.0))
+        scale_backing = torch.tensor(
+            scale_values,
+            dtype=torch.float32,
+            device=pool.device,
+        )
+        kv_backing = torch.empty(backing_elements, dtype=dtype, device=pool.device)
+        prefix_bytes = (-int(kv_backing.data_ptr())) % _KV_TENSOR_ALIGNMENT_BYTES
+        if prefix_bytes % element_size:
+            raise RuntimeError(
+                "K/V backing cannot satisfy dtype-aligned pointer padding"
+            )
+        aligned_backing = kv_backing.narrow(
+            0,
+            prefix_bytes // element_size,
+            elements,
+        )
+
+        layers = []
+        scale_index = 0
+        for entry in layout:
+            if entry is None:
+                layers.append(None)
+                continue
+            k_start, v_start, shape = entry
+            count = int(np.prod(shape))
+            k_cache = aligned_backing.narrow(0, k_start, count).view(shape)
+            v_cache = aligned_backing.narrow(0, v_start, count).view(shape)
+            if (
+                int(k_cache.data_ptr()) % _KV_TENSOR_ALIGNMENT_BYTES
+                or int(v_cache.data_ptr()) % _KV_TENSOR_ALIGNMENT_BYTES
+            ):
+                raise RuntimeError(
+                    "grouped K/V view does not satisfy pointer alignment"
+                )
+            # Page zero is the no-op physical page and may be read by padded rows.
+            # Live pages are written before being mapped, so zeroing the full cache
+            # would add a model-startup memset proportional to context capacity.
+            k_cache[0].zero_()
+            v_cache[0].zero_()
+            layers.append(
+                PagedKVLayerStorage(
+                    k_cache=k_cache,
+                    v_cache=v_cache,
+                    k_scale_tensor=scale_backing[scale_index],
+                    v_scale_tensor=scale_backing[scale_index + 1],
+                )
+            )
+            scale_index += 2
+    except Exception:
+        pool._release_bytes(storage_bytes)
+        raise
+
+    # Views retain ``kv_backing``. It is the sole accounting owner; cache views
+    # must never install independent pool finalizers.
+    weakref.finalize(kv_backing, pool._release_bytes, storage_bytes)
+    return PagedKVStorage(
+        n_pages=int(n_pages),
+        page_size=int(page_size),
+        dtype=dtype,
+        layer_specs=tuple(layer_specs),
+        layers=tuple(layers),
+        _kv_backing=kv_backing,
+        _scale_backing=scale_backing,
+    )
+
+
+def _largest_storage_pages(
+    upper: int,
+    available_bytes: int,
+    *,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    page_size: int,
+    dtype: torch.dtype,
+) -> int:
+    """Bound a probe by bytes; successful allocation remains authoritative."""
+
+    low, high = 0, max(0, int(upper))
+    while low < high:
+        middle = (low + high + 1) // 2
+        if paged_kv_storage_bytes(
+            middle,
+            layer_specs=layer_specs,
+            page_size=page_size,
+            dtype=dtype,
+        ) <= int(available_bytes):
+            low = middle
+        else:
+            high = middle - 1
+    return low
+
+
+def fit_and_allocate_paged_kv_storage(
+    requested_pages: int,
+    *,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+    page_size: int,
+    dtype: torch.dtype,
+    pool: KVMemoryPool,
+    stream: Any,
+    allocate_additional: Callable[[int], _AdditionalStorage] | None = None,
+) -> tuple[PagedKVStorage, _AdditionalStorage | None]:
+    """Allocate the largest exact fixed K/V cache that the device can retain.
+
+    Page-dependent caller resources are allocated first for each probe. The
+    accepted grouped K/V allocation and those resources are returned without
+    being freed or recreated, so pointer stability does not depend on allocator
+    estimates or cache reuse.
+    """
+
+    requested_pages = int(requested_pages)
+    if requested_pages < 3:
+        raise ValueError(
+            "requested_pages must include reserved, padding, and serving pages"
+        )
+
+    candidate = requested_pages
+    budget_available = pool.budget_available_bytes()
+    if budget_available is not None:
+        candidate = _largest_storage_pages(
+            candidate,
+            budget_available,
+            layer_specs=layer_specs,
+            page_size=page_size,
+            dtype=dtype,
+        )
+    if pool.device.type == "cuda":
+        with torch.cuda.device(pool.device):
+            torch.cuda.empty_cache()
+            driver_free, _driver_total = torch.cuda.mem_get_info(pool.device)
+        candidate = _largest_storage_pages(
+            candidate,
+            int(driver_free),
+            layer_specs=layer_specs,
+            page_size=page_size,
+            dtype=dtype,
+        )
+
+    last_failure: Exception | None = None
+    while candidate >= 3:
+        additional = None
+        try:
+            # Candidate page tables enqueue H2D work, and accepted K/V tensors
+            # are consumed on this same stream. Keeping allocation and retry
+            # cleanup on one stream makes allocator reuse safe and predictable.
+            with stream_context(stream):
+                if allocate_additional is not None:
+                    additional = allocate_additional(candidate)
+
+                # Flush only unowned allocator slack after the exact additional
+                # resources are resident. Driver free is an upper-bound hint;
+                # the retained allocation below is the acceptance criterion.
+                if pool.device.type == "cuda":
+                    with torch.cuda.device(pool.device):
+                        torch.cuda.empty_cache()
+                        driver_free, _driver_total = torch.cuda.mem_get_info(
+                            pool.device
+                        )
+                    bounded = _largest_storage_pages(
+                        candidate,
+                        int(driver_free),
+                        layer_specs=layer_specs,
+                        page_size=page_size,
+                        dtype=dtype,
+                    )
+                    if bounded < candidate:
+                        del additional
+                        gc.collect()
+                        candidate = bounded
+                        continue
+
+                budget_available = pool.budget_available_bytes()
+                if budget_available is not None:
+                    bounded = _largest_storage_pages(
+                        candidate,
+                        budget_available,
+                        layer_specs=layer_specs,
+                        page_size=page_size,
+                        dtype=dtype,
+                    )
+                    if bounded < candidate:
+                        del additional
+                        gc.collect()
+                        candidate = bounded
+                        continue
+
+                storage = allocate_paged_kv_storage(
+                    candidate,
+                    layer_specs=layer_specs,
+                    page_size=page_size,
+                    dtype=dtype,
+                    pool=pool,
+                )
+        except (MemoryError, torch.OutOfMemoryError) as exc:
+            last_failure = exc
+            del additional
+            gc.collect()
+            if pool.device.type == "cuda":
+                with torch.cuda.device(pool.device):
+                    torch.cuda.empty_cache()
+            candidate -= 1
+            continue
+        return storage, additional
+
+    detail = "" if last_failure is None else f": {last_failure}"
+    raise MemoryError(
+        f"insufficient memory for reserved, padding, and serving K/V pages{detail}"
+    )
+
+
 def allocate_paged_kv_layers(
     *,
     layer_specs: Sequence[PagedKVLayerSpec | None],
     page_table: "PageTable",
     pool: KVMemoryPool,
     dtype: torch.dtype,
+    storage: PagedKVStorage | None = None,
 ) -> tuple[PagedKVCache | None, ...]:
     """Allocate the sparse physical K/V layers described by ``layer_specs``."""
+
+    if storage is not None and (
+        storage.n_pages != int(page_table.n_pages)
+        or storage.page_size != int(page_table.page_size)
+        or storage.dtype is not dtype
+        or storage.layer_specs != tuple(layer_specs)
+        or len(storage.layers) != len(layer_specs)
+    ):
+        raise ValueError("preallocated K/V storage does not match the page table")
 
     return tuple(
         None
@@ -263,8 +670,9 @@ def allocate_paged_kv_layers(
             pool=pool,
             k_scale=spec.k_scale,
             v_scale=spec.v_scale,
+            storage=None if storage is None else storage.layers[index],
         )
-        for spec in layer_specs
+        for index, spec in enumerate(layer_specs)
     )
 
 

--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -539,7 +539,9 @@ def fit_and_allocate_paged_kv_storage(
     Fixed runtime resources are materialized once before observing available
     memory. Page-dependent caller resources are then allocated first for each
     probe. A caller may then validate its real transient serving path while the
-    candidate K/V allocation is live. The accepted grouped K/V allocation and
+    candidate K/V allocation is live. Page-dependent memory must be monotonic
+    in ``n_pages``; failed probes are exponentially bracketed and binary-searched
+    instead of retrying every page. The accepted grouped K/V allocation and
     page-dependent resources are returned without being freed or recreated, so
     pointer stability does not depend on allocator estimates or cache reuse.
     """
@@ -576,19 +578,32 @@ def fit_and_allocate_paged_kv_storage(
             dtype=dtype,
         )
 
-    last_failure: str | None = None
-    while candidate >= 3:
+    def reclaim_probe() -> None:
+        gc.collect()
+        if pool.device.type == "cuda":
+            with torch.cuda.device(pool.device):
+                torch.cuda.empty_cache()
+
+    def attempt(
+        pages: int,
+    ) -> tuple[
+        PagedKVStorage | None,
+        _AdditionalStorage | None,
+        str | None,
+        int | None,
+    ]:
         additional = None
         storage = None
         transient = None
         retry_failure = None
+        rebound = None
         try:
             # Candidate page tables enqueue H2D work, and accepted K/V tensors
             # are consumed on this same stream. Keeping allocation and retry
             # cleanup on one stream makes allocator reuse safe and predictable.
             with stream_context(stream):
                 if allocate_additional is not None:
-                    additional = allocate_additional(candidate)
+                    additional = allocate_additional(pages)
 
                 # Flush only unowned allocator slack after the exact additional
                 # resources are resident. Driver free is an upper-bound hint;
@@ -600,58 +615,52 @@ def fit_and_allocate_paged_kv_storage(
                             pool.device
                         )
                     bounded = _largest_storage_pages(
-                        candidate,
+                        pages,
                         int(driver_free),
                         layer_specs=layer_specs,
                         page_size=page_size,
                         dtype=dtype,
                     )
-                    if bounded < candidate:
-                        del additional
-                        gc.collect()
-                        candidate = bounded
-                        continue
+                    if bounded < pages:
+                        rebound = bounded
 
                 budget_available = pool.budget_available_bytes()
-                if budget_available is not None:
+                if rebound is None and budget_available is not None:
                     bounded = _largest_storage_pages(
-                        candidate,
+                        pages,
                         budget_available,
                         layer_specs=layer_specs,
                         page_size=page_size,
                         dtype=dtype,
                     )
-                    if bounded < candidate:
-                        del additional
-                        gc.collect()
-                        candidate = bounded
-                        continue
+                    if bounded < pages:
+                        rebound = bounded
 
-                storage = allocate_paged_kv_storage(
-                    candidate,
-                    layer_specs=layer_specs,
-                    page_size=page_size,
-                    dtype=dtype,
-                    pool=pool,
-                )
-                if validate_transient is not None:
-                    with torch.inference_mode():
-                        transient = validate_transient(storage, additional)
-                    # Keep the probe result alive until every operation that
-                    # produced it has completed. This makes the live peak, not
-                    # an allocator estimate, the candidate acceptance gate.
-                    if pool.device.type == "cuda":
-                        if stream is None:
-                            torch.cuda.synchronize(pool.device)
-                        else:
-                            stream.synchronize()
+                if rebound is None:
+                    storage = allocate_paged_kv_storage(
+                        pages,
+                        layer_specs=layer_specs,
+                        page_size=page_size,
+                        dtype=dtype,
+                        pool=pool,
+                    )
+                    if validate_transient is not None:
+                        with torch.inference_mode():
+                            transient = validate_transient(storage, additional)
+                        # Keep the probe result alive until every operation that
+                        # produced it has completed. This makes the live peak,
+                        # not an allocator estimate, the acceptance gate.
+                        if pool.device.type == "cuda":
+                            if stream is None:
+                                torch.cuda.synchronize(pool.device)
+                            else:
+                                stream.synchronize()
         except (MemoryError, torch.OutOfMemoryError) as exc:
             # Do not retain ``exc``: its traceback owns this frame, including
             # the failed storage and any partially-produced probe output.
             retry_failure = f"{type(exc).__name__}: {exc}"
 
-        if retry_failure is not None:
-            last_failure = retry_failure
+        if retry_failure is not None or rebound is not None:
             if pool.device.type == "cuda":
                 if stream is None:
                     torch.cuda.synchronize(pool.device)
@@ -660,15 +669,75 @@ def fit_and_allocate_paged_kv_storage(
             transient = None
             storage = None
             additional = None
-            gc.collect()
-            if pool.device.type == "cuda":
-                with torch.cuda.device(pool.device):
-                    torch.cuda.empty_cache()
-            candidate -= 1
-            continue
+            reclaim_probe()
+            return None, None, retry_failure, rebound
+
         del transient
         assert storage is not None
-        return storage, additional
+        return storage, additional, None, None
+
+    last_failure: str | None = None
+    failed_above: int | None = None
+    passed_below: int | None = None
+    descent = 1
+    while candidate >= 3:
+        storage, additional, retry_failure, rebound = attempt(candidate)
+
+        if rebound is not None:
+            # The exact byte bound proves this candidate cannot fit. Preserve
+            # a tighter failure bound, then probe within the remaining range.
+            failed_above = (
+                candidate if failed_above is None else min(failed_above, candidate)
+            )
+            if passed_below is not None and candidate == passed_below:
+                passed_below = None
+                descent = 1
+            if passed_below is None:
+                if candidate == 3:
+                    break
+                candidate = max(3, int(rebound))
+            elif failed_above - passed_below == 1:
+                candidate = passed_below
+            else:
+                candidate = (passed_below + failed_above) // 2
+            continue
+
+        if retry_failure is not None:
+            last_failure = retry_failure
+            failed_above = (
+                candidate if failed_above is None else min(failed_above, candidate)
+            )
+            if passed_below is not None and candidate == passed_below:
+                # A final re-probe can fail after allocator state changes. Drop
+                # the stale passing observation and search below it.
+                passed_below = None
+                descent = 1
+
+            if passed_below is None:
+                if candidate == 3:
+                    break
+                candidate = max(3, candidate - descent)
+                descent *= 2
+            elif failed_above - passed_below == 1:
+                candidate = passed_below
+            else:
+                candidate = (passed_below + failed_above) // 2
+            continue
+
+        assert storage is not None
+        if failed_above is None or failed_above == candidate + 1:
+            return storage, additional
+
+        passed_below = candidate
+        if pool.device.type == "cuda":
+            if stream is None:
+                torch.cuda.synchronize(pool.device)
+            else:
+                stream.synchronize()
+        storage = None
+        additional = None
+        reclaim_probe()
+        candidate = (passed_below + failed_above) // 2
 
     detail = "" if last_failure is None else f": {last_failure}"
     raise MemoryError(

--- a/kestrel/kv_cache.py
+++ b/kestrel/kv_cache.py
@@ -314,6 +314,7 @@ class PagedKVStorage:
 
 _KV_TENSOR_ALIGNMENT_BYTES = 256
 _AdditionalStorage = TypeVar("_AdditionalStorage")
+_TransientProbe = TypeVar("_TransientProbe")
 
 
 def paged_kv_bytes_per_page(
@@ -532,14 +533,16 @@ def fit_and_allocate_paged_kv_storage(
     stream: Any,
     materialize_fixed: Callable[[], None] | None = None,
     allocate_additional: Callable[[int], _AdditionalStorage] | None = None,
+    validate_transient: Callable[[], _TransientProbe] | None = None,
 ) -> tuple[PagedKVStorage, _AdditionalStorage | None]:
     """Allocate the largest exact fixed K/V cache that the device can retain.
 
     Fixed runtime resources are materialized once before observing available
     memory. Page-dependent caller resources are then allocated first for each
-    probe. The accepted grouped K/V allocation and those resources are returned
-    without being freed or recreated, so pointer stability does not depend on
-    allocator estimates or cache reuse.
+    probe. A caller may then validate its real transient serving path while the
+    candidate K/V allocation is live. The accepted grouped K/V allocation and
+    page-dependent resources are returned without being freed or recreated, so
+    pointer stability does not depend on allocator estimates or cache reuse.
     """
 
     requested_pages = int(requested_pages)
@@ -549,7 +552,8 @@ def fit_and_allocate_paged_kv_storage(
         )
 
     if materialize_fixed is not None:
-        materialize_fixed()
+        with torch.inference_mode():
+            materialize_fixed()
 
     candidate = requested_pages
     budget_available = pool.budget_available_bytes()
@@ -573,9 +577,12 @@ def fit_and_allocate_paged_kv_storage(
             dtype=dtype,
         )
 
-    last_failure: Exception | None = None
+    last_failure: str | None = None
     while candidate >= 3:
         additional = None
+        storage = None
+        transient = None
+        retry_failure = None
         try:
             # Candidate page tables enqueue H2D work, and accepted K/V tensors
             # are consumed on this same stream. Keeping allocation and retry
@@ -628,15 +635,40 @@ def fit_and_allocate_paged_kv_storage(
                     dtype=dtype,
                     pool=pool,
                 )
+                if validate_transient is not None:
+                    with torch.inference_mode():
+                        transient = validate_transient()
+                    # Keep the probe result alive until every operation that
+                    # produced it has completed. This makes the live peak, not
+                    # an allocator estimate, the candidate acceptance gate.
+                    if pool.device.type == "cuda":
+                        if stream is None:
+                            torch.cuda.synchronize(pool.device)
+                        else:
+                            stream.synchronize()
         except (MemoryError, torch.OutOfMemoryError) as exc:
-            last_failure = exc
-            del additional
+            # Do not retain ``exc``: its traceback owns this frame, including
+            # the failed storage and any partially-produced probe output.
+            retry_failure = f"{type(exc).__name__}: {exc}"
+
+        if retry_failure is not None:
+            last_failure = retry_failure
+            if pool.device.type == "cuda":
+                if stream is None:
+                    torch.cuda.synchronize(pool.device)
+                else:
+                    stream.synchronize()
+            transient = None
+            storage = None
+            additional = None
             gc.collect()
             if pool.device.type == "cuda":
                 with torch.cuda.device(pool.device):
                     torch.cuda.empty_cache()
             candidate -= 1
             continue
+        del transient
+        assert storage is not None
         return storage, additional
 
     detail = "" if last_failure is None else f": {last_failure}"

--- a/kestrel/models/gemma4/generated_decode.py
+++ b/kestrel/models/gemma4/generated_decode.py
@@ -14,19 +14,33 @@ from kestrel.runtime.generated_decode import (
 _WEIGHT_LAYER_PREFIX = "model.language_model.layers"
 
 
-def _rope_tables(runtime: Any) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
+def _rope_tables(runtime: Any, length: int) -> dict[str, torch.Tensor]:
+    length = int(length)
+    if length < 1 or length > runtime.max_seq_length:
+        raise ValueError(
+            f"Gemma RoPE table length must lie in [1, {runtime.max_seq_length}]"
+        )
     positions = torch.arange(
-        runtime.max_seq_length,
+        length,
         dtype=torch.int64,
         device=runtime.device,
     ).view(1, -1)
     probe = torch.empty((1, 1, 1), dtype=runtime.dtype, device=runtime.device)
     rotary = runtime.model.model.language_model.rotary_emb
-    return {
+    tables = {
         kind: tuple(
-            table[0].float().contiguous() for table in rotary(probe, positions, kind)
+            table[0].float().contiguous()
+            for table in rotary(probe, positions, kind)
         )
         for kind in ("sliding_attention", "full_attention")
+    }
+    local_cos, local_sin = tables["sliding_attention"]
+    global_cos, global_sin = tables["full_attention"]
+    return {
+        "rope_cos_local": local_cos,
+        "rope_sin_local": local_sin,
+        "rope_cos_global": global_cos,
+        "rope_sin_global": global_sin,
     }
 
 
@@ -41,15 +55,10 @@ def create_generated_decode(
     config = runtime.model.model.language_model.config
 
     def rope_inputs(bound_runtime: Any) -> dict[str, torch.Tensor]:
-        ropes = _rope_tables(bound_runtime)
-        local_cos, local_sin = ropes["sliding_attention"]
-        global_cos, global_sin = ropes["full_attention"]
-        return {
-            "rope_cos_local": local_cos,
-            "rope_sin_local": local_sin,
-            "rope_cos_global": global_cos,
-            "rope_sin_global": global_sin,
-        }
+        ropes = bound_runtime._generated_rope_inputs
+        if ropes is None:
+            raise RuntimeError("Gemma generated decode requires prepared RoPE tables")
+        return ropes
 
     bindings = PagedDecodeBindings(
         layers,
@@ -65,7 +74,7 @@ def create_generated_decode(
         weight_root=runtime.model,
         weight_layer_prefix=_WEIGHT_LAYER_PREFIX,
         bindings=bindings,
-        weight_storage=getattr(runtime, "_generated_weight_storage", None),
+        weight_storage=runtime._generated_weight_storage,
     )
     if required:
         return GeneratedDecode.require(

--- a/kestrel/models/gemma4/generated_decode.py
+++ b/kestrel/models/gemma4/generated_decode.py
@@ -11,6 +11,9 @@ from kestrel.runtime.generated_decode import (
 )
 
 
+_WEIGHT_LAYER_PREFIX = "model.language_model.layers"
+
+
 def _rope_tables(runtime: Any) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
     positions = torch.arange(
         runtime.max_seq_length,
@@ -60,8 +63,9 @@ def create_generated_decode(
     spec = GeneratedDecodeSpec(
         label="Gemma",
         weight_root=runtime.model,
-        weight_layer_prefix="model.language_model.layers",
+        weight_layer_prefix=_WEIGHT_LAYER_PREFIX,
         bindings=bindings,
+        weight_storage=getattr(runtime, "_generated_weight_storage", None),
     )
     if required:
         return GeneratedDecode.require(

--- a/kestrel/models/gemma4/loader.py
+++ b/kestrel/models/gemma4/loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Callable
 
 import torch
 from huggingface_hub import snapshot_download
@@ -13,6 +14,7 @@ from kestrel.runtime.bounded_projection import (
     bind_declared_packed_projections,
     declared_packed_projection_source_keys,
 )
+from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 
 from .config import Gemma4Config
 from .model import Gemma4InferenceModel
@@ -159,12 +161,77 @@ def load_weights(source: str | Path, model: torch.nn.Module) -> None:
         raise RuntimeError(f"Gemma checkpoint is missing tensors: {missing[:10]}")
 
 
+def _fill_derived_buffer(
+    module: torch.nn.Module,
+    name: str,
+    value: float,
+    *,
+    device: torch.device,
+) -> None:
+    buffer = module._buffers[name]
+    if buffer.device.type == "meta":
+        module._buffers[name] = torch.full(
+            tuple(buffer.shape), value, dtype=buffer.dtype, device=device
+        )
+    else:
+        with torch.no_grad():
+            buffer.fill_(value)
+
+
+def _restore_checkpoint_independent_state(
+    model: Gemma4InferenceModel,
+    config: Gemma4Config,
+    *,
+    device: torch.device,
+) -> None:
+    """Restore constants intentionally omitted from Gemma checkpoints."""
+
+    for module in model.modules():
+        if (
+            hasattr(module, "eps")
+            and "weight" in module._non_persistent_buffers_set
+            and module._buffers.get("weight") is not None
+        ):
+            _fill_derived_buffer(module, "weight", 1.0, device=device)
+
+    text = model.model.language_model
+    _fill_derived_buffer(
+        text.embed_tokens,
+        "embed_scale",
+        config.text_config.hidden_size**0.5,
+        device=device,
+    )
+    if config.text_config.hidden_size_per_layer_input:
+        _fill_derived_buffer(
+            text.embed_tokens_per_layer,
+            "embed_scale",
+            config.text_config.hidden_size_per_layer_input**0.5,
+            device=device,
+        )
+        _fill_derived_buffer(
+            text,
+            "per_layer_input_scale",
+            2.0**-0.5,
+            device=device,
+        )
+    text.rotary_emb = type(text.rotary_emb)(config.text_config, device=device)
+    vision = model.model.vision_tower
+    vision.encoder.rotary_emb = type(vision.encoder.rotary_emb)(
+        config.vision_config.head_dim,
+        config.vision_config.rope.theta,
+        dimensions=2,
+        device=device,
+    )
+
+
 def load_model(
     source: str | Path,
     *,
     device: torch.device,
     dtype: torch.dtype,
     revision: str | None = None,
+    prepare_model: Callable[[torch.nn.Module], None] | None = None,
+    finalize_model: Callable[[torch.nn.Module], None] | None = None,
 ) -> Gemma4InferenceModel:
     snapshot = _snapshot(source, revision=revision)
     config_path = snapshot / "config.json"
@@ -174,13 +241,20 @@ def load_model(
     old_dtype = torch.get_default_dtype()
     torch.set_default_dtype(dtype)
     try:
-        with torch.device(device):
+        construction_device = torch.device("meta") if prepare_model else device
+        with torch.device(construction_device):
             model = Gemma4InferenceModel(config)
     finally:
         torch.set_default_dtype(old_dtype)
+    if prepare_model is not None:
+        prepare_model(model)
+        _restore_checkpoint_independent_state(model, config, device=device)
+        materialize_remaining_meta_tensors(model, device=device)
 
     load_weights(snapshot, model)
     model.lm_head.weight = model.model.language_model.embed_tokens.weight
+    if finalize_model is not None:
+        finalize_model(model)
     return model.to(device=device).eval()
 
 

--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -139,22 +139,28 @@ class Gemma4TextAttention(nn.Module):
         use_alternative_attention = config.attention_k_eq_v and not self.is_sliding
         num_kv_heads = attention_kv_heads(config, is_sliding=self.is_sliding)
 
-        self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=False
-        )
+        query_out_features = config.num_attention_heads * self.head_dim
         self.q_norm = _rmsnorm_state(self.head_dim, config.rms_norm_eps)
 
         if self.owns_kv:
             self.k_norm = _rmsnorm_state(self.head_dim, config.rms_norm_eps)
             self.v_norm = _rmsnorm_state(
                 self.head_dim, config.rms_norm_eps, with_scale=False)
-            self.k_proj = nn.Linear(
-                config.hidden_size, num_kv_heads * self.head_dim, bias=False
+            kv_out_features = num_kv_heads * self.head_dim
+            self.qkv_proj = PackedLinear(
+                config.hidden_size,
+                (query_out_features, kv_out_features, kv_out_features),
+                source_names=(
+                    "q_proj",
+                    "k_proj",
+                    "k_proj" if use_alternative_attention else "v_proj",
+                ),
             )
-            self.v_proj = (
-                nn.Linear(config.hidden_size, num_kv_heads * self.head_dim, bias=False)
-                if not use_alternative_attention
-                else None
+        else:
+            self.qkv_proj = PackedLinear(
+                config.hidden_size,
+                (query_out_features,),
+                source_names=("q_proj",),
             )
 
         self.o_proj = nn.Linear(
@@ -176,13 +182,12 @@ class Gemma4TextAttention(nn.Module):
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)
 
-        query_states = self.q_proj(hidden_states).view(hidden_shape)
-        query_states = _dense_runtime.rmsnorm(
-            query_states, self.q_norm.weight, self.q_norm.eps)
-
         key_states: Optional[torch.Tensor] = None
         value_states: Optional[torch.Tensor] = None
         if not self.owns_kv:
+            query_states = self.qkv_proj(hidden_states).view(hidden_shape)
+            query_states = _dense_runtime.rmsnorm(
+                query_states, self.q_norm.weight, self.q_norm.eps)
             query_states, _ = _apply_neox_rotary(
                 query_states, None, position_embeddings
             )
@@ -195,10 +200,17 @@ class Gemma4TextAttention(nn.Module):
                 )
             key_states, value_states = source
         else:
-            key_states = self.k_proj(hidden_states).view(hidden_shape)
-            value_states = (
-                self.v_proj(hidden_states).view(hidden_shape) if self.v_proj is not None else key_states
+            query_states, key_states, value_states = self.qkv_proj(
+                hidden_states
+            ).split(
+                self.qkv_proj.packed_out_features,
+                dim=-1,
             )
+            query_states = query_states.view(hidden_shape)
+            key_states = key_states.view(hidden_shape)
+            value_states = value_states.view(hidden_shape)
+            query_states = _dense_runtime.rmsnorm(
+                query_states, self.q_norm.weight, self.q_norm.eps)
             key_states = _dense_runtime.rmsnorm(
                 key_states, self.k_norm.weight, self.k_norm.eps)
             query_states, key_states = _apply_neox_rotary(

--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -361,7 +361,7 @@ class Gemma4TextExperts(nn.Module):
             top_k=self.top_k,
             hidden_size=self.hidden_size,
             intermediate_size=self.intermediate_size,
-            activation="gelu",
+            activation="geglu",
             weight_format=weight_format,
             dtype=flat_hidden.dtype,
             backend="auto",

--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -268,6 +268,11 @@ class Gemma4TextMLP(nn.Module):
             config.hidden_size,
             (self.intermediate_size, self.intermediate_size),
             source_names=("gate_proj", "up_proj"),
+            output_layout=(
+                "interleaved_i8"
+                if self.intermediate_size % 8 == 0
+                else "contiguous"
+            ),
         )
         self.down_proj = nn.Linear(
             self.intermediate_size, config.hidden_size, bias=False
@@ -280,7 +285,7 @@ class Gemma4TextMLP(nn.Module):
             hidden,
             gate_up,
             activation="gelu_tanh",
-            layout="contiguous",
+            layout=self.gate_up_proj.output_layout,
         )
         return self.down_proj(hidden)
 

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import sys
 import threading
 from dataclasses import dataclass
 from typing import Any, Sequence
@@ -13,6 +14,8 @@ from kestrel.device import make_event, make_stream, materialize_blas_runtime
 from kestrel.kv_cache import (
     KVMemoryPool,
     PageTable,
+    PagedKVLayerSpec,
+    PagedKVStorage,
     allocate_paged_kv_layers,
     fit_and_allocate_paged_kv_storage,
 )
@@ -33,7 +36,14 @@ from kestrel.runtime.staging import AsyncPreprocessor, BatchedTensorStager
 from kestrel.runtime.tokenizer import load_tokenizer
 from kestrel.runtime.uncached_paged import UncachedPagedRuntime
 
-from .image import MAX_IMAGE_TOKENS, MAX_PATCHES, preprocess_image
+from .image import (
+    MAX_IMAGE_TOKENS,
+    MAX_PATCHES,
+    PATCH_SIZE,
+    POOLING_KERNEL_SIZE,
+    GemmaImageInputs,
+    preprocess_image,
+)
 from .loader import load_model
 from .paged_cache import paged_kv_specs
 from .prompt_template import (
@@ -51,6 +61,23 @@ class _PagedRuntimeResources:
     rope_inputs: dict[str, torch.Tensor] | None
     decode_page_tables: tuple[torch.Tensor, ...]
     page_table: PageTable
+
+
+@dataclass(frozen=True, slots=True)
+class _PageTableSnapshot:
+    free_pages: tuple[int, ...]
+    free_batch_idx: tuple[int, ...]
+    page_table_cpu: tuple[tuple[int, ...], ...]
+    capacity: tuple[int, ...]
+    num_blocks_per_row: tuple[int, ...]
+    cpu_mapping: torch.Tensor
+
+
+@dataclass(frozen=True, slots=True)
+class _ImagePrefillProbeResult:
+    logits: torch.Tensor
+    image_features: tuple[torch.Tensor, ...]
+    prepared_sequences: tuple[Any, ...]
 
 
 def _generated_kv_binding_inputs(
@@ -111,11 +138,22 @@ def _install_decode_page_tables(
         slot.paged_kv_page_table = table
 
 
-def _vision_probe_records(runtime: Any) -> tuple[dict[str, torch.Tensor], ...]:
-    """Build a full-patch record for every admitted vision batch row."""
+def _maximum_vision_grid(config: Any) -> tuple[int, int]:
+    """Validate the fixed Gemma preprocessing contract and return its grid."""
 
-    config = runtime._config.vision_config
     pooling = int(config.pooling_kernel_size)
+    if int(config.patch_size) != PATCH_SIZE:
+        raise ValueError(
+            f"Gemma vision patch_size must be {PATCH_SIZE}, got {config.patch_size}"
+        )
+    if pooling != POOLING_KERNEL_SIZE:
+        raise ValueError(
+            f"Gemma vision pooling_kernel_size must be {POOLING_KERNEL_SIZE}, "
+            f"got {pooling}"
+        )
+    if MAX_IMAGE_TOKENS != MAX_PATCHES // pooling**2:
+        raise RuntimeError("Gemma maximum image-token contract is inconsistent")
+
     grid_height = 0
     grid_width = 0
     for candidate in range(math.isqrt(MAX_PATCHES), 0, -1):
@@ -129,9 +167,23 @@ def _vision_probe_records(runtime: Any) -> tuple[dict[str, torch.Tensor], ...]:
         raise RuntimeError(
             "maximum vision patch count has no pooling-aligned rectangular grid"
         )
+    position_embedding_size = int(config.position_embedding_size)
+    if position_embedding_size < max(grid_height, grid_width):
+        raise ValueError(
+            "Gemma vision position_embedding_size cannot represent the "
+            f"maximum {grid_height}x{grid_width} patch grid"
+        )
+    return grid_height, grid_width
+
+
+def _vision_probe_inputs(runtime: Any) -> tuple[GemmaImageInputs, ...]:
+    """Build a distinct full-patch image input for every admitted batch row."""
+
+    config = runtime._config.vision_config
+    grid_height, grid_width = _maximum_vision_grid(config)
 
     pixel_values = torch.zeros(
-        (MAX_PATCHES, 3 * int(config.patch_size) ** 2),
+        (MAX_PATCHES, 3 * PATCH_SIZE**2),
         dtype=runtime.dtype,
     )
     position_ids = torch.stack(
@@ -142,17 +194,28 @@ def _vision_probe_records(runtime: Any) -> tuple[dict[str, torch.Tensor], ...]:
         dim=-1,
     )
     return tuple(
-        {"pixel_values": pixel_values, "position_ids": position_ids}
+        GemmaImageInputs(
+            pixel_values=pixel_values,
+            image_position_ids=position_ids,
+            num_image_tokens=MAX_IMAGE_TOKENS,
+        )
         for _row in range(int(runtime.max_batch_size))
     )
 
 
 def _run_vision_transient_probe(
     runtime: Any,
-    records: Sequence[dict[str, torch.Tensor]],
+    inputs: Sequence[GemmaImageInputs],
 ) -> torch.Tensor:
     """Run the maximum admitted full vision path through its real stager."""
 
+    records = tuple(
+        {
+            "pixel_values": image.pixel_values,
+            "position_ids": image.image_position_ids,
+        }
+        for image in inputs
+    )
     staged = runtime._vision_stager.stage(records)
     return runtime.model.model.get_image_features(
         staged["pixel_values"],
@@ -162,7 +225,7 @@ def _run_vision_transient_probe(
 
 def _materialize_fixed_runtime_resources(
     runtime: Any,
-    vision_records: Sequence[dict[str, torch.Tensor]],
+    vision_inputs: Sequence[GemmaImageInputs],
 ) -> None:
     """Prime exact scheduler-thread BLAS and maximum vision resources."""
 
@@ -175,13 +238,257 @@ def _materialize_fixed_runtime_resources(
             runtime.model.lm_head.weight.t(),
             out=slot.logits[:rows],
         )
-        return _run_vision_transient_probe(runtime, vision_records)
+        return _run_vision_transient_probe(runtime, vision_inputs)
 
     materialize_blas_runtime(
         runtime.device,
         runtime._compute_stream,
         warm,
     )
+
+
+def _copy_image_features_into_embeddings(
+    inputs_embeds: torch.Tensor,
+    token_rows: Sequence[Sequence[int]],
+    image_features: Sequence[torch.Tensor | None],
+    *,
+    image_token_id: int,
+) -> None:
+    """Copy each contiguous image feature block without a packed duplicate."""
+
+    if len(token_rows) != len(image_features):
+        raise ValueError("token rows and image features must have equal length")
+    if inputs_embeds.ndim != 3 or inputs_embeds.shape[0] != 1:
+        raise ValueError("prefill embeddings must have shape [1, tokens, hidden]")
+
+    copies = []
+    flat_offset = 0
+    for row_index, (token_row, features) in enumerate(
+        zip(token_rows, image_features, strict=True)
+    ):
+        positions = [
+            index
+            for index, token_id in enumerate(token_row)
+            if int(token_id) == int(image_token_id)
+        ]
+        if features is None:
+            if positions:
+                raise RuntimeError(
+                    f"prefill row {row_index} has image tokens without features"
+                )
+        else:
+            if not isinstance(features, torch.Tensor):
+                raise TypeError(f"image features for row {row_index} must be a tensor")
+            if not positions:
+                raise RuntimeError(
+                    f"prefill row {row_index} has image features without tokens"
+                )
+            start = positions[0]
+            if positions != list(range(start, start + len(positions))):
+                raise RuntimeError(
+                    f"prefill row {row_index} image tokens must be contiguous"
+                )
+            if features.ndim != 2:
+                raise RuntimeError(
+                    f"image features for row {row_index} must be 2D, got "
+                    f"{features.ndim}D"
+                )
+            if int(features.shape[0]) != len(positions):
+                raise RuntimeError(
+                    f"encoded {features.shape[0]} image features for "
+                    f"{len(positions)} image tokens in row {row_index}"
+                )
+            if int(features.shape[1]) != int(inputs_embeds.shape[2]):
+                raise RuntimeError(
+                    f"image features for row {row_index} have shape "
+                    f"{tuple(features.shape)}, expected "
+                    f"({len(positions)}, {inputs_embeds.shape[2]})"
+                )
+            if features.dtype is not inputs_embeds.dtype:
+                raise RuntimeError(
+                    f"image features for row {row_index} have dtype "
+                    f"{features.dtype}, expected {inputs_embeds.dtype}"
+                )
+            if features.device != inputs_embeds.device:
+                raise RuntimeError(
+                    f"image features for row {row_index} are on "
+                    f"{features.device}, expected {inputs_embeds.device}"
+                )
+            copies.append(
+                (
+                    flat_offset + start,
+                    flat_offset + start + len(positions),
+                    features,
+                )
+            )
+        flat_offset += len(token_row)
+
+    if flat_offset != int(inputs_embeds.shape[1]):
+        raise ValueError("token rows do not cover the packed prefill embeddings")
+    for start, end, features in copies:
+        inputs_embeds[0, start:end].copy_(features)
+
+
+def _snapshot_page_table(page_table: PageTable) -> _PageTableSnapshot:
+    if page_table._dirty_rows:
+        raise RuntimeError("transient probe requires a committed candidate page table")
+    return _PageTableSnapshot(
+        free_pages=tuple(page_table.free_pages),
+        free_batch_idx=tuple(page_table.free_batch_idx),
+        page_table_cpu=tuple(tuple(row) for row in page_table.page_table_cpu),
+        capacity=tuple(int(value) for value in page_table.capacity),
+        num_blocks_per_row=tuple(int(value) for value in page_table.num_blocks_per_row),
+        cpu_mapping=page_table._page_table_cpu_tensor.clone(),
+    )
+
+
+def _restore_page_table(
+    page_table: PageTable,
+    snapshot: _PageTableSnapshot,
+) -> None:
+    page_table.free_pages[:] = snapshot.free_pages
+    page_table.free_batch_idx[:] = snapshot.free_batch_idx
+    page_table.page_table_cpu[:] = [list(row) for row in snapshot.page_table_cpu]
+    page_table.capacity[:] = snapshot.capacity
+    page_table.num_blocks_per_row[:] = snapshot.num_blocks_per_row
+    page_table._page_table_cpu_tensor.copy_(snapshot.cpu_mapping)
+    page_table._dirty_rows.clear()
+    page_table._sync_full_page_table()
+
+
+def _run_image_prefill_transient_probe(
+    runtime: Any,
+    vision_inputs: Sequence[GemmaImageInputs],
+    storage: PagedKVStorage,
+    resources: _PagedRuntimeResources | None,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+) -> _ImagePrefillProbeResult:
+    """Run a production image prefill while candidate K/V resources are live."""
+
+    if resources is None:
+        raise RuntimeError("Gemma transient probe requires paged resources")
+    if len(vision_inputs) != int(runtime.max_batch_size):
+        raise ValueError("Gemma transient probe must cover the maximum batch")
+
+    page_table = resources.page_table
+    page_table_snapshot = _snapshot_page_table(page_table)
+    previous_page_table = getattr(runtime, "page_table", None)
+    previous_kv_cache = getattr(runtime, "_kv_cache", None)
+    had_page_table = hasattr(runtime, "page_table")
+    had_kv_cache = hasattr(runtime, "_kv_cache")
+    probe_kv_cache = allocate_paged_kv_layers(
+        layer_specs=layer_specs,
+        page_table=page_table,
+        pool=runtime._kv_pool,
+        dtype=runtime.dtype,
+        storage=storage,
+    )
+    runtime.page_table = page_table
+    runtime._kv_cache = probe_kv_cache
+
+    prepared_sequences = []
+    projected_features: list[torch.Tensor] = []
+    touched_pages: set[int] = set()
+    result = None
+
+    def retain_projected_features(
+        _module: Any,
+        _inputs: tuple[Any, ...],
+        output: torch.Tensor,
+    ) -> None:
+        projected_features.append(output)
+
+    hook = None
+    try:
+        prompt_tokens = tuple(
+            TextToken(token_id=token_id)
+            for token_id in (TURN_ID, USER_ROLE_ID, NEWLINE_ID, NEWLINE_ID)
+        )
+        hook = runtime.model.model.embed_vision.register_forward_hook(
+            retain_projected_features
+        )
+        for image_inputs in vision_inputs:
+            prepared = runtime.prepare_sequence(
+                prompt_tokens,
+                image_crops=image_inputs,
+                max_new_tokens=1,
+            )
+            prepared_sequences.append(prepared)
+            touched_pages.update(
+                page_table.page_table_cpu[int(prepared.state.batch_idx)]
+            )
+        logits = runtime.launch_prepared_batch(
+            prepared_sequences,
+            runtime._prefill_slot,
+            image_crops_list=vision_inputs,
+        )
+        if len(projected_features) != 1:
+            raise RuntimeError(
+                "maximum-batch image prefill must produce one packed feature owner"
+            )
+        result = _ImagePrefillProbeResult(
+            logits=logits,
+            image_features=tuple(projected_features),
+            prepared_sequences=tuple(prepared_sequences),
+        )
+    finally:
+        primary_error = sys.exception()
+        cleanup_failures = []
+
+        def clean(label: str, operation: Any) -> None:
+            try:
+                operation()
+            except BaseException as exc:
+                cleanup_failures.append(f"{label}: {type(exc).__name__}: {exc}")
+
+        def synchronize() -> None:
+            if runtime.device.type == "cuda":
+                runtime._compute_stream.synchronize()
+
+        def abort_prepared() -> None:
+            for prepared in reversed(prepared_sequences):
+                if int(prepared.state.batch_idx) not in page_table.free_batch_idx:
+                    runtime.abort_prepared_sequence(prepared)
+
+        def assert_page_zero_unmapped() -> None:
+            if 0 in touched_pages:
+                raise RuntimeError(
+                    "transient prefill probe mapped reserved physical page 0"
+                )
+
+        def restore_runtime_attributes() -> None:
+            if had_page_table:
+                runtime.page_table = previous_page_table
+            else:
+                del runtime.page_table
+            if had_kv_cache:
+                runtime._kv_cache = previous_kv_cache
+            else:
+                del runtime._kv_cache
+
+        clean("pre-cleanup stream synchronization", synchronize)
+        clean("reserved page-zero mapping validation", assert_page_zero_unmapped)
+        # Probe pages remain unowned after restoring the table. A serving
+        # prefill overwrites each mapped K/V slot before it can be read.
+        clean("prepared-sequence abort", abort_prepared)
+        clean(
+            "accepted page-table restoration",
+            lambda: _restore_page_table(page_table, page_table_snapshot),
+        )
+        clean("prefill-slot restoration", runtime._prefill_slot.batch_idx.zero_)
+        clean("post-cleanup stream synchronization", synchronize)
+        if hook is not None:
+            clean("feature-owner hook removal", hook.remove)
+        clean("runtime resource restoration", restore_runtime_attributes)
+
+        if cleanup_failures:
+            detail = "; ".join(cleanup_failures)
+            if primary_error is None:
+                raise RuntimeError(f"Gemma transient probe cleanup failed: {detail}")
+            primary_error.add_note(f"Gemma transient probe cleanup failures: {detail}")
+
+    assert result is not None
+    return result
 
 
 class Gemma4Runtime(UncachedPagedRuntime):
@@ -213,7 +520,9 @@ class Gemma4Runtime(UncachedPagedRuntime):
         from kestrel.models.registry import get_spec
 
         model_spec = get_spec(self._model_name)
-        model_source = cfg.model_path if cfg.model_path is not None else model_spec.repo_id
+        model_source = (
+            cfg.model_path if cfg.model_path is not None else model_spec.repo_id
+        )
         if model_source is None:
             raise ValueError("Gemma model spec must declare repo_id")
         self._generated_weight_storage = None
@@ -247,9 +556,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
                             self._generated_weight_storage,
                             label="Gemma",
                             layer_prefix=_WEIGHT_LAYER_PREFIX,
-                            required_batch_sizes=range(
-                                1, self.max_batch_size + 1
-                            ),
+                            required_batch_sizes=range(1, self.max_batch_size + 1),
                         )
                     )
 
@@ -296,7 +603,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
             preprocess_image,
             workers=derive_preprocessing_workers(self.max_batch_size),
         )
-        vision_probe_records = _vision_probe_records(self)
+        vision_probe_inputs = _vision_probe_inputs(self)
 
         text_config = self._config.text_config
         self.vocab_size = int(text_config.vocab_size)
@@ -344,8 +651,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
         kv_layer_specs = paged_kv_specs(text_config)
         self._generated_rope_inputs = None
         has_generated_decode = (
-            self.decode_path != "native"
-            and self._generated_weight_storage is not None
+            self.decode_path != "native" and self._generated_weight_storage is not None
         )
         if self.decode_path == "generated" and not has_generated_decode:
             raise RuntimeError(
@@ -375,18 +681,16 @@ class Gemma4Runtime(UncachedPagedRuntime):
                 tuple(text_config.layer_types),
             )
             if programs:
-                self._generated_binding_reservation = (
-                    reserve_generated_binding_storage(
-                        programs,
-                        weight_storage=self._generated_weight_storage,
-                        runtime_inputs_by_slot=tuple(
-                            sparse_inputs for _slot in self.decode_slots
-                        ),
-                        device=self.device,
-                        stream=self._compute_stream,
-                        label="Gemma",
-                        required=self.decode_path == "generated",
-                    )
+                self._generated_binding_reservation = reserve_generated_binding_storage(
+                    programs,
+                    weight_storage=self._generated_weight_storage,
+                    runtime_inputs_by_slot=tuple(
+                        sparse_inputs for _slot in self.decode_slots
+                    ),
+                    device=self.device,
+                    stream=self._compute_stream,
+                    label="Gemma",
+                    required=self.decode_path == "generated",
                 )
             if self._generated_binding_reservation is None:
                 has_generated_decode = False
@@ -437,12 +741,17 @@ class Gemma4Runtime(UncachedPagedRuntime):
             stream=self._compute_stream,
             materialize_fixed=lambda: _materialize_fixed_runtime_resources(
                 self,
-                vision_probe_records,
+                vision_probe_inputs,
             ),
             allocate_additional=allocate_paged_resources,
-            validate_transient=lambda: _run_vision_transient_probe(
-                self,
-                vision_probe_records,
+            validate_transient=lambda storage, resources: (
+                _run_image_prefill_transient_probe(
+                    self,
+                    vision_probe_inputs,
+                    storage,
+                    resources,
+                    kv_layer_specs,
+                )
             ),
         )
         if paged_resources is None:
@@ -499,6 +808,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
             options={"triton.cudagraphs": False},
         )
         config = self._config.vision_config
+        _maximum_vision_grid(config)
 
         def inputs(batch_size: int) -> tuple[torch.Tensor, ...]:
             return (
@@ -694,9 +1004,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
             raise ValueError("Gemma4Runtime does not support encoder inputs")
         batch_size = len(prepared_sequences)
         if not 0 < batch_size <= self.max_batch_size:
-            raise ValueError(
-                f"prefill batch must lie in [1, {self.max_batch_size}]"
-            )
+            raise ValueError(f"prefill batch must lie in [1, {self.max_batch_size}]")
         if image_crops_list is None:
             image_crops_list = [None] * batch_size
         if len(image_crops_list) != batch_size:
@@ -716,28 +1024,24 @@ class Gemma4Runtime(UncachedPagedRuntime):
             token_rows.append([int(token.token_id) for token in tokens])
             lengths.append(len(tokens))
 
-        flat_ids = [token_id for row in token_rows for token_id in row]
-        input_ids = torch.tensor([flat_ids], dtype=torch.long, device=self.device)
-        image_mask = input_ids == self._config.image_token_id
-        model_ids = input_ids.masked_fill(image_mask, 0)
-        inputs_embeds = self.model.model.language_model.embed(model_ids)
-        packed_image_features = [
-            features for features in image_features if features is not None
-        ]
-        feature_count = sum(int(features.shape[0]) for features in packed_image_features)
-        image_token_count = sum(
-            row.count(self._config.image_token_id) for row in token_rows
+        model_ids = torch.tensor(
+            [
+                [
+                    0 if token_id == self._config.image_token_id else token_id
+                    for row in token_rows
+                    for token_id in row
+                ]
+            ],
+            dtype=torch.long,
+            device=self.device,
         )
-        if feature_count != image_token_count:
-            raise RuntimeError(
-                f"encoded {feature_count} image features for "
-                f"{image_token_count} image tokens"
-            )
-        if packed_image_features:
-            inputs_embeds.masked_scatter_(
-                image_mask.unsqueeze(-1).expand_as(inputs_embeds),
-                torch.cat(packed_image_features),
-            )
+        inputs_embeds = self.model.model.language_model.embed(model_ids)
+        _copy_image_features_into_embeddings(
+            inputs_embeds,
+            token_rows,
+            image_features,
+            image_token_id=self._config.image_token_id,
+        )
 
         prefill_slot.batch_idx[:batch_size].copy_(
             torch.tensor(batch_indices, dtype=torch.long, device=self.device)
@@ -751,9 +1055,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
             [
                 [
                     batch_idx
-                    for batch_idx, length in zip(
-                        batch_indices, lengths, strict=True
-                    )
+                    for batch_idx, length in zip(batch_indices, lengths, strict=True)
                     for _ in range(length)
                 ]
             ],

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -80,6 +80,20 @@ class _ImagePrefillProbeResult:
     prepared_sequences: tuple[Any, ...]
 
 
+def _add_exception_note(error: BaseException, note: str) -> None:
+    """Attach cleanup context on every supported Python version."""
+
+    add_note = getattr(error, "add_note", None)
+    if callable(add_note):
+        add_note(note)
+        return
+    notes = getattr(error, "__notes__", None)
+    if notes is None:
+        notes = []
+        setattr(error, "__notes__", notes)
+    notes.append(note)
+
+
 def _generated_kv_binding_inputs(
     layer_specs: Sequence[Any],
     layer_kinds: Sequence[str],
@@ -432,7 +446,7 @@ def _run_image_prefill_transient_probe(
             prepared_sequences=tuple(prepared_sequences),
         )
     finally:
-        primary_error = sys.exception()
+        primary_error = sys.exc_info()[1]
         cleanup_failures = []
 
         def clean(label: str, operation: Any) -> None:
@@ -485,7 +499,10 @@ def _run_image_prefill_transient_probe(
             detail = "; ".join(cleanup_failures)
             if primary_error is None:
                 raise RuntimeError(f"Gemma transient probe cleanup failed: {detail}")
-            primary_error.add_note(f"Gemma transient probe cleanup failures: {detail}")
+            _add_exception_note(
+                primary_error,
+                f"Gemma transient probe cleanup failures: {detail}",
+            )
 
     assert result is not None
     return result

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -370,19 +370,50 @@ def _restore_page_table(
     page_table._sync_full_page_table()
 
 
+def _maximum_admitted_image_prefill_prompt(
+    runtime: Any,
+    page_table: PageTable,
+    image_inputs: GemmaImageInputs,
+) -> tuple[TextToken, ...]:
+    """Build the longest image query admitted by the candidate page budget."""
+
+    image_tokens = int(image_inputs.num_image_tokens) + 2
+    if image_tokens != int(runtime.image_prefix_length):
+        raise RuntimeError(
+            "Gemma capacity probe image length does not match runtime admission"
+        )
+    target_length = min(
+        int(runtime.max_seq_length),
+        int(page_table.pages_available) * int(page_table.page_size),
+    )
+    # Engine generation requests reserve at least one token beyond prefill.
+    text_length = target_length - 1 - image_tokens
+    required_prefix = (TURN_ID, USER_ROLE_ID, NEWLINE_ID, NEWLINE_ID)
+    if text_length < len(required_prefix):
+        raise MemoryError(
+            "candidate K/V cache cannot admit the minimum Gemma image query"
+        )
+    filler = (TextToken(token_id=NEWLINE_ID),) * (
+        text_length - len(required_prefix)
+    )
+    return tuple(TextToken(token_id=token_id) for token_id in required_prefix) + filler
+
+
 def _run_image_prefill_transient_probe(
     runtime: Any,
     vision_inputs: Sequence[GemmaImageInputs],
     storage: PagedKVStorage,
     resources: _PagedRuntimeResources | None,
     layer_specs: Sequence[PagedKVLayerSpec | None],
+    *,
+    prompt_tokens: Sequence[TextToken] | None = None,
 ) -> _ImagePrefillProbeResult:
     """Run a production image prefill while candidate K/V resources are live."""
 
     if resources is None:
         raise RuntimeError("Gemma transient probe requires paged resources")
-    if len(vision_inputs) != int(runtime.max_batch_size):
-        raise ValueError("Gemma transient probe must cover the maximum batch")
+    if not 0 < len(vision_inputs) <= int(runtime.max_batch_size):
+        raise ValueError("Gemma transient probe batch is outside runtime capacity")
 
     page_table = resources.page_table
     page_table_snapshot = _snapshot_page_table(page_table)
@@ -414,10 +445,11 @@ def _run_image_prefill_transient_probe(
 
     hook = None
     try:
-        prompt_tokens = tuple(
-            TextToken(token_id=token_id)
-            for token_id in (TURN_ID, USER_ROLE_ID, NEWLINE_ID, NEWLINE_ID)
-        )
+        if prompt_tokens is None:
+            prompt_tokens = tuple(
+                TextToken(token_id=token_id)
+                for token_id in (TURN_ID, USER_ROLE_ID, NEWLINE_ID, NEWLINE_ID)
+            )
         hook = runtime.model.model.embed_vision.register_forward_hook(
             retain_projected_features
         )
@@ -506,6 +538,57 @@ def _run_image_prefill_transient_probe(
 
     assert result is not None
     return result
+
+
+def _run_steady_state_image_prefill_probe(
+    runtime: Any,
+    vision_inputs: Sequence[GemmaImageInputs],
+    storage: PagedKVStorage,
+    resources: _PagedRuntimeResources | None,
+    layer_specs: Sequence[PagedKVLayerSpec | None],
+) -> _ImagePrefillProbeResult:
+    """Validate consecutive maximum-admitted prefills with resources live."""
+
+    if resources is None:
+        raise RuntimeError("Gemma transient probe requires paged resources")
+    if len(vision_inputs) != int(runtime.max_batch_size):
+        raise ValueError("Gemma steady-state probe must cover the maximum batch")
+    probe_inputs = vision_inputs[:1]
+    prompt_tokens = _maximum_admitted_image_prefill_prompt(
+        runtime,
+        resources.page_table,
+        probe_inputs[0],
+    )
+
+    maximum_batch = _run_image_prefill_transient_probe(
+        runtime,
+        vision_inputs,
+        storage,
+        resources,
+        layer_specs,
+    )
+    # The maximum-batch image+language path and the maximum-length language
+    # path are independent serving peaks. Neither result may overlap the next.
+    del maximum_batch
+    warmup = _run_image_prefill_transient_probe(
+        runtime,
+        probe_inputs,
+        storage,
+        resources,
+        layer_specs,
+        prompt_tokens=prompt_tokens,
+    )
+    # Release every first-pass result owner while preserving allocator state.
+    # The second maximum-length pass is the steady-state acceptance criterion.
+    del warmup
+    return _run_image_prefill_transient_probe(
+        runtime,
+        probe_inputs,
+        storage,
+        resources,
+        layer_specs,
+        prompt_tokens=prompt_tokens,
+    )
 
 
 class Gemma4Runtime(UncachedPagedRuntime):
@@ -762,7 +845,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
             ),
             allocate_additional=allocate_paged_resources,
             validate_transient=lambda storage, resources: (
-                _run_image_prefill_transient_probe(
+                _run_steady_state_image_prefill_probe(
                     self,
                     vision_probe_inputs,
                     storage,

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -8,7 +8,7 @@ from typing import Any, Sequence
 
 import torch
 
-from kestrel.device import make_event, make_stream
+from kestrel.device import make_event, make_stream, materialize_blas_runtime
 from kestrel.kv_cache import (
     KVMemoryPool,
     PageTable,
@@ -108,6 +108,22 @@ def _install_decode_page_tables(
         raise RuntimeError("decode page tables must be unbound one-column placeholders")
     for slot, table in zip(slots, tables, strict=True):
         slot.paged_kv_page_table = table
+
+
+def _materialize_fixed_blas_resources(runtime: Any) -> None:
+    """Prime the scheduler's exact compute-stream BF16 output matmul path."""
+
+    slot = runtime.decode_slots[0]
+    rows = min(int(runtime.max_batch_size), int(slot.hidden_last.shape[0]))
+    materialize_blas_runtime(
+        runtime.device,
+        runtime._compute_stream,
+        lambda: torch.mm(
+            slot.hidden_last[:rows],
+            runtime.model.lm_head.weight.t(),
+            out=slot.logits[:rows],
+        ),
+    )
 
 
 class Gemma4Runtime(UncachedPagedRuntime):
@@ -360,6 +376,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
             dtype=self.dtype,
             pool=self._kv_pool,
             stream=self._compute_stream,
+            materialize_fixed=lambda: _materialize_fixed_blas_resources(self),
             allocate_additional=allocate_paged_resources,
         )
         if paged_resources is None:

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import threading
 from dataclasses import dataclass
 from typing import Any, Sequence
@@ -110,19 +111,76 @@ def _install_decode_page_tables(
         slot.paged_kv_page_table = table
 
 
-def _materialize_fixed_blas_resources(runtime: Any) -> None:
-    """Prime the scheduler's exact compute-stream BF16 output matmul path."""
+def _vision_probe_records(runtime: Any) -> tuple[dict[str, torch.Tensor], ...]:
+    """Build a full-patch record for every admitted vision batch row."""
+
+    config = runtime._config.vision_config
+    pooling = int(config.pooling_kernel_size)
+    grid_height = 0
+    grid_width = 0
+    for candidate in range(math.isqrt(MAX_PATCHES), 0, -1):
+        if MAX_PATCHES % candidate:
+            continue
+        other = MAX_PATCHES // candidate
+        if candidate % pooling == 0 and other % pooling == 0:
+            grid_height, grid_width = candidate, other
+            break
+    if not grid_height:
+        raise RuntimeError(
+            "maximum vision patch count has no pooling-aligned rectangular grid"
+        )
+
+    pixel_values = torch.zeros(
+        (MAX_PATCHES, 3 * int(config.patch_size) ** 2),
+        dtype=runtime.dtype,
+    )
+    position_ids = torch.stack(
+        (
+            torch.arange(grid_width).repeat(grid_height),
+            torch.arange(grid_height).repeat_interleave(grid_width),
+        ),
+        dim=-1,
+    )
+    return tuple(
+        {"pixel_values": pixel_values, "position_ids": position_ids}
+        for _row in range(int(runtime.max_batch_size))
+    )
+
+
+def _run_vision_transient_probe(
+    runtime: Any,
+    records: Sequence[dict[str, torch.Tensor]],
+) -> torch.Tensor:
+    """Run the maximum admitted full vision path through its real stager."""
+
+    staged = runtime._vision_stager.stage(records)
+    return runtime.model.model.get_image_features(
+        staged["pixel_values"],
+        staged["position_ids"],
+    ).detach()
+
+
+def _materialize_fixed_runtime_resources(
+    runtime: Any,
+    vision_records: Sequence[dict[str, torch.Tensor]],
+) -> None:
+    """Prime exact scheduler-thread BLAS and maximum vision resources."""
 
     slot = runtime.decode_slots[0]
     rows = min(int(runtime.max_batch_size), int(slot.hidden_last.shape[0]))
-    materialize_blas_runtime(
-        runtime.device,
-        runtime._compute_stream,
-        lambda: torch.mm(
+
+    def warm() -> torch.Tensor:
+        torch.mm(
             slot.hidden_last[:rows],
             runtime.model.lm_head.weight.t(),
             out=slot.logits[:rows],
-        ),
+        )
+        return _run_vision_transient_probe(runtime, vision_records)
+
+    materialize_blas_runtime(
+        runtime.device,
+        runtime._compute_stream,
+        warm,
     )
 
 
@@ -238,6 +296,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
             preprocess_image,
             workers=derive_preprocessing_workers(self.max_batch_size),
         )
+        vision_probe_records = _vision_probe_records(self)
 
         text_config = self._config.text_config
         self.vocab_size = int(text_config.vocab_size)
@@ -376,8 +435,15 @@ class Gemma4Runtime(UncachedPagedRuntime):
             dtype=self.dtype,
             pool=self._kv_pool,
             stream=self._compute_stream,
-            materialize_fixed=lambda: _materialize_fixed_blas_resources(self),
+            materialize_fixed=lambda: _materialize_fixed_runtime_resources(
+                self,
+                vision_probe_records,
+            ),
             allocate_additional=allocate_paged_resources,
+            validate_transient=lambda: _run_vision_transient_probe(
+                self,
+                vision_probe_records,
+            ),
         )
         if paged_resources is None:
             raise RuntimeError("Gemma paged resource allocation returned no resources")

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import threading
+from dataclasses import dataclass
 from typing import Any, Sequence
 
 import torch
 
 from kestrel.device import make_event, make_stream
-from kestrel.kv_cache import KVMemoryPool, PageTable, allocate_paged_kv_layers
+from kestrel.kv_cache import (
+    KVMemoryPool,
+    PageTable,
+    allocate_paged_kv_layers,
+    fit_and_allocate_paged_kv_storage,
+)
 from kestrel.runtime import ExecutionShape, SequenceState, TextToken, Token
 from kestrel.runtime.compilation import (
     canonicalize_immutable_scalar_buffers,
@@ -37,6 +43,71 @@ from .prompt_template import (
     TURN_ID,
     USER_ROLE_ID,
 )
+
+
+@dataclass(frozen=True, slots=True)
+class _PagedRuntimeResources:
+    rope_inputs: dict[str, torch.Tensor] | None
+    decode_page_tables: tuple[torch.Tensor, ...]
+    page_table: PageTable
+
+
+def _generated_kv_binding_inputs(
+    layer_specs: Sequence[Any],
+    layer_kinds: Sequence[str],
+) -> dict[str, tuple[Any | None, ...]]:
+    """Describe the exact pre-allocation layer collections for estimation."""
+
+    if len(layer_specs) != len(layer_kinds):
+        raise ValueError("Gemma K/V specs and layer kinds must have equal length")
+    marker = object()
+    inputs = {}
+    for suffix, kind in (
+        ("local", "sliding_attention"),
+        ("global", "full_attention"),
+    ):
+        layers = tuple(
+            marker if spec is not None and actual_kind == kind else None
+            for spec, actual_kind in zip(layer_specs, layer_kinds, strict=True)
+        )
+        inputs[f"mK_{suffix}"] = layers
+        inputs[f"mV_{suffix}"] = layers
+    return inputs
+
+
+def _allocate_decode_page_tables(
+    *,
+    count: int,
+    rows: int,
+    pages: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, ...]:
+    """Allocate exact per-slot page tables without publishing their pointers."""
+
+    return tuple(
+        torch.empty(
+            (rows, pages),
+            dtype=torch.int32,
+            device=device,
+        )
+        for _index in range(int(count))
+    )
+
+
+def _install_decode_page_tables(
+    slots: Sequence[Any], tables: Sequence[torch.Tensor]
+) -> None:
+    """Publish fitted page tables once, before native or generated binding."""
+
+    if len(slots) != len(tables):
+        raise ValueError("decode slots and fitted page tables must have equal length")
+    if not tables:
+        return
+    expected = (int(tables[0].shape[0]), 1)
+    if any(tuple(slot.paged_kv_page_table.shape) != expected for slot in slots):
+        raise RuntimeError("decode page tables must be unbound one-column placeholders")
+    for slot, table in zip(slots, tables, strict=True):
+        slot.paged_kv_page_table = table
 
 
 class Gemma4Runtime(UncachedPagedRuntime):
@@ -134,10 +205,8 @@ class Gemma4Runtime(UncachedPagedRuntime):
         self.execution_shape = ExecutionShape.AUTOREGRESSIVE
         self.spec = None
         self.page_size = cfg.page_size
-        self.max_seq_length = int(
-            self._config.text_config.max_position_embeddings
-        )
-        self._kv_cache_pages = bound_kv_cache_pages(
+        self.max_seq_length = int(self._config.text_config.max_position_embeddings)
+        requested_kv_cache_pages = bound_kv_cache_pages(
             cfg.kv_cache_pages,
             page_size=self.page_size,
             max_batch_size=self.max_batch_size,
@@ -164,17 +233,6 @@ class Gemma4Runtime(UncachedPagedRuntime):
         )
         self._copy_stream = make_stream(self.device)
         self.graph_capture_lock = threading.RLock()
-        self.page_table = PageTable(
-            n_pages=self._kv_cache_pages,
-            page_size=self.page_size,
-            max_batch_size=self.max_batch_slots,
-            device=str(self.device),
-            prefix_cache=None,
-            h2d_stream=self._compute_stream,
-        )
-        self.page_table.free_batch_idx.remove(self._padding_batch_idx)
-        self.page_table.reserve(self._padding_batch_idx, 1)
-        self.page_table.commit_block_table([self._padding_batch_idx])
         self._prefill_slot = PrefillSlot(
             slot_id=0,
             batch_idx=torch.zeros(
@@ -197,7 +255,7 @@ class Gemma4Runtime(UncachedPagedRuntime):
                 device=self.device,
                 dtype=self.dtype,
                 max_batch_slots=decode_rows,
-                kv_cache_pages=self._kv_cache_pages,
+                kv_cache_pages=1,
                 vocab_size=text_config.vocab_size,
                 hidden_dim=text_config.hidden_size,
                 position_shape=(decode_rows, 1),
@@ -208,17 +266,129 @@ class Gemma4Runtime(UncachedPagedRuntime):
         )
         self.active_sequences: dict[int, SequenceState] = {}
 
+        kv_layer_specs = paged_kv_specs(text_config)
+        self._generated_rope_inputs = None
+        has_generated_decode = (
+            self.decode_path != "native"
+            and self._generated_weight_storage is not None
+        )
+        if self.decode_path == "generated" and not has_generated_decode:
+            raise RuntimeError(
+                "generated Gemma decode has no finalized load-time weight storage"
+            )
+        self._generated_binding_reservation = None
+        if has_generated_decode:
+            from kestrel.runtime.generated_decode import (
+                generated_weight_programs_for_loading,
+                reserve_generated_binding_storage,
+            )
+            from .generated_decode import _WEIGHT_LAYER_PREFIX
+
+            programs = generated_weight_programs_for_loading(
+                self,
+                self.model,
+                label="Gemma",
+                layer_prefix=_WEIGHT_LAYER_PREFIX,
+                required_batch_sizes=range(1, self.max_batch_size + 1),
+                required=self.decode_path == "generated",
+            )
+            if programs:
+                for program in programs:
+                    program.preload(self.device)
+            sparse_inputs = _generated_kv_binding_inputs(
+                kv_layer_specs,
+                tuple(text_config.layer_types),
+            )
+            if programs:
+                self._generated_binding_reservation = (
+                    reserve_generated_binding_storage(
+                        programs,
+                        weight_storage=self._generated_weight_storage,
+                        runtime_inputs_by_slot=tuple(
+                            sparse_inputs for _slot in self.decode_slots
+                        ),
+                        device=self.device,
+                        stream=self._compute_stream,
+                        label="Gemma",
+                        required=self.decode_path == "generated",
+                    )
+                )
+            if self._generated_binding_reservation is None:
+                has_generated_decode = False
+                self._generated_weight_storage = None
+        rope_builder = None
+        if has_generated_decode:
+            from .generated_decode import _rope_tables
+
+            rope_builder = _rope_tables
+
+        def allocate_paged_resources(pages: int) -> _PagedRuntimeResources:
+            reachable_tokens = min(
+                self.max_seq_length,
+                (int(pages) - 2) * self.page_size,
+            )
+            rope_inputs = (
+                None if rope_builder is None else rope_builder(self, reachable_tokens)
+            )
+            decode_page_tables = _allocate_decode_page_tables(
+                count=len(self.decode_slots),
+                rows=decode_rows,
+                pages=pages,
+                device=self.device,
+            )
+            page_table = PageTable(
+                n_pages=pages,
+                page_size=self.page_size,
+                max_batch_size=self.max_batch_slots,
+                device=str(self.device),
+                prefix_cache=None,
+                h2d_stream=self._compute_stream,
+            )
+            page_table.free_batch_idx.remove(self._padding_batch_idx)
+            page_table.reserve(self._padding_batch_idx, 1)
+            page_table.commit_block_table([self._padding_batch_idx])
+            return _PagedRuntimeResources(
+                rope_inputs=rope_inputs,
+                decode_page_tables=decode_page_tables,
+                page_table=page_table,
+            )
+
+        self._kv_storage, paged_resources = fit_and_allocate_paged_kv_storage(
+            requested_kv_cache_pages,
+            layer_specs=kv_layer_specs,
+            page_size=self.page_size,
+            dtype=self.dtype,
+            pool=self._kv_pool,
+            stream=self._compute_stream,
+            allocate_additional=allocate_paged_resources,
+        )
+        if paged_resources is None:
+            raise RuntimeError("Gemma paged resource allocation returned no resources")
+        self._kv_cache_pages = self._kv_storage.n_pages
+        self._generated_rope_inputs = paged_resources.rope_inputs
+        _install_decode_page_tables(
+            self.decode_slots,
+            paged_resources.decode_page_tables,
+        )
+        self.page_table = paged_resources.page_table
         self._kv_cache = allocate_paged_kv_layers(
-            layer_specs=paged_kv_specs(text_config),
+            layer_specs=kv_layer_specs,
             page_table=self.page_table,
             pool=self._kv_pool,
             dtype=self.dtype,
+            storage=self._kv_storage,
         )
         self._initialize_generated_decode()
 
     def _initialize_generated_decode(self) -> None:
         """Apply the runtime-wide decode policy after model state is ready."""
 
+        # Generated bindings own exactly the tensors represented by this
+        # reservation. Release it only after every other resident allocation,
+        # so binding assembly can reuse the reserved allocator block.
+        reservation = self._generated_binding_reservation
+        self._generated_binding_reservation = None
+        del reservation
         self.generated_decode = None
         if self.decode_path == "native":
             return

--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -64,17 +64,57 @@ class Gemma4Runtime(UncachedPagedRuntime):
 
         self._model_name = cfg.model
         self.decode_path = getattr(cfg, "decode_path", "auto")
+        self.max_batch_size = cfg.max_batch_size
         from kestrel.models.registry import get_spec
 
         model_spec = get_spec(self._model_name)
         model_source = cfg.model_path if cfg.model_path is not None else model_spec.repo_id
         if model_source is None:
             raise ValueError("Gemma model spec must declare repo_id")
+        self._generated_weight_storage = None
+        prepare_model = None
+        finalize_model = None
+        if self.decode_path != "native":
+            from kestrel.runtime.generated_decode import (
+                finalize_generated_weight_storage_after_loading,
+                prepare_generated_weight_storage_for_loading,
+            )
+            from .generated_decode import _WEIGHT_LAYER_PREFIX
+
+            def prepare_model(model: torch.nn.Module) -> None:
+                self._generated_weight_storage = (
+                    prepare_generated_weight_storage_for_loading(
+                        self,
+                        model,
+                        label="Gemma",
+                        layer_prefix=_WEIGHT_LAYER_PREFIX,
+                        required_batch_sizes=range(1, self.max_batch_size + 1),
+                        required=self.decode_path == "generated",
+                    )
+                )
+
+            def finalize_model(model: torch.nn.Module) -> None:
+                if self._generated_weight_storage is not None:
+                    self._generated_weight_storage = (
+                        finalize_generated_weight_storage_after_loading(
+                            self,
+                            model,
+                            self._generated_weight_storage,
+                            label="Gemma",
+                            layer_prefix=_WEIGHT_LAYER_PREFIX,
+                            required_batch_sizes=range(
+                                1, self.max_batch_size + 1
+                            ),
+                        )
+                    )
+
         self.model = load_model(
             model_source,
             device=self.device,
             dtype=self.dtype,
             revision=model_spec.revision,
+            prepare_model=prepare_model,
+            finalize_model=finalize_model,
         )
         self._config = self.model.config
         self._configure_model(cfg)
@@ -93,7 +133,6 @@ class Gemma4Runtime(UncachedPagedRuntime):
 
         self.execution_shape = ExecutionShape.AUTOREGRESSIVE
         self.spec = None
-        self.max_batch_size = cfg.max_batch_size
         self.page_size = cfg.page_size
         self.max_seq_length = int(
             self._config.text_config.max_position_embeddings
@@ -182,6 +221,12 @@ class Gemma4Runtime(UncachedPagedRuntime):
 
         self.generated_decode = None
         if self.decode_path == "native":
+            return
+        if self._generated_weight_storage is None:
+            if self.decode_path == "generated":
+                raise RuntimeError(
+                    "generated Gemma decode has no finalized load-time weight storage"
+                )
             return
 
         from .generated_decode import create_generated_decode

--- a/kestrel/models/qwen35/generated_decode.py
+++ b/kestrel/models/qwen35/generated_decode.py
@@ -12,89 +12,14 @@ from kestrel.runtime.generated_decode import (
 )
 
 
+_WEIGHT_LAYER_PREFIX = "model.language_model.layers"
+
+
 def _state_tensors(state_pool: Any, field: str) -> list[torch.Tensor | None]:
     return [
         None if storage is None else getattr(storage, field)
         for storage in state_pool.layers
     ]
-
-
-def prepare_generated_weight_storage(
-    runtime: Any,
-    model: torch.nn.Module,
-    *,
-    required: bool,
-) -> Any | None:
-    """Bind checkpoint load targets directly into the final generated layout."""
-
-    if runtime.device.type != "cuda" or runtime.dtype is not torch.bfloat16:
-        if required:
-            raise RuntimeError(
-                "generated Qwen decode requires CUDA BF16 model storage"
-            )
-        return None
-    try:
-        from kestrel_kernels import generated_decode as generated_runtime
-    except ModuleNotFoundError as exc:
-        if exc.name not in {"kestrel_kernels", "kestrel_kernels.generated_decode"}:
-            raise
-        if required:
-            raise RuntimeError(
-                "generated Qwen decode requires load-time weight binding support"
-            )
-        return None
-    allocate_weight_storage_for_loading = getattr(
-        generated_runtime, "allocate_weight_storage_for_loading", None
-    )
-    resolve_compatible_programs = getattr(
-        generated_runtime, "resolve_compatible_programs", None
-    )
-    if not callable(allocate_weight_storage_for_loading) or not callable(
-        resolve_compatible_programs
-    ):
-        if required:
-            raise RuntimeError(
-                "generated Qwen decode requires load-time weight binding support"
-            )
-        return None
-
-    properties = torch.cuda.get_device_properties(runtime.device)
-    programs = tuple(resolve_compatible_programs(
-        model,
-        layer_prefix="model.language_model.layers",
-        arch=f"sm{properties.major}{properties.minor}",
-        device_sms=int(properties.multi_processor_count),
-    ))
-    missing_batches = []
-    for batch_size in range(1, runtime.max_batch_size + 1):
-        covered = False
-        for program in programs:
-            static = program.static_extent_bindings.get("active_batch")
-            minimum = int(
-                program.runtime_extent_minimums.get("active_batch", 1)
-            )
-            covered = covered or (
-                (static is None and minimum <= batch_size <= program.capacity)
-                or static == batch_size
-            )
-        if not covered:
-            missing_batches.append(batch_size)
-    if missing_batches:
-        if required:
-            raise RuntimeError(
-                "generated Qwen decode has no load-time artifact coverage for "
-                f"batch sizes {missing_batches}"
-            )
-        return None
-    contracts = {repr(program.descriptor["weights"]) for program in programs}
-    if len(contracts) != 1:
-        raise RuntimeError("generated Qwen artifacts disagree on weight storage")
-    return allocate_weight_storage_for_loading(
-        model,
-        programs[0].descriptor,
-        device=runtime.device,
-        layer_prefix="model.language_model.layers",
-    )
 
 
 def _generated_decode_spec(runtime: Any) -> GeneratedDecodeSpec:
@@ -139,7 +64,7 @@ def _generated_decode_spec(runtime: Any) -> GeneratedDecodeSpec:
     return GeneratedDecodeSpec(
         label="Qwen",
         weight_root=runtime.model,
-        weight_layer_prefix="model.language_model.layers",
+        weight_layer_prefix=_WEIGHT_LAYER_PREFIX,
         bindings=bindings,
         weight_storage=getattr(runtime, "_generated_weight_storage", None),
         capacity_inputs=state_inputs,
@@ -194,5 +119,4 @@ def create_generated_decode(
 __all__ = [
     "create_generated_decode",
     "generated_decode_slot_capacity",
-    "prepare_generated_weight_storage",
 ]

--- a/kestrel/models/qwen35/generated_decode.py
+++ b/kestrel/models/qwen35/generated_decode.py
@@ -66,7 +66,7 @@ def _generated_decode_spec(runtime: Any) -> GeneratedDecodeSpec:
         weight_root=runtime.model,
         weight_layer_prefix=_WEIGHT_LAYER_PREFIX,
         bindings=bindings,
-        weight_storage=getattr(runtime, "_generated_weight_storage", None),
+        weight_storage=runtime._generated_weight_storage,
         capacity_inputs=state_inputs,
         preparations=(
             DeviceInputPreparation(

--- a/kestrel/models/qwen35/prefill_slot.py
+++ b/kestrel/models/qwen35/prefill_slot.py
@@ -32,8 +32,6 @@ class Qwen35PrefillScratch:
     pixel_values: CpuGpuBuffer | None = None
     pixel_capacity: int = 0
     pixel_dim: int = 0
-    image_grid_thw: CpuGpuBuffer | None = None
-    image_grid_capacity: int = 0
     vision_bilinear_indices: CpuGpuBuffer | None = None
     vision_bilinear_weights: CpuGpuBuffer | None = None
     vision_position_ids: CpuGpuBuffer | None = None
@@ -97,7 +95,6 @@ class Qwen35PrefillScratch:
         batch_size: int,
         pixel_rows: int,
         pixel_dim: int,
-        image_grid_rows: int,
         vision_sequence_count: int = 0,
     ) -> "Qwen35PrefillScratch":
         token_capacity = self.token_capacity
@@ -120,7 +117,6 @@ class Qwen35PrefillScratch:
                 batch_size=batch_size,
                 pixel_rows=pixel_rows,
                 pixel_dim=pixel_dim,
-                image_grid_rows=image_grid_rows,
                 vision_sequence_count=vision_sequence_count,
             )
 
@@ -136,16 +132,6 @@ class Qwen35PrefillScratch:
                 device=self.device,
                 pin_memory=self.device.type == "cuda",
                 with_numpy=False,
-            )
-
-        if image_grid_rows > self.image_grid_capacity:
-            self.image_grid_capacity = max(1, image_grid_rows)
-            self.image_grid_thw = CpuGpuBuffer(
-                self.image_grid_capacity,
-                3,
-                dtype=torch.long,
-                device=self.device,
-                pin_memory=self.device.type == "cuda",
             )
 
         if pixel_rows > self.vision_token_capacity:

--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -12,6 +12,7 @@ from huggingface_hub import hf_hub_download
 from safetensors import safe_open
 
 from kestrel.ops.rotary import default_inv_freq
+from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 
 from .qwen_config import Qwen3_5Config
 from .qwen_model import (
@@ -701,40 +702,6 @@ def _resolve_checkpoint_file(
     return hf_hub_download(source, filename, **kwargs)
 
 
-def _materialize_remaining_meta_tensors(
-    model: torch.nn.Module,
-    *,
-    device: torch.device,
-) -> None:
-    parameter_replacements: dict[int, torch.nn.Parameter] = {}
-    buffer_replacements: dict[int, torch.Tensor] = {}
-    for module in model.modules():
-        for name, parameter in tuple(module._parameters.items()):
-            if parameter is None or parameter.device.type != "meta":
-                continue
-            replacement = parameter_replacements.get(id(parameter))
-            if replacement is None:
-                replacement = torch.nn.Parameter(
-                    torch.empty_like(parameter, device=device),
-                    requires_grad=parameter.requires_grad,
-                )
-                parameter_replacements[id(parameter)] = replacement
-            module._parameters[name] = replacement
-        for name, buffer in tuple(module._buffers.items()):
-            if buffer is None or buffer.device.type != "meta":
-                continue
-            if name in module._non_persistent_buffers_set:
-                raise RuntimeError(
-                    "Qwen load-time preparation left derived buffer "
-                    f"{type(module).__name__}.{name} uninitialized"
-                )
-            replacement = buffer_replacements.get(id(buffer))
-            if replacement is None:
-                replacement = torch.empty_like(buffer, device=device)
-                buffer_replacements[id(buffer)] = replacement
-            module._buffers[name] = replacement
-
-
 def _restore_rotary_buffers(
     model: Qwen3_5ForConditionalGeneration,
     config: Qwen3_5Config,
@@ -783,7 +750,7 @@ def load_qwen35_model(
     if prepare_model is not None:
         prepare_model(model)
         _restore_rotary_buffers(model, config, device=device)
-        _materialize_remaining_meta_tensors(model, device=device)
+        materialize_remaining_meta_tensors(model, device=device)
 
     index_path = _resolve_checkpoint_file(
         source, "model.safetensors.index.json", revision=revision

--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -732,6 +732,7 @@ def load_qwen35_model(
     dtype: torch.dtype,
     revision: str | None = None,
     prepare_model: Callable[[torch.nn.Module], None] | None = None,
+    finalize_model: Callable[[torch.nn.Module], None] | None = None,
 ) -> Qwen3_5ForConditionalGeneration:
     config_path = _resolve_checkpoint_file(
         source, "config.json", revision=revision
@@ -776,6 +777,8 @@ def load_qwen35_model(
         with torch.no_grad():
             model.lm_head.weight.copy_(embedding_weight)
         model.lm_head.weight = embedding_weight
+    if finalize_model is not None:
+        finalize_model(model)
     model = model.eval()
     if device.type == "cuda":
         torch.cuda.synchronize(device)

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Sequence
 
 import torch
 import torch.nn.functional as F
@@ -65,6 +65,64 @@ def _rmsnorm_state(dim: int, eps: float) -> nn.ModuleDict:
 class _TextModelOutput:
     last_hidden_state: torch.Tensor
     past_key_values: Qwen35InferenceCache | None = None
+
+
+def _copy_image_features_into_embeddings(
+    inputs_embeds: torch.Tensor,
+    image_features: torch.Tensor,
+    image_token_spans: Sequence[tuple[int, int]],
+) -> None:
+    """Copy ordered image features into packed embeddings without repacking."""
+
+    if inputs_embeds.ndim != 3 or inputs_embeds.shape[0] != 1:
+        raise ValueError("prefill embeddings must have shape [1, tokens, hidden]")
+    if not isinstance(image_features, torch.Tensor):
+        raise TypeError("image features must be a tensor")
+    if image_features.ndim != 2:
+        raise ValueError(f"image features must be 2D, got {image_features.ndim}D")
+
+    validated_spans: list[tuple[int, int]] = []
+    previous_end = 0
+    feature_count = 0
+    token_count = int(inputs_embeds.shape[1])
+    hidden_size = int(inputs_embeds.shape[2])
+    for image_index, span in enumerate(image_token_spans):
+        if len(span) != 2:
+            raise ValueError(f"image token span {image_index} must have two bounds")
+        start, end = (int(bound) for bound in span)
+        if start < previous_end or start < 0 or end <= start or end > token_count:
+            raise ValueError(
+                f"image token span {image_index} is invalid or out of order: "
+                f"({start}, {end}) for {token_count} tokens"
+            )
+        feature_count += end - start
+        validated_spans.append((start, end))
+        previous_end = end
+
+    expected_shape = (feature_count, hidden_size)
+    if tuple(image_features.shape) != expected_shape:
+        raise ValueError(
+            f"image features have shape {tuple(image_features.shape)}, "
+            f"expected {expected_shape}"
+        )
+    try:
+        normalized = image_features.to(
+            device=inputs_embeds.device,
+            dtype=inputs_embeds.dtype,
+        )
+    except (NotImplementedError, RuntimeError) as exc:
+        raise ValueError(
+            "image features could not be converted to "
+            f"{inputs_embeds.device}/{inputs_embeds.dtype}"
+        ) from exc
+
+    feature_offset = 0
+    for start, end in validated_spans:
+        feature_end = feature_offset + end - start
+        inputs_embeds[0, start:end].copy_(
+            normalized[feature_offset:feature_end]
+        )
+        feature_offset = feature_end
 
 
 @dataclass
@@ -1227,15 +1285,12 @@ class Qwen3_5Model(nn.Module):
     def get_image_features(
         self,
         pixel_values: torch.FloatTensor,
-        image_grid_thw: torch.LongTensor | None = None,
         *,
         bilinear_indices: torch.Tensor | None = None,
         bilinear_weights: torch.Tensor | None = None,
         position_ids: torch.Tensor | None = None,
         cu_seqlens: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, ...]:
-        if image_grid_thw is None:
-            raise ValueError("image_grid_thw is required with pixel_values")
+    ) -> torch.Tensor:
         if any(
             value is None
             for value in (
@@ -1247,18 +1302,13 @@ class Qwen3_5Model(nn.Module):
         ):
             raise ValueError("Qwen vision metadata must be precomputed by the runtime")
         pixel_values = pixel_values.type(_module_dtype(self.visual))
-        image_embeds = self.visual(
+        return self.visual(
             pixel_values,
             bilinear_indices=bilinear_indices,
             bilinear_weights=bilinear_weights,
             position_ids=position_ids,
             cu_seqlens=cu_seqlens,
         )
-        split_sizes = (
-            image_grid_thw.prod(-1)
-            // self.config.vision_config.spatial_merge_size**2
-        ).tolist()
-        return torch.split(image_embeds, split_sizes)
 
     def forward(
         self,
@@ -1267,7 +1317,6 @@ class Qwen3_5Model(nn.Module):
         attention_mask: torch.Tensor | None = None,
         past_key_values: Qwen35InferenceCache | None = None,
         pixel_values: torch.Tensor | None = None,
-        image_grid_thw: torch.LongTensor | None = None,
         cache_position_ids: torch.Tensor | None = None,
         slot_mapping: torch.Tensor | None = None,
         page_table: torch.Tensor | None = None,
@@ -1281,30 +1330,29 @@ class Qwen3_5Model(nn.Module):
         vision_bilinear_weights: torch.Tensor | None = None,
         vision_position_ids: torch.Tensor | None = None,
         vision_cu_seqlens: torch.Tensor | None = None,
+        image_token_spans: Sequence[tuple[int, int]] | None = None,
     ) -> _TextModelOutput:
         inputs_embeds = self.language_model.embed_tokens(input_ids)
 
         if pixel_values is not None:
+            if not image_token_spans:
+                raise ValueError(
+                    "packed image-token spans are required with pixel values"
+                )
             image_embeds = self.get_image_features(
                 pixel_values,
-                image_grid_thw,
                 bilinear_indices=vision_bilinear_indices,
                 bilinear_weights=vision_bilinear_weights,
                 position_ids=vision_position_ids,
                 cu_seqlens=vision_cu_seqlens,
             )
-            image_embeds = torch.cat(image_embeds, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
-            image_token_mask = input_ids == self.config.image_token_id
-            image_mask = image_token_mask.unsqueeze(-1).expand_as(inputs_embeds).to(
-                inputs_embeds.device
+            _copy_image_features_into_embeddings(
+                inputs_embeds,
+                image_embeds,
+                image_token_spans,
             )
-            if inputs_embeds[image_mask].numel() != image_embeds.numel():
-                raise ValueError(
-                    "Image features and image tokens do not match, "
-                    f"tokens: {image_token_mask.sum()}, "
-                    f"features: {image_embeds.shape[0]}"
-                )
-            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+        elif image_token_spans:
+            raise ValueError("packed image-token spans require pixel values")
 
         outputs = self.language_model(
             input_ids=None,

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -469,6 +469,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
         from .qwen_loader import load_qwen35_model
 
         from kestrel.runtime.generated_decode import (
+            finalize_generated_weight_storage_after_loading,
             prepare_generated_weight_storage_for_loading,
         )
         from .generated_decode import _WEIGHT_LAYER_PREFIX
@@ -485,12 +486,28 @@ class Qwen35Runtime(UncachedPagedRuntime):
                 )
             )
 
+        def finalize_model(model: nn.Module) -> None:
+            if self._generated_weight_storage is not None:
+                self._generated_weight_storage = (
+                    finalize_generated_weight_storage_after_loading(
+                        self,
+                        model,
+                        self._generated_weight_storage,
+                        label="Qwen",
+                        layer_prefix=_WEIGHT_LAYER_PREFIX,
+                        required_batch_sizes=range(
+                            1, self.max_batch_size + 1
+                        ),
+                    )
+                )
+
         return load_qwen35_model(
             source,
             device=self.device,
             dtype=self.dtype,
             revision=self._spec.revision,
             prepare_model=prepare_model,
+            finalize_model=finalize_model,
         )
 
     def acquire_prefill_slot(self, slot_id: int) -> Any:

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -70,8 +70,8 @@ class _PackedPrefillBatch:
     paged_kv_seqlens_k: torch.Tensor
     slot_mapping: torch.Tensor
     rope_deltas: torch.Tensor
+    image_token_spans: tuple[tuple[int, int], ...]
     pixel_values: Optional[torch.Tensor] = None
-    image_grid_thw: Optional[torch.Tensor] = None
     vision_bilinear_indices: Optional[torch.Tensor] = None
     vision_bilinear_weights: Optional[torch.Tensor] = None
     vision_position_ids: Optional[torch.Tensor] = None
@@ -597,6 +597,11 @@ class Qwen35Runtime(UncachedPagedRuntime):
                         f"Qwen chat prompt has {len(markers)} image marker(s) "
                         f"but {num_images} image(s) were provided"
                     )
+                marker_indices = [index for _, index in markers]
+                if marker_indices != list(range(num_images)):
+                    raise RuntimeError(
+                        "Qwen image markers must appear in image input order"
+                    )
                 for pos, idx in sorted(markers, reverse=True):
                     block = (
                         [TextToken(token_id=VISION_START_ID)]
@@ -768,7 +773,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
         batch_size: int,
         pixel_rows: int,
         pixel_dim: int,
-        image_grid_rows: int,
         vision_sequence_count: int,
     ) -> Qwen35PrefillScratch:
         scratch = getattr(slot, "scratch", None)
@@ -787,7 +791,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
             batch_size=batch_size,
             pixel_rows=pixel_rows,
             pixel_dim=pixel_dim,
-            image_grid_rows=image_grid_rows,
             vision_sequence_count=vision_sequence_count,
         )
         if grown is not scratch:
@@ -813,13 +816,14 @@ class Qwen35Runtime(UncachedPagedRuntime):
         end: int,
         mm_token_type_ids: np.ndarray,
         image_grid_thw: np.ndarray,
-    ) -> int:
+    ) -> tuple[int, tuple[tuple[int, int], ...]]:
         spatial_merge_size = int(
             self.architecture.vision_config.spatial_merge_size
         )
         cursor = start
         current_pos = 0
         image_idx = 0
+        image_token_spans: list[tuple[int, int]] = []
         while cursor < end:
             modality_type = int(mm_token_type_ids[cursor - start])
             group_end = cursor + 1
@@ -851,6 +855,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
                         "Qwen image token count does not match image grid: "
                         f"tokens={group_end - cursor}, grid={image_len}"
                     )
+                image_token_spans.append((cursor, group_end))
                 offset = current_pos
                 temporal = np.repeat(np.arange(grid_t, dtype=np.int64), grid_h * grid_w)
                 height = np.tile(
@@ -869,7 +874,8 @@ class Qwen35Runtime(UncachedPagedRuntime):
 
         if image_idx != image_grid_thw.shape[0]:
             raise RuntimeError("Qwen image grid metadata has unused rows")
-        return int(out[:, 0, start:end].max()) + 1 - (end - start)
+        rope_delta = int(out[:, 0, start:end].max()) + 1 - (end - start)
+        return rope_delta, tuple(image_token_spans)
 
     def _fill_vision_metadata(
         self,
@@ -963,7 +969,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
         batch_size: int,
         has_images: bool,
         pixel_rows: int,
-        image_grid_rows: int,
         vision_sequence_count: int,
     ) -> None:
         # One H2D for every text-metadata field (input ids, positions, slot
@@ -976,9 +981,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
             if scratch.pixel_values is None:
                 raise RuntimeError("Qwen pixel scratch was not allocated")
             scratch.pixel_values.copy_to_gpu(pixel_rows)
-            if scratch.image_grid_thw is None:
-                raise RuntimeError("Qwen image grid scratch was not allocated")
-            scratch.image_grid_thw.copy_to_gpu(image_grid_rows)
             if (
                 scratch.vision_bilinear_indices is None
                 or scratch.vision_bilinear_weights is None
@@ -1039,9 +1041,9 @@ class Qwen35Runtime(UncachedPagedRuntime):
         total_tokens = 0
         pixel_rows = 0
         pixel_dim = 0
-        image_grid_rows = 0
         vision_sequence_count = 0
         has_images = False
+        image_token_spans: list[tuple[int, int]] = []
 
         for prepared, crops in zip(prepared_sequences, image_crops_list):
             tokens = prepared.tokens_list
@@ -1073,9 +1075,12 @@ class Qwen35Runtime(UncachedPagedRuntime):
                 if grid_np.ndim != 2 or grid_np.shape[1] != 3:
                     raise ValueError("Qwen image_grid_thw must have shape [N, 3]")
                 crop_grid_rows.append(grid_np)
-                image_grid_rows += int(grid_np.shape[0])
                 vision_sequence_count += int(grid_np[:, 0].sum())
             else:
+                if IMAGE_PAD_ID in token_ids:
+                    raise ValueError(
+                        "Qwen prefill row has image tokens without image inputs"
+                    )
                 crop_grid_rows.append(None)
 
         scratch = self._prefill_scratch_for(
@@ -1084,13 +1089,11 @@ class Qwen35Runtime(UncachedPagedRuntime):
             batch_size=len(prepared_sequences),
             pixel_rows=pixel_rows,
             pixel_dim=pixel_dim,
-            image_grid_rows=image_grid_rows,
             vision_sequence_count=vision_sequence_count,
         )
 
         offset = 0
         pixel_offset = 0
-        grid_offset = 0
         scratch.text_meta.cu_seq_lens_q.np[0] = 0
 
         for row, (token_ids, crops, grid_np, batch_idx) in enumerate(
@@ -1126,17 +1129,15 @@ class Qwen35Runtime(UncachedPagedRuntime):
             else:
                 mm_types[ids_np == IMAGE_PAD_ID] = 1
                 assert grid_np is not None
-                grid_end = grid_offset + grid_np.shape[0]
-                if scratch.image_grid_thw is None:
-                    raise RuntimeError("Qwen image grid scratch was not allocated")
-                scratch.image_grid_thw.np[grid_offset:grid_end] = grid_np
-                scratch.text_meta.rope_deltas.np[row, 0] = self._fill_multimodal_position_ids(
+                rope_delta, row_image_token_spans = self._fill_multimodal_position_ids(
                     scratch.text_meta.position_ids.np,
                     start=offset,
                     end=end,
                     mm_token_type_ids=mm_types,
                     image_grid_thw=grid_np,
                 )
+                scratch.text_meta.rope_deltas.np[row, 0] = rope_delta
+                image_token_spans.extend(row_image_token_spans)
                 pixel_end = pixel_offset + int(crops.pixel_values.shape[0])
                 if scratch.pixel_values is None:
                     raise RuntimeError("Qwen pixel scratch was not allocated")
@@ -1144,7 +1145,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
                     crops.pixel_values
                 )
                 pixel_offset = pixel_end
-                grid_offset = grid_end
             offset += length
 
         if has_images:
@@ -1161,7 +1161,6 @@ class Qwen35Runtime(UncachedPagedRuntime):
             batch_size=len(prepared_sequences),
             has_images=has_images,
             pixel_rows=pixel_rows,
-            image_grid_rows=image_grid_rows,
             vision_sequence_count=vision_sequence_count,
         )
         prefill_slot.batch_idx[: len(prepared_sequences)].copy_(
@@ -1192,14 +1191,10 @@ class Qwen35Runtime(UncachedPagedRuntime):
             paged_kv_seqlens_k=scratch.paged_kv_seqlens_k[:batch_size],
             slot_mapping=scratch.text_meta.slot_mapping.gpu[:, :total_tokens],
             rope_deltas=scratch.text_meta.rope_deltas.gpu[:batch_size],
+            image_token_spans=tuple(image_token_spans),
             pixel_values=(
                 scratch.pixel_values.gpu[:pixel_rows]
                 if has_images and scratch.pixel_values is not None
-                else None
-            ),
-            image_grid_thw=(
-                scratch.image_grid_thw.gpu[:image_grid_rows]
-                if has_images and scratch.image_grid_thw is not None
                 else None
             ),
             vision_bilinear_indices=(
@@ -1234,12 +1229,12 @@ class Qwen35Runtime(UncachedPagedRuntime):
             input_ids=packed.input_ids,
             past_key_values=cache,
             pixel_values=packed.pixel_values,
-            image_grid_thw=packed.image_grid_thw,
             position_ids=packed.position_ids,
             vision_bilinear_indices=packed.vision_bilinear_indices,
             vision_bilinear_weights=packed.vision_bilinear_weights,
             vision_position_ids=packed.vision_position_ids,
             vision_cu_seqlens=packed.vision_cu_seqlens,
+            image_token_spans=packed.image_token_spans,
             cache_position_ids=packed.cache_position_ids,
             slot_mapping=packed.slot_mapping,
             page_table=packed.paged_kv_page_table,

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -468,13 +468,21 @@ class Qwen35Runtime(UncachedPagedRuntime):
     def _load_model(self, source: str | Path) -> nn.Module:
         from .qwen_loader import load_qwen35_model
 
-        from .generated_decode import prepare_generated_weight_storage
+        from kestrel.runtime.generated_decode import (
+            prepare_generated_weight_storage_for_loading,
+        )
+        from .generated_decode import _WEIGHT_LAYER_PREFIX
 
         def prepare_model(model: nn.Module) -> None:
-            self._generated_weight_storage = prepare_generated_weight_storage(
-                self,
-                model,
-                required=True,
+            self._generated_weight_storage = (
+                prepare_generated_weight_storage_for_loading(
+                    self,
+                    model,
+                    label="Qwen",
+                    layer_prefix=_WEIGHT_LAYER_PREFIX,
+                    required_batch_sizes=range(1, self.max_batch_size + 1),
+                    required=True,
+                )
             )
 
         return load_qwen35_model(

--- a/kestrel/runtime/bounded_projection.py
+++ b/kestrel/runtime/bounded_projection.py
@@ -329,12 +329,14 @@ def bind_declared_packed_projections(
                 ),
                 dim=1,
             ).reshape(sum(child.packed_out_features), child.in_features)
+        elif len(weights) == 1:
+            packed_weight = weights[0]
         else:
             packed_weight = torch.cat(weights, dim=0)
         state_dict[target_weight_key] = packed_weight
         for bound_name, value in packed_bounds.items():
             state_dict[target_prefix + bound_name] = value
-        for key in source_weight_keys:
+        for key in dict.fromkeys(source_weight_keys):
             state_dict.pop(key)
-        for key in source_bound_keys:
+        for key in dict.fromkeys(source_bound_keys):
             state_dict.pop(key)

--- a/kestrel/runtime/bounded_projection.py
+++ b/kestrel/runtime/bounded_projection.py
@@ -115,6 +115,7 @@ class PackedLinear(nn.Linear):
         *,
         source_names: Sequence[str],
         source_weight_leaf: str = "weight",
+        output_layout: str = "contiguous",
     ) -> None:
         packed_out_features = tuple(int(size) for size in out_features)
         source_names = tuple(source_names)
@@ -124,6 +125,19 @@ class PackedLinear(nn.Linear):
             or len(source_names) != len(packed_out_features)
         ):
             raise ValueError("packed linear sources and output sizes must align")
+        if output_layout not in ("contiguous", "interleaved_i8"):
+            raise ValueError(
+                f"unsupported packed linear output layout {output_layout!r}"
+            )
+        if output_layout == "interleaved_i8" and (
+            len(packed_out_features) != 2
+            or packed_out_features[0] != packed_out_features[1]
+            or packed_out_features[0] % 8
+        ):
+            raise ValueError(
+                "interleaved_i8 packed linear requires two equal output sizes "
+                "divisible by 8"
+            )
         super().__init__(
             int(in_features),
             sum(packed_out_features),
@@ -132,6 +146,7 @@ class PackedLinear(nn.Linear):
         self.packed_out_features = packed_out_features
         self.source_names = source_names
         self.source_weight_leaf = source_weight_leaf
+        self.output_layout = output_layout
 
 
 def declared_packed_projection_source_keys(module: nn.Module) -> set[str]:
@@ -305,7 +320,17 @@ def bind_declared_packed_projections(
                     ]
                 )
 
-        packed_weight = torch.cat(weights, dim=0)
+        if isinstance(child, PackedLinear) and child.output_layout == "interleaved_i8":
+            block_rows = child.packed_out_features[0] // 8
+            packed_weight = torch.stack(
+                tuple(
+                    weight.reshape(block_rows, 8, child.in_features)
+                    for weight in weights
+                ),
+                dim=1,
+            ).reshape(sum(child.packed_out_features), child.in_features)
+        else:
+            packed_weight = torch.cat(weights, dim=0)
         state_dict[target_weight_key] = packed_weight
         for bound_name, value in packed_bounds.items():
             state_dict[target_prefix + bound_name] = value

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -256,6 +256,187 @@ def _selectable_programs(
     )
 
 
+def _generated_weight_runtime(*, label: str, required: bool) -> Any | None:
+    try:
+        from kestrel_kernels import generated_decode as generated_runtime
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"kestrel_kernels", "kestrel_kernels.generated_decode"}:
+            raise
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode requires load-time weight support"
+            )
+        return None
+    capabilities = (
+        "resolve_compatible_programs",
+        "allocate_weight_storage_for_loading",
+        "finalize_weight_storage_after_loading",
+    )
+    if not all(
+        callable(getattr(generated_runtime, name, None)) for name in capabilities
+    ):
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode requires load-time weight binding "
+                "and finalization support"
+            )
+        return None
+    return generated_runtime
+
+
+def generated_weight_programs_for_loading(
+    runtime: Any,
+    model: torch.nn.Module,
+    *,
+    label: str,
+    layer_prefix: str,
+    required_batch_sizes: Sequence[int],
+    required: bool,
+) -> tuple[Any, ...]:
+    """Resolve the exact load-time program set or fail soft when optional."""
+
+    if runtime.device.type != "cuda" or runtime.dtype is not torch.bfloat16:
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode requires CUDA BF16 model storage"
+            )
+        return ()
+    generated_runtime = _generated_weight_runtime(label=label, required=required)
+    if generated_runtime is None:
+        return ()
+
+    properties = torch.cuda.get_device_properties(runtime.device)
+    programs = tuple(generated_runtime.resolve_compatible_programs(
+        model,
+        layer_prefix=layer_prefix,
+        arch=f"sm{properties.major}{properties.minor}",
+        device_sms=int(properties.multi_processor_count),
+    ))
+    missing = [
+        int(batch_size)
+        for batch_size in required_batch_sizes
+        if _select_program(programs, int(batch_size)) is None
+    ]
+    if missing:
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode has no load-time artifact coverage "
+                f"for batch sizes {missing}"
+            )
+        return ()
+    selected = _selectable_programs(programs, runtime.max_batch_size)
+    if not selected:
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode has no selectable load-time artifact"
+            )
+        return ()
+    contracts = {repr(program.descriptor["weights"]) for program in selected}
+    if len(contracts) != 1:
+        raise RuntimeError(
+            f"generated {label} artifacts disagree on weight storage"
+        )
+    return selected
+
+
+def prepare_generated_weight_storage_for_loading(
+    runtime: Any,
+    model: torch.nn.Module,
+    *,
+    label: str,
+    layer_prefix: str,
+    required_batch_sizes: Sequence[int],
+    required: bool,
+) -> Any | None:
+    """Bind checkpoint targets into the selected generated program's final slabs."""
+
+    selected = generated_weight_programs_for_loading(
+        runtime,
+        model,
+        label=label,
+        layer_prefix=layer_prefix,
+        required_batch_sizes=required_batch_sizes,
+        required=required,
+    )
+    if not selected:
+        return None
+    generated_runtime = _generated_weight_runtime(label=label, required=True)
+    assert generated_runtime is not None
+
+    return generated_runtime.allocate_weight_storage_for_loading(
+        model,
+        selected[0].descriptor,
+        device=runtime.device,
+        layer_prefix=layer_prefix,
+    )
+
+
+def finalize_generated_weight_storage_after_loading(
+    runtime: Any,
+    model: torch.nn.Module,
+    storage: Any,
+    *,
+    label: str,
+    layer_prefix: str,
+    required_batch_sizes: Sequence[int],
+) -> Any:
+    """Finalize retained recipes against the exact selected weight contract."""
+
+    selected = generated_weight_programs_for_loading(
+        runtime,
+        model,
+        label=label,
+        layer_prefix=layer_prefix,
+        required_batch_sizes=required_batch_sizes,
+        required=True,
+    )
+    generated_runtime = _generated_weight_runtime(label=label, required=True)
+    assert generated_runtime is not None
+
+    return generated_runtime.finalize_weight_storage_after_loading(
+        model,
+        selected[0].descriptor,
+        storage,
+        layer_prefix=layer_prefix,
+    )
+
+
+def materialize_remaining_meta_tensors(
+    model: torch.nn.Module,
+    *,
+    device: torch.device,
+) -> None:
+    """Materialize checkpoint-backed tensors not claimed by a load-time layout."""
+
+    parameter_replacements: dict[int, torch.nn.Parameter] = {}
+    buffer_replacements: dict[int, torch.Tensor] = {}
+    for module in model.modules():
+        for name, parameter in tuple(module._parameters.items()):
+            if parameter is None or parameter.device.type != "meta":
+                continue
+            replacement = parameter_replacements.get(id(parameter))
+            if replacement is None:
+                replacement = torch.nn.Parameter(
+                    torch.empty_like(parameter, device=device),
+                    requires_grad=parameter.requires_grad,
+                )
+                parameter_replacements[id(parameter)] = replacement
+            module._parameters[name] = replacement
+        for name, buffer in tuple(module._buffers.items()):
+            if buffer is None or buffer.device.type != "meta":
+                continue
+            if name in module._non_persistent_buffers_set:
+                raise RuntimeError(
+                    "load-time preparation left derived buffer "
+                    f"{type(module).__name__}.{name} uninitialized"
+                )
+            replacement = buffer_replacements.get(id(buffer))
+            if replacement is None:
+                replacement = torch.empty_like(buffer, device=device)
+                buffer_replacements[id(buffer)] = replacement
+            module._buffers[name] = replacement
+
+
 class GeneratedDecode:
     """Select bundled capacities and bind them to one serving runtime."""
 
@@ -441,6 +622,10 @@ class GeneratedDecode:
                     raise RuntimeError(
                         "preloaded generated weights do not match the selected program"
                     )
+                if getattr(spec.weight_storage, "finalized", None) is not True:
+                    raise RuntimeError(
+                        "preloaded generated weights were not finalized after loading"
+                    )
                 self.weight_storage = spec.weight_storage
             shared_inputs = dict(spec.bindings.runtime_inputs(runtime))
             weights_ready.record(runtime.compute_stream)
@@ -613,4 +798,8 @@ __all__ = [
     "GeneratedDecodeBindings",
     "GeneratedDecodeSpec",
     "PagedDecodeBindings",
+    "finalize_generated_weight_storage_after_loading",
+    "generated_weight_programs_for_loading",
+    "materialize_remaining_meta_tensors",
+    "prepare_generated_weight_storage_for_loading",
 ]

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -6,6 +6,8 @@ from typing import Any, Callable, Mapping, Protocol, Sequence
 
 import torch
 
+from kestrel.device import stream_context
+
 from .carried_state import StateRepresentationRequirement
 
 
@@ -399,6 +401,64 @@ def finalize_generated_weight_storage_after_loading(
         storage,
         layer_prefix=layer_prefix,
     )
+
+
+def reserve_generated_binding_storage(
+    programs: Sequence[Any],
+    *,
+    weight_storage: Any,
+    runtime_inputs_by_slot: Sequence[Mapping[str, Any]],
+    device: torch.device,
+    stream: Any,
+    label: str,
+    required: bool,
+) -> tuple[torch.Tensor, ...] | None:
+    """Reserve exact allocator-owned storage for later binding assembly.
+
+    Callers keep the shape- and dtype-exact tensors alive while fitting and
+    allocating other resident tensors, then release them immediately before
+    constructing :class:`GeneratedDecode`. The caching allocator can reuse
+    those same size classes for the per-program binding tensors.
+    """
+
+    generated_runtime = _generated_weight_runtime(label=label, required=required)
+    if generated_runtime is None:
+        return None
+    reserve = getattr(generated_runtime, "reserve_binding_storage", None)
+    if not callable(reserve):
+        if required:
+            raise RuntimeError(
+                f"generated {label} decode requires binding-storage reservation"
+            )
+        return None
+    if getattr(weight_storage, "finalized", None) is not True:
+        raise RuntimeError(
+            f"generated {label} binding reservation requires finalized weights"
+        )
+    weights = getattr(weight_storage, "buffers", None)
+    if not isinstance(weights, Mapping):
+        raise RuntimeError(
+            f"generated {label} binding reservation requires weight buffers"
+        )
+    if not programs or not runtime_inputs_by_slot:
+        raise ValueError(
+            "generated binding reservation needs programs and decode slots"
+        )
+
+    # Binding assembly runs on the runtime compute stream. Reserving on that
+    # stream keeps the exact-size blocks reusable by the CUDA caching allocator.
+    with stream_context(stream):
+        return tuple(
+            tensor
+            for runtime_inputs in runtime_inputs_by_slot
+            for program in programs
+            for tensor in reserve(
+                program.descriptor,
+                weights=weights,
+                runtime_inputs=runtime_inputs,
+                device=device,
+            )
+        )
 
 
 def materialize_remaining_meta_tensors(
@@ -802,4 +862,5 @@ __all__ = [
     "generated_weight_programs_for_loading",
     "materialize_remaining_meta_tensors",
     "prepare_generated_weight_storage_for_loading",
+    "reserve_generated_binding_storage",
 ]

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -1819,13 +1819,19 @@ class GenerationScheduler:
         # has to run for prefill too. The runtime owns the staging.
         runtime_step = None
         if self._hooks.post_sample is not None:
-            hidden_rows: list[Tensor] = []
-            for seq in sequences:
-                hidden_last = seq.state.last_hidden
-                if hidden_last is None:  # pragma: no cover - defensive
-                    raise RuntimeError("Missing last_hidden after prefill")
-                hidden_rows.append(hidden_last)
-            hidden_last = torch.stack(hidden_rows, dim=0)
+            try:
+                hidden_rows: list[Tensor] = []
+                for seq in sequences:
+                    hidden_row = seq.state.last_hidden
+                    if hidden_row is None:  # pragma: no cover - defensive
+                        raise RuntimeError("Missing last_hidden after prefill")
+                    hidden_rows.append(hidden_row)
+                hidden_last = torch.stack(hidden_rows, dim=0)
+            finally:
+                # A row can be a view into the full prompt activation. The
+                # stack owns the hook values, so release every prompt backing.
+                for seq in sequences:
+                    seq.state.last_hidden = None
             runtime_step = self._hooks.post_sample(
                 prefill_slot,
                 sampled_ids=sampled_ids.view(-1),
@@ -1837,6 +1843,9 @@ class GenerationScheduler:
                 token_logprobs=sampled_logprobs,
                 ready_event=prefill_slot.step_done_event,
             )
+        else:
+            for seq in sequences:
+                seq.state.last_hidden = None
         self._pending_token_ids.index_copy_(0, batch_idx, sampled_ids.view(-1))
         prefill_slot.commit_done_event.record()
         for seq in sequences:

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -7,8 +7,24 @@ import torch
 from safetensors.torch import save_file
 from torch import nn
 
-from kestrel.models.gemma4.loader import load_weights
+from kestrel.models.gemma4.config import (
+    Gemma4Config,
+    Gemma4TextConfig,
+    Gemma4VisionConfig,
+    RopeSpec,
+)
+from kestrel.models.gemma4.loader import (
+    _restore_checkpoint_independent_state,
+    load_weights,
+)
+from kestrel.models.gemma4.model import Gemma4InferenceModel
 from kestrel.runtime.bounded_projection import PackedLinear
+from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
+from kestrel_kernels.generated_decode import (
+    allocate_weight_storage_for_loading,
+    finalize_weight_storage_after_loading,
+    materialize_weights,
+)
 
 
 class _ToyShardedModel(nn.Module):
@@ -20,6 +36,53 @@ class _ToyShardedModel(nn.Module):
             source_names=("gate", "up"),
         )
         self.exact = nn.Linear(2, 2, bias=False)
+
+
+def _tiny_gemma_config() -> Gemma4Config:
+    rope = RopeSpec(kind="default", theta=10_000.0)
+    return Gemma4Config(
+        text_config=Gemma4TextConfig(
+            vocab_size=16,
+            hidden_size=8,
+            intermediate_size=8,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=4,
+            max_position_embeddings=32,
+            rms_norm_eps=1e-6,
+            rope={
+                "sliding_attention": rope,
+                "full_attention": rope,
+            },
+            sliding_window=8,
+            layer_types=("sliding_attention", "full_attention"),
+            final_logit_softcapping=30.0,
+            vocab_size_per_layer_input=0,
+            hidden_size_per_layer_input=0,
+            num_global_key_value_heads=1,
+            global_head_dim=4,
+            attention_k_eq_v=True,
+            num_kv_shared_layers=0,
+            use_double_wide_mlp=False,
+        ),
+        vision_config=Gemma4VisionConfig(
+            hidden_size=8,
+            intermediate_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=4,
+            rms_norm_eps=1e-6,
+            rope=rope,
+            pooling_kernel_size=2,
+            patch_size=2,
+            position_embedding_size=4,
+            use_clipped_linears=False,
+            standardize=False,
+        ),
+        image_token_id=15,
+    )
 
 
 def test_load_weights_streams_packed_projection_parts_across_shards(tmp_path) -> None:
@@ -80,3 +143,90 @@ def test_load_weights_rejects_unexpected_checkpoint_tensor(tmp_path) -> None:
 
     with pytest.raises(RuntimeError, match="unexpected.weight"):
         load_weights(tmp_path, _ToyShardedModel())
+
+
+def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retained():
+    config = _tiny_gemma_config()
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        with torch.device("meta"):
+            model = Gemma4InferenceModel(config)
+    finally:
+        torch.set_default_dtype(old_dtype)
+    descriptor = {
+        "weight_layer_prefix": "model.language_model.layers",
+        "weights": [
+            {
+                "name": "text_embedding_table",
+                "source": "model.language_model.embed_tokens.weight",
+                "prep": "cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": False,
+                "physical_layers": [None],
+                "kind": "param",
+            },
+            {
+                "name": "w_qkv_local",
+                "sources": [
+                    "self_attn.q_proj.weight",
+                    "self_attn.k_proj.weight",
+                    "self_attn.v_proj.weight",
+                ],
+                "prep": "concat_rows|cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": True,
+                "physical_layers": [0],
+                "kind": "param",
+            },
+            {
+                "name": "w_gate_up_fresh",
+                "source": "mlp.gate_up_proj.weight",
+                "prep": "interleave_gate_up_rows8_axis0|cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": True,
+                "physical_layers": [0],
+                "kind": "param",
+            },
+        ],
+    }
+
+    storage = allocate_weight_storage_for_loading(
+        model,
+        descriptor,
+        device="cpu",
+    )
+    final_storages = {
+        int(value.untyped_storage()._cdata): int(value.untyped_storage().nbytes())
+        for value in storage.buffers.values()
+    }
+    final_bytes = sum(final_storages.values())
+    _restore_checkpoint_independent_state(model, config, device=torch.device("cpu"))
+    materialize_remaining_meta_tensors(model, device=torch.device("cpu"))
+    layer = model.model.language_model.layers[0]
+    layer.self_attn.q_proj.weight.data.fill_(1)
+    layer.self_attn.k_proj.weight.data.fill_(2)
+    layer.self_attn.v_proj.weight.data.fill_(3)
+    layer.mlp.gate_up_proj.weight.data.copy_(
+        torch.arange(16, dtype=torch.bfloat16).view(16, 1).expand(16, 8)
+    )
+
+    finalize_weight_storage_after_loading(model, descriptor, storage)
+
+    assert final_bytes == 3 * 16 * 8 * 2
+    assert storage.aliased_source_bytes == 16 * 8 * 2
+    assert storage.retained_source_bytes == (8 * 8 + 4 * 8 + 4 * 8 + 16 * 8) * 2
+    assert storage.finalized
+    assert model.lm_head.weight is model.model.language_model.embed_tokens.weight
+    assert not any(
+        tensor.device.type == "meta"
+        for tensor in (*model.parameters(), *model.buffers())
+    )
+    assert not any(
+        tensor.device.type == "meta"
+        for tensor in model.model.language_model.rotary_emb.inv_freq.values()
+    )
+    assert materialize_weights(model, descriptor) is storage

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import asdict
 import json
 
 import pytest
@@ -15,6 +16,7 @@ from kestrel.models.gemma4.config import (
 )
 from kestrel.models.gemma4.loader import (
     _restore_checkpoint_independent_state,
+    load_model,
     load_weights,
 )
 from kestrel.models.gemma4.model import Gemma4InferenceModel
@@ -83,6 +85,86 @@ def _tiny_gemma_config() -> Gemma4Config:
         ),
         image_token_id=15,
     )
+
+
+def _rope_config(spec: RopeSpec) -> dict[str, object]:
+    return {
+        "rope_type": spec.kind,
+        "rope_theta": spec.theta,
+        "partial_rotary_factor": spec.partial_rotary_factor,
+        "factor": spec.factor,
+    }
+
+
+def _tiny_gemma_config_data() -> dict[str, object]:
+    config = _tiny_gemma_config()
+    text = asdict(config.text_config)
+    text.pop("rope")
+    text.update(
+        rope_parameters={
+            name: _rope_config(spec)
+            for name, spec in config.text_config.rope.items()
+        },
+        hidden_activation="gelu_pytorch_tanh",
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+    vision = asdict(config.vision_config)
+    vision.pop("rope")
+    vision.update(
+        rope_parameters=_rope_config(config.vision_config.rope),
+        hidden_activation="gelu_pytorch_tanh",
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+    return {
+        "tie_word_embeddings": True,
+        "text_config": text,
+        "vision_config": vision,
+        "image_token_id": config.image_token_id,
+    }
+
+
+def _tiny_generated_weight_descriptor() -> dict[str, object]:
+    return {
+        "weight_layer_prefix": "model.language_model.layers",
+        "weights": [
+            {
+                "name": "text_embedding_table",
+                "source": "model.language_model.embed_tokens.weight",
+                "prep": "cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": False,
+                "physical_layers": [None],
+                "kind": "param",
+            },
+            {
+                "name": "w_qkv_local",
+                "sources": [
+                    "self_attn.q_proj.weight",
+                    "self_attn.k_proj.weight",
+                    "self_attn.v_proj.weight",
+                ],
+                "prep": "concat_rows|cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": True,
+                "physical_layers": [0],
+                "kind": "param",
+            },
+            {
+                "name": "w_gate_up_fresh",
+                "source": "mlp.gate_up_proj.weight",
+                "prep": "interleave_gate_up_rows8_axis0|cast_bf16",
+                "shape": [16, 8],
+                "dtype": "bf16",
+                "per_layer": True,
+                "physical_layers": [0],
+                "kind": "param",
+            },
+        ],
+    }
 
 
 def test_load_weights_streams_packed_projection_parts_across_shards(tmp_path) -> None:
@@ -154,45 +236,7 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
             model = Gemma4InferenceModel(config)
     finally:
         torch.set_default_dtype(old_dtype)
-    descriptor = {
-        "weight_layer_prefix": "model.language_model.layers",
-        "weights": [
-            {
-                "name": "text_embedding_table",
-                "source": "model.language_model.embed_tokens.weight",
-                "prep": "cast_bf16",
-                "shape": [16, 8],
-                "dtype": "bf16",
-                "per_layer": False,
-                "physical_layers": [None],
-                "kind": "param",
-            },
-            {
-                "name": "w_qkv_local",
-                "sources": [
-                    "self_attn.q_proj.weight",
-                    "self_attn.k_proj.weight",
-                    "self_attn.v_proj.weight",
-                ],
-                "prep": "concat_rows|cast_bf16",
-                "shape": [16, 8],
-                "dtype": "bf16",
-                "per_layer": True,
-                "physical_layers": [0],
-                "kind": "param",
-            },
-            {
-                "name": "w_gate_up_fresh",
-                "source": "mlp.gate_up_proj.weight",
-                "prep": "interleave_gate_up_rows8_axis0|cast_bf16",
-                "shape": [16, 8],
-                "dtype": "bf16",
-                "per_layer": True,
-                "physical_layers": [0],
-                "kind": "param",
-            },
-        ],
-    }
+    descriptor = _tiny_generated_weight_descriptor()
 
     storage = allocate_weight_storage_for_loading(
         model,
@@ -228,5 +272,86 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
     assert not any(
         tensor.device.type == "meta"
         for tensor in model.model.language_model.rotary_emb.inv_freq.values()
+    )
+    assert materialize_weights(model, descriptor) is storage
+
+
+def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
+    tmp_path,
+) -> None:
+    config = _tiny_gemma_config()
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        reference = Gemma4InferenceModel(config)
+    finally:
+        torch.set_default_dtype(old_dtype)
+    checkpoint = {
+        name: value.detach().clone()
+        for name, value in reference.state_dict().items()
+        if name != "lm_head.weight"
+    }
+    expected_embedding = checkpoint[
+        "model.language_model.embed_tokens.weight"
+    ].clone()
+    (tmp_path / "config.json").write_text(
+        json.dumps(_tiny_gemma_config_data()),
+        encoding="utf-8",
+    )
+    save_file(checkpoint, tmp_path / "model.safetensors")
+
+    descriptor = _tiny_generated_weight_descriptor()
+    lifecycle: list[str] = []
+    storage_box = {}
+
+    def prepare_model(model: torch.nn.Module) -> None:
+        lifecycle.append("prepare")
+        storage = allocate_weight_storage_for_loading(
+            model,
+            descriptor,
+            device="cpu",
+        )
+        assert not storage.finalized
+        storage_box["storage"] = storage
+
+    def finalize_model(model: torch.nn.Module) -> None:
+        lifecycle.append("finalize")
+        storage = storage_box["storage"]
+        assert not any(tensor.device.type == "meta" for tensor in model.parameters())
+        finalize_weight_storage_after_loading(model, descriptor, storage)
+        assert storage.finalized
+
+    model = load_model(
+        tmp_path,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        prepare_model=prepare_model,
+        finalize_model=finalize_model,
+    )
+
+    storage = storage_box["storage"]
+    embedding = model.model.language_model.embed_tokens.weight
+    assert lifecycle == ["prepare", "finalize"]
+    assert storage.finalized
+    assert model.lm_head.weight is embedding
+    assert torch._C._is_alias_of(
+        embedding,
+        storage.buffers["text_embedding_table"],
+    )
+    torch.testing.assert_close(embedding, expected_embedding)
+    assert not any(
+        tensor.device.type == "meta"
+        for tensor in (*model.parameters(), *model.buffers())
+    )
+    assert not any(
+        tensor.device.type == "meta"
+        for tensor in model.model.language_model.rotary_emb.inv_freq.values()
+    )
+    torch.testing.assert_close(
+        model.model.language_model.embed_tokens.embed_scale,
+        torch.full_like(
+            model.model.language_model.embed_tokens.embed_scale,
+            config.text_config.hidden_size**0.5,
+        ),
     )
     assert materialize_weights(model, descriptor) is storage

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -171,6 +171,57 @@ def _tiny_generated_weight_descriptor() -> dict[str, object]:
     }
 
 
+def _hf_style_text_checkpoint(
+    model: Gemma4InferenceModel,
+) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+    checkpoint = {
+        name: value.detach().clone()
+        for name, value in model.state_dict().items()
+        if name != "lm_head.weight"
+    }
+    expected_packed: dict[str, torch.Tensor] = {}
+    for module_name, module in model.named_modules():
+        if not isinstance(module, PackedLinear):
+            continue
+        target_key = f"{module_name}.weight"
+        packed = checkpoint.pop(target_key)
+        if module.output_layout == "interleaved_i8":
+            block_rows = module.packed_out_features[0] // 8
+            parts = tuple(
+                part.reshape(-1, module.in_features)
+                for part in packed.reshape(block_rows, 2, 8, module.in_features).unbind(
+                    1
+                )
+            )
+        else:
+            parts = packed.split(module.packed_out_features, dim=0)
+
+        parent_name, separator, _ = module_name.rpartition(".")
+        source_prefix = f"{parent_name}." if separator else ""
+        source_tensors: dict[str, torch.Tensor] = {}
+        for source_name, part in zip(module.source_names, parts, strict=True):
+            source_key = f"{source_prefix}{source_name}.{module.source_weight_leaf}"
+            if source_key not in source_tensors:
+                source_tensors[source_key] = part.contiguous().clone()
+        checkpoint.update(source_tensors)
+
+        ordered = tuple(
+            source_tensors[f"{source_prefix}{source_name}.{module.source_weight_leaf}"]
+            for source_name in module.source_names
+        )
+        if module.output_layout == "interleaved_i8":
+            expected = torch.stack(
+                tuple(
+                    part.reshape(block_rows, 8, module.in_features) for part in ordered
+                ),
+                dim=1,
+            ).reshape_as(packed)
+        else:
+            expected = torch.cat(ordered, dim=0)
+        expected_packed[target_key] = expected
+    return checkpoint, expected_packed
+
+
 def test_load_weights_streams_packed_projection_parts_across_shards(tmp_path) -> None:
     gate = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
     up = torch.tensor([[5.0, 6.0], [7.0, 8.0]])
@@ -554,14 +605,18 @@ def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
         reference = Gemma4InferenceModel(config)
     finally:
         torch.set_default_dtype(old_dtype)
-    checkpoint = {
-        name: value.detach().clone()
-        for name, value in reference.state_dict().items()
-        if name != "lm_head.weight"
-    }
-    expected_embedding = checkpoint[
-        "model.language_model.embed_tokens.weight"
-    ].clone()
+    checkpoint, expected_packed = _hf_style_text_checkpoint(reference)
+    expected_embedding = checkpoint["model.language_model.embed_tokens.weight"].clone()
+    layer_prefix = "model.language_model.layers"
+    assert f"{layer_prefix}.0.self_attn.qkv_proj.weight" not in checkpoint
+    assert f"{layer_prefix}.0.mlp.gate_up_proj.weight" not in checkpoint
+    assert f"{layer_prefix}.0.self_attn.q_proj.weight" in checkpoint
+    assert f"{layer_prefix}.0.self_attn.k_proj.weight" in checkpoint
+    assert f"{layer_prefix}.0.self_attn.v_proj.weight" in checkpoint
+    assert f"{layer_prefix}.0.mlp.gate_proj.weight" in checkpoint
+    assert f"{layer_prefix}.0.mlp.up_proj.weight" in checkpoint
+    assert f"{layer_prefix}.1.self_attn.v_proj.weight" not in checkpoint
+    assert f"{layer_prefix}.1.self_attn.k_proj.weight" in checkpoint
     (tmp_path / "config.json").write_text(
         json.dumps(_tiny_gemma_config_data()),
         encoding="utf-8",
@@ -613,6 +668,21 @@ def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
     assert torch._C._is_alias_of(
         model.model.language_model.layers[0].mlp.gate_up_proj.weight,
         storage.buffers["w_gate_up_fresh"][0],
+    )
+    assert torch._C._is_alias_of(
+        model.model.language_model.layers[0].self_attn.qkv_proj.weight,
+        storage.buffers["w_qkv_local"][0],
+    )
+    loaded_state = model.state_dict()
+    for name, expected in expected_packed.items():
+        assert torch.equal(loaded_state[name], expected)
+    assert torch.equal(
+        storage.buffers["w_gate_up_fresh"][0],
+        expected_packed[f"{layer_prefix}.0.mlp.gate_up_proj.weight"],
+    )
+    assert torch.equal(
+        storage.buffers["w_qkv_local"][0],
+        expected_packed[f"{layer_prefix}.0.self_attn.qkv_proj.weight"],
     )
     torch.testing.assert_close(embedding, expected_embedding)
     assert not any(

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, replace
 import json
 
 import pytest
 import torch
 from safetensors.torch import save_file
 from torch import nn
+from torch.nn import functional as F
 
 from kestrel.models.gemma4.config import (
     Gemma4Config,
@@ -19,7 +20,11 @@ from kestrel.models.gemma4.loader import (
     load_model,
     load_weights,
 )
-from kestrel.models.gemma4.model import Gemma4InferenceModel, Gemma4TextMLP
+from kestrel.models.gemma4.model import (
+    Gemma4InferenceModel,
+    Gemma4TextAttention,
+    Gemma4TextMLP,
+)
 from kestrel.runtime.bounded_projection import (
     PackedLinear,
     bind_declared_packed_projections,
@@ -144,12 +149,8 @@ def _tiny_generated_weight_descriptor() -> dict[str, object]:
             },
             {
                 "name": "w_qkv_local",
-                "sources": [
-                    "self_attn.q_proj.weight",
-                    "self_attn.k_proj.weight",
-                    "self_attn.v_proj.weight",
-                ],
-                "prep": "concat_rows|cast_bf16",
+                "source": "self_attn.qkv_proj.weight",
+                "prep": "identity",
                 "shape": [16, 8],
                 "dtype": "bf16",
                 "per_layer": True,
@@ -278,6 +279,151 @@ def test_text_mlp_interleaved_checkpoint_layout_matches_gate_up_math(
     torch.testing.assert_close(actual, expected)
 
 
+def test_text_attention_owner_packs_qkv_and_matches_projection_math() -> None:
+    torch.manual_seed(8)
+    config = _tiny_gemma_config().text_config
+    attention = Gemma4TextAttention(
+        config,
+        layer_idx=0,
+        kv_source_layer_idx=0,
+        publishes_kv=True,
+    )
+    q = torch.randn((8, 8))
+    k = torch.randn((4, 8))
+    v = torch.randn((4, 8))
+    packed = {
+        "q_proj.weight": q,
+        "k_proj.weight": k,
+        "v_proj.weight": v,
+    }
+    bind_declared_packed_projections(attention, packed)
+    with torch.no_grad():
+        attention.qkv_proj.weight.copy_(packed["qkv_proj.weight"])
+    hidden = torch.randn((3, 8))
+
+    actual = attention.qkv_proj(hidden).split(
+        attention.qkv_proj.packed_out_features,
+        dim=-1,
+    )
+    expected = tuple(F.linear(hidden, weight) for weight in (q, k, v))
+
+    assert attention.qkv_proj.source_names == ("q_proj", "k_proj", "v_proj")
+    assert not any(
+        name.startswith(("q_proj.", "k_proj.", "v_proj."))
+        for name, _ in attention.named_parameters()
+    )
+    for actual_part, expected_part in zip(actual, expected):
+        torch.testing.assert_close(actual_part, expected_part)
+
+
+def test_text_attention_k_equals_v_still_normalizes_k_and_v_separately(
+    monkeypatch,
+) -> None:
+    import kestrel.models.gemma4.model as gemma_model
+
+    torch.manual_seed(9)
+    config = _tiny_gemma_config().text_config
+    attention = Gemma4TextAttention(
+        config,
+        layer_idx=1,
+        kv_source_layer_idx=1,
+        publishes_kv=True,
+    )
+    q = torch.randn((8, 8))
+    k = torch.randn((4, 8))
+    packed = {"q_proj.weight": q, "k_proj.weight": k}
+    bind_declared_packed_projections(attention, packed)
+    with torch.no_grad():
+        attention.qkv_proj.weight.copy_(packed["qkv_proj.weight"])
+
+    observed: dict[str, torch.Tensor] = {}
+
+    class DenseRuntime:
+        @staticmethod
+        def rmsnorm(value, weight, eps):
+            del eps
+            if weight is attention.k_norm.weight:
+                observed["raw_k"] = value.clone()
+                return value + 10
+            if weight is attention.v_norm.weight:
+                observed["raw_v"] = value.clone()
+                return value + 20
+            return value
+
+    class Cache:
+        @staticmethod
+        def update(**kwargs):
+            observed["normalized_k"] = kwargs["k_val"]
+            observed["normalized_v"] = kwargs["v_val"]
+
+    monkeypatch.setattr(gemma_model, "_dense_runtime", DenseRuntime())
+    monkeypatch.setattr(
+        gemma_model,
+        "_apply_neox_rotary",
+        lambda query, key, position: (query, key),
+    )
+    monkeypatch.setattr(
+        gemma_model.attention_ops,
+        "dense_attention",
+        lambda query, key, value, **kwargs: query,
+    )
+    hidden = torch.randn((1, 2, 8))
+
+    attention(
+        hidden,
+        (torch.empty(0), torch.empty(0)),
+        [None, None],
+        Cache(),
+        torch.arange(2),
+        torch.arange(2),
+        None,
+    )
+
+    assert attention.qkv_proj.source_names == ("q_proj", "k_proj", "k_proj")
+    torch.testing.assert_close(observed["raw_k"], observed["raw_v"])
+    torch.testing.assert_close(
+        observed["normalized_k"],
+        observed["raw_k"] + 10,
+    )
+    torch.testing.assert_close(
+        observed["normalized_v"],
+        observed["raw_v"] + 20,
+    )
+
+
+def test_text_attention_shared_kv_packs_only_query() -> None:
+    config = _tiny_gemma_config().text_config
+    config = replace(
+        config,
+        num_kv_shared_layers=1,
+        layer_types=("sliding_attention", "sliding_attention"),
+    )
+    attention = Gemma4TextAttention(
+        config,
+        layer_idx=1,
+        kv_source_layer_idx=0,
+        publishes_kv=False,
+    )
+    q = torch.randn((8, 8))
+    packed = {"q_proj.weight": q}
+
+    bind_declared_packed_projections(attention, packed)
+    with torch.no_grad():
+        attention.qkv_proj.weight.copy_(packed["qkv_proj.weight"])
+    hidden = torch.ones((1, 8))
+
+    assert attention.qkv_proj.source_names == ("q_proj",)
+    assert packed["qkv_proj.weight"] is q
+    torch.testing.assert_close(
+        attention.qkv_proj(hidden),
+        F.linear(hidden, q),
+    )
+    assert not any(
+        name.startswith(("q_proj.", "k_proj.", "v_proj."))
+        for name, _ in attention.named_parameters()
+    )
+
+
 def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retained():
     config = _tiny_gemma_config()
     old_dtype = torch.get_default_dtype()
@@ -302,9 +448,15 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
     _restore_checkpoint_independent_state(model, config, device=torch.device("cpu"))
     materialize_remaining_meta_tensors(model, device=torch.device("cpu"))
     layer = model.model.language_model.layers[0]
-    layer.self_attn.q_proj.weight.data.fill_(1)
-    layer.self_attn.k_proj.weight.data.fill_(2)
-    layer.self_attn.v_proj.weight.data.fill_(3)
+    layer.self_attn.qkv_proj.weight.data.copy_(
+        torch.cat(
+            (
+                torch.full((8, 8), 1, dtype=torch.bfloat16),
+                torch.full((4, 8), 2, dtype=torch.bfloat16),
+                torch.full((4, 8), 3, dtype=torch.bfloat16),
+            )
+        )
+    )
     layer.mlp.gate_up_proj.weight.data.copy_(
         torch.arange(16, dtype=torch.bfloat16).view(16, 1).expand(16, 8)
     )
@@ -312,10 +464,10 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
     finalize_weight_storage_after_loading(model, descriptor, storage)
 
     assert final_bytes == 3 * 16 * 8 * 2
-    assert storage.aliased_source_bytes == 2 * 16 * 8 * 2
-    assert storage.retained_source_bytes == (8 * 8 + 4 * 8 + 4 * 8) * 2
+    assert storage.aliased_source_bytes == 3 * 16 * 8 * 2
+    assert storage.retained_source_bytes == 0
     assert all(
-        retained.name != "w_gate_up_fresh"
+        retained.name not in {"w_gate_up_fresh", "w_qkv_local"}
         for retained in storage.retained_recipes
     )
     assert storage.finalized
@@ -323,6 +475,20 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
     assert torch._C._is_alias_of(
         layer.mlp.gate_up_proj.weight,
         storage.buffers["w_gate_up_fresh"][0],
+    )
+    assert torch._C._is_alias_of(
+        layer.self_attn.qkv_proj.weight,
+        storage.buffers["w_qkv_local"][0],
+    )
+    assert not any(
+        name.endswith(
+            (
+                "self_attn.q_proj.weight",
+                "self_attn.k_proj.weight",
+                "self_attn.v_proj.weight",
+            )
+        )
+        for name, _ in model.named_parameters()
     )
     assert not any(
         tensor.device.type == "meta"
@@ -333,6 +499,49 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
         for tensor in model.model.language_model.rotary_emb.inv_freq.values()
     )
     assert materialize_weights(model, descriptor) is storage
+
+
+def test_gemma_generated_shared_query_projection_aliases_direct_row() -> None:
+    text_config = replace(
+        _tiny_gemma_config().text_config,
+        num_kv_shared_layers=1,
+        layer_types=("sliding_attention", "sliding_attention"),
+    )
+    config = replace(_tiny_gemma_config(), text_config=text_config)
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        with torch.device("meta"):
+            model = Gemma4InferenceModel(config)
+    finally:
+        torch.set_default_dtype(old_dtype)
+    descriptor = {
+        "weight_layer_prefix": "model.language_model.layers",
+        "weights": [
+            {
+                "name": "w_q_local",
+                "source": "self_attn.qkv_proj.weight",
+                "prep": "identity",
+                "shape": [8, 8],
+                "dtype": "bf16",
+                "per_layer": True,
+                "physical_layers": [1],
+                "kind": "param",
+            },
+        ],
+    }
+
+    storage = allocate_weight_storage_for_loading(
+        model,
+        descriptor,
+        device="cpu",
+    )
+    query = model.model.language_model.layers[1].self_attn.qkv_proj.weight
+
+    assert storage.finalized
+    assert storage.retained_source_bytes == 0
+    assert torch._C._is_alias_of(query, storage.buffers["w_q_local"][0])
+    assert tuple(query.stride()) == tuple(storage.buffers["w_q_local"][0].stride())
 
 
 def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
@@ -371,15 +580,18 @@ def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
             descriptor,
             device="cpu",
         )
-        assert not storage.finalized
+        assert storage.finalized
         storage_box["storage"] = storage
 
     def finalize_model(model: torch.nn.Module) -> None:
         lifecycle.append("finalize")
         storage = storage_box["storage"]
         assert not any(tensor.device.type == "meta" for tensor in model.parameters())
-        finalize_weight_storage_after_loading(model, descriptor, storage)
         assert storage.finalized
+        assert (
+            finalize_weight_storage_after_loading(model, descriptor, storage)
+            is storage
+        )
 
     model = load_model(
         tmp_path,

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -19,8 +19,11 @@ from kestrel.models.gemma4.loader import (
     load_model,
     load_weights,
 )
-from kestrel.models.gemma4.model import Gemma4InferenceModel
-from kestrel.runtime.bounded_projection import PackedLinear
+from kestrel.models.gemma4.model import Gemma4InferenceModel, Gemma4TextMLP
+from kestrel.runtime.bounded_projection import (
+    PackedLinear,
+    bind_declared_packed_projections,
+)
 from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 from kestrel_kernels.generated_decode import (
     allocate_weight_storage_for_loading,
@@ -156,7 +159,7 @@ def _tiny_generated_weight_descriptor() -> dict[str, object]:
             {
                 "name": "w_gate_up_fresh",
                 "source": "mlp.gate_up_proj.weight",
-                "prep": "interleave_gate_up_rows8_axis0|cast_bf16",
+                "prep": "identity",
                 "shape": [16, 8],
                 "dtype": "bf16",
                 "per_layer": True,
@@ -227,6 +230,54 @@ def test_load_weights_rejects_unexpected_checkpoint_tensor(tmp_path) -> None:
         load_weights(tmp_path, _ToyShardedModel())
 
 
+def test_text_mlp_interleaved_checkpoint_layout_matches_gate_up_math(
+    monkeypatch,
+) -> None:
+    import kestrel.models.gemma4.model as gemma_model
+
+    torch.manual_seed(7)
+    config = _tiny_gemma_config().text_config
+    mlp = Gemma4TextMLP(config, layer_idx=0)
+    gate = torch.randn((config.intermediate_size, config.hidden_size))
+    up = torch.randn_like(gate)
+    down = torch.randn((config.hidden_size, config.intermediate_size))
+    packed = {"gate_proj.weight": gate, "up_proj.weight": up}
+    bind_declared_packed_projections(mlp, packed)
+    with torch.no_grad():
+        mlp.gate_up_proj.weight.copy_(packed["gate_up_proj.weight"])
+        mlp.down_proj.weight.copy_(down)
+
+    observed_layouts: list[str] = []
+
+    def gated_activation_into(out, gate_up, *, activation, layout) -> None:
+        observed_layouts.append(layout)
+        assert activation == "gelu_tanh"
+        blocks = gate_up.reshape(*gate_up.shape[:-1], config.intermediate_size // 8, 16)
+        gate_out = blocks[..., :8].reshape_as(out)
+        up_out = blocks[..., 8:].reshape_as(out)
+        out.copy_(torch.nn.functional.gelu(
+            gate_out, approximate="tanh"
+        ) * up_out)
+
+    monkeypatch.setattr(
+        gemma_model,
+        "_kestrel_gated_activation_into",
+        gated_activation_into,
+    )
+    hidden = torch.randn((3, config.hidden_size))
+
+    actual = mlp(hidden)
+    expected = torch.nn.functional.linear(
+        torch.nn.functional.gelu(
+            torch.nn.functional.linear(hidden, gate), approximate="tanh"
+        ) * torch.nn.functional.linear(hidden, up),
+        down,
+    )
+
+    assert observed_layouts == ["interleaved_i8"]
+    torch.testing.assert_close(actual, expected)
+
+
 def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retained():
     config = _tiny_gemma_config()
     old_dtype = torch.get_default_dtype()
@@ -261,10 +312,18 @@ def test_gemma_generated_weight_storage_streams_direct_rows_and_finalizes_retain
     finalize_weight_storage_after_loading(model, descriptor, storage)
 
     assert final_bytes == 3 * 16 * 8 * 2
-    assert storage.aliased_source_bytes == 16 * 8 * 2
-    assert storage.retained_source_bytes == (8 * 8 + 4 * 8 + 4 * 8 + 16 * 8) * 2
+    assert storage.aliased_source_bytes == 2 * 16 * 8 * 2
+    assert storage.retained_source_bytes == (8 * 8 + 4 * 8 + 4 * 8) * 2
+    assert all(
+        retained.name != "w_gate_up_fresh"
+        for retained in storage.retained_recipes
+    )
     assert storage.finalized
     assert model.lm_head.weight is model.model.language_model.embed_tokens.weight
+    assert torch._C._is_alias_of(
+        layer.mlp.gate_up_proj.weight,
+        storage.buffers["w_gate_up_fresh"][0],
+    )
     assert not any(
         tensor.device.type == "meta"
         for tensor in (*model.parameters(), *model.buffers())
@@ -338,6 +397,10 @@ def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
     assert torch._C._is_alias_of(
         embedding,
         storage.buffers["text_embedding_table"],
+    )
+    assert torch._C._is_alias_of(
+        model.model.language_model.layers[0].mlp.gate_up_proj.weight,
+        storage.buffers["w_gate_up_fresh"][0],
     )
     torch.testing.assert_close(embedding, expected_embedding)
     assert not any(

--- a/tests/gemma4/test_loader.py
+++ b/tests/gemma4/test_loader.py
@@ -306,6 +306,7 @@ def test_load_model_runs_generated_weight_lifecycle_through_tiny_checkpoint(
 
     def prepare_model(model: torch.nn.Module) -> None:
         lifecycle.append("prepare")
+        assert all(tensor.device.type == "meta" for tensor in model.parameters())
         storage = allocate_weight_storage_for_loading(
             model,
             descriptor,

--- a/tests/gemma4/test_moe.py
+++ b/tests/gemma4/test_moe.py
@@ -152,7 +152,7 @@ def test_experts_use_shared_contiguous_geglu_runtime(monkeypatch) -> None:
 
     spec = calls["spec"]
     forward = calls["forward"]
-    assert spec.activation == "gelu"
+    assert spec.activation == "geglu"
     assert spec.backend == "auto"
     assert spec.intermediate_size == config.moe_intermediate_size
     assert forward["weights"].weight_scale_layout == "block128"

--- a/tests/gemma4/test_runtime_resources.py
+++ b/tests/gemma4/test_runtime_resources.py
@@ -1,0 +1,144 @@
+"""Resource sizing for Gemma generated decode."""
+
+import gc
+import weakref
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from kestrel.models.gemma4.generated_decode import _rope_tables
+from kestrel.models.gemma4.runtime import (
+    Gemma4Runtime,
+    _allocate_decode_page_tables,
+    _generated_kv_binding_inputs,
+    _install_decode_page_tables,
+)
+
+
+class _Rotary:
+    def __call__(self, _probe, positions, kind):
+        offset = 1 if kind == "sliding_attention" else 10
+        values = positions.unsqueeze(-1).expand(-1, -1, 3) + offset
+        values = values.to(torch.bfloat16)
+        return values, values + 1
+
+
+def _runtime(max_seq_length: int = 8):
+    language_model = SimpleNamespace(rotary_emb=_Rotary())
+    return SimpleNamespace(
+        max_seq_length=max_seq_length,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        model=SimpleNamespace(
+            model=SimpleNamespace(language_model=language_model),
+        ),
+    )
+
+
+def test_rope_tables_materialize_only_requested_reachable_positions() -> None:
+    tables = _rope_tables(_runtime(), 3)
+
+    assert set(tables) == {
+        "rope_cos_local",
+        "rope_sin_local",
+        "rope_cos_global",
+        "rope_sin_global",
+    }
+    assert all(tuple(table.shape) == (3, 3) for table in tables.values())
+    assert all(table.dtype is torch.float32 for table in tables.values())
+    assert all(table.is_contiguous() for table in tables.values())
+
+
+@pytest.mark.parametrize("length", [0, 9])
+def test_rope_tables_reject_lengths_outside_model_context(length: int) -> None:
+    with pytest.raises(ValueError, match="must lie"):
+        _rope_tables(_runtime(), length)
+
+
+def test_generated_binding_inputs_preserve_sparse_layer_topology() -> None:
+    inputs = _generated_kv_binding_inputs(
+        (object(), None, object(), object()),
+        (
+            "sliding_attention",
+            "full_attention",
+            "full_attention",
+            "sliding_attention",
+        ),
+    )
+
+    assert inputs["mK_local"] is inputs["mV_local"]
+    assert inputs["mK_global"] is inputs["mV_global"]
+    assert [value is not None for value in inputs["mK_local"]] == [
+        True,
+        False,
+        False,
+        True,
+    ]
+    assert [value is not None for value in inputs["mK_global"]] == [
+        False,
+        False,
+        True,
+        False,
+    ]
+
+
+def test_generated_binding_reservation_is_released_before_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.gemma4 import generated_decode
+
+    released = []
+
+    class _Reservation:
+        def __del__(self):
+            released.append(True)
+
+    runtime = object.__new__(Gemma4Runtime)
+    runtime.decode_path = "auto"
+    runtime._generated_weight_storage = object()
+    runtime._generated_binding_reservation = _Reservation()
+    expected = object()
+
+    def create(_runtime, *, required=False):
+        assert released == [True]
+        assert required is False
+        return expected
+
+    monkeypatch.setattr(generated_decode, "create_generated_decode", create)
+
+    runtime._initialize_generated_decode()
+
+    assert runtime._generated_binding_reservation is None
+    assert runtime.generated_decode is expected
+
+
+def test_decode_page_table_placeholders_are_replaced_before_binding() -> None:
+    slots = tuple(
+        SimpleNamespace(paged_kv_page_table=torch.empty((3, 1), dtype=torch.int32))
+        for _ in range(2)
+    )
+    old_tables = tuple(weakref.ref(slot.paged_kv_page_table) for slot in slots)
+    tables = _allocate_decode_page_tables(
+        count=2,
+        rows=3,
+        pages=11,
+        device=torch.device("cpu"),
+    )
+
+    _install_decode_page_tables(slots, tables)
+
+    assert all(tuple(slot.paged_kv_page_table.shape) == (3, 11) for slot in slots)
+    assert all(slot.paged_kv_page_table is table for slot, table in zip(slots, tables))
+    gc.collect()
+    assert all(reference() is None for reference in old_tables)
+    with pytest.raises(RuntimeError, match="unbound one-column placeholders"):
+        _install_decode_page_tables(
+            slots,
+            _allocate_decode_page_tables(
+                count=2,
+                rows=3,
+                pages=12,
+                device=torch.device("cpu"),
+            ),
+        )

--- a/tests/gemma4/test_runtime_resources.py
+++ b/tests/gemma4/test_runtime_resources.py
@@ -12,6 +12,7 @@ from kestrel.models.gemma4.image import GemmaImageInputs
 from kestrel.models.gemma4.runtime import (
     Gemma4Runtime,
     _PagedRuntimeResources,
+    _add_exception_note,
     _allocate_decode_page_tables,
     _copy_image_features_into_embeddings,
     _generated_kv_binding_inputs,
@@ -37,6 +38,16 @@ class _Rotary:
         values = positions.unsqueeze(-1).expand(-1, -1, 3) + offset
         values = values.to(torch.bfloat16)
         return values, values + 1
+
+
+def test_exception_note_compatibility_path_without_add_note() -> None:
+    class LegacyError:
+        pass
+
+    error = LegacyError()
+    _add_exception_note(error, "cleanup detail")
+
+    assert error.__notes__ == ["cleanup detail"]
 
 
 def _runtime(max_seq_length: int = 8):

--- a/tests/gemma4/test_runtime_resources.py
+++ b/tests/gemma4/test_runtime_resources.py
@@ -8,14 +8,27 @@ import pytest
 import torch
 
 from kestrel.models.gemma4.generated_decode import _rope_tables
+from kestrel.models.gemma4.image import GemmaImageInputs
 from kestrel.models.gemma4.runtime import (
     Gemma4Runtime,
+    _PagedRuntimeResources,
     _allocate_decode_page_tables,
+    _copy_image_features_into_embeddings,
     _generated_kv_binding_inputs,
     _install_decode_page_tables,
     _materialize_fixed_runtime_resources,
-    _vision_probe_records,
+    _maximum_vision_grid,
+    _run_image_prefill_transient_probe,
+    _vision_probe_inputs,
 )
+from kestrel.kv_cache import (
+    KVMemoryPool,
+    PageTable,
+    PagedKVLayerSpec,
+    allocate_paged_kv_layers,
+    allocate_paged_kv_storage,
+)
+from kestrel.models.gemma4.prompt_template import Gemma4PromptTemplate
 
 
 class _Rotary:
@@ -170,9 +183,7 @@ def test_fixed_runtime_resources_use_resident_matmul_and_full_vision_path(
             }
 
     def get_image_features(pixel_values, position_ids):
-        calls.append(
-            ("vision", tuple(pixel_values.shape), tuple(position_ids.shape))
-        )
+        calls.append(("vision", tuple(pixel_values.shape), tuple(position_ids.shape)))
         return torch.ones(pixel_values.shape[0], 2)
 
     runtime = SimpleNamespace(
@@ -186,11 +197,12 @@ def test_fixed_runtime_resources_use_resident_matmul_and_full_vision_path(
         decode_slots=(SimpleNamespace(hidden_last=hidden, logits=logits),),
         _vision_stager=Stager(),
     )
-    records = tuple(
-        {
-            "pixel_values": torch.zeros(3, 4),
-            "position_ids": torch.zeros(3, 2, dtype=torch.long),
-        }
+    inputs = tuple(
+        GemmaImageInputs(
+            pixel_values=torch.zeros(3, 4),
+            image_position_ids=torch.zeros(3, 2, dtype=torch.long),
+            num_image_tokens=2,
+        )
         for _row in range(2)
     )
 
@@ -201,7 +213,7 @@ def test_fixed_runtime_resources_use_resident_matmul_and_full_vision_path(
 
     monkeypatch.setattr(runtime_module, "materialize_blas_runtime", materialize)
 
-    _materialize_fixed_runtime_resources(runtime, records)
+    _materialize_fixed_runtime_resources(runtime, inputs)
 
     assert calls == [
         (torch.device("cpu"), compute_stream),
@@ -212,7 +224,7 @@ def test_fixed_runtime_resources_use_resident_matmul_and_full_vision_path(
     torch.testing.assert_close(logits[:2], hidden[:2] @ weight.t())
 
 
-def test_vision_probe_records_cover_pooling_aligned_max_patch_grid() -> None:
+def test_vision_probe_inputs_cover_pooling_aligned_max_patch_grid() -> None:
     runtime = SimpleNamespace(
         max_batch_size=3,
         dtype=torch.bfloat16,
@@ -220,17 +232,394 @@ def test_vision_probe_records_cover_pooling_aligned_max_patch_grid() -> None:
             vision_config=SimpleNamespace(
                 patch_size=16,
                 pooling_kernel_size=3,
+                position_embedding_size=64,
             )
         ),
     )
 
-    records = _vision_probe_records(runtime)
+    inputs = _vision_probe_inputs(runtime)
 
-    assert len(records) == 3
-    assert tuple(records[0]["pixel_values"].shape) == (2520, 768)
-    assert tuple(records[0]["position_ids"].shape) == (2520, 2)
-    positions = records[0]["position_ids"]
+    assert len(inputs) == 3
+    assert len({id(item) for item in inputs}) == 3
+    assert tuple(inputs[0].pixel_values.shape) == (2520, 768)
+    assert tuple(inputs[0].image_position_ids.shape) == (2520, 2)
+    assert inputs[0].num_image_tokens == 280
+    positions = inputs[0].image_position_ids
     width = int(positions[:, 0].max()) + 1
     height = int(positions[:, 1].max()) + 1
     assert width * height == 2520
     assert width % 3 == height % 3 == 0
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"patch_size": 14}, "patch_size must be 16"),
+        ({"pooling_kernel_size": 2}, "pooling_kernel_size must be 3"),
+        ({"position_embedding_size": 59}, "cannot represent"),
+    ],
+)
+def test_maximum_vision_grid_rejects_unsupported_preprocessing_contract(
+    overrides: dict[str, int],
+    match: str,
+) -> None:
+    values = {
+        "patch_size": 16,
+        "pooling_kernel_size": 3,
+        "position_embedding_size": 64,
+        **overrides,
+    }
+
+    with pytest.raises(ValueError, match=match):
+        _maximum_vision_grid(SimpleNamespace(**values))
+
+
+def test_direct_image_feature_copy_matches_masked_scatter_without_packing() -> None:
+    image_token_id = 9
+    token_rows = ([1, 9, 9, 2], [3, 4], [9, 9, 5])
+    shared = torch.arange(6, dtype=torch.bfloat16).view(3, 2).t()
+    assert not shared.is_contiguous()
+    features = (shared, None, shared)
+    embeddings = torch.randn(1, 9, 3, dtype=torch.bfloat16)
+    expected = embeddings.clone()
+    flat_ids = torch.tensor([[token for row in token_rows for token in row]])
+    image_mask = flat_ids == image_token_id
+    expected.masked_scatter_(
+        image_mask.unsqueeze(-1).expand_as(expected),
+        torch.cat([shared, shared]),
+    )
+
+    _copy_image_features_into_embeddings(
+        embeddings,
+        token_rows,
+        features,
+        image_token_id=image_token_id,
+    )
+
+    assert torch.equal(embeddings, expected)
+
+
+@pytest.mark.parametrize(
+    ("failure", "match"),
+    [
+        ("dtype", "dtype"),
+        ("device", "expected cpu"),
+        ("rank", "must be 2D"),
+        ("width", "expected \\(2, 3\\)"),
+        ("noncontiguous_tokens", "must be contiguous"),
+        ("missing", "without features"),
+    ],
+)
+def test_direct_image_feature_copy_validates_all_rows_before_writing(
+    failure: str,
+    match: str,
+) -> None:
+    token_rows = ([9, 9], [9, 9])
+    valid = torch.ones(2, 3, dtype=torch.bfloat16)
+    invalid: torch.Tensor | None = valid
+    if failure == "dtype":
+        invalid = valid.float()
+    elif failure == "device":
+        invalid = torch.empty(2, 3, dtype=torch.bfloat16, device="meta")
+    elif failure == "rank":
+        invalid = torch.ones(6, dtype=torch.bfloat16)
+    elif failure == "width":
+        invalid = torch.ones(2, 2, dtype=torch.bfloat16)
+    elif failure == "noncontiguous_tokens":
+        token_rows = ([9, 9], [9, 4, 9])
+    elif failure == "missing":
+        invalid = None
+    embeddings = torch.randn(
+        1,
+        sum(len(row) for row in token_rows),
+        3,
+        dtype=torch.bfloat16,
+    )
+    before = embeddings.clone()
+
+    with pytest.raises(RuntimeError, match=match):
+        _copy_image_features_into_embeddings(
+            embeddings,
+            token_rows,
+            (valid, invalid),
+            image_token_id=9,
+        )
+
+    assert torch.equal(embeddings, before)
+
+
+class _ProbeStager:
+    def stage(self, records):
+        return {
+            "pixel_values": torch.stack([record["pixel_values"] for record in records]),
+            "position_ids": torch.stack([record["position_ids"] for record in records]),
+        }
+
+
+class _ProbeLanguageModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.touched_pages: set[int] = set()
+        self.raise_oom = False
+
+    def embed(self, input_ids: torch.Tensor) -> torch.Tensor:
+        values = input_ids.to(torch.bfloat16).unsqueeze(-1)
+        return values.expand(-1, -1, 4).clone()
+
+    def forward(
+        self,
+        *,
+        inputs_embeds,
+        position_ids,
+        kv_cache,
+        per_layer_inputs,
+        cache_position_ids,
+        slot_mapping,
+        cu_seqlens,
+    ):
+        del position_ids, per_layer_inputs, cache_position_ids, cu_seqlens
+        pages = torch.unique(slot_mapping // int(kv_cache[0].page_table.page_size)).to(
+            torch.long
+        )
+        self.touched_pages.update(int(page) for page in pages.tolist())
+        for cache in kv_cache:
+            if cache is not None:
+                cache.k_cache.index_fill_(0, pages, 7)
+                cache.v_cache.index_fill_(0, pages, 8)
+        if self.raise_oom:
+            raise torch.OutOfMemoryError("synthetic language-prefill peak")
+        return inputs_embeds
+
+
+class _ProbeModel(torch.nn.Module):
+    def __init__(self, language_model: _ProbeLanguageModel) -> None:
+        super().__init__()
+        self.language_model = language_model
+        self.embed_vision = torch.nn.Identity()
+
+    def get_image_features(self, pixel_values, image_position_ids):
+        del image_position_ids
+        count = int(pixel_values.shape[0]) * 280
+        features = torch.arange(count * 4, dtype=torch.float32).view(count, 4)
+        return self.embed_vision(features.to(torch.bfloat16))
+
+
+class _ProbeHead(torch.nn.Module):
+    def forward(self, rows):
+        return rows[:, :3]
+
+
+def _image_prefill_probe_runtime():
+    runtime = object.__new__(Gemma4Runtime)
+    runtime.device = torch.device("cpu")
+    runtime.dtype = torch.bfloat16
+    runtime.max_batch_size = 2
+    runtime.max_batch_slots = 4
+    runtime.max_seq_length = 1024
+    runtime.page_size = 16
+    runtime.image_prefix_length = 282
+    runtime._padding_batch_idx = 3
+    runtime._compute_stream = None
+    runtime._prefill_slot = SimpleNamespace(
+        batch_idx=torch.full((2,), -1, dtype=torch.long)
+    )
+    runtime._prefill_slot.batch_idx.zero_()
+    runtime._prefill_slot_in_use = False
+    runtime.active_sequences = {}
+    runtime.prompt_template = Gemma4PromptTemplate("unit-test")
+    runtime._config = SimpleNamespace(
+        image_token_id=258_880,
+        vision_config=SimpleNamespace(
+            patch_size=16,
+            pooling_kernel_size=3,
+            position_embedding_size=64,
+        ),
+        text_config=SimpleNamespace(
+            hidden_size_per_layer_input=False,
+            final_logit_softcapping=30.0,
+        ),
+    )
+    runtime._vision_stager = _ProbeStager()
+    language_model = _ProbeLanguageModel()
+    runtime.model = SimpleNamespace(
+        model=_ProbeModel(language_model),
+        lm_head=_ProbeHead(),
+    )
+    pool = KVMemoryPool(device="cpu")
+    runtime._kv_pool = pool
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=2),)
+    storage = allocate_paged_kv_storage(
+        64,
+        layer_specs=specs,
+        page_size=16,
+        dtype=torch.bfloat16,
+        pool=pool,
+    )
+    accepted = PageTable(
+        n_pages=64,
+        page_size=16,
+        max_batch_size=4,
+        device="cpu",
+    )
+    accepted.free_batch_idx.remove(runtime._padding_batch_idx)
+    accepted.reserve(runtime._padding_batch_idx, 1)
+    accepted.commit_block_table([runtime._padding_batch_idx])
+    resources = _PagedRuntimeResources(
+        rope_inputs=None,
+        decode_page_tables=(),
+        page_table=accepted,
+    )
+    return (
+        runtime,
+        language_model,
+        specs,
+        storage,
+        resources,
+        _vision_probe_inputs(runtime),
+    )
+
+
+def _page_table_state(page_table: PageTable):
+    return (
+        tuple(page_table.free_pages),
+        tuple(page_table.free_batch_idx),
+        tuple(tuple(row) for row in page_table.page_table_cpu),
+        tuple(page_table.capacity),
+        tuple(int(value) for value in page_table.num_blocks_per_row),
+        page_table._page_table_cpu_tensor.clone(),
+        page_table.page_table.clone(),
+    )
+
+
+def test_image_prefill_probe_restores_accepted_resources_and_runtime() -> None:
+    runtime, language, specs, storage, resources, inputs = (
+        _image_prefill_probe_runtime()
+    )
+    accepted_before = _page_table_state(resources.page_table)
+
+    result = _run_image_prefill_transient_probe(
+        runtime,
+        inputs,
+        storage,
+        resources,
+        specs,
+    )
+
+    assert tuple(result.logits.shape) == (2, 3)
+    assert len(result.prepared_sequences) == 2
+    assert len(result.image_features) == 1
+    assert tuple(result.image_features[0].shape) == (560, 4)
+    assert not hasattr(runtime, "page_table")
+    assert not hasattr(runtime, "_kv_cache")
+    assert torch.equal(
+        runtime._prefill_slot.batch_idx, torch.zeros(2, dtype=torch.long)
+    )
+    accepted_after = _page_table_state(resources.page_table)
+    assert accepted_after[:-2] == accepted_before[:-2]
+    assert torch.equal(accepted_after[-2], accepted_before[-2])
+    assert torch.equal(accepted_after[-1], accepted_before[-1])
+    assert language.touched_pages and 0 not in language.touched_pages
+    layer = storage.layers[0]
+    assert layer is not None
+    assert torch.count_nonzero(layer.k_cache[0].view(torch.uint8)) == 0
+    assert torch.count_nonzero(layer.v_cache[0].view(torch.uint8)) == 0
+    assert not runtime.model.model.embed_vision._forward_hooks
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_paged_kv_mapping_preserves_raw_zero_page_on_device() -> None:
+    device = torch.device("cuda")
+    pool = KVMemoryPool(device=device)
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=4),)
+    storage = allocate_paged_kv_storage(
+        8,
+        layer_specs=specs,
+        page_size=2,
+        dtype=torch.bfloat16,
+        pool=pool,
+    )
+    page_table = PageTable(
+        n_pages=8,
+        page_size=2,
+        max_batch_size=3,
+        device=str(device),
+    )
+    batch_idx = page_table.allocate()
+    page_table.reserve(batch_idx, 5)
+    page_table.commit_block_table([batch_idx])
+    positions = torch.arange(5, dtype=torch.long, device=device).view(1, -1)
+    logical_rows = torch.full_like(positions, batch_idx)
+    slot_mapping = page_table.build_slot_mapping(
+        batch_idx=logical_rows,
+        positions=positions,
+    )
+    mapped_pages = torch.unique(slot_mapping // page_table.page_size)
+    assert mapped_pages.numel() and not bool((mapped_pages == 0).any().item())
+    cache = allocate_paged_kv_layers(
+        layer_specs=specs,
+        page_table=page_table,
+        pool=pool,
+        dtype=torch.bfloat16,
+        storage=storage,
+    )[0]
+    assert cache is not None
+    values = torch.ones(
+        1,
+        5,
+        1,
+        4,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    cache.update(
+        positions,
+        values * 7,
+        values * 8,
+        slot_mapping=slot_mapping,
+    )
+    layer = storage.layers[0]
+    assert layer is not None
+    torch.cuda.synchronize(device)
+
+    assert torch.equal(
+        layer.k_cache[0].view(torch.uint8).cpu(),
+        torch.zeros_like(layer.k_cache[0].view(torch.uint8), device="cpu"),
+    )
+    assert torch.equal(
+        layer.v_cache[0].view(torch.uint8).cpu(),
+        torch.zeros_like(layer.v_cache[0].view(torch.uint8), device="cpu"),
+    )
+
+
+def test_image_prefill_probe_preserves_oom_when_cleanup_also_fails() -> None:
+    runtime, language, specs, storage, resources, inputs = (
+        _image_prefill_probe_runtime()
+    )
+    accepted_before = _page_table_state(resources.page_table)
+    language.raise_oom = True
+
+    def fail_abort(_prepared):
+        raise RuntimeError("synthetic abort failure")
+
+    runtime.abort_prepared_sequence = fail_abort
+
+    with pytest.raises(torch.OutOfMemoryError, match="language-prefill peak") as caught:
+        _run_image_prefill_transient_probe(
+            runtime,
+            inputs,
+            storage,
+            resources,
+            specs,
+        )
+
+    assert any("synthetic abort failure" in note for note in caught.value.__notes__)
+    assert not hasattr(runtime, "page_table")
+    assert not hasattr(runtime, "_kv_cache")
+    assert torch.equal(
+        runtime._prefill_slot.batch_idx, torch.zeros(2, dtype=torch.long)
+    )
+    accepted_after = _page_table_state(resources.page_table)
+    assert accepted_after[:-2] == accepted_before[:-2]
+    assert torch.equal(accepted_after[-2], accepted_before[-2])
+    assert torch.equal(accepted_after[-1], accepted_before[-1])
+    assert not runtime.model.model.embed_vision._forward_hooks

--- a/tests/gemma4/test_runtime_resources.py
+++ b/tests/gemma4/test_runtime_resources.py
@@ -13,6 +13,7 @@ from kestrel.models.gemma4.runtime import (
     _allocate_decode_page_tables,
     _generated_kv_binding_inputs,
     _install_decode_page_tables,
+    _materialize_fixed_blas_resources,
 )
 
 
@@ -142,3 +143,33 @@ def test_decode_page_table_placeholders_are_replaced_before_binding() -> None:
                 device=torch.device("cpu"),
             ),
         )
+
+
+def test_fixed_blas_resources_use_resident_output_matmul(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.gemma4 import runtime as runtime_module
+
+    hidden = torch.randn(4, 3, dtype=torch.bfloat16)
+    weight = torch.randn(5, 3, dtype=torch.bfloat16)
+    logits = torch.empty(4, 5, dtype=torch.bfloat16)
+    compute_stream = object()
+    calls = []
+    runtime = SimpleNamespace(
+        device=torch.device("cpu"),
+        _compute_stream=compute_stream,
+        max_batch_size=2,
+        model=SimpleNamespace(lm_head=SimpleNamespace(weight=weight)),
+        decode_slots=(SimpleNamespace(hidden_last=hidden, logits=logits),),
+    )
+
+    def materialize(device, stream, operation):
+        calls.append((device, stream))
+        operation()
+
+    monkeypatch.setattr(runtime_module, "materialize_blas_runtime", materialize)
+
+    _materialize_fixed_blas_resources(runtime)
+
+    assert calls == [(torch.device("cpu"), compute_stream)]
+    torch.testing.assert_close(logits[:2], hidden[:2] @ weight.t())

--- a/tests/gemma4/test_runtime_resources.py
+++ b/tests/gemma4/test_runtime_resources.py
@@ -18,8 +18,10 @@ from kestrel.models.gemma4.runtime import (
     _generated_kv_binding_inputs,
     _install_decode_page_tables,
     _materialize_fixed_runtime_resources,
+    _maximum_admitted_image_prefill_prompt,
     _maximum_vision_grid,
     _run_image_prefill_transient_probe,
+    _run_steady_state_image_prefill_probe,
     _vision_probe_inputs,
 )
 from kestrel.kv_cache import (
@@ -535,6 +537,102 @@ def test_image_prefill_probe_restores_accepted_resources_and_runtime() -> None:
     assert torch.count_nonzero(layer.k_cache[0].view(torch.uint8)) == 0
     assert torch.count_nonzero(layer.v_cache[0].view(torch.uint8)) == 0
     assert not runtime.model.model.embed_vision._forward_hooks
+
+
+def test_capacity_probe_uses_maximum_scheduler_admitted_prefill_length() -> None:
+    runtime, _language, _specs, _storage, resources, inputs = (
+        _image_prefill_probe_runtime()
+    )
+
+    prompt = _maximum_admitted_image_prefill_prompt(
+        runtime,
+        resources.page_table,
+        inputs[0],
+    )
+    expected_target = min(
+        runtime.max_seq_length,
+        resources.page_table.pages_available * resources.page_table.page_size,
+    )
+    runtime.page_table = resources.page_table
+    try:
+        prepared = runtime.prepare_sequence(
+            prompt,
+            image_crops=inputs[0],
+            max_new_tokens=1,
+        )
+
+        assert prepared.state.length == expected_target - 1
+        assert prepared.state.length > 286
+        assert prepared.state.max_length == expected_target
+    finally:
+        del runtime.page_table
+
+
+def test_steady_state_probe_releases_first_result_before_second_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.gemma4 import runtime as runtime_module
+
+    runtime = SimpleNamespace(
+        max_seq_length=1024,
+        image_prefix_length=282,
+        max_batch_size=2,
+    )
+    vision_inputs = tuple(
+        SimpleNamespace(num_image_tokens=280) for _row in range(2)
+    )
+    storage = object()
+    resources = SimpleNamespace(
+        page_table=SimpleNamespace(pages_available=512, page_size=1)
+    )
+    layer_specs = (object(),)
+    owner_refs: list[weakref.ReferenceType[torch.Tensor]] = []
+    calls = []
+    second = object()
+
+    def run_once(*args, **kwargs):
+        calls.append((args, kwargs))
+        if owner_refs:
+            assert owner_refs[-1]() is None
+        if len(calls) < 3:
+            first_owner = torch.ones(1)
+            owner_refs.append(weakref.ref(first_owner))
+            return SimpleNamespace(owner=first_owner)
+        return second
+
+    monkeypatch.setattr(
+        runtime_module,
+        "_run_image_prefill_transient_probe",
+        run_once,
+    )
+
+    with pytest.raises(ValueError, match="maximum batch"):
+        _run_steady_state_image_prefill_probe(
+            runtime,
+            vision_inputs[:1],
+            storage,
+            resources,
+            layer_specs,
+        )
+
+    result = _run_steady_state_image_prefill_probe(
+        runtime,
+        vision_inputs,
+        storage,
+        resources,
+        layer_specs,
+    )
+
+    assert result is second
+    assert [args for args, _kwargs in calls] == [
+        (runtime, vision_inputs, storage, resources, layer_specs),
+        (runtime, vision_inputs[:1], storage, resources, layer_specs),
+        (runtime, vision_inputs[:1], storage, resources, layer_specs),
+    ]
+    assert calls[0][1] == {}
+    prompt_rows = [kwargs["prompt_tokens"] for _args, kwargs in calls[1:]]
+    assert prompt_rows[0] is prompt_rows[1]
+    assert len(prompt_rows[0]) + runtime.image_prefix_length == 511
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/gemma4/test_runtime_resources.py
+++ b/tests/gemma4/test_runtime_resources.py
@@ -13,7 +13,8 @@ from kestrel.models.gemma4.runtime import (
     _allocate_decode_page_tables,
     _generated_kv_binding_inputs,
     _install_decode_page_tables,
-    _materialize_fixed_blas_resources,
+    _materialize_fixed_runtime_resources,
+    _vision_probe_records,
 )
 
 
@@ -145,7 +146,7 @@ def test_decode_page_table_placeholders_are_replaced_before_binding() -> None:
         )
 
 
-def test_fixed_blas_resources_use_resident_output_matmul(
+def test_fixed_runtime_resources_use_resident_matmul_and_full_vision_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from kestrel.models.gemma4 import runtime as runtime_module
@@ -155,21 +156,81 @@ def test_fixed_blas_resources_use_resident_output_matmul(
     logits = torch.empty(4, 5, dtype=torch.bfloat16)
     compute_stream = object()
     calls = []
+
+    class Stager:
+        def stage(self, records):
+            calls.append(("stage", len(records)))
+            return {
+                "pixel_values": torch.stack(
+                    [record["pixel_values"] for record in records]
+                ),
+                "position_ids": torch.stack(
+                    [record["position_ids"] for record in records]
+                ),
+            }
+
+    def get_image_features(pixel_values, position_ids):
+        calls.append(
+            ("vision", tuple(pixel_values.shape), tuple(position_ids.shape))
+        )
+        return torch.ones(pixel_values.shape[0], 2)
+
     runtime = SimpleNamespace(
         device=torch.device("cpu"),
         _compute_stream=compute_stream,
         max_batch_size=2,
-        model=SimpleNamespace(lm_head=SimpleNamespace(weight=weight)),
+        model=SimpleNamespace(
+            lm_head=SimpleNamespace(weight=weight),
+            model=SimpleNamespace(get_image_features=get_image_features),
+        ),
         decode_slots=(SimpleNamespace(hidden_last=hidden, logits=logits),),
+        _vision_stager=Stager(),
+    )
+    records = tuple(
+        {
+            "pixel_values": torch.zeros(3, 4),
+            "position_ids": torch.zeros(3, 2, dtype=torch.long),
+        }
+        for _row in range(2)
     )
 
     def materialize(device, stream, operation):
         calls.append((device, stream))
-        operation()
+        result = operation()
+        calls.append(("result", tuple(result.shape)))
 
     monkeypatch.setattr(runtime_module, "materialize_blas_runtime", materialize)
 
-    _materialize_fixed_blas_resources(runtime)
+    _materialize_fixed_runtime_resources(runtime, records)
 
-    assert calls == [(torch.device("cpu"), compute_stream)]
+    assert calls == [
+        (torch.device("cpu"), compute_stream),
+        ("stage", 2),
+        ("vision", (2, 3, 4), (2, 3, 2)),
+        ("result", (2, 2)),
+    ]
     torch.testing.assert_close(logits[:2], hidden[:2] @ weight.t())
+
+
+def test_vision_probe_records_cover_pooling_aligned_max_patch_grid() -> None:
+    runtime = SimpleNamespace(
+        max_batch_size=3,
+        dtype=torch.bfloat16,
+        _config=SimpleNamespace(
+            vision_config=SimpleNamespace(
+                patch_size=16,
+                pooling_kernel_size=3,
+            )
+        ),
+    )
+
+    records = _vision_probe_records(runtime)
+
+    assert len(records) == 3
+    assert tuple(records[0]["pixel_values"].shape) == (2520, 768)
+    assert tuple(records[0]["position_ids"].shape) == (2520, 2)
+    positions = records[0]["position_ids"]
+    width = int(positions[:, 0].max()) + 1
+    height = int(positions[:, 1].max()) + 1
+    assert width * height == 2520
+    assert width % 3 == height % 3 == 0

--- a/tests/qwen35/test_generated_decode.py
+++ b/tests/qwen35/test_generated_decode.py
@@ -277,6 +277,7 @@ def test_generated_decode_binds_rope_offsets_without_dropping_old_bundle_prep(
     page_table = object()
     runtime = SimpleNamespace(
         max_batch_size=4,
+        _generated_weight_storage=None,
         _decode_rope_deltas=rope_deltas,
         _gather_decode_rope_deltas=lambda *_args: None,
         _prepare_decode_position_ids=lambda *_args: None,
@@ -368,6 +369,7 @@ def test_generated_decode_binds_rope_offsets_without_dropping_old_bundle_prep(
 def test_generated_decode_reports_compiled_slot_capacity(monkeypatch):
     runtime = SimpleNamespace(
         max_batch_size=1,
+        _generated_weight_storage=None,
         _decode_rope_deltas=object(),
         _gather_decode_rope_deltas=lambda *_args: None,
         _prepare_decode_position_ids=lambda *_args: None,
@@ -409,6 +411,7 @@ def test_generated_capacity_inputs_resolve_state_after_cached_field_snapshot(
     pool = _state_pool(config)
     runtime = SimpleNamespace(
         max_batch_size=4,
+        _generated_weight_storage=None,
         _decode_rope_deltas=object(),
         _gather_decode_rope_deltas=lambda *_args: None,
         _prepare_decode_position_ids=lambda *_args: None,

--- a/tests/qwen35/test_image_embeddings.py
+++ b/tests/qwen35/test_image_embeddings.py
@@ -1,0 +1,132 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from kestrel.models.qwen35.qwen_model import (
+    Qwen3_5Model,
+    _copy_image_features_into_embeddings,
+)
+from kestrel.models.qwen35.runtime import Qwen35Runtime
+
+
+class _PackedVision(torch.nn.Module):
+    def __init__(self, output: torch.Tensor) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.empty((), dtype=output.dtype))
+        self.output = output
+
+    def forward(self, *args, **kwargs) -> torch.Tensor:
+        return self.output
+
+
+def test_image_features_preserve_packed_visual_output() -> None:
+    packed = torch.randn(5, 3, dtype=torch.bfloat16)
+    model = object.__new__(Qwen3_5Model)
+    torch.nn.Module.__init__(model)
+    model.visual = _PackedVision(packed)
+
+    result = model.get_image_features(
+        torch.zeros(2, 3, dtype=torch.bfloat16),
+        bilinear_indices=torch.empty(0),
+        bilinear_weights=torch.empty(0),
+        position_ids=torch.empty(0),
+        cu_seqlens=torch.empty(0),
+    )
+
+    assert result is packed
+
+
+def test_direct_image_feature_copy_preserves_order_without_packing() -> None:
+    features = torch.arange(15, dtype=torch.bfloat16).view(3, 5).t()
+    assert not features.is_contiguous()
+    embeddings = torch.randn(1, 10, 3, dtype=torch.bfloat16)
+    expected = embeddings.clone()
+    expected[0, 1:3].copy_(features[:2])
+    expected[0, 6:9].copy_(features[2:])
+    storage = embeddings.untyped_storage().data_ptr()
+
+    _copy_image_features_into_embeddings(
+        embeddings,
+        features,
+        ((1, 3), (6, 9)),
+    )
+
+    assert embeddings.untyped_storage().data_ptr() == storage
+    assert torch.equal(embeddings, expected)
+
+
+@pytest.mark.parametrize(
+    ("failure", "match"),
+    [
+        ("count", "expected"),
+        ("device", "could not be converted"),
+        ("rank", "must be 2D"),
+        ("shape", "expected"),
+        ("bounds", "invalid or out of order"),
+        ("overlap", "invalid or out of order"),
+    ],
+)
+def test_direct_image_feature_copy_validates_before_writing(
+    failure: str,
+    match: str,
+) -> None:
+    features = torch.ones(4, 3, dtype=torch.bfloat16)
+    spans = ((1, 3), (5, 7))
+    if failure == "count":
+        features = torch.ones(3, 3, dtype=torch.bfloat16)
+    elif failure == "device":
+        features = torch.empty(4, 3, dtype=torch.bfloat16, device="meta")
+    elif failure == "rank":
+        features = torch.ones(12, dtype=torch.bfloat16)
+    elif failure == "shape":
+        features = torch.ones(4, 2, dtype=torch.bfloat16)
+    elif failure == "bounds":
+        spans = ((1, 3), (7, 11))
+    elif failure == "overlap":
+        spans = ((1, 3), (2, 4))
+    embeddings = torch.randn(1, 10, 3, dtype=torch.bfloat16)
+    before = embeddings.clone()
+
+    with pytest.raises((TypeError, ValueError), match=match):
+        _copy_image_features_into_embeddings(embeddings, features, spans)
+
+    assert torch.equal(embeddings, before)
+
+
+def test_direct_image_feature_copy_preserves_dtype_conversion_semantics() -> None:
+    embeddings = torch.zeros(1, 4, 3, dtype=torch.bfloat16)
+    features = torch.tensor(
+        [[1.125, 2.25, 3.5], [4.75, 5.0, 6.5]],
+        dtype=torch.float32,
+    )
+
+    _copy_image_features_into_embeddings(embeddings, features, ((1, 3),))
+
+    torch.testing.assert_close(
+        embeddings[0, 1:3],
+        features.to(torch.bfloat16),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_multimodal_position_ids_return_ordered_packed_image_spans() -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.architecture = SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2)
+    )
+    token_types = np.asarray([0, 1, 1, 0, 1, 1, 1, 1, 0], dtype=np.int64)
+    grid = np.asarray([[1, 2, 4], [1, 4, 4]], dtype=np.int64)
+    position_ids = np.zeros((3, 1, 12), dtype=np.int64)
+
+    _, spans = runtime._fill_multimodal_position_ids(
+        position_ids,
+        start=2,
+        end=11,
+        mm_token_type_ids=token_types,
+        image_grid_thw=grid,
+    )
+
+    assert spans == ((3, 5), (6, 10))

--- a/tests/qwen35/test_image_kv_length.py
+++ b/tests/qwen35/test_image_kv_length.py
@@ -64,3 +64,33 @@ def test_qwen_prepare_sequence_reserves_exact_expanded_length() -> None:
     assert prepared["image_length"] == 258
     assert len(prepared["tokens"]) == 259
     assert prepared["target_length"] == 1795
+
+
+@pytest.mark.parametrize(
+    "markers",
+    (
+        (ImageMarker(1), ImageMarker(0)),
+        (ImageMarker(0), ImageMarker(0)),
+    ),
+)
+def test_qwen_prepare_sequence_rejects_out_of_order_image_markers(
+    markers: tuple[ImageMarker, ...],
+) -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.architecture = SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2)
+    )
+    runtime._chat_image_crops = {}
+    runtime._prepare_uncached_sequence = lambda **kwargs: kwargs
+    crops = QwenImageInputs(
+        pixel_values=torch.empty((2, 3)),
+        image_grid_thw=torch.tensor([[1, 2, 2], [1, 2, 2]]),
+        num_image_tokens=2,
+    )
+
+    with pytest.raises(RuntimeError, match="must appear in image input order"):
+        runtime.prepare_sequence(
+            list(markers),
+            image=[object(), object()],
+            image_crops=crops,
+        )

--- a/tests/qwen35/test_loader.py
+++ b/tests/qwen35/test_loader.py
@@ -12,11 +12,11 @@ from kestrel.models.qwen35.qwen_loader import (
     _dequantize_fp8_weight,
     _interleave_gate_up_weight,
     _load_sharded_safetensors,
-    _materialize_remaining_meta_tensors,
     _restore_rotary_buffers,
 )
 import kestrel.models.qwen35.qwen_loader as loader_module
 from kestrel.ops.rotary import default_inv_freq
+from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 
 
 class _FusedExpertHolder(torch.nn.Module):
@@ -299,7 +299,7 @@ def test_remaining_meta_tensors_materialize_without_replacing_bound_storage() ->
         module.register_buffer("pending_buffer", torch.empty(2))
     bound = module.bound
 
-    _materialize_remaining_meta_tensors(module, device=torch.device("cpu"))
+    materialize_remaining_meta_tensors(module, device=torch.device("cpu"))
 
     assert module.bound is bound
     assert module.pending.device.type == "cpu"
@@ -313,7 +313,7 @@ def test_remaining_meta_tensors_reject_uninitialized_derived_buffers() -> None:
         module.register_buffer("derived", torch.empty(2), persistent=False)
 
     try:
-        _materialize_remaining_meta_tensors(module, device=torch.device("cpu"))
+        materialize_remaining_meta_tensors(module, device=torch.device("cpu"))
     except RuntimeError as exc:
         assert "derived buffer" in str(exc)
     else:

--- a/tests/qwen35/test_loader.py
+++ b/tests/qwen35/test_loader.py
@@ -15,6 +15,7 @@ from kestrel.models.qwen35.qwen_loader import (
     _restore_rotary_buffers,
 )
 import kestrel.models.qwen35.qwen_loader as loader_module
+from kestrel.models.qwen35.runtime import Qwen35Runtime
 from kestrel.ops.rotary import default_inv_freq
 from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 
@@ -318,6 +319,125 @@ def test_remaining_meta_tensors_reject_uninitialized_derived_buffers() -> None:
         assert "derived buffer" in str(exc)
     else:
         raise AssertionError("uninitialized derived buffer was accepted")
+
+
+def test_load_model_runs_prepare_load_finalize_lifecycle(monkeypatch, tmp_path) -> None:
+    events: list[str] = []
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self, config) -> None:
+            super().__init__()
+            self.config = config
+            self.weight = torch.nn.Parameter(torch.empty(2))
+
+        def eval(self):
+            events.append("eval")
+            return super().eval()
+
+    config = SimpleNamespace(
+        text_config=SimpleNamespace(tie_word_embeddings=False)
+    )
+    (tmp_path / "config.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "model.safetensors.index.json").write_text(
+        '{"weight_map":{"weight":"model.safetensors"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        loader_module.Qwen3_5Config,
+        "from_dict",
+        lambda _data: config,
+    )
+    monkeypatch.setattr(
+        loader_module,
+        "Qwen3_5ForConditionalGeneration",
+        TinyModel,
+    )
+    monkeypatch.setattr(loader_module, "_restore_rotary_buffers", lambda *a, **k: None)
+
+    def load_weights(model, source, shard_names, *, device, revision=None):
+        del source, shard_names, revision
+        events.append("load")
+        assert device == torch.device("cpu")
+        assert model.weight.device.type == "cpu"
+        with torch.no_grad():
+            model.weight.fill_(7)
+        return [], []
+
+    monkeypatch.setattr(loader_module, "_load_sharded_safetensors", load_weights)
+
+    def prepare_model(model: torch.nn.Module) -> None:
+        events.append("prepare")
+        assert model.weight.device.type == "meta"
+
+    def finalize_model(model: torch.nn.Module) -> None:
+        events.append("finalize")
+        assert model.weight.device.type == "cpu"
+        torch.testing.assert_close(model.weight, torch.full((2,), 7.0))
+
+    model = loader_module.load_qwen35_model(
+        tmp_path,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        prepare_model=prepare_model,
+        finalize_model=finalize_model,
+    )
+
+    assert events == ["prepare", "load", "finalize", "eval"]
+    assert not model.training
+
+
+def test_runtime_replaces_prepared_storage_with_finalized_storage(
+    monkeypatch,
+) -> None:
+    import kestrel.models.qwen35.qwen_loader as qwen_loader
+    import kestrel.runtime.generated_decode as generated_decode
+
+    events: list[tuple[str, object]] = []
+    prepared_storage = object()
+    finalized_storage = object()
+    model = torch.nn.Module()
+
+    def prepare_storage(runtime, loaded_model, **kwargs):
+        events.append(("prepare", loaded_model))
+        assert kwargs["label"] == "Qwen"
+        assert tuple(kwargs["required_batch_sizes"]) == (1, 2, 3, 4)
+        return prepared_storage
+
+    def finalize_storage(runtime, loaded_model, storage, **kwargs):
+        events.append(("finalize", storage))
+        assert storage is prepared_storage
+        assert kwargs["label"] == "Qwen"
+        assert tuple(kwargs["required_batch_sizes"]) == (1, 2, 3, 4)
+        return finalized_storage
+
+    def load_model(source, **kwargs):
+        assert source == "checkpoint"
+        kwargs["prepare_model"](model)
+        kwargs["finalize_model"](model)
+        return model
+
+    monkeypatch.setattr(
+        generated_decode,
+        "prepare_generated_weight_storage_for_loading",
+        prepare_storage,
+    )
+    monkeypatch.setattr(
+        generated_decode,
+        "finalize_generated_weight_storage_after_loading",
+        finalize_storage,
+    )
+    monkeypatch.setattr(qwen_loader, "load_qwen35_model", load_model)
+
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.device = torch.device("cpu")
+    runtime.dtype = torch.bfloat16
+    runtime.max_batch_size = 4
+    runtime._spec = SimpleNamespace(revision="revision")
+    runtime._generated_weight_storage = None
+
+    assert runtime._load_model("checkpoint") is model
+    assert events == [("prepare", model), ("finalize", prepared_storage)]
+    assert runtime._generated_weight_storage is finalized_storage
 
 
 def test_rotary_buffers_are_recomputed_after_meta_construction() -> None:

--- a/tests/scheduler/test_release_sequence.py
+++ b/tests/scheduler/test_release_sequence.py
@@ -4,8 +4,10 @@ from collections import deque
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Sequence
+import weakref
 
 import pytest
+import torch
 
 from kestrel.runtime import SequenceState, TextToken, Token
 from kestrel.scheduler.pipeline import (
@@ -17,6 +19,7 @@ from kestrel.scheduler.pipeline import (
 from kestrel.scheduler.queues import RunningQueue
 from kestrel.scheduler.scheduler import GenerationScheduler
 from kestrel.scheduler.types import GeneratedPrefix, GenerationRequest, RequestLifecycle
+from kestrel.runtime.sampling import SamplingHooks
 
 from tests.scheduler._fake_runtime import FakeRuntime
 
@@ -229,6 +232,86 @@ def test_prefill_finalize_failure_retires_adapter_and_slot() -> None:
     assert runtime.released_prefill_slots == [slot]
     assert lifecycle.request.lora_slot == 0
     assert lifecycle.lora_slot_ready is False
+
+
+@pytest.mark.parametrize("hook_mode", ["none", "success", "error"])
+def test_prefill_finalize_releases_last_hidden_after_optional_hook(
+    hook_mode: str,
+) -> None:
+    runtime = FakeRuntime(max_batch_size=2)
+    states = [
+        SequenceState(batch_idx=index, length=2, max_length=4)
+        for index in range(2)
+    ]
+    expected = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    prompt_storage_refs = []
+    for state, values in zip(states, expected, strict=True):
+        prompt_hidden = torch.cat((torch.zeros(3, 2), values.view(1, 2)))
+        prompt_storage = prompt_hidden.untyped_storage()
+        state.last_hidden = prompt_hidden[-1].detach()
+        prompt_storage_refs.append(weakref.ref(prompt_storage))
+    del prompt_hidden, prompt_storage
+    sequences = [SimpleNamespace(state=state) for state in states]
+    seen = []
+    hook_result = object()
+
+    def post_sample(_slot, *, hidden_last, sequences, **_kwargs):
+        assert all(sequence.state.last_hidden is None for sequence in sequences)
+        seen.append(hidden_last)
+        if hook_mode == "error":
+            raise RuntimeError("synthetic post-sample failure")
+        return hook_result
+
+    scheduler = object.__new__(GenerationScheduler)
+    scheduler._hooks = SamplingHooks(
+        post_sample=None if hook_mode == "none" else post_sample,
+    )
+    scheduler._sample_batch = lambda *_args, **_kwargs: (
+        torch.tensor([10, 11]),
+        torch.zeros(2),
+        torch.ones(2),
+        torch.zeros(2),
+    )
+    scheduler._pending_token_ids = torch.zeros(2, dtype=torch.long)
+    scheduler.running = RunningQueue()
+    prefill_slot = runtime.prefill_slots[0]
+    prefill_slot.batch_idx = torch.tensor([0, 1], dtype=torch.long)
+    staging = SimpleNamespace(
+        sampled_ids=torch.zeros(2, dtype=torch.long),
+        sampled_logprobs=torch.zeros(2),
+        render=SimpleNamespace(transfer=lambda *_args, **_kwargs: object()),
+    )
+    handle = LaunchHandle(
+        kind="prefill",
+        sequences=sequences,
+        payload=PrefillLaunch(
+            staging=staging,
+            slot_id=0,
+            logits=torch.zeros(2, 3),
+            prepared_sequences=[object(), object()],
+            prefill_slot=prefill_slot,
+        ),
+    )
+
+    if hook_mode == "error":
+        with pytest.raises(RuntimeError, match="synthetic post-sample failure"):
+            scheduler._finalize_prefill(handle)
+        pending = None
+    else:
+        pending = scheduler._finalize_prefill(handle)
+
+    assert all(state.last_hidden is None for state in states)
+    assert all(storage() is None for storage in prompt_storage_refs)
+    if hook_mode != "none":
+        assert len(seen) == 1
+        torch.testing.assert_close(seen[0], expected)
+        if hook_mode == "success":
+            assert pending is not None
+            assert pending.payload.runtime_step is hook_result
+    else:
+        assert seen == []
+        assert pending is not None
+        assert pending.payload.runtime_step is None
 
 
 def test_prefill_commit_failure_fences_before_returning_adapter() -> None:

--- a/tests/test_bounded_projection.py
+++ b/tests/test_bounded_projection.py
@@ -38,6 +38,39 @@ def test_packed_linear_binding_waits_for_all_streamed_parts() -> None:
     torch.testing.assert_close(state["packed.weight"], torch.cat((q, k)))
 
 
+def test_packed_linear_single_source_reuses_source_tensor() -> None:
+    module = nn.Module()
+    module.packed = PackedLinear(
+        3,
+        (2,),
+        source_names=("q",),
+    )
+    q = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    state = {"q.weight": q}
+
+    bind_declared_packed_projections(module, state)
+
+    assert state == {"packed.weight": q}
+    assert state["packed.weight"] is q
+
+
+def test_packed_linear_repeated_source_packs_each_declared_partition() -> None:
+    module = nn.Module()
+    module.packed = PackedLinear(
+        3,
+        (2, 1, 1),
+        source_names=("q", "k", "k"),
+    )
+    q = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    k = torch.arange(3, dtype=torch.float32).reshape(1, 3) + 10
+    state = {"q.weight": q, "k.weight": k}
+
+    bind_declared_packed_projections(module, state)
+
+    assert set(state) == {"packed.weight"}
+    torch.testing.assert_close(state["packed.weight"], torch.cat((q, k, k)))
+
+
 def test_packed_linear_binding_honors_interleaved_output_layout() -> None:
     module = nn.Module()
     module.packed = PackedLinear(
@@ -109,6 +142,38 @@ def test_packed_bounded_binding_waits_for_streamed_bounds() -> None:
         "packed.output_max",
         "packed.output_min",
     }
+
+
+def test_packed_bounded_repeated_source_removes_each_bound_once() -> None:
+    module = nn.Module()
+    module.packed = PackedBoundedProjections(
+        2,
+        (1, 1),
+        source_names=("k", "k"),
+        use_bounds=True,
+    )
+    weight = torch.ones((1, 2))
+    state = {
+        "k.linear.weight": weight,
+        "k.input_min": torch.tensor(-1.0),
+        "k.input_max": torch.tensor(1.0),
+        "k.output_min": torch.tensor(-2.0),
+        "k.output_max": torch.tensor(2.0),
+    }
+
+    bind_declared_packed_projections(module, state)
+
+    assert set(state) == {
+        "packed.input_max",
+        "packed.input_min",
+        "packed.linear.weight",
+        "packed.output_max",
+        "packed.output_min",
+    }
+    torch.testing.assert_close(
+        state["packed.linear.weight"],
+        torch.cat((weight, weight)),
+    )
 
 
 def test_packed_binding_skips_already_loaded_target() -> None:

--- a/tests/test_bounded_projection.py
+++ b/tests/test_bounded_projection.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from torch import nn
 
@@ -35,6 +36,40 @@ def test_packed_linear_binding_waits_for_all_streamed_parts() -> None:
     )
     assert set(state) == {"packed.weight"}
     torch.testing.assert_close(state["packed.weight"], torch.cat((q, k)))
+
+
+def test_packed_linear_binding_honors_interleaved_output_layout() -> None:
+    module = nn.Module()
+    module.packed = PackedLinear(
+        3,
+        (16, 16),
+        source_names=("gate", "up"),
+        output_layout="interleaved_i8",
+    )
+    gate = torch.arange(48, dtype=torch.float32).reshape(16, 3)
+    up = torch.arange(48, 96, dtype=torch.float32).reshape(16, 3)
+    state = {"gate.weight": gate, "up.weight": up}
+
+    bind_declared_packed_projections(module, state)
+
+    expected = torch.stack(
+        (gate.reshape(2, 8, 3), up.reshape(2, 8, 3)), dim=1
+    ).reshape(32, 3)
+    torch.testing.assert_close(state["packed.weight"], expected)
+
+
+@pytest.mark.parametrize(
+    "out_features",
+    ((8, 8, 8), (8, 16), (10, 10)),
+)
+def test_packed_linear_rejects_invalid_interleaved_shape(out_features) -> None:
+    with pytest.raises(ValueError, match="two equal output sizes"):
+        PackedLinear(
+            3,
+            out_features,
+            source_names=tuple(f"source_{index}" for index in range(len(out_features))),
+            output_layout="interleaved_i8",
+        )
 
 
 def test_packed_bounded_binding_waits_for_streamed_bounds() -> None:

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -88,6 +88,27 @@ def test_gemma_native_does_not_construct_generated_decode(
     assert runtime.generated_decode is None
 
 
+def test_gemma_auto_without_finalized_load_time_storage_uses_native(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.gemma4 import generated_decode as gemma_generated
+
+    runtime = object.__new__(Gemma4Runtime)
+    runtime.decode_path = "auto"
+    runtime._generated_weight_storage = None
+    monkeypatch.setattr(
+        gemma_generated,
+        "create_generated_decode",
+        lambda *_args, **_kwargs: pytest.fail(
+            "auto mode cannot materialize a second generated-weight slab"
+        ),
+    )
+
+    runtime._initialize_generated_decode()
+
+    assert runtime.generated_decode is None
+
+
 def test_qwen_required_generated_unavailable_refuses_before_graph_capture(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -75,6 +75,7 @@ def test_gemma_native_does_not_construct_generated_decode(
 
     runtime = object.__new__(Gemma4Runtime)
     runtime.decode_path = "native"
+    runtime._generated_binding_reservation = None
     monkeypatch.setattr(
         gemma_generated,
         "create_generated_decode",
@@ -96,6 +97,7 @@ def test_gemma_auto_without_finalized_load_time_storage_uses_native(
     runtime = object.__new__(Gemma4Runtime)
     runtime.decode_path = "auto"
     runtime._generated_weight_storage = None
+    runtime._generated_binding_reservation = None
     monkeypatch.setattr(
         gemma_generated,
         "create_generated_decode",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -40,6 +40,41 @@ def test_empty_cache_cpu_is_noop() -> None:
     empty_cache(CPU)
 
 
+def test_empty_cache_cuda_targets_supplied_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.device as device_module
+
+    target = torch.device("cuda:3")
+    events = []
+    active_devices = []
+
+    @contextmanager
+    def cuda_device(device):
+        events.append(("enter", device))
+        active_devices.append(device)
+        try:
+            yield
+        finally:
+            assert active_devices.pop() == device
+            events.append(("exit", device))
+
+    def cuda_empty_cache() -> None:
+        assert active_devices == [target]
+        events.append(("empty_cache", target))
+
+    monkeypatch.setattr(device_module.torch.cuda, "device", cuda_device)
+    monkeypatch.setattr(device_module.torch.cuda, "empty_cache", cuda_empty_cache)
+
+    empty_cache(target)
+
+    assert events == [
+        ("enter", target),
+        ("empty_cache", target),
+        ("exit", target),
+    ]
+
+
 def test_get_device_capability_cpu_returns_zero_tuple() -> None:
     assert get_device_capability(CPU) == (0, 0)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2,6 +2,7 @@
 
 from contextlib import contextmanager
 import threading
+import weakref
 
 import pytest
 import torch
@@ -88,9 +89,14 @@ def test_materialize_blas_runtime_returns_cuda_handle_from_worker(
 
     caller_thread = threading.get_ident()
     events = []
+    result_ref = None
+
+    class Result:
+        pass
 
     class Stream:
         def synchronize(self):
+            assert result_ref is not None and result_ref() is not None
             events.append(("synchronize", threading.get_ident(), self))
 
     compute_stream = Stream()
@@ -114,16 +120,23 @@ def test_materialize_blas_runtime_returns_cuda_handle_from_worker(
     monkeypatch.setattr(device_module.torch.cuda, "device", cuda_device)
     monkeypatch.setattr(device_module, "stream_context", use_stream)
 
-    materialize_blas_runtime(
-        torch.device("cuda:0"),
-        compute_stream,
-        lambda: events.append(
+    def operation():
+        nonlocal result_ref
+        result = Result()
+        result_ref = weakref.ref(result)
+        events.append(
             (
                 "operation",
                 threading.get_ident(),
                 torch.is_inference_mode_enabled(),
             )
-        ),
+        )
+        return result
+
+    materialize_blas_runtime(
+        torch.device("cuda:0"),
+        compute_stream,
+        operation,
     )
 
     worker_threads = {event[1] for event in events}
@@ -137,6 +150,7 @@ def test_materialize_blas_runtime_returns_cuda_handle_from_worker(
         "device-exit",
     ]
     assert events[2][2] is True
+    assert result_ref is not None and result_ref() is None
 
 
 # --- CUDA path: thin wrappers, only run when present ------------------------

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,5 +1,8 @@
 """Tests for the device-agnostic primitive wrappers in ``kestrel.device``."""
 
+from contextlib import contextmanager
+import threading
+
 import pytest
 import torch
 
@@ -9,6 +12,7 @@ from kestrel.device import (
     get_device_capability,
     make_event,
     make_stream,
+    materialize_blas_runtime,
     set_device,
     stream_context,
     synchronize,
@@ -60,6 +64,79 @@ def test_stream_context_with_none_yields_inline() -> None:
     with stream_context(None):
         entered = True
     assert entered
+
+
+def test_materialize_blas_runtime_runs_non_cuda_operation_inline() -> None:
+    thread = threading.get_ident()
+    observed = []
+
+    materialize_blas_runtime(
+        CPU,
+        None,
+        lambda: observed.append(
+            (threading.get_ident(), torch.is_inference_mode_enabled())
+        ),
+    )
+
+    assert observed == [(thread, True)]
+
+
+def test_materialize_blas_runtime_returns_cuda_handle_from_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.device as device_module
+
+    caller_thread = threading.get_ident()
+    events = []
+
+    class Stream:
+        def synchronize(self):
+            events.append(("synchronize", threading.get_ident(), self))
+
+    compute_stream = Stream()
+
+    @contextmanager
+    def cuda_device(device):
+        events.append(("device-enter", threading.get_ident(), device))
+        try:
+            yield
+        finally:
+            events.append(("device-exit", threading.get_ident(), device))
+
+    @contextmanager
+    def use_stream(stream):
+        events.append(("stream-enter", threading.get_ident(), stream))
+        try:
+            yield
+        finally:
+            events.append(("stream-exit", threading.get_ident(), stream))
+
+    monkeypatch.setattr(device_module.torch.cuda, "device", cuda_device)
+    monkeypatch.setattr(device_module, "stream_context", use_stream)
+
+    materialize_blas_runtime(
+        torch.device("cuda:0"),
+        compute_stream,
+        lambda: events.append(
+            (
+                "operation",
+                threading.get_ident(),
+                torch.is_inference_mode_enabled(),
+            )
+        ),
+    )
+
+    worker_threads = {event[1] for event in events}
+    assert caller_thread not in worker_threads
+    assert [event[0] for event in events] == [
+        "device-enter",
+        "stream-enter",
+        "operation",
+        "synchronize",
+        "stream-exit",
+        "device-exit",
+    ]
+    assert events[2][2] is True
 
 
 # --- CUDA path: thin wrappers, only run when present ------------------------

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,6 +11,7 @@ import numpy as np
 
 import pytest
 
+import kestrel.engine.core as engine_core
 from kestrel.engine import (
     InferenceEngine,
     _AdmissionCoordinator,
@@ -407,6 +408,38 @@ def test_transcribe_only_runtime_skips_legacy_query_warmup() -> None:
 
     engine.query = query  # type: ignore[method-assign]
     asyncio.run(engine._warmup_query_pipeline())
+
+
+def test_startup_reclaims_allocator_only_after_warmup_and_quiescence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = object.__new__(InferenceEngine)
+    device = object()
+    engine._runtime_cfg = SimpleNamespace(resolved_device=lambda: device)
+    calls: list[object] = []
+
+    async def warmup() -> None:
+        calls.append("warmup")
+
+    engine._warmup_query_pipeline = warmup  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        engine_core,
+        "synchronize",
+        lambda actual: calls.append(("synchronize", actual)),
+    )
+    monkeypatch.setattr(
+        engine_core,
+        "empty_cache",
+        lambda actual: calls.append(("empty_cache", actual)),
+    )
+
+    asyncio.run(engine._warmup_and_reclaim_allocator())
+
+    assert calls == [
+        "warmup",
+        ("synchronize", device),
+        ("empty_cache", device),
+    ]
 
 
 def test_extract_private_logprobs_setting() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,7 +11,6 @@ import numpy as np
 
 import pytest
 
-import kestrel.engine.core as engine_core
 from kestrel.engine import (
     InferenceEngine,
     _AdmissionCoordinator,
@@ -408,38 +407,6 @@ def test_transcribe_only_runtime_skips_legacy_query_warmup() -> None:
 
     engine.query = query  # type: ignore[method-assign]
     asyncio.run(engine._warmup_query_pipeline())
-
-
-def test_startup_reclaims_allocator_only_after_warmup_and_quiescence(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    engine = object.__new__(InferenceEngine)
-    device = object()
-    engine._runtime_cfg = SimpleNamespace(resolved_device=lambda: device)
-    calls: list[object] = []
-
-    async def warmup() -> None:
-        calls.append("warmup")
-
-    engine._warmup_query_pipeline = warmup  # type: ignore[method-assign]
-    monkeypatch.setattr(
-        engine_core,
-        "synchronize",
-        lambda actual: calls.append(("synchronize", actual)),
-    )
-    monkeypatch.setattr(
-        engine_core,
-        "empty_cache",
-        lambda actual: calls.append(("empty_cache", actual)),
-    )
-
-    asyncio.run(engine._warmup_and_reclaim_allocator())
-
-    assert calls == [
-        "warmup",
-        ("synchronize", device),
-        ("empty_cache", device),
-    ]
 
 
 def test_extract_private_logprobs_setting() -> None:

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -7,6 +8,7 @@ import torch
 from kestrel.runtime.generated_decode import (
     GeneratedDecode,
     prepare_generated_weight_storage_for_loading,
+    reserve_generated_binding_storage,
 )
 
 
@@ -180,3 +182,95 @@ def test_load_time_weight_preparation_fails_soft_only_when_optional(
         prepare_generated_weight_storage_for_loading(
             runtime, Mock(), required=True, **options
         )
+
+
+def test_binding_reservation_allocates_every_program_slot_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel_kernels import generated_decode as generated_runtime
+
+    programs = tuple(
+        SimpleNamespace(descriptor={"owned_bytes": owned_bytes})
+        for owned_bytes in (10, 20)
+    )
+    storage = SimpleNamespace(finalized=True, buffers={"weight": torch.empty(1)})
+    first = {"slot": 1}
+    second = {"slot": 2}
+    calls = []
+    compute_stream = object()
+    stream_contexts = []
+
+    @contextmanager
+    def use_stream(stream):
+        stream_contexts.append(("enter", stream))
+        yield
+        stream_contexts.append(("exit", stream))
+
+    def reserve(descriptor, *, weights, runtime_inputs, device):
+        calls.append((descriptor, weights, runtime_inputs))
+        return (
+            torch.empty(
+                descriptor["owned_bytes"] + runtime_inputs["slot"],
+                dtype=torch.uint8,
+                device=device,
+            ),
+        )
+
+    monkeypatch.setattr(
+        generated_runtime,
+        "reserve_binding_storage",
+        reserve,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "kestrel.runtime.generated_decode.stream_context",
+        use_stream,
+    )
+
+    reservation = reserve_generated_binding_storage(
+        programs,
+        weight_storage=storage,
+        runtime_inputs_by_slot=(first, second),
+        device=torch.device("cpu"),
+        stream=compute_stream,
+        label="test",
+        required=True,
+    )
+
+    assert reservation is not None
+    assert [tensor.dtype for tensor in reservation] == [torch.uint8] * 4
+    assert [tensor.numel() for tensor in reservation] == [11, 21, 12, 22]
+    assert calls == [
+        (programs[0].descriptor, storage.buffers, first),
+        (programs[1].descriptor, storage.buffers, first),
+        (programs[0].descriptor, storage.buffers, second),
+        (programs[1].descriptor, storage.buffers, second),
+    ]
+    assert stream_contexts == [
+        ("enter", compute_stream),
+        ("exit", compute_stream),
+    ]
+
+
+def test_binding_reservation_fails_soft_only_when_optional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel_kernels import generated_decode as generated_runtime
+
+    monkeypatch.delattr(
+        generated_runtime,
+        "reserve_binding_storage",
+        raising=False,
+    )
+    options = dict(
+        programs=(SimpleNamespace(descriptor={}),),
+        weight_storage=SimpleNamespace(finalized=True, buffers={}),
+        runtime_inputs_by_slot=({},),
+        device=torch.device("cpu"),
+        stream=None,
+        label="test",
+    )
+
+    assert reserve_generated_binding_storage(required=False, **options) is None
+    with pytest.raises(RuntimeError, match="binding-storage reservation"):
+        reserve_generated_binding_storage(required=True, **options)

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -4,7 +4,10 @@ from unittest.mock import Mock, patch
 import pytest
 import torch
 
-from kestrel.runtime.generated_decode import GeneratedDecode
+from kestrel.runtime.generated_decode import (
+    GeneratedDecode,
+    prepare_generated_weight_storage_for_loading,
+)
 
 
 def _program(capacity, *, active_batch=None, minimum_batch=1):
@@ -132,3 +135,48 @@ def test_slot_capacity_refuses_incomplete_required_domain(monkeypatch):
         object(),
         required_batch_sizes=range(1, 5),
     ) is None
+
+
+@pytest.mark.parametrize(
+    "missing_capability",
+    (
+        "allocate_weight_storage_for_loading",
+        "finalize_weight_storage_after_loading",
+    ),
+)
+def test_load_time_weight_preparation_fails_soft_only_when_optional(
+    monkeypatch: pytest.MonkeyPatch,
+    missing_capability: str,
+) -> None:
+    from kestrel_kernels import generated_decode as generated_runtime
+
+    runtime = SimpleNamespace(
+        device=torch.device("cuda", 0),
+        dtype=torch.bfloat16,
+        max_batch_size=1,
+    )
+    program = _program(1, active_batch=1)
+    program.descriptor = {"weights": []}
+    properties = SimpleNamespace(major=9, minor=0, multi_processor_count=132)
+    monkeypatch.setattr(
+        generated_runtime,
+        "resolve_compatible_programs",
+        lambda *_args, **_kwargs: (program,),
+    )
+    monkeypatch.delattr(generated_runtime, missing_capability)
+    monkeypatch.setattr(
+        torch.cuda, "get_device_properties", lambda _device: properties
+    )
+
+    options = dict(
+        label="Gemma",
+        layer_prefix="model.language_model.layers",
+        required_batch_sizes=(1,),
+    )
+    assert prepare_generated_weight_storage_for_loading(
+        runtime, Mock(), required=False, **options
+    ) is None
+    with pytest.raises(RuntimeError, match="binding and finalization support"):
+        prepare_generated_weight_storage_for_loading(
+            runtime, Mock(), required=True, **options
+        )

--- a/tests/test_generated_decode_static_extents.py
+++ b/tests/test_generated_decode_static_extents.py
@@ -157,7 +157,9 @@ def test_generated_decode_materializes_explicit_weight_sources(monkeypatch):
 
 
 def test_generated_decode_reuses_matching_preloaded_weight_storage(monkeypatch):
-    storage = SimpleNamespace(buffers={}, weight_contract=repr([]))
+    storage = SimpleNamespace(
+        buffers={}, weight_contract=repr([]), finalized=True
+    )
     calls = []
 
     generated, _launches = _build(
@@ -173,9 +175,25 @@ def test_generated_decode_reuses_matching_preloaded_weight_storage(monkeypatch):
 
 
 def test_generated_decode_rejects_mismatched_preloaded_weight_storage(monkeypatch):
-    storage = SimpleNamespace(buffers={}, weight_contract="different")
+    storage = SimpleNamespace(
+        buffers={}, weight_contract="different", finalized=True
+    )
 
     with pytest.raises(RuntimeError, match="preloaded generated weights"):
+        _build(
+            monkeypatch,
+            _programs("b1"),
+            max_batch_size=1,
+            weight_storage=storage,
+        )
+
+
+def test_generated_decode_rejects_unfinalized_preloaded_weight_storage(monkeypatch):
+    storage = SimpleNamespace(
+        buffers={}, weight_contract=repr([]), finalized=False
+    )
+
+    with pytest.raises(RuntimeError, match="not finalized"):
         _build(
             monkeypatch,
             _programs("b1"),

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -7,10 +7,22 @@ without exceeding a total cap.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+
 import pytest
 import torch
 
-from kestrel.kv_cache import KVMemoryPool, PageTable, PagedKVCache
+from kestrel.kv_cache import (
+    KVMemoryPool,
+    PageTable,
+    PagedKVCache,
+    PagedKVLayerSpec,
+    allocate_paged_kv_layers,
+    allocate_paged_kv_storage,
+    fit_and_allocate_paged_kv_storage,
+    paged_kv_bytes_per_page,
+    paged_kv_storage_bytes,
+)
 
 
 def _make_page_table(*, page_size: int = 1, n_pages: int = 4) -> PageTable:
@@ -72,6 +84,324 @@ def test_pool_rejects_negative_budget() -> None:
 def test_pool_normalizes_string_device() -> None:
     pool = KVMemoryPool(device="cpu")
     assert pool.device == torch.device("cpu")
+
+
+def test_paged_kv_bytes_per_page_counts_sparse_layers_and_page_size() -> None:
+    specs = (
+        PagedKVLayerSpec(n_heads=2, head_dim=8),
+        None,
+        PagedKVLayerSpec(n_heads=1, head_dim=16),
+    )
+
+    assert paged_kv_bytes_per_page(
+        specs,
+        page_size=4,
+        dtype=torch.bfloat16,
+    ) == 2 * (2 * 8 + 1 * 16) * 4 * 2
+
+
+def test_fitted_paged_kv_storage_respects_consumed_shared_pool_budget() -> None:
+    specs = (PagedKVLayerSpec(n_heads=2, head_dim=8), None)
+    bytes_per_page = paged_kv_bytes_per_page(
+        specs,
+        page_size=4,
+        dtype=torch.bfloat16,
+    )
+    storage_bytes = paged_kv_storage_bytes(
+        8,
+        layer_specs=specs,
+        page_size=4,
+        dtype=torch.bfloat16,
+    )
+    pool = KVMemoryPool(
+        device="cpu",
+        budget_bytes=2 * bytes_per_page + storage_bytes,
+    )
+    pool.allocated_bytes = 2 * bytes_per_page
+
+    storage, additional = fit_and_allocate_paged_kv_storage(
+        100,
+        layer_specs=specs,
+        page_size=4,
+        dtype=torch.bfloat16,
+        pool=pool,
+        stream=None,
+    )
+
+    assert storage.n_pages == 8
+    assert additional is None
+    assert pool.allocated_bytes == pool.budget_bytes
+
+
+def test_fitted_paged_kv_storage_retains_first_successful_fragmented_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.kv_cache as kv_cache
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cpu")
+    original_allocate = allocate_paged_kv_storage
+    attempts = []
+    resources = []
+    compute_stream = object()
+    stream_contexts = []
+
+    @contextmanager
+    def use_stream(stream):
+        stream_contexts.append(("enter", stream))
+        try:
+            yield
+        finally:
+            stream_contexts.append(("exit", stream))
+
+    def allocate_storage(n_pages, **kwargs):
+        attempts.append(n_pages)
+        if n_pages > 5:
+            raise torch.OutOfMemoryError("synthetic fragmented allocator")
+        return original_allocate(n_pages, **kwargs)
+
+    def allocate_additional(n_pages):
+        value = torch.empty(n_pages, dtype=torch.int32)
+        resources.append(value)
+        return value
+
+    monkeypatch.setattr(kv_cache, "allocate_paged_kv_storage", allocate_storage)
+    monkeypatch.setattr(kv_cache, "stream_context", use_stream)
+
+    storage, additional = fit_and_allocate_paged_kv_storage(
+        8,
+        layer_specs=specs,
+        page_size=2,
+        dtype=torch.bfloat16,
+        pool=pool,
+        stream=compute_stream,
+        allocate_additional=allocate_additional,
+    )
+
+    assert attempts == [8, 7, 6, 5]
+    assert storage.n_pages == 5
+    assert additional is resources[-1]
+    assert additional.numel() == 5
+    assert stream_contexts == [
+        item
+        for _attempt in attempts
+        for item in (("enter", compute_stream), ("exit", compute_stream))
+    ]
+
+
+def test_fitted_paged_kv_storage_rejects_capacity_without_serving_page() -> None:
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    two_page_bytes = paged_kv_storage_bytes(
+        2,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.float32,
+    )
+    pool = KVMemoryPool(device="cpu", budget_bytes=two_page_bytes)
+
+    with pytest.raises(MemoryError, match="serving K/V pages"):
+        fit_and_allocate_paged_kv_storage(
+            8,
+            layer_specs=specs,
+            page_size=1,
+            dtype=torch.float32,
+            pool=pool,
+            stream=None,
+        )
+
+
+def test_grouped_paged_kv_storage_alignment_zero_page_and_pointer_reuse() -> None:
+    specs = (
+        PagedKVLayerSpec(n_heads=3, head_dim=5),
+        None,
+        PagedKVLayerSpec(n_heads=1, head_dim=7),
+    )
+    pool = KVMemoryPool(device="cpu")
+    storage = allocate_paged_kv_storage(
+        5,
+        layer_specs=specs,
+        page_size=3,
+        dtype=torch.bfloat16,
+        pool=pool,
+    )
+    before = tuple(
+        None if layer is None else (layer.k_cache.data_ptr(), layer.v_cache.data_ptr())
+        for layer in storage.layers
+    )
+    page_table = _make_page_table(page_size=3, n_pages=5)
+    caches = allocate_paged_kv_layers(
+        layer_specs=specs,
+        page_table=page_table,
+        pool=pool,
+        dtype=torch.bfloat16,
+        storage=storage,
+    )
+
+    after = tuple(
+        None if cache is None else (cache.k_cache.data_ptr(), cache.v_cache.data_ptr())
+        for cache in caches
+    )
+    assert after == before
+    assert all(
+        pointer % 256 == 0 for pair in before if pair is not None for pointer in pair
+    )
+    for cache in caches:
+        if cache is not None:
+            torch.testing.assert_close(
+                cache.k_cache[0], torch.zeros_like(cache.k_cache[0])
+            )
+            torch.testing.assert_close(
+                cache.v_cache[0], torch.zeros_like(cache.v_cache[0])
+            )
+    assert pool.allocated_bytes == paged_kv_storage_bytes(
+        5,
+        layer_specs=specs,
+        page_size=3,
+        dtype=torch.bfloat16,
+    )
+
+
+@pytest.mark.parametrize(
+    "mismatched_specs",
+    [
+        (
+            PagedKVLayerSpec(
+                n_heads=1,
+                head_dim=8,
+                k_scale=0.75,
+                v_scale=0.25,
+            ),
+            None,
+        ),
+        (
+            None,
+            PagedKVLayerSpec(
+                n_heads=1,
+                head_dim=8,
+                k_scale=0.5,
+                v_scale=0.25,
+            ),
+        ),
+    ],
+)
+def test_grouped_paged_kv_storage_rejects_scale_or_topology_reuse(
+    mismatched_specs,
+) -> None:
+    specs = (
+        PagedKVLayerSpec(
+            n_heads=1,
+            head_dim=8,
+            k_scale=0.5,
+            v_scale=0.25,
+        ),
+        None,
+    )
+    pool = KVMemoryPool(device="cpu")
+    storage = allocate_paged_kv_storage(
+        4,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.float8_e4m3fn,
+        pool=pool,
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        allocate_paged_kv_layers(
+            layer_specs=mismatched_specs,
+            page_table=_make_page_table(n_pages=4),
+            pool=pool,
+            dtype=torch.float8_e4m3fn,
+            storage=storage,
+        )
+
+
+def test_grouped_paged_kv_storage_has_one_accounting_owner() -> None:
+    import gc
+    import weakref
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cpu")
+    storage = allocate_paged_kv_storage(
+        4,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.float32,
+        pool=pool,
+    )
+    backing = weakref.ref(storage._kv_backing)
+    caches = allocate_paged_kv_layers(
+        layer_specs=specs,
+        page_table=_make_page_table(n_pages=4),
+        pool=pool,
+        dtype=torch.float32,
+        storage=storage,
+    )
+    allocated = pool.allocated_bytes
+    del storage
+    gc.collect()
+    assert backing() is not None
+    assert pool.allocated_bytes == allocated
+
+    del caches
+    gc.collect()
+    assert backing() is None
+    assert pool.allocated_bytes == 0
+
+
+def test_grouped_paged_kv_storage_budget_failure_rolls_back() -> None:
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    required = paged_kv_storage_bytes(
+        3,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.float32,
+    )
+    pool = KVMemoryPool(device="cpu", budget_bytes=required - 1)
+
+    with pytest.raises(MemoryError, match="budget exceeded"):
+        allocate_paged_kv_storage(
+            3,
+            layer_specs=specs,
+            page_size=1,
+            dtype=torch.float32,
+            pool=pool,
+        )
+    assert pool.allocated_bytes == 0
+
+
+def test_paged_kv_storage_bytes_includes_alignment_padding() -> None:
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=1),)
+
+    assert paged_kv_storage_bytes(
+        3,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.float32,
+    ) == 520
+
+
+def test_fitted_storage_requires_three_requested_pages() -> None:
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+
+    with pytest.raises(ValueError, match="reserved, padding, and serving"):
+        fit_and_allocate_paged_kv_storage(
+            2,
+            layer_specs=specs,
+            page_size=1,
+            dtype=torch.float32,
+            pool=KVMemoryPool(device="cpu"),
+            stream=None,
+        )
+
+
+def test_paged_kv_bytes_per_page_excludes_fixed_alignment_padding() -> None:
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+
+    assert paged_kv_bytes_per_page(
+        specs,
+        page_size=1,
+        dtype=torch.float32,
+    ) == 64
 
 
 def test_paged_cache_update_accepts_fused_projection_value_slice() -> None:

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -189,6 +189,63 @@ def test_fitted_paged_kv_storage_retains_first_successful_fragmented_probe(
     ]
 
 
+def test_fitted_paged_kv_storage_materializes_fixed_resources_before_sizing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.kv_cache as kv_cache
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cuda:0")
+    observed_free = 4096
+    events = []
+
+    @contextmanager
+    def cuda_device(_device):
+        yield
+
+    def materialize_fixed():
+        nonlocal observed_free
+        events.append("materialize")
+        observed_free = 2048
+
+    def mem_get_info(_device):
+        events.append(("observe", observed_free))
+        return observed_free, 8192
+
+    def largest(upper, available_bytes, **_kwargs):
+        events.append(("size", available_bytes))
+        return min(int(upper), 3)
+
+    storage = type("Storage", (), {"n_pages": 3})()
+    monkeypatch.setattr(kv_cache.torch.cuda, "device", cuda_device)
+    monkeypatch.setattr(kv_cache.torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(kv_cache.torch.cuda, "mem_get_info", mem_get_info)
+    monkeypatch.setattr(kv_cache, "_largest_storage_pages", largest)
+    monkeypatch.setattr(
+        kv_cache,
+        "allocate_paged_kv_storage",
+        lambda *_args, **_kwargs: storage,
+    )
+
+    fitted, additional = fit_and_allocate_paged_kv_storage(
+        8,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.bfloat16,
+        pool=pool,
+        stream=None,
+        materialize_fixed=materialize_fixed,
+    )
+
+    assert fitted is storage
+    assert additional is None
+    assert events[0] == "materialize"
+    assert events.count("materialize") == 1
+    assert all(event != ("observe", 4096) for event in events)
+    assert ("observe", 2048) in events
+    assert ("size", 2048) in events
+
+
 def test_fitted_paged_kv_storage_rejects_capacity_without_serving_page() -> None:
     specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
     two_page_bytes = paged_kv_storage_bytes(

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -137,7 +137,7 @@ def test_fitted_paged_kv_storage_respects_consumed_shared_pool_budget() -> None:
     assert pool.allocated_bytes == pool.budget_bytes
 
 
-def test_fitted_paged_kv_storage_retains_first_successful_fragmented_probe(
+def test_fitted_paged_kv_storage_retains_largest_successful_fragmented_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import kestrel.kv_cache as kv_cache
@@ -182,7 +182,7 @@ def test_fitted_paged_kv_storage_retains_first_successful_fragmented_probe(
         allocate_additional=allocate_additional,
     )
 
-    assert attempts == [8, 7, 6, 5]
+    assert attempts == [8, 7, 5, 6, 5]
     assert storage.n_pages == 5
     assert additional is resources[-1]
     assert additional.numel() == 5
@@ -191,6 +191,234 @@ def test_fitted_paged_kv_storage_retains_first_successful_fragmented_probe(
         for _attempt in attempts
         for item in (("enter", compute_stream), ("exit", compute_stream))
     ]
+
+
+def test_fitted_paged_kv_storage_brackets_distant_capacity_logarithmically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.kv_cache as kv_cache
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cpu")
+    original_allocate = allocate_paged_kv_storage
+    attempts = []
+    backing_refs = []
+    additional_refs = []
+
+    def allocate_storage(n_pages, **kwargs):
+        attempts.append(n_pages)
+        if n_pages > 37:
+            raise torch.OutOfMemoryError("synthetic distant capacity")
+        storage = original_allocate(n_pages, **kwargs)
+        backing_refs.append(weakref.ref(storage._kv_backing))
+        return storage
+
+    def allocate_additional(n_pages):
+        value = torch.empty(n_pages, dtype=torch.int32)
+        additional_refs.append(weakref.ref(value))
+        return value
+
+    monkeypatch.setattr(kv_cache, "allocate_paged_kv_storage", allocate_storage)
+
+    storage, additional = fit_and_allocate_paged_kv_storage(
+        128,
+        layer_specs=specs,
+        page_size=2,
+        dtype=torch.bfloat16,
+        pool=pool,
+        stream=None,
+        allocate_additional=allocate_additional,
+    )
+
+    assert storage.n_pages == 37
+    assert attempts == [
+        128,
+        127,
+        125,
+        121,
+        113,
+        97,
+        65,
+        3,
+        34,
+        49,
+        41,
+        37,
+        39,
+        38,
+        37,
+    ]
+    assert len(attempts) < 20
+    assert all(reference() is None for reference in backing_refs[:-1])
+    assert backing_refs[-1]() is storage._kv_backing
+    assert all(reference() is None for reference in additional_refs[:-1])
+    assert additional_refs[-1]() is additional
+    assert pool.allocated_bytes == paged_kv_storage_bytes(
+        37,
+        layer_specs=specs,
+        page_size=2,
+        dtype=torch.bfloat16,
+    )
+
+
+def test_fitted_paged_kv_storage_does_not_rebound_below_known_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.kv_cache as kv_cache
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cpu", budget_bytes=1 << 20)
+    original_allocate = allocate_paged_kv_storage
+    storage_attempts = []
+    additional_attempts = []
+
+    def largest(upper, _available_bytes, **_kwargs):
+        return 4 if upper == 6 else upper
+
+    def allocate_storage(n_pages, **kwargs):
+        storage_attempts.append(n_pages)
+        if n_pages > 5:
+            raise torch.OutOfMemoryError("synthetic fragmented allocator")
+        return original_allocate(n_pages, **kwargs)
+
+    def allocate_additional(n_pages):
+        additional_attempts.append(n_pages)
+        return torch.empty(n_pages, dtype=torch.int32)
+
+    monkeypatch.setattr(kv_cache, "_largest_storage_pages", largest)
+    monkeypatch.setattr(kv_cache, "allocate_paged_kv_storage", allocate_storage)
+
+    storage, additional = fit_and_allocate_paged_kv_storage(
+        8,
+        layer_specs=specs,
+        page_size=2,
+        dtype=torch.bfloat16,
+        pool=pool,
+        stream=None,
+        allocate_additional=allocate_additional,
+    )
+
+    assert storage.n_pages == 5
+    assert additional is not None and additional.numel() == 5
+    assert storage_attempts == [8, 7, 5, 5]
+    assert additional_attempts == [8, 7, 5, 6, 5]
+
+
+def test_fitted_paged_kv_storage_probes_minimum_after_dynamic_rebound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.kv_cache as kv_cache
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cpu", budget_bytes=1 << 20)
+    bound_calls = 0
+    additional_attempts = []
+    storage_attempts = []
+    original_allocate = allocate_paged_kv_storage
+
+    def largest(upper, _available_bytes, **_kwargs):
+        nonlocal bound_calls
+        bound_calls += 1
+        if upper == 4 and bound_calls > 1:
+            return 0
+        return upper
+
+    def allocate_additional(n_pages):
+        additional_attempts.append(n_pages)
+        return torch.empty(n_pages, dtype=torch.int32)
+
+    def allocate_storage(n_pages, **kwargs):
+        storage_attempts.append(n_pages)
+        return original_allocate(n_pages, **kwargs)
+
+    monkeypatch.setattr(kv_cache, "_largest_storage_pages", largest)
+    monkeypatch.setattr(kv_cache, "allocate_paged_kv_storage", allocate_storage)
+
+    storage, additional = fit_and_allocate_paged_kv_storage(
+        4,
+        layer_specs=specs,
+        page_size=2,
+        dtype=torch.bfloat16,
+        pool=pool,
+        stream=None,
+        allocate_additional=allocate_additional,
+    )
+
+    assert storage.n_pages == 3
+    assert additional is not None and additional.numel() == 3
+    assert additional_attempts == [4, 3]
+    assert storage_attempts == [3]
+
+
+def test_fitted_paged_kv_storage_recovers_when_final_probe_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.kv_cache as kv_cache
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cpu")
+    original_allocate = allocate_paged_kv_storage
+    attempts = []
+    page_five_attempts = 0
+
+    def allocate_storage(n_pages, **kwargs):
+        nonlocal page_five_attempts
+        attempts.append(n_pages)
+        if n_pages == 5:
+            page_five_attempts += 1
+        if n_pages > 5 or (n_pages == 5 and page_five_attempts > 1):
+            raise torch.OutOfMemoryError("synthetic changed allocator state")
+        return original_allocate(n_pages, **kwargs)
+
+    monkeypatch.setattr(kv_cache, "allocate_paged_kv_storage", allocate_storage)
+
+    storage, additional = fit_and_allocate_paged_kv_storage(
+        8,
+        layer_specs=specs,
+        page_size=2,
+        dtype=torch.bfloat16,
+        pool=pool,
+        stream=None,
+    )
+
+    assert storage.n_pages == 4
+    assert additional is None
+    assert attempts == [8, 7, 5, 6, 5, 4]
+
+
+def test_fitted_paged_kv_storage_finds_every_monotonic_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.kv_cache as kv_cache
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    original_allocate = allocate_paged_kv_storage
+    monkeypatch.setattr(kv_cache.gc, "collect", lambda: 0)
+
+    for capacity in range(3, 129):
+        pool = KVMemoryPool(device="cpu")
+
+        def allocate_storage(n_pages, **kwargs):
+            if n_pages > capacity:
+                raise torch.OutOfMemoryError("synthetic monotonic capacity")
+            return original_allocate(n_pages, **kwargs)
+
+        monkeypatch.setattr(
+            kv_cache,
+            "allocate_paged_kv_storage",
+            allocate_storage,
+        )
+        storage, additional = fit_and_allocate_paged_kv_storage(
+            128,
+            layer_specs=specs,
+            page_size=2,
+            dtype=torch.bfloat16,
+            pool=pool,
+            stream=None,
+        )
+
+        assert storage.n_pages == capacity
+        assert additional is None
 
 
 def test_fitted_paged_kv_storage_materializes_fixed_resources_before_sizing(

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -94,11 +94,14 @@ def test_paged_kv_bytes_per_page_counts_sparse_layers_and_page_size() -> None:
         PagedKVLayerSpec(n_heads=1, head_dim=16),
     )
 
-    assert paged_kv_bytes_per_page(
-        specs,
-        page_size=4,
-        dtype=torch.bfloat16,
-    ) == 2 * (2 * 8 + 1 * 16) * 4 * 2
+    assert (
+        paged_kv_bytes_per_page(
+            specs,
+            page_size=4,
+            dtype=torch.bfloat16,
+        )
+        == 2 * (2 * 8 + 1 * 16) * 4 * 2
+    )
 
 
 def test_fitted_paged_kv_storage_respects_consumed_shared_pool_budget() -> None:
@@ -271,9 +274,11 @@ def test_fitted_paged_kv_storage_retries_failed_transient_without_retaining_it(
         additional_refs.append(weakref.ref(value))
         return value
 
-    def validate_transient():
+    def validate_transient(storage, additional):
         nonlocal probe_attempts
         assert torch.is_inference_mode_enabled()
+        assert storage._kv_backing is backing_refs[-1]()
+        assert additional is additional_refs[-1]()
         probe_attempts += 1
         if probe_attempts == 1:
             raise torch.OutOfMemoryError("synthetic live-workspace failure")
@@ -333,9 +338,11 @@ def test_fitted_paged_kv_storage_keeps_transient_alive_through_stream_sync(
     def use_stream(_stream):
         yield
 
-    def validate_transient():
+    def validate_transient(candidate_storage, additional):
         nonlocal probe_ref
         assert torch.is_inference_mode_enabled()
+        assert candidate_storage is storage
+        assert additional is None
         probe = Probe()
         probe_ref = weakref.ref(probe)
         return probe
@@ -553,12 +560,15 @@ def test_grouped_paged_kv_storage_budget_failure_rolls_back() -> None:
 def test_paged_kv_storage_bytes_includes_alignment_padding() -> None:
     specs = (PagedKVLayerSpec(n_heads=1, head_dim=1),)
 
-    assert paged_kv_storage_bytes(
-        3,
-        layer_specs=specs,
-        page_size=1,
-        dtype=torch.float32,
-    ) == 520
+    assert (
+        paged_kv_storage_bytes(
+            3,
+            layer_specs=specs,
+            page_size=1,
+            dtype=torch.float32,
+        )
+        == 520
+    )
 
 
 def test_fitted_storage_requires_three_requested_pages() -> None:
@@ -578,11 +588,14 @@ def test_fitted_storage_requires_three_requested_pages() -> None:
 def test_paged_kv_bytes_per_page_excludes_fixed_alignment_padding() -> None:
     specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
 
-    assert paged_kv_bytes_per_page(
-        specs,
-        page_size=1,
-        dtype=torch.float32,
-    ) == 64
+    assert (
+        paged_kv_bytes_per_page(
+            specs,
+            page_size=1,
+            dtype=torch.float32,
+        )
+        == 64
+    )
 
 
 def test_paged_cache_update_accepts_fused_projection_value_slice() -> None:
@@ -689,9 +702,7 @@ def test_paged_cache_update_accepts_batched_decode_value_slice() -> None:
     torch.testing.assert_close(cache.v_cache, expected_v)
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="requires CUDA"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_pool_canonicalizes_indexless_cuda_device() -> None:
     """``KVMemoryPool(device='cuda')`` must compare equal to the same
     device built from ``RuntimeConfig`` so shared-pool wiring doesn't

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -8,6 +8,7 @@ without exceeding a total cap.
 from __future__ import annotations
 
 from contextlib import contextmanager
+import weakref
 
 import pytest
 import torch
@@ -205,6 +206,7 @@ def test_fitted_paged_kv_storage_materializes_fixed_resources_before_sizing(
 
     def materialize_fixed():
         nonlocal observed_free
+        assert torch.is_inference_mode_enabled()
         events.append("materialize")
         observed_free = 2048
 
@@ -244,6 +246,128 @@ def test_fitted_paged_kv_storage_materializes_fixed_resources_before_sizing(
     assert all(event != ("observe", 4096) for event in events)
     assert ("observe", 2048) in events
     assert ("size", 2048) in events
+
+
+def test_fitted_paged_kv_storage_retries_failed_transient_without_retaining_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.kv_cache as kv_cache
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cpu")
+    original_allocate = allocate_paged_kv_storage
+    backing_refs = []
+    additional_refs = []
+    probe_refs = []
+    probe_attempts = 0
+
+    def allocate_storage(n_pages, **kwargs):
+        storage = original_allocate(n_pages, **kwargs)
+        backing_refs.append(weakref.ref(storage._kv_backing))
+        return storage
+
+    def allocate_additional(n_pages):
+        value = torch.empty(n_pages, dtype=torch.int32)
+        additional_refs.append(weakref.ref(value))
+        return value
+
+    def validate_transient():
+        nonlocal probe_attempts
+        assert torch.is_inference_mode_enabled()
+        probe_attempts += 1
+        if probe_attempts == 1:
+            raise torch.OutOfMemoryError("synthetic live-workspace failure")
+        value = torch.empty(1)
+        probe_refs.append(weakref.ref(value))
+        return value
+
+    monkeypatch.setattr(kv_cache, "allocate_paged_kv_storage", allocate_storage)
+
+    storage, additional = fit_and_allocate_paged_kv_storage(
+        4,
+        layer_specs=specs,
+        page_size=2,
+        dtype=torch.bfloat16,
+        pool=pool,
+        stream=None,
+        allocate_additional=allocate_additional,
+        validate_transient=validate_transient,
+    )
+
+    assert storage.n_pages == 3
+    assert probe_attempts == 2
+    assert backing_refs[0]() is None
+    assert backing_refs[1]() is storage._kv_backing
+    assert additional_refs[0]() is None
+    assert additional_refs[1]() is additional
+    assert probe_refs[0]() is None
+    assert pool.allocated_bytes == paged_kv_storage_bytes(
+        3,
+        layer_specs=specs,
+        page_size=2,
+        dtype=torch.bfloat16,
+    )
+
+
+def test_fitted_paged_kv_storage_keeps_transient_alive_through_stream_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kestrel.kv_cache as kv_cache
+
+    specs = (PagedKVLayerSpec(n_heads=1, head_dim=8),)
+    pool = KVMemoryPool(device="cuda:0")
+    probe_ref = None
+
+    class Probe:
+        pass
+
+    class Stream:
+        def synchronize(self):
+            assert probe_ref is not None and probe_ref() is not None
+
+    @contextmanager
+    def cuda_device(_device):
+        yield
+
+    @contextmanager
+    def use_stream(_stream):
+        yield
+
+    def validate_transient():
+        nonlocal probe_ref
+        assert torch.is_inference_mode_enabled()
+        probe = Probe()
+        probe_ref = weakref.ref(probe)
+        return probe
+
+    storage = type("Storage", (), {"n_pages": 3})()
+    monkeypatch.setattr(kv_cache.torch.cuda, "device", cuda_device)
+    monkeypatch.setattr(kv_cache.torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        kv_cache.torch.cuda,
+        "mem_get_info",
+        lambda _device: (1 << 30, 1 << 31),
+    )
+    monkeypatch.setattr(kv_cache, "stream_context", use_stream)
+    monkeypatch.setattr(
+        kv_cache,
+        "allocate_paged_kv_storage",
+        lambda *_args, **_kwargs: storage,
+    )
+
+    fitted, additional = fit_and_allocate_paged_kv_storage(
+        3,
+        layer_specs=specs,
+        page_size=1,
+        dtype=torch.bfloat16,
+        pool=pool,
+        stream=Stream(),
+        validate_transient=validate_transient,
+    )
+
+    assert fitted is storage
+    assert additional is None
+    assert probe_ref is not None and probe_ref() is None
 
 
 def test_fitted_paged_kv_storage_rejects_capacity_without_serving_page() -> None:


### PR DESCRIPTION
## Summary

- stream Qwen and Gemma generated weights directly into their final compiler-ready layouts
- correct Gemma MoE inference to use standard GEGLU semantics
- retain the largest safe Gemma paged KV allocation after generated bindings, page tables, RoPE tables, fixed BLAS resources, and image-prefill transients are resident
- validate both maximum-batch image prefill and the maximum admitted single-request prefill, including a second steady-state pass before accepting capacity
- release per-sequence prefill hidden-state ownership immediately after its sole scheduler consumer
- stream Qwen image features directly into packed embeddings

## Verification

- focused host suites: 74 passed, 9 skipped; Ruff and `git diff --check` clean
- independent adversarial review reached zero findings after fixes for nonzero CUDA-device cache targeting, maximum-batch coverage, and prefill hidden-state lifetime
- exact H100 Gemma 4 31B C1: 64/64 requests, 54/64 correct (0.84375), realized concurrency 0.999969, 25,110 generated launches, zero native/fallback decode calls
- exact H100 Gemma 4 31B C8: 64/64 requests, 53/64 correct (0.828125), realized concurrency 0.999979, 3,442 generated launches across B1/B2/B4/B8, zero native/fallback decode calls
- exact capacity boundaries: C1 accepted 18,532 pages and rejected 18,533; C8 accepted 18,345 and rejected 18,346
- both H100 gates used JIT-disabled source identity `40d1601+diff-sha256-fdf3c039...`, private revision `d57ef668`, CUDA 13, and the exact sm90 AOT archive SHA-256 `674384d211a08cd25b12cbba491b3b974c8aa979b78dd8a3b1c0f8c5cc2420f2`

The diagnostic H100 runs enabled synchronous allocator telemetry, so their throughput is qualification evidence rather than canonical performance-board data.

## Scope

This targets the next major release; it does not publish or release anything.

This PR fully supersedes #198. The streaming commits are patch-equivalent, and this branch contains the retained KV work with additional stream, fixed-resource, transient, exact-admission, and steady-state hardening. Do not merge both overlapping histories; leave #198 open until this PR lands, then close #198 as superseded.
