### PR TITLE
Route Qwen projections through runtime linear

### DIFF
--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -44,6 +44,7 @@ _kestrel_supports_packed_gdn = _kestrel_runtime.gated_delta.supports_packed_gdn
 _kestrel_add_rmsnorm = _kestrel_runtime.dense.add_rmsnorm
 _kestrel_gated_activation_into = _kestrel_runtime.dense.gated_activation_into
 _kestrel_fused_mlp_gelu_bias_residual = _kestrel_runtime.dense.fused_mlp_gelu_bias_residual
+_kestrel_linear = _kestrel_runtime.linear.linear
 _kestrel_text_mrope_apply = _kestrel_runtime.rotary.text_mrope_apply
 _kestrel_spatial_rope_apply = _kestrel_runtime.rotary.spatial_rope_apply
 _kestrel_moe_runtime = _kestrel_runtime.moe
@@ -998,8 +999,9 @@ class Qwen3_5VisionPatchMerger(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.norm(x).view(-1, self.hidden_size)
-        x = self.linear_fc2(self.act_fn(self.linear_fc1(x)))
-        return x
+        x = _kestrel_linear(x, self.linear_fc1.weight, self.linear_fc1.bias)
+        x = self.act_fn(x)
+        return _kestrel_linear(x, self.linear_fc2.weight, self.linear_fc2.bias)
 
 
 class Qwen3_5VisionAttention(nn.Module):

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -1033,9 +1033,12 @@ class Qwen3_5VisionAttention(nn.Module):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
-        query_states, key_states, value_states = (
-            self.qkv(hidden_states).reshape(seq_length, 3, self.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
+        qkv = _kestrel_linear(
+            hidden_states, self.qkv.weight, self.qkv.bias
+        ).view(
+            seq_length, 3, self.num_heads, self.head_dim
         )
+        query_states, key_states, value_states = qkv.unbind(dim=1)
         cos, sin = position_embeddings
         query_states, key_states = _kestrel_spatial_rope_apply(
             query_states, key_states, cos, sin, axis_blocks=1

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -1043,7 +1043,9 @@ class Qwen3_5VisionAttention(nn.Module):
         )
 
         attn_output = attn_output.reshape(seq_length, -1).contiguous()
-        attn_output = self.proj(attn_output)
+        attn_output = _kestrel_linear(
+            attn_output, self.proj.weight, self.proj.bias
+        )
         return attn_output
 
 

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -985,7 +985,7 @@ class Qwen3_5VisionPatchEmbed(nn.Module):
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        return self.proj(hidden_states)
+        return _kestrel_linear(hidden_states, self.proj.weight, self.proj.bias)
 
 
 class Qwen3_5VisionPatchMerger(nn.Module):

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -377,7 +377,9 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             dtype=torch.long,
         ).view(-1).contiguous()
 
-        in_proj = self.in_proj(hidden_states)
+        in_proj = _kestrel_linear(
+            hidden_states, self.in_proj.weight, self.in_proj.bias
+        )
         mixed_qkv, z, b, a = torch.split(
             in_proj,
             [self.conv_dim, self.value_dim, self.num_v_heads, self.num_v_heads],
@@ -464,7 +466,9 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(batch_size, seq_len, -1)
 
-        output = self.out_proj(core_attn_out)
+        output = _kestrel_linear(
+            core_attn_out, self.out_proj.weight, self.out_proj.bias
+        )
         return output
 
 
@@ -509,7 +513,9 @@ class Qwen3_5Attention(nn.Module):
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)
 
-        q_gate, key_states, value_states = self.qkv_proj(hidden_states).split(
+        q_gate, key_states, value_states = _kestrel_linear(
+            hidden_states, self.qkv_proj.weight, self.qkv_proj.bias
+        ).split(
             [self.q_gate_size, self.kv_size, self.kv_size],
             dim=-1,
         )
@@ -575,7 +581,9 @@ class Qwen3_5Attention(nn.Module):
         attn_output = attn_output * torch.sigmoid(gate)
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
 
-        attn_output = self.o_proj(attn_output)
+        attn_output = _kestrel_linear(
+            attn_output, self.o_proj.weight, self.o_proj.bias
+        )
         return attn_output, attn_weights
 
 
@@ -600,7 +608,9 @@ class Qwen3_5MLP(nn.Module):
         )
 
     def forward(self, x):
-        gate_up = self.gate_up_proj(x)
+        gate_up = _kestrel_linear(
+            x, self.gate_up_proj.weight, self.gate_up_proj.bias
+        )
         hidden = gate_up.new_empty(*gate_up.shape[:-1], self.intermediate_size)
         _kestrel_gated_activation_into(
             hidden,
@@ -608,7 +618,9 @@ class Qwen3_5MLP(nn.Module):
             activation="silu",
             layout=_KESTREL_MOE_GATE_UP_LAYOUT,
         )
-        return self.down_proj(hidden)
+        return _kestrel_linear(
+            hidden, self.down_proj.weight, self.down_proj.bias
+        )
 
 
 class Qwen3_5Experts(nn.Module):

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -49,6 +49,7 @@ from .qwen_image import preprocess_image
 
 
 _PREFILL_SCRATCH_TOKENS = 1024
+_kestrel_linear = get_runtime().linear.linear
 
 
 @dataclass
@@ -717,7 +718,11 @@ class Qwen35Runtime(UncachedPagedRuntime):
             for row, prepared in enumerate(prepared_sequences):
                 prepared.state.last_hidden = hidden_rows[row].detach()
 
-            return self.model.lm_head(hidden_rows)
+            return _kestrel_linear(
+                hidden_rows,
+                self.model.lm_head.weight,
+                self.model.lm_head.bias,
+            )
         finally:
             self._record_prefill_slot_done(prefill_slot)
 

--- a/tests/qwen35/test_prefill_topology.py
+++ b/tests/qwen35/test_prefill_topology.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import torch
 
 from kestrel.models.qwen35 import runtime as qwen_runtime
+from kestrel.models.qwen35 import qwen_model as qwen_model_module
 from kestrel.models.qwen35.qwen_model import Qwen3_5GatedDeltaNet
 from kestrel.models.qwen35.runtime import Qwen35Runtime, _PackedPrefillBatch
 from kestrel.runtime.tokens import TextToken
@@ -101,8 +102,9 @@ def test_packed_prefill_batch_forwards_host_sequence_lengths() -> None:
     assert observed["max"] == 544
 
 
-def test_gdn_prefill_forwards_topology_to_combined_prefill() -> None:
+def test_gdn_prefill_forwards_topology_to_combined_prefill(monkeypatch) -> None:
     observed: dict[str, object] = {}
+    linear_calls: list[tuple[torch.Tensor, torch.Tensor | None]] = []
     layer = SimpleNamespace(
         conv_states=None,
         recurrent_states=torch.empty((1, 1, 1, 1), dtype=torch.bfloat16),
@@ -134,7 +136,10 @@ def test_gdn_prefill_forwards_topology_to_combined_prefill() -> None:
         A_log=torch.zeros((1,)),
         dt_bias=torch.zeros((1,)),
         conv1d=conv1d,
-        in_proj=lambda hidden: torch.zeros((1, 3, 4)),
+        in_proj=SimpleNamespace(
+            weight=torch.zeros((4, 1)),
+            bias=None,
+        ),
         supports_packed_gdn=lambda *args: True,
         causal_conv1d_packed=lambda **kwargs: kwargs["x"],
         allocate_packed_gdn_prefill_workspace=lambda *args, **kwargs: object(),
@@ -143,8 +148,17 @@ def test_gdn_prefill_forwards_topology_to_combined_prefill() -> None:
         ),
         packed_gated_delta_rule_prefill=packed_prefill,
         norm=lambda value, gate: value,
-        out_proj=lambda value: value,
+        out_proj=SimpleNamespace(
+            weight=torch.ones((1, 1)),
+            bias=None,
+        ),
     )
+
+    def runtime_linear(value, weight, bias):
+        linear_calls.append((weight, bias))
+        return torch.nn.functional.linear(value, weight, bias)
+
+    monkeypatch.setattr(qwen_model_module, "_kestrel_linear", runtime_linear)
 
     result = Qwen3_5GatedDeltaNet.forward(
         fake,
@@ -159,5 +173,10 @@ def test_gdn_prefill_forwards_topology_to_combined_prefill() -> None:
     )
 
     assert result.shape == (1, 3, 1)
+    assert len(linear_calls) == 2
+    assert linear_calls[0][0] is fake.in_proj.weight
+    assert linear_calls[0][1] is fake.in_proj.bias
+    assert linear_calls[1][0] is fake.out_proj.weight
+    assert linear_calls[1][1] is fake.out_proj.bias
     assert observed["sequence_lengths"] == (3,)
     assert observed["topology_token"] is fake

--- a/tests/qwen35/test_prefill_topology.py
+++ b/tests/qwen35/test_prefill_topology.py
@@ -102,6 +102,62 @@ def test_packed_prefill_batch_forwards_host_sequence_lengths() -> None:
     assert observed["max"] == 544
 
 
+def test_launch_prepared_batch_uses_runtime_linear_for_lm_head(monkeypatch) -> None:
+    observed: dict[str, object] = {}
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.max_batch_size = 2
+    runtime._chat_image_crops = {}
+    runtime.page_table = SimpleNamespace(
+        commit_block_table=lambda indices: observed.setdefault(
+            "batch_indices", indices
+        )
+    )
+    packed = SimpleNamespace(
+        last_token_offsets=torch.tensor([1, 3]),
+        batch_indices=torch.tensor([4, 7]),
+        rope_deltas=object(),
+    )
+    runtime._build_packed_prefill_batch = lambda *args, **kwargs: packed
+    last_hidden = torch.arange(16, dtype=torch.float32).view(1, 4, 4)
+    cache = object()
+    runtime._forward_packed_prefill = lambda value: (last_hidden, cache)
+    runtime._store_packed_sequence_caches = (
+        lambda *args, **kwargs: observed.setdefault("stored", (args, kwargs))
+    )
+    runtime._record_prefill_slot_done = lambda slot: observed.setdefault(
+        "done", slot
+    )
+    weight = torch.arange(12, dtype=torch.float32).view(3, 4)
+    runtime.model = SimpleNamespace(
+        lm_head=SimpleNamespace(weight=weight, bias=None)
+    )
+    prepared = [
+        SimpleNamespace(state=SimpleNamespace(batch_idx=4, last_hidden=None)),
+        SimpleNamespace(state=SimpleNamespace(batch_idx=7, last_hidden=None)),
+    ]
+    linear_calls = []
+
+    def runtime_linear(value, linear_weight, bias):
+        linear_calls.append((value, linear_weight, bias))
+        return torch.nn.functional.linear(value, linear_weight, bias)
+
+    monkeypatch.setattr(qwen_runtime, "_kestrel_linear", runtime_linear)
+    prefill_slot = object()
+
+    logits = runtime.launch_prepared_batch(prepared, prefill_slot)
+
+    hidden_rows = last_hidden[0].index_select(0, packed.last_token_offsets)
+    assert len(linear_calls) == 1
+    torch.testing.assert_close(linear_calls[0][0], hidden_rows)
+    assert linear_calls[0][1] is weight
+    assert linear_calls[0][2] is None
+    torch.testing.assert_close(logits, torch.nn.functional.linear(hidden_rows, weight))
+    torch.testing.assert_close(prepared[0].state.last_hidden, hidden_rows[0])
+    torch.testing.assert_close(prepared[1].state.last_hidden, hidden_rows[1])
+    assert observed["batch_indices"] == [4, 7]
+    assert observed["done"] is prefill_slot
+
+
 def test_gdn_prefill_forwards_topology_to_combined_prefill(monkeypatch) -> None:
     observed: dict[str, object] = {}
     linear_calls: list[tuple[torch.Tensor, torch.Tensor | None]] = []

--- a/tests/qwen35/test_text_linear.py
+++ b/tests/qwen35/test_text_linear.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+import kestrel.models.qwen35.qwen_model as model_module
+from kestrel.models.qwen35.qwen_model import Qwen3_5Attention, Qwen3_5MLP
+
+
+def test_attention_uses_runtime_linear_without_changing_semantics(
+    monkeypatch,
+) -> None:
+    config = SimpleNamespace(
+        head_dim=2,
+        hidden_size=4,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        rms_norm_eps=1e-6,
+    )
+    attention = Qwen3_5Attention(config, layer_idx=0).eval()
+    inputs = torch.randn(1, 3, config.hidden_size)
+    calls = []
+
+    def runtime_linear(x, weight, bias):
+        calls.append((x, weight, bias))
+        return F.linear(x, weight, bias)
+
+    monkeypatch.setattr(model_module, "_kestrel_linear", runtime_linear)
+    monkeypatch.setattr(
+        model_module,
+        "_kestrel_rmsnorm",
+        lambda value, weight, eps: value,
+    )
+    monkeypatch.setattr(
+        model_module,
+        "_kestrel_text_mrope_apply",
+        lambda query, key, cos, sin: (query, key),
+    )
+    monkeypatch.setattr(
+        model_module,
+        "dense_attention",
+        lambda query, *args, **kwargs: query.transpose(1, 2),
+    )
+
+    actual, weights = attention(
+        inputs,
+        position_embeddings=(torch.empty(0), torch.empty(0)),
+        attention_mask=None,
+        cu_seq_lens_q=torch.tensor([0, inputs.shape[1]], dtype=torch.int32),
+    )
+
+    assert weights is None
+    assert len(calls) == 2
+    assert calls[0][1] is attention.qkv_proj.weight
+    assert calls[0][2] is attention.qkv_proj.bias
+    assert calls[1][1] is attention.o_proj.weight
+    assert calls[1][2] is attention.o_proj.bias
+    torch.testing.assert_close(
+        actual,
+        F.linear(calls[1][0], attention.o_proj.weight, attention.o_proj.bias),
+    )
+
+
+def test_mlp_uses_runtime_linear_without_changing_semantics(monkeypatch) -> None:
+    config = SimpleNamespace(hidden_size=4)
+    intermediate_size = 3
+    mlp = Qwen3_5MLP(config, intermediate_size=intermediate_size).eval()
+    inputs = torch.randn(2, config.hidden_size)
+    calls = []
+
+    def runtime_linear(x, weight, bias):
+        calls.append((x, weight, bias))
+        return F.linear(x, weight, bias)
+
+    def gated_activation(output, gate_up, **kwargs):
+        output.copy_(gate_up[..., :intermediate_size])
+
+    monkeypatch.setattr(model_module, "_kestrel_linear", runtime_linear)
+    monkeypatch.setattr(
+        model_module,
+        "_kestrel_gated_activation_into",
+        gated_activation,
+    )
+
+    actual = mlp(inputs)
+
+    assert len(calls) == 2
+    assert calls[0][1] is mlp.gate_up_proj.weight
+    assert calls[0][2] is mlp.gate_up_proj.bias
+    assert calls[1][1] is mlp.down_proj.weight
+    assert calls[1][2] is mlp.down_proj.bias
+    torch.testing.assert_close(
+        actual,
+        F.linear(calls[1][0], mlp.down_proj.weight, mlp.down_proj.bias),
+    )

--- a/tests/qwen35/test_vision.py
+++ b/tests/qwen35/test_vision.py
@@ -74,12 +74,8 @@ def test_vision_attention_output_uses_runtime_linear_without_changing_semantics(
     attention = Qwen3_5VisionAttention(config).eval()
     inputs = torch.randn(3, config.hidden_size)
     projected_inputs = torch.randn_like(inputs)
-    attention.qkv.forward = lambda hidden_states: torch.zeros(
-        hidden_states.shape[0],
-        3 * config.hidden_size,
-        dtype=hidden_states.dtype,
-        device=hidden_states.device,
-    )
+    attention.qkv.weight.data.zero_()
+    attention.qkv.bias.data.zero_()
     monkeypatch.setattr(
         model_module,
         "_kestrel_spatial_rope_apply",
@@ -107,8 +103,11 @@ def test_vision_attention_output_uses_runtime_linear_without_changing_semantics(
         position_embeddings=(torch.empty(0), torch.empty(0)),
     )
 
-    assert len(calls) == 1
-    torch.testing.assert_close(calls[0][0], projected_inputs)
-    assert calls[0][1] is attention.proj.weight
-    assert calls[0][2] is attention.proj.bias
+    assert len(calls) == 2
+    torch.testing.assert_close(calls[0][0], inputs)
+    assert calls[0][1] is attention.qkv.weight
+    assert calls[0][2] is attention.qkv.bias
+    torch.testing.assert_close(calls[1][0], projected_inputs)
+    assert calls[1][1] is attention.proj.weight
+    assert calls[1][2] is attention.proj.bias
     torch.testing.assert_close(actual, expected)

--- a/tests/qwen35/test_vision.py
+++ b/tests/qwen35/test_vision.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+import kestrel.models.qwen35.qwen_model as model_module
+from kestrel.models.qwen35.qwen_model import Qwen3_5VisionPatchMerger
+
+
+def test_patch_merger_uses_runtime_linear_without_changing_semantics(
+    monkeypatch,
+) -> None:
+    config = SimpleNamespace(
+        hidden_size=2,
+        spatial_merge_size=2,
+        out_hidden_size=3,
+    )
+    merger = Qwen3_5VisionPatchMerger(config).eval()
+    inputs = torch.randn(8, config.hidden_size)
+    normalized = merger.norm(inputs).view(-1, merger.hidden_size)
+    expected = merger.linear_fc2(
+        merger.act_fn(merger.linear_fc1(normalized))
+    )
+    calls = []
+
+    def runtime_linear(x, weight, bias):
+        calls.append((weight, bias))
+        return F.linear(x, weight, bias)
+
+    monkeypatch.setattr(model_module, "_kestrel_linear", runtime_linear)
+
+    actual = merger(inputs)
+
+    assert len(calls) == 2
+    assert calls[0][0] is merger.linear_fc1.weight
+    assert calls[0][1] is merger.linear_fc1.bias
+    assert calls[1][0] is merger.linear_fc2.weight
+    assert calls[1][1] is merger.linear_fc2.bias
+    torch.testing.assert_close(actual, expected)

--- a/tests/qwen35/test_vision.py
+++ b/tests/qwen35/test_vision.py
@@ -5,6 +5,33 @@ import torch.nn.functional as F
 
 import kestrel.models.qwen35.qwen_model as model_module
 from kestrel.models.qwen35.qwen_model import Qwen3_5VisionPatchMerger
+from kestrel.models.qwen35.qwen_model import Qwen3_5VisionPatchEmbed
+
+
+def test_patch_embed_uses_runtime_linear_without_changing_semantics(
+    monkeypatch,
+) -> None:
+    config = SimpleNamespace(
+        in_channels=3,
+        temporal_patch_size=2,
+        patch_size=2,
+        hidden_size=5,
+    )
+    patch_embed = Qwen3_5VisionPatchEmbed(config).eval()
+    inputs = torch.randn(7, 24)
+    expected = patch_embed.proj(inputs)
+    calls = []
+
+    def runtime_linear(x, weight, bias):
+        calls.append((weight, bias))
+        return F.linear(x, weight, bias)
+
+    monkeypatch.setattr(model_module, "_kestrel_linear", runtime_linear)
+
+    actual = patch_embed(inputs)
+
+    assert calls == [(patch_embed.proj.weight, patch_embed.proj.bias)]
+    torch.testing.assert_close(actual, expected)
 
 
 def test_patch_merger_uses_runtime_linear_without_changing_semantics(

--- a/tests/qwen35/test_vision.py
+++ b/tests/qwen35/test_vision.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn.functional as F
 
 import kestrel.models.qwen35.qwen_model as model_module
+from kestrel.models.qwen35.qwen_model import Qwen3_5VisionAttention
 from kestrel.models.qwen35.qwen_model import Qwen3_5VisionPatchMerger
 from kestrel.models.qwen35.qwen_model import Qwen3_5VisionPatchEmbed
 
@@ -63,4 +64,51 @@ def test_patch_merger_uses_runtime_linear_without_changing_semantics(
     assert calls[0][1] is merger.linear_fc1.bias
     assert calls[1][0] is merger.linear_fc2.weight
     assert calls[1][1] is merger.linear_fc2.bias
+    torch.testing.assert_close(actual, expected)
+
+
+def test_vision_attention_output_uses_runtime_linear_without_changing_semantics(
+    monkeypatch,
+) -> None:
+    config = SimpleNamespace(hidden_size=4, num_heads=2)
+    attention = Qwen3_5VisionAttention(config).eval()
+    inputs = torch.randn(3, config.hidden_size)
+    projected_inputs = torch.randn_like(inputs)
+    attention.qkv.forward = lambda hidden_states: torch.zeros(
+        hidden_states.shape[0],
+        3 * config.hidden_size,
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    monkeypatch.setattr(
+        model_module,
+        "_kestrel_spatial_rope_apply",
+        lambda query, key, cos, sin, axis_blocks: (query, key),
+    )
+    monkeypatch.setattr(
+        model_module,
+        "dense_attention",
+        lambda *args, **kwargs: projected_inputs,
+    )
+    calls = []
+
+    def runtime_linear(x, weight, bias):
+        calls.append((x, weight, bias))
+        return F.linear(x, weight, bias)
+
+    monkeypatch.setattr(model_module, "_kestrel_linear", runtime_linear)
+    expected = F.linear(
+        projected_inputs, attention.proj.weight, attention.proj.bias
+    )
+
+    actual = attention(
+        inputs,
+        cu_seqlens=torch.tensor([0, inputs.shape[0]], dtype=torch.int32),
+        position_embeddings=(torch.empty(0), torch.empty(0)),
+    )
+
+    assert len(calls) == 1
+    torch.testing.assert_close(calls[0][0], projected_inputs)
+    assert calls[0][1] is attention.proj.weight
+    assert calls[0][2] is attention.proj.bias
     torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
## Summary

- route Qwen vision patch, attention, MLP, and merger projections through the canonical runtime linear operation
- route Qwen text projections through the same backend-neutral operation
- route packed-prefill LM-head logits through the same operation so L4 uses the invariant kernel selector

## Evidence

- Modal CPU routing suite: 7 focused Qwen tests passed
- focused L4 LM-head probe: the routed Kestrel operation produced exact B1/B8 logits
- exact C1/C2/C4/C8 end-to-end qualification is in progress on public `591a69eef` and private `6bea72d2c`

This PR remains draft until the exact end-to-end qualification clears.
