### PR TITLE
Forward generated binding reservation stream

### DIFF
--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -457,6 +457,7 @@ def reserve_generated_binding_storage(
                 weights=weights,
                 runtime_inputs=runtime_inputs,
                 device=device,
+                stream=stream,
             )
         )
 

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -206,8 +206,8 @@ def test_binding_reservation_allocates_every_program_slot_pair(
         yield
         stream_contexts.append(("exit", stream))
 
-    def reserve(descriptor, *, weights, runtime_inputs, device):
-        calls.append((descriptor, weights, runtime_inputs))
+    def reserve(descriptor, *, weights, runtime_inputs, device, stream):
+        calls.append((descriptor, weights, runtime_inputs, stream))
         return (
             torch.empty(
                 descriptor["owned_bytes"] + runtime_inputs["slot"],
@@ -241,10 +241,10 @@ def test_binding_reservation_allocates_every_program_slot_pair(
     assert [tensor.dtype for tensor in reservation] == [torch.uint8] * 4
     assert [tensor.numel() for tensor in reservation] == [11, 21, 12, 22]
     assert calls == [
-        (programs[0].descriptor, storage.buffers, first),
-        (programs[1].descriptor, storage.buffers, first),
-        (programs[0].descriptor, storage.buffers, second),
-        (programs[1].descriptor, storage.buffers, second),
+        (programs[0].descriptor, storage.buffers, first, compute_stream),
+        (programs[1].descriptor, storage.buffers, first, compute_stream),
+        (programs[0].descriptor, storage.buffers, second, compute_stream),
+        (programs[1].descriptor, storage.buffers, second, compute_stream),
     ]
     assert stream_contexts == [
         ("enter", compute_stream),


### PR DESCRIPTION
## Summary
- pass the active compute stream into generated binding-storage reservation
- keep allocator reservation and binding assembly on one stream
- update the device contract test to assert exact stream propagation

## Validation
- Modal CPU combined runtime suite: 125 passed, 1 skipped
- adversarial self-review: no remaining findings