### PR TITLE
Align MoE capacity with generated decode buckets

### DIFF
--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -33,7 +33,7 @@ _moe_runtime = get_runtime().moe
 _kestrel_gated_activation_into = _dense_runtime.gated_activation_into
 _prepare_neox_rotary = _rotary_runtime.prepare_neox
 _apply_neox_rotary = _rotary_runtime.apply_neox
-_MOE_DECODE_MAX_TOKENS = 16
+_MOE_DECODE_MAX_TOKENS = 8
 _MOE_MIN_PREFILL_BUCKET_TOKENS = 64
 
 
@@ -42,7 +42,7 @@ def _moe_capacity_for_tokens(tokens: int) -> tuple[int, str]:
     if tokens <= 0:
         raise ValueError("tokens must be positive")
     if tokens <= _MOE_DECODE_MAX_TOKENS:
-        return tokens, "decode"
+        return 1 << (tokens - 1).bit_length(), "decode"
     return (
         max(_MOE_MIN_PREFILL_BUCKET_TOKENS, 1 << (tokens - 1).bit_length()),
         "prefill",

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -48,7 +48,7 @@ _kestrel_text_mrope_apply = _kestrel_runtime.rotary.text_mrope_apply
 _kestrel_spatial_rope_apply = _kestrel_runtime.rotary.spatial_rope_apply
 _kestrel_moe_runtime = _kestrel_runtime.moe
 _kestrel_moe_topk_fwd = _kestrel_moe_runtime.topk_fwd
-_KESTREL_MOE_DECODE_MAX_TOKENS = 16
+_KESTREL_MOE_DECODE_MAX_TOKENS = 8
 _KESTREL_MOE_MIN_PREFILL_BUCKET_TOKENS = 64
 _KESTREL_MOE_GATE_UP_LAYOUT = "interleaved_i8"
 _KESTREL_MOE_FP8_WEIGHT_SCALE_LAYOUT = "block128_interleaved8"
@@ -171,7 +171,7 @@ def _kestrel_moe_capacity_for_tokens(tokens: int) -> tuple[int, str]:
     if tokens <= 0:
         raise ValueError("tokens must be positive")
     if tokens <= _KESTREL_MOE_DECODE_MAX_TOKENS:
-        return tokens, "decode"
+        return 1 << (tokens - 1).bit_length(), "decode"
     return (
         max(_KESTREL_MOE_MIN_PREFILL_BUCKET_TOKENS, 1 << (tokens - 1).bit_length()),
         "prefill",

--- a/tests/gemma4/test_moe.py
+++ b/tests/gemma4/test_moe.py
@@ -14,6 +14,19 @@ from kestrel.models.registry import get_spec
 import kestrel.models.gemma4.model as model_module
 
 
+def test_moe_capacity_matches_generated_decode_buckets() -> None:
+    assert [
+        model_module._moe_capacity_for_tokens(tokens)
+        for tokens in (1, 3, 8, 9, 16)
+    ] == [
+        (1, "decode"),
+        (4, "decode"),
+        (8, "decode"),
+        (64, "prefill"),
+        (64, "prefill"),
+    ]
+
+
 def _text_config(*, moe: bool = True) -> Gemma4TextConfig:
     return Gemma4TextConfig(
         vocab_size=32,

--- a/tests/qwen35/test_moe.py
+++ b/tests/qwen35/test_moe.py
@@ -7,6 +7,19 @@ from kestrel.models.qwen35.qwen_model import Qwen3_5Experts
 import kestrel.models.qwen35.qwen_model as model_module
 
 
+def test_moe_capacity_matches_generated_decode_buckets() -> None:
+    assert [
+        model_module._kestrel_moe_capacity_for_tokens(tokens)
+        for tokens in (1, 3, 8, 9, 16)
+    ] == [
+        (1, "decode"),
+        (4, "decode"),
+        (8, "decode"),
+        (64, "prefill"),
+        (64, "prefill"),
+    ]
+
+
 def _moe_config() -> Qwen3_5TextConfig:
     return Qwen3_5TextConfig(
         vocab_size=32,


### PR DESCRIPTION
## Summary
- map decode batches to the generated 1/2/4/8 MoE capacity buckets
- switch batches above 8 tokens to the existing prefill capacity policy
- cover Qwen3.5 and Gemma4 boundaries symmetrically

## Validation
- `tests/qwen35/test_moe.py`: 2 passed
- `tests/gemma4/test_moe.py`: 5 passed
- independent adversarial review: no findings

GPU resolution and fallback-clean behavior will be exercised by the H100 board retake.