### PR TITLE
Stream reasoning deltas separately

### DIFF
--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -149,14 +149,16 @@ class RequestLifecycle:
             self.logprobs.append(float(logprob))
         callback = self.request.stream_callback
         if callback is not None:
-            delta = self.skill_state.pop_stream_delta(runtime)
-            if delta:
+            text_delta = self.skill_state.pop_stream_delta(runtime)
+            reasoning_delta = self.skill_state.pop_reasoning_stream_delta(runtime)
+            if text_delta or reasoning_delta:
                 callback(
                     StreamUpdate(
                         request_id=self.request.request_id,
                         token=token,
-                        text=delta,
+                        text=text_delta or "",
                         token_index=self.skill_state.token_count - 1,
+                        reasoning=reasoning_delta,
                     )
                 )
 
@@ -282,6 +284,7 @@ class StreamUpdate:
     token: Token
     text: str
     token_index: int
+    reasoning: Optional[str] = None
 
 
 StreamCallback = Callable[[StreamUpdate], None]

--- a/kestrel/skills/base.py
+++ b/kestrel/skills/base.py
@@ -322,6 +322,14 @@ class SkillState:
 
         return None
 
+    def pop_reasoning_stream_delta(
+        self, runtime: "AutoregressiveRuntime"
+    ) -> Optional[str]:
+        """Return newly available reasoning text for streaming clients."""
+
+        return None
+
+
 class SkillRegistry:
     """Maps a model's capability names to their skills.
 

--- a/kestrel/skills/chat.py
+++ b/kestrel/skills/chat.py
@@ -307,6 +307,7 @@ class ChatSkillState(SkillState):
         self._reasoning_tokens: List[int] = []
         self._answer_tokens: List[int] = []
         self._streaming = bool(chat_request.stream)
+        self._reasoning_stream_offset = 0
         self._answer_stream_offset = 0
         self._answer_id: Optional[int] = None
         self._stop_ids: Optional[Set[int]] = None
@@ -387,6 +388,18 @@ class ChatSkillState(SkillState):
             return None
         chunk = text[self._answer_stream_offset :]
         self._answer_stream_offset = len(text)
+        return chunk or None
+
+    def pop_reasoning_stream_delta(
+        self, runtime: "MoondreamRuntime"
+    ) -> Optional[str]:
+        if not self._streaming or not self._reasoning_tokens:
+            return None
+        text = runtime.tokenizer.decode(self._reasoning_tokens)
+        if len(text) <= self._reasoning_stream_offset:
+            return None
+        chunk = text[self._reasoning_stream_offset :]
+        self._reasoning_stream_offset = len(text)
         return chunk or None
 
     def finalize(

--- a/kestrel/skills/query.py
+++ b/kestrel/skills/query.py
@@ -197,6 +197,7 @@ class QuerySkillState(SkillState):
         self._start_ground_id: Optional[int] = None
         self._end_ground_id: Optional[int] = None
         self._streaming = bool(query_request.stream)
+        self._reasoning_stream_offset = 0
         self._answer_stream_offset = 0
         # After reasoning ends (answer_id generated), replay the model's
         # post_reasoning_prefix one token at a time via allowed_token_ids.
@@ -336,6 +337,18 @@ class QuerySkillState(SkillState):
         if not chunk:
             return None
         return chunk
+
+    def pop_reasoning_stream_delta(
+        self, runtime: "AutoregressiveRuntime"
+    ) -> Optional[str]:
+        if not self._streaming or not self._reasoning_tokens:
+            return None
+        text = runtime.tokenizer.decode(self._reasoning_tokens)
+        if len(text) <= self._reasoning_stream_offset:
+            return None
+        chunk = text[self._reasoning_stream_offset :]
+        self._reasoning_stream_offset = len(text)
+        return chunk or None
 
     def finalize(
         self,

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -43,6 +43,18 @@ class _FailingFinalizeSkillState(_SkillStateStub):
         raise RuntimeError("finalize failed")
 
 
+class _ReasoningStreamSkillState(_SkillStateStub):
+    def __init__(self, request: GenerationRequest) -> None:
+        super().__init__(request)
+        self._reasoning_pending = True
+
+    def pop_reasoning_stream_delta(self, runtime: object) -> str | None:
+        if not self._reasoning_pending:
+            return None
+        self._reasoning_pending = False
+        return "think"
+
+
 def _make_lifecycle(*, return_logprobs: bool | None) -> RequestLifecycle:
     request = GenerationRequest(
         request_id=7,
@@ -173,6 +185,25 @@ def test_decode_step_exposes_selected_logprob_before_skill_consumption() -> None
 
     assert seen == [-0.75]
     assert seq.logprobs == [-0.75]
+
+
+def test_stage_token_emits_reasoning_without_answer_text() -> None:
+    updates = []
+    seq = _make_lifecycle_with_state(
+        _ReasoningStreamSkillState,
+        return_logprobs=None,
+    )
+    seq.request.stream_callback = updates.append
+
+    seq.stage_token(SimpleNamespace(), TextToken(10))
+    seq.stage_token(SimpleNamespace(), TextToken(11))
+
+    assert len(updates) == 1
+    assert updates[0].request_id == 7
+    assert updates[0].token == TextToken(10)
+    assert updates[0].token_index == 0
+    assert updates[0].text == ""
+    assert updates[0].reasoning == "think"
 
 
 def test_scheduler_result_keeps_generated_prefix_logprobs_aligned() -> None:

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -87,9 +87,11 @@ def _chat_runtime(chat: bool = True) -> SimpleNamespace:
     )
 
 
-def _ctx(messages, reasoning: bool = False) -> ChatRequest:
+def _ctx(messages, reasoning: bool = False, stream: bool = False) -> ChatRequest:
     built = ChatSkill().build_request(
-        None, {"messages": messages, "reasoning": reasoning}, None
+        None,
+        {"messages": messages, "reasoning": reasoning, "stream": stream},
+        None,
     )
     return built.request_context
 
@@ -344,6 +346,33 @@ def test_state_reasoning_splits_thinking_and_answer() -> None:
         "content": "ans",
         "reasoning": "think",
     }
+
+
+def test_state_streams_reasoning_separately_from_answer() -> None:
+    runtime = _chat_runtime()
+    state = ChatSkill().create_state(
+        runtime,
+        SimpleNamespace(),
+        _ctx(
+            [{"role": "user", "content": "hi"}],
+            reasoning=True,
+            stream=True,
+        ),
+    )
+    state.on_prefill(runtime)
+
+    _drive(state, runtime, _ords("t"))
+    assert state.pop_reasoning_stream_delta(runtime) == "t"
+    assert state.pop_stream_delta(runtime) is None
+
+    state.consume_step(
+        runtime,
+        DecodeStep(token=TextToken(token_id=THINK_E), position=1),
+    )
+    _drive(state, runtime, [DNL])
+    _drive(state, runtime, _ords("a"))
+    assert state.pop_reasoning_stream_delta(runtime) is None
+    assert state.pop_stream_delta(runtime) == "a"
 
 
 # -- Moondream flatten-into-query subclass --------------------------------

--- a/tests/test_query_skill.py
+++ b/tests/test_query_skill.py
@@ -202,6 +202,8 @@ def test_reasoning_stop_token_is_not_emitted() -> None:
     state.consume_step(runtime, DecodeStep(TextToken(token_id=88), position=1))
 
     assert state.pop_stream_delta(runtime) is None
+    assert state.pop_reasoning_stream_delta(runtime) == "<42>"
+    assert state.pop_reasoning_stream_delta(runtime) is None
     result = state.finalize(runtime, reason="stop")
     assert result.output == {
         "answer": "",
@@ -417,3 +419,25 @@ def test_reasoning_start_contract_rejects_scalar_and_sequence() -> None:
         match="query template must not set both reasoning start token fields",
     ):
         state.on_prefill(runtime)
+
+
+def test_reasoning_and_answer_streams_remain_separate() -> None:
+    runtime = _Runtime()
+    runtime.prompt_template.answer_id = 7
+    runtime.tokenizer = _VisibleTokenizer()
+    context = QueryRequest(
+        question="hi",
+        image=None,
+        reasoning=True,
+        stream=True,
+    )
+    state = QuerySkill().create_state(runtime, SimpleNamespace(), context)
+
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=41), position=0))
+    assert state.pop_reasoning_stream_delta(runtime) == "<41>"
+    assert state.pop_stream_delta(runtime) is None
+
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=7), position=1))
+    state.consume_step(runtime, DecodeStep(TextToken(token_id=42), position=2))
+    assert state.pop_reasoning_stream_delta(runtime) is None
+    assert state.pop_stream_delta(runtime) == "<42>"


### PR DESCRIPTION
## Summary
- add an optional reasoning channel to autoregressive stream updates
- emit reasoning and answer deltas without merging their text
- preserve per-token identity and indexing for streamed updates

## Validation
- Modal CPU: 98 passed across scheduler logprob, chat-skill, and query-skill test files
- adversarial self-review: no remaining findings