### PR TITLE
Pass exact MoE capacity to the runtime

### DIFF
--- a/kestrel/models/gemma4/model.py
+++ b/kestrel/models/gemma4/model.py
@@ -34,19 +34,6 @@ _kestrel_gated_activation_into = _dense_runtime.gated_activation_into
 _prepare_neox_rotary = _rotary_runtime.prepare_neox
 _apply_neox_rotary = _rotary_runtime.apply_neox
 _MOE_DECODE_MAX_TOKENS = 16
-_MOE_MIN_PREFILL_BUCKET_TOKENS = 64
-
-
-def _moe_capacity_for_tokens(tokens: int) -> tuple[int, str]:
-    tokens = int(tokens)
-    if tokens <= 0:
-        raise ValueError("tokens must be positive")
-    if tokens <= _MOE_DECODE_MAX_TOKENS:
-        return tokens, "decode"
-    return (
-        max(_MOE_MIN_PREFILL_BUCKET_TOKENS, 1 << (tokens - 1).bit_length()),
-        "prefill",
-    )
 
 
 def _rmsnorm_state(
@@ -342,7 +329,6 @@ class Gemma4TextExperts(nn.Module):
         input_shape = hidden_states.shape
         flat_hidden = hidden_states.reshape(-1, self.hidden_size)
         tokens = int(flat_hidden.shape[0])
-        capacity_tokens, capacity_mode = _moe_capacity_for_tokens(tokens)
         if top_k_index.dtype != torch.int32:
             top_k_index = top_k_index.to(torch.int32)
         weight_formats = {
@@ -369,8 +355,8 @@ class Gemma4TextExperts(nn.Module):
         handle = _moe_runtime.prepare(
             spec,
             _MOE_API.MoeCapacity(
-                max_tokens=capacity_tokens,
-                mode=capacity_mode,
+                max_tokens=tokens,
+                mode="decode" if tokens <= _MOE_DECODE_MAX_TOKENS else "prefill",
             ),
             device=flat_hidden.device,
         )

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -49,7 +49,6 @@ _kestrel_spatial_rope_apply = _kestrel_runtime.rotary.spatial_rope_apply
 _kestrel_moe_runtime = _kestrel_runtime.moe
 _kestrel_moe_topk_fwd = _kestrel_moe_runtime.topk_fwd
 _KESTREL_MOE_DECODE_MAX_TOKENS = 16
-_KESTREL_MOE_MIN_PREFILL_BUCKET_TOKENS = 64
 _KESTREL_MOE_GATE_UP_LAYOUT = "interleaved_i8"
 _KESTREL_MOE_FP8_WEIGHT_SCALE_LAYOUT = "block128_interleaved8"
 
@@ -164,18 +163,6 @@ def _module_dtype(module: nn.Module) -> torch.dtype:
         return next(module.parameters()).dtype
     except StopIteration:
         return torch.get_default_dtype()
-
-
-def _kestrel_moe_capacity_for_tokens(tokens: int) -> tuple[int, str]:
-    tokens = int(tokens)
-    if tokens <= 0:
-        raise ValueError("tokens must be positive")
-    if tokens <= _KESTREL_MOE_DECODE_MAX_TOKENS:
-        return tokens, "decode"
-    return (
-        max(_KESTREL_MOE_MIN_PREFILL_BUCKET_TOKENS, 1 << (tokens - 1).bit_length()),
-        "prefill",
-    )
 
 
 class Qwen3_5VisionRotaryEmbedding(nn.Module):
@@ -693,7 +680,6 @@ class Qwen3_5Experts(nn.Module):
         top_k_weights: torch.Tensor,
     ) -> torch.Tensor:
         tokens = int(hidden_states.shape[0])
-        capacity_tokens, capacity_mode = _kestrel_moe_capacity_for_tokens(tokens)
         if top_k_index.dtype != torch.int32:
             top_k_index = top_k_index.to(torch.int32)
         spec = _MOE_API.MoeSpec(
@@ -709,8 +695,12 @@ class Qwen3_5Experts(nn.Module):
         handle = _kestrel_moe_runtime.prepare(
             spec,
             _MOE_API.MoeCapacity(
-                max_tokens=capacity_tokens,
-                mode=capacity_mode,
+                max_tokens=tokens,
+                mode=(
+                    "decode"
+                    if tokens <= _KESTREL_MOE_DECODE_MAX_TOKENS
+                    else "prefill"
+                ),
             ),
             device=hidden_states.device,
         )

--- a/tests/gemma4/test_moe.py
+++ b/tests/gemma4/test_moe.py
@@ -155,6 +155,7 @@ def test_experts_use_shared_contiguous_geglu_runtime(monkeypatch) -> None:
     assert spec.activation == "geglu"
     assert spec.backend == "auto"
     assert spec.intermediate_size == config.moe_intermediate_size
+    assert calls["capacity"].max_tokens == indices.shape[0]
     assert forward["weights"].weight_scale_layout == "block128"
     assert forward["topk_ids"].dtype == torch.int32
     torch.testing.assert_close(output, hidden + 1)

--- a/tests/qwen35/test_moe.py
+++ b/tests/qwen35/test_moe.py
@@ -59,5 +59,6 @@ def test_bf16_experts_use_device_selected_moe_backend(monkeypatch) -> None:
     spec = calls["spec"]
     assert spec.backend == "auto"
     assert spec.weight_format == "bf16"
+    assert calls["capacity"].max_tokens == hidden.shape[0]
     assert calls["forward"]["topk_ids"].dtype == torch.int32
     torch.testing.assert_close(output, hidden + 1)


### PR DESCRIPTION
## Summary
- pass the exact logical token capacity from Qwen3.5 and Gemma4 to the MoE runtime
- remove model-specific physical bucketing helpers and minimum-prefill constants
- leave calibrated physical capacity selection to the backend dispatcher

## Validation
- `tests/qwen35/test_moe.py`: 1 passed
- `tests/gemma4/test_moe.py`: 4 passed
- proprietary dispatcher suite: 56 passed

The paired runtime change maps logical C3/C5 requests to calibrated C4/C8 handles and permits execution below a prepared maximum capacity.