### PR TITLE
Keep MoE capacity routing backend-local

### DIFF
--- a/kestrel/models/moondream/moe.py
+++ b/kestrel/models/moondream/moe.py
@@ -76,17 +76,6 @@ class MoEModule(nn.Module):
             auto_backend_token_threshold=self.config.auto_backend_token_threshold,
         )
 
-    @staticmethod
-    def _capacity_tokens_for_mode(
-        num_tokens: int,
-        mode: Literal["prefill", "decode"],
-    ) -> int:
-        if num_tokens <= 0:
-            raise ValueError("num_tokens must be positive")
-        if mode == "decode":
-            return num_tokens
-        return 1 << (num_tokens - 1).bit_length()
-
     def _get_moe_handle(
         self,
         *,
@@ -97,9 +86,8 @@ class MoEModule(nn.Module):
         max_lora_rank: int = 0,
     ) -> _MOE_API.MoeHandle:
         spec = self._spec_for_weights(dtype=hidden_states.dtype, weight_format=weight_format)
-        max_tokens = self._capacity_tokens_for_mode(int(hidden_states.shape[0]), mode)
         capacity = _MOE_API.MoeCapacity(
-            max_tokens=max_tokens,
+            max_tokens=int(hidden_states.shape[0]),
             max_loras=max_loras,
             max_lora_rank=max_lora_rank,
             mode=mode,

--- a/tests/moondream/test_moe.py
+++ b/tests/moondream/test_moe.py
@@ -43,7 +43,7 @@ def _make_module(runtime: _FakeMoeRuntime) -> MoEModule:
     return module
 
 
-def test_prefill_moe_handles_reuse_power_of_two_capacity_bucket() -> None:
+def test_prefill_moe_handle_passes_exact_capacity_to_runtime() -> None:
     runtime = _FakeMoeRuntime()
     module = _make_module(runtime)
 
@@ -60,8 +60,8 @@ def test_prefill_moe_handles_reuse_power_of_two_capacity_bucket() -> None:
         mode="prefill",
     )
 
-    assert first is second
-    assert [capacity.max_tokens for capacity in runtime.capacities] == [256]
+    assert first is not second
+    assert [capacity.max_tokens for capacity in runtime.capacities] == [129, 200]
 
 
 def test_decode_moe_handles_remain_exact_capacity_for_cuda_graph_buckets() -> None:


### PR DESCRIPTION
## Summary
- pass exact logical MoE capacity from the Moondream model wrapper
- leave physical workspace and kernel bucketing to the backend runtime

## Validation
- 14 passed, 1 skipped: tests/moondream/test_moe.py
- private runtime capacity suite: 57 passed