### PR TITLE
Reduce Moondream FP8 load peak memory

### DIFF
--- a/kestrel/models/moondream/_moe_layout.py
+++ b/kestrel/models/moondream/_moe_layout.py
@@ -74,10 +74,33 @@ def build_md3_moe_up_slab(
     stay zero (the megakernel never tiles them). Returns ``(up_w_slab, up_scale_slab)``; the caller
     fills each MoE layer's view via :func:`set_md3_moe_up_layer`."""
     n_layers = len(text.blocks)
+
+    # ``build_moe_mlp`` has already materialized one bf16 up-projection
+    # parameter per MoE layer.  The FP8 checkpoint never loads those
+    # placeholders: the slab below replaces them with uint8 views.  Drop all
+    # placeholder storages before requesting the single large slab, otherwise
+    # model construction transiently holds both layouts (12 GiB of bf16
+    # placeholders plus the 6 GiB FP8 slab for MD3) and cannot fit on a 24 GiB
+    # Ampere GPU.
+    target_device = torch.device(device)
+    for block in text.blocks:
+        if not hasattr(block.mlp, "router"):
+            continue
+        up_experts = block.mlp["mlp"].up_experts
+        up_experts.weight = nn.Parameter(
+            torch.empty(0, dtype=torch.uint8, device=target_device),
+            requires_grad=False,
+        )
+    if target_device.type == "cuda":
+        # The slab is one contiguous allocation whereas the discarded
+        # placeholders were per-layer allocations.  Return their cached CUDA
+        # segments before allocating the slab so the driver can satisfy it.
+        torch.cuda.empty_cache()
+
     up_w_slab = torch.zeros(
-        n_layers, num_experts, two_inter, hidden, dtype=torch.uint8, device=device)
+        n_layers, num_experts, two_inter, hidden, dtype=torch.uint8, device=target_device)
     up_scale_slab = torch.zeros(
-        n_layers, num_experts, two_inter, dtype=torch.float32, device=device)
+        n_layers, num_experts, two_inter, dtype=torch.float32, device=target_device)
     # Stash the slabs on the text module: THE contract the megakernel session asserts against (each
     # MoE layer's up_experts view must alias these). Plain attributes -- not buffers -- so they do
     # not appear twice in the state_dict (the per-layer views already round-trip the bytes).

--- a/tests/moondream/test_moe.py
+++ b/tests/moondream/test_moe.py
@@ -283,6 +283,53 @@ def _build_moe_slab_text(cls):
     return text
 
 
+def test_moe_up_slab_releases_bf16_placeholders_before_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.moondream import _moe_layout
+    from kestrel.models.moondream.layers import build_dense_mlp, build_moe_mlp
+
+    blocks = nn.ModuleList(
+        [
+            nn.ModuleDict({"mlp": build_dense_mlp(8, 32, torch.bfloat16)}),
+            nn.ModuleDict({"mlp": build_moe_mlp(8, 16, 4, torch.bfloat16, top_k=2)}),
+            nn.ModuleDict({"mlp": build_moe_mlp(8, 16, 4, torch.bfloat16, top_k=2)}),
+        ]
+    )
+    text = _moe_layout.MoEUpSlabModuleDict({"blocks": blocks})
+    old_weights = [
+        text.blocks[index].mlp["mlp"].up_experts.weight
+        for index in (1, 2)
+    ]
+    assert all(weight.dtype == torch.bfloat16 and weight.numel() for weight in old_weights)
+
+    real_zeros = torch.zeros
+    observed_placeholder_shapes: list[tuple[int, ...]] = []
+
+    def recording_zeros(*shape, **kwargs):
+        observed_placeholder_shapes.extend(
+            tuple(text.blocks[index].mlp["mlp"].up_experts.weight.shape)
+            for index in (1, 2)
+        )
+        return real_zeros(*shape, **kwargs)
+
+    monkeypatch.setattr(_moe_layout.torch, "zeros", recording_zeros)
+    slab, _ = _moe_layout.build_md3_moe_up_slab(
+        text,
+        num_experts=4,
+        two_inter=32,
+        hidden=8,
+        device="cpu",
+    )
+
+    assert observed_placeholder_shapes[:2] == [(0,), (0,)]
+    assert slab.shape == (3, 4, 32, 8)
+    assert all(
+        text.blocks[index].mlp["mlp"].up_experts.weight.numel() == 0
+        for index in (1, 2)
+    )
+
+
 def _moe_up_views(text):
     return [
         (li, text.blocks[li].mlp["mlp"].up_experts)


### PR DESCRIPTION
## Summary
- release unused BF16 MoE up-projection placeholders before allocating the FP8 slab
- preserve the existing engine-owned slab and per-layer aliasing contract
- allow Moondream 3 construction to fit the 24 GiB L4 memory envelope

## Validation
- Modal CPU combined runtime suite: 125 passed, 1 skipped
- adversarial self-review: no remaining findings