### PR TITLE
Pipeline Parakeet generated decode readback

### DIFF
--- a/kestrel/models/parakeet_tdt/generated_decode.py
+++ b/kestrel/models/parakeet_tdt/generated_decode.py
@@ -2,20 +2,15 @@
 
 from __future__ import annotations
 
-import threading
-from collections import deque
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
 import torch
 from torch import Tensor
 
-from kestrel.device import make_event, stream_context
-from kestrel.runtime.decode_graph import DecodeGraphManager
 from kestrel.runtime.generated_decode import GeneratedDecode, GeneratedDecodeSpec
-from kestrel.utils import CpuGpuBuffer
 
-from .model import ParakeetTdt, TdtOutput, _TdtBatchState
+from .model import ParakeetTdt, TdtOutput, _decode_batch
 
 
 @dataclass(slots=True)
@@ -28,14 +23,7 @@ class _TdtDecodeSlot:
     decoder_hidden: Tensor
     hidden: tuple[Tensor, ...]
     cell: tuple[Tensor, ...]
-    decisions: CpuGpuBuffer
-    frames: Tensor
-    valid_lengths: Tensor
-    steps_remaining: Tensor
-    tokens_remaining: Tensor
-    batch_offsets: Tensor
-    duration_values: Tensor
-    read_done: Any
+    decisions: Tensor
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,8 +58,8 @@ class _TdtDecodeBindings:
             "encoded": slot.encoded[:capacity].flatten(0, 1),
             "frame_indices": slot.frame_indices[:capacity],
             "active": slot.active[:capacity],
-            "token": slot.decisions.gpu[0, :capacity],
-            "duration": slot.decisions.gpu[1, :capacity],
+            "token": slot.decisions[0, :capacity],
+            "duration": slot.decisions[1, :capacity],
             **state,
             **{f"{name}_next": value for name, value in state.items()},
         }
@@ -84,7 +72,7 @@ class _TdtDecodeBindings:
 
 
 class _TdtBatchGeneratedDecoder:
-    """Pipeline generated TDT decisions over two asynchronous readback slots."""
+    """Run one complete TDT decision per generated kernel launch."""
 
     minimum_batch = 1
 
@@ -115,18 +103,6 @@ class _TdtBatchGeneratedDecoder:
         if generated is None:
             return None
         decoder._generated = generated
-        decoder._graphs = DecodeGraphManager[_TdtDecodeSlot](
-            enabled=True,
-            device=decoder.device,
-            max_batch=max_batch,
-            graph_capture_lock=threading.RLock(),
-            compute_stream=compute_stream,
-            run_forward=decoder._run_step,
-            prepare_step=lambda _slot, _batch_size: None,
-            zero_padding=decoder._zero_padding,
-            zero_for_capture=decoder._zero_for_capture,
-        )
-        decoder._graphs.ensure_ready(decoder.decode_slots)
         return decoder
 
     def __init__(
@@ -154,134 +130,31 @@ class _TdtBatchGeneratedDecoder:
         self._initial_decoder_hidden = initial_decoder_hidden[:, 0]
         self._initial_hidden = tuple(initial_hidden.unbind())
         self._initial_cell = tuple(initial_cell.unbind())
-        max_frames = config.encoder.max_position_embeddings
-        encoded = torch.empty(
-            (max_batch, max_frames, config.decoder_hidden_size),
-            device=self.device,
-            dtype=self.dtype,
-        )
-        frame_indices = torch.zeros(
-            max_batch, dtype=torch.long, device=self.device
-        )
-        active = torch.zeros(max_batch, dtype=torch.bool, device=self.device)
-        decoder_hidden = torch.empty_like(self._initial_decoder_hidden)
-        hidden = tuple(torch.empty_like(value) for value in self._initial_hidden)
-        cell = tuple(torch.empty_like(value) for value in self._initial_cell)
-        frames = torch.zeros(max_batch, dtype=torch.long, device=self.device)
-        valid_lengths = torch.zeros(
-            max_batch, dtype=torch.long, device=self.device
-        )
-        steps_remaining = torch.zeros(
-            max_batch, dtype=torch.long, device=self.device
-        )
-        tokens_remaining = torch.zeros(
-            max_batch, dtype=torch.long, device=self.device
-        )
-        batch_offsets = (
-            torch.arange(max_batch, device=self.device, dtype=torch.long)
-            * max_frames
-        )
-        duration_values = torch.tensor(
-            config.durations, device=self.device, dtype=torch.long
-        )
-
-        # The recurrence is one shared causal device state. Only decisions are
-        # double-buffered so the host can consume step N while step N+1 runs.
-        def make_slot(slot_id: int) -> _TdtDecodeSlot:
-            return _TdtDecodeSlot(
-                slot_id=slot_id,
-                compute_stream=compute_stream,
-                encoded=encoded,
-                frame_indices=frame_indices,
-                active=active,
-                decoder_hidden=decoder_hidden,
-                hidden=hidden,
-                cell=cell,
-                decisions=CpuGpuBuffer(
-                    2,
+        self.slot = _TdtDecodeSlot(
+            slot_id=0,
+            compute_stream=compute_stream,
+            encoded=torch.empty(
+                (
                     max_batch,
-                    dtype=torch.int32,
-                    device=self.device,
-                    pin_memory=True,
-                    with_numpy=False,
-                    zero=False,
+                    config.encoder.max_position_embeddings,
+                    config.decoder_hidden_size,
                 ),
-                frames=frames,
-                valid_lengths=valid_lengths,
-                steps_remaining=steps_remaining,
-                tokens_remaining=tokens_remaining,
-                batch_offsets=batch_offsets,
-                duration_values=duration_values,
-                read_done=make_event(self.device),
-            )
-
-        self.decode_slots: Sequence[_TdtDecodeSlot] = (
-            make_slot(0),
-            make_slot(1),
+                device=self.device,
+                dtype=self.dtype,
+            ),
+            frame_indices=torch.zeros(
+                max_batch, dtype=torch.long, device=self.device
+            ),
+            active=torch.zeros(max_batch, dtype=torch.bool, device=self.device),
+            decoder_hidden=torch.empty_like(self._initial_decoder_hidden),
+            hidden=tuple(torch.empty_like(value) for value in self._initial_hidden),
+            cell=tuple(torch.empty_like(value) for value in self._initial_cell),
+            decisions=torch.empty(
+                (2, max_batch), dtype=torch.int32, device=self.device
+            ),
         )
+        self.decode_slots: Sequence[_TdtDecodeSlot] = (self.slot,)
         self._generated: GeneratedDecode
-        self._graphs: DecodeGraphManager[_TdtDecodeSlot]
-
-    def _advance(self, slot: _TdtDecodeSlot, batch: int) -> None:
-        config = self.model.config
-        active = slot.active[:batch]
-        token = slot.decisions.gpu[0, :batch].to(torch.long)
-        duration_index = slot.decisions.gpu[1, :batch].to(torch.long)
-        duration = slot.duration_values[duration_index]
-        duration = torch.where(
-            (token == config.blank_token_id) & (duration == 0),
-            1,
-            duration,
-        )
-        duration = torch.where(active, duration, 0)
-        emitted = active & (token != config.blank_token_id)
-        slot.frames[:batch].add_(duration)
-        slot.steps_remaining[:batch].sub_(active.to(torch.long))
-        slot.tokens_remaining[:batch].sub_(emitted.to(torch.long))
-        slot.active[:batch].copy_(
-            (slot.frames[:batch] < slot.valid_lengths[:batch])
-            & (slot.steps_remaining[:batch] > 0)
-            & (slot.tokens_remaining[:batch] > 0)
-        )
-        slot.frame_indices[:batch].copy_(
-            slot.batch_offsets[:batch]
-            + slot.frames[:batch].clamp_max(slot.encoded.shape[1] - 1)
-        )
-
-    def _run_step(self, slot: _TdtDecodeSlot, batch: int) -> None:
-        self._generated.static_launcher(slot, batch)()
-        self._advance(slot, batch)
-
-    @staticmethod
-    def _zero_padding(
-        slot: _TdtDecodeSlot, batch: int, graph_batch: int
-    ) -> None:
-        slot.active[batch:graph_batch].zero_()
-
-    @staticmethod
-    def _zero_for_capture(slot: _TdtDecodeSlot) -> None:
-        slot.encoded.zero_()
-        slot.frame_indices.zero_()
-        slot.active.zero_()
-        slot.decoder_hidden.zero_()
-        for value in (*slot.hidden, *slot.cell):
-            value.zero_()
-        slot.decisions.gpu.zero_()
-        slot.frames.zero_()
-        slot.valid_lengths.zero_()
-        slot.steps_remaining.zero_()
-        slot.tokens_remaining.zero_()
-
-    def _launch(self, slot: _TdtDecodeSlot, batch: int) -> None:
-        with stream_context(self.compute_stream):
-            self._graphs.run(slot, batch)
-            slot.decisions.copy_to_cpu()
-            slot.read_done.record(self.compute_stream)
-
-    @staticmethod
-    def _read(slot: _TdtDecodeSlot, batch: int) -> list[list[int]]:
-        slot.read_done.synchronize()
-        return slot.decisions.cpu[:, :batch].T.tolist()
 
     def generate(
         self,
@@ -293,59 +166,41 @@ class _TdtBatchGeneratedDecoder:
         batch, width, _ = encoded.shape
         if not self.minimum_batch <= batch <= self.max_batch_size:
             raise ValueError("TDT generated decode requires a supported batch")
-        control = self.decode_slots[0]
-        if width > control.encoded.shape[1]:
+        if width > self.slot.encoded.shape[1]:
             return self.model._generate_batch(
                 encoded, valid, max_tokens=max_tokens
             )
 
-        valid_tensor = valid.sum(-1)
-        valid_lengths = valid_tensor.tolist()
-        state = _TdtBatchState.create(
-            self.model.config, valid_lengths, max_tokens
+        valid_lengths = valid.sum(-1).tolist()
+        slot = self.slot
+        slot.encoded[:batch, :width].copy_(encoded)
+        slot.decoder_hidden.copy_(self._initial_decoder_hidden)
+        for current, initial in zip(
+            (*slot.hidden, *slot.cell),
+            (*self._initial_hidden, *self._initial_cell),
+            strict=True,
+        ):
+            current.copy_(initial)
+        max_frames = slot.encoded.shape[1]
+        launch = self._generated.static_launcher(slot, batch)
+
+        def step(frames: list[int], active: list[bool]) -> list[list[int]]:
+            slot.frame_indices[:batch].copy_(torch.tensor(
+                [row * max_frames + min(frame, max_frames - 1)
+                 for row, frame in enumerate(frames)],
+                device=self.device,
+            ))
+            slot.active[:batch].copy_(torch.tensor(active, device=self.device))
+            launch()
+            return slot.decisions[:, :batch].T.tolist()
+
+        return _decode_batch(
+            self.model.config,
+            valid_lengths,
+            max_tokens,
+            self.device,
+            step,
         )
-        with stream_context(self.compute_stream):
-            control.encoded[:batch, :width].copy_(encoded)
-            control.decoder_hidden.copy_(self._initial_decoder_hidden)
-            for current, initial in zip(
-                (*control.hidden, *control.cell),
-                (*self._initial_hidden, *self._initial_cell),
-                strict=True,
-            ):
-                current.copy_(initial)
-            control.frames[:batch].zero_()
-            control.valid_lengths[:batch].copy_(valid_tensor)
-            control.steps_remaining[:batch].copy_(
-                valid_tensor * self.model.config.max_symbols_per_step
-            )
-            control.tokens_remaining[:batch].fill_(
-                torch.iinfo(torch.long).max if max_tokens is None else max_tokens
-            )
-            control.active[:batch].copy_(
-                (control.valid_lengths[:batch] > 0)
-                & (control.steps_remaining[:batch] > 0)
-                & (control.tokens_remaining[:batch] > 0)
-            )
-            control.frame_indices[:batch].copy_(control.batch_offsets[:batch])
-
-        available = deque(self.decode_slots)
-        pending: deque[_TdtDecodeSlot] = deque()
-        active = state.active()
-        while any(active):
-            while len(pending) < 2:
-                slot = available.popleft()
-                self._launch(slot, batch)
-                pending.append(slot)
-            slot = pending.popleft()
-            decisions = self._read(slot, batch)
-            available.append(slot)
-            state.commit(decisions, active)
-            active = state.active()
-
-        for slot in pending:
-            slot.read_done.synchronize()
-        with stream_context(self.compute_stream):
-            return state.output(self.device)
 
 
 __all__ = ["_TdtBatchGeneratedDecoder"]

--- a/kestrel/models/parakeet_tdt/generated_decode.py
+++ b/kestrel/models/parakeet_tdt/generated_decode.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
@@ -9,8 +10,9 @@ import torch
 from torch import Tensor
 
 from kestrel.runtime.generated_decode import GeneratedDecode, GeneratedDecodeSpec
+from kestrel.utils import CpuGpuBuffer
 
-from .model import ParakeetTdt, TdtOutput, _decode_batch
+from .model import ParakeetTdt, TdtOutput, _TdtBatchDecodeState
 
 
 @dataclass(slots=True)
@@ -18,12 +20,14 @@ class _TdtDecodeSlot:
     slot_id: int
     compute_stream: torch.cuda.Stream
     encoded: Tensor
+    valid_lengths: Tensor
     frame_indices: Tensor
     active: Tensor
     decoder_hidden: Tensor
     hidden: tuple[Tensor, ...]
     cell: tuple[Tensor, ...]
-    decisions: Tensor
+    decisions: CpuGpuBuffer
+    read_done: torch.cuda.Event
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,7 +38,7 @@ class _TdtDecodeBindings:
             config.decoder_hidden_size == 640
             and config.vocab_size == 8193
             and config.blank_token_id == 8192
-            and len(config.durations) == 5
+            and tuple(config.durations) == (0, 1, 2, 3, 4)
             and config.num_decoder_layers == 2
             and config.encoder.max_position_embeddings == 5000
         )
@@ -43,6 +47,7 @@ class _TdtDecodeBindings:
         return {}
 
     def slot_inputs(self, slot: _TdtDecodeSlot, capacity: int) -> Mapping[str, Any]:
+        decisions = slot.decisions.gpu.view(2, -1)
         state = {
             "decoder_hidden": slot.decoder_hidden[:capacity],
             **{
@@ -56,10 +61,13 @@ class _TdtDecodeBindings:
         }
         return {
             "encoded": slot.encoded[:capacity].flatten(0, 1),
+            "valid_lengths": slot.valid_lengths[:capacity],
             "frame_indices": slot.frame_indices[:capacity],
+            "frame_indices_next": slot.frame_indices[:capacity],
             "active": slot.active[:capacity],
-            "token": slot.decisions[0, :capacity],
-            "duration": slot.decisions[1, :capacity],
+            "active_next": slot.active[:capacity],
+            "token": decisions[0, :capacity],
+            "duration": decisions[1, :capacity],
             **state,
             **{f"{name}_next": value for name, value in state.items()},
         }
@@ -74,9 +82,9 @@ class _TdtDecodeBindings:
 class _TdtBatchGeneratedDecoder:
     """Run one complete TDT decision per generated kernel launch."""
 
-    # Tried an outer CUDA graph around the generated step plus device recurrence:
-    # it returned an empty L4 transcript. The graph-free tensor recurrence was
-    # correct but slowed C1 from 75.4 ms to 127.2 ms; keeping host recurrence.
+    # Tried an outer CUDA graph plus PyTorch tensor recurrence: it returned an
+    # empty L4 transcript; graph-free recurrence slowed C1 75.4 -> 127.2 ms.
+    # Keep recurrence inside the generated decision and pipeline only readback.
 
     minimum_batch = 1
 
@@ -134,30 +142,51 @@ class _TdtBatchGeneratedDecoder:
         self._initial_decoder_hidden = initial_decoder_hidden[:, 0]
         self._initial_hidden = tuple(initial_hidden.unbind())
         self._initial_cell = tuple(initial_cell.unbind())
-        self.slot = _TdtDecodeSlot(
-            slot_id=0,
-            compute_stream=compute_stream,
-            encoded=torch.empty(
-                (
-                    max_batch,
-                    config.encoder.max_position_embeddings,
-                    config.decoder_hidden_size,
-                ),
-                device=self.device,
-                dtype=self.dtype,
+        encoded = torch.empty(
+            (
+                max_batch,
+                config.encoder.max_position_embeddings,
+                config.decoder_hidden_size,
             ),
-            frame_indices=torch.zeros(
-                max_batch, dtype=torch.long, device=self.device
-            ),
-            active=torch.zeros(max_batch, dtype=torch.bool, device=self.device),
-            decoder_hidden=torch.empty_like(self._initial_decoder_hidden),
-            hidden=tuple(torch.empty_like(value) for value in self._initial_hidden),
-            cell=tuple(torch.empty_like(value) for value in self._initial_cell),
-            decisions=torch.empty(
-                (2, max_batch), dtype=torch.int32, device=self.device
-            ),
+            device=self.device,
+            dtype=self.dtype,
         )
-        self.decode_slots: Sequence[_TdtDecodeSlot] = (self.slot,)
+        valid_lengths = torch.zeros(
+            max_batch, dtype=torch.long, device=self.device
+        )
+        frame_indices = torch.zeros(
+            max_batch, dtype=torch.long, device=self.device
+        )
+        active = torch.zeros(max_batch, dtype=torch.bool, device=self.device)
+        decoder_hidden = torch.empty_like(self._initial_decoder_hidden)
+        hidden = tuple(torch.empty_like(value) for value in self._initial_hidden)
+        cell = tuple(torch.empty_like(value) for value in self._initial_cell)
+        self._initial_frame_indices = torch.arange(
+            max_batch, dtype=torch.long, device=self.device
+        ) * config.encoder.max_position_embeddings
+        self._inactive = torch.zeros(1, dtype=torch.bool, pin_memory=True)
+        self.decode_slots: Sequence[_TdtDecodeSlot] = tuple(
+            _TdtDecodeSlot(
+                slot_id=slot_id,
+                compute_stream=compute_stream,
+                encoded=encoded,
+                valid_lengths=valid_lengths,
+                frame_indices=frame_indices,
+                active=active,
+                decoder_hidden=decoder_hidden,
+                hidden=hidden,
+                cell=cell,
+                decisions=CpuGpuBuffer(
+                    2 * max_batch,
+                    dtype=torch.int32,
+                    device=self.device,
+                    pin_memory=True,
+                    zero=False,
+                ),
+                read_done=torch.cuda.Event(enable_timing=False),
+            )
+            for slot_id in range(2)
+        )
         self._generated: GeneratedDecode
 
     def generate(
@@ -170,41 +199,78 @@ class _TdtBatchGeneratedDecoder:
         batch, width, _ = encoded.shape
         if not self.minimum_batch <= batch <= self.max_batch_size:
             raise ValueError("TDT generated decode requires a supported batch")
-        if width > self.slot.encoded.shape[1]:
+        first_slot = self.decode_slots[0]
+        if width > first_slot.encoded.shape[1]:
             return self.model._generate_batch(
                 encoded, valid, max_tokens=max_tokens
             )
 
-        valid_lengths = valid.sum(-1).tolist()
-        slot = self.slot
-        slot.encoded[:batch, :width].copy_(encoded)
-        slot.decoder_hidden.copy_(self._initial_decoder_hidden)
-        for current, initial in zip(
-            (*slot.hidden, *slot.cell),
-            (*self._initial_hidden, *self._initial_cell),
-            strict=True,
-        ):
-            current.copy_(initial)
-        max_frames = slot.encoded.shape[1]
-        launch = self._generated.static_launcher(slot, batch)
+        with torch.cuda.stream(self.compute_stream):
+            valid_device = valid.sum(-1).to(dtype=torch.long)
+            valid_lengths = valid_device.tolist()
+            state = _TdtBatchDecodeState.create(
+                self.model.config, valid_lengths, max_tokens
+            )
+            active = state.active()
+            if not any(active):
+                return state.output(self.device)
 
-        def step(frames: list[int], active: list[bool]) -> list[list[int]]:
-            slot.frame_indices[:batch].copy_(torch.tensor(
-                [row * max_frames + min(frame, max_frames - 1)
-                 for row, frame in enumerate(frames)],
-                device=self.device,
-            ))
-            slot.active[:batch].copy_(torch.tensor(active, device=self.device))
-            launch()
-            return slot.decisions[:, :batch].T.tolist()
+            first_slot.encoded[:batch, :width].copy_(encoded)
+            first_slot.valid_lengths[:batch].copy_(valid_device)
+            first_slot.frame_indices[:batch].copy_(
+                self._initial_frame_indices[:batch]
+            )
+            first_slot.active[:batch].copy_(
+                torch.tensor(active, device=self.device)
+            )
+            first_slot.decoder_hidden.copy_(self._initial_decoder_hidden)
+            for current, initial in zip(
+                (*first_slot.hidden, *first_slot.cell),
+                (*self._initial_hidden, *self._initial_cell),
+                strict=True,
+            ):
+                current.copy_(initial)
 
-        return _decode_batch(
-            self.model.config,
-            valid_lengths,
-            max_tokens,
-            self.device,
-            step,
-        )
+            launchers = tuple(
+                self._generated.static_launcher(slot, batch)
+                for slot in self.decode_slots
+            )
+            pending: deque[_TdtDecodeSlot] = deque()
+
+            def enqueue(slot: _TdtDecodeSlot) -> None:
+                launchers[slot.slot_id]()
+                slot.decisions.copy_to_cpu()
+                slot.read_done.record(self.compute_stream)
+                pending.append(slot)
+
+            enqueue(self.decode_slots[0])
+            enqueue(self.decode_slots[1])
+            policy_stopped: set[int] = set()
+            while pending:
+                slot = pending.popleft()
+                slot.read_done.synchronize()
+                active = state.active()
+                decisions = (
+                    slot.decisions.cpu.view(2, self.max_batch_size)
+                    [:, :batch]
+                    .T.tolist()
+                )
+                state.commit(decisions, active)
+                next_active = state.active()
+                if not any(next_active):
+                    break
+
+                newly_stopped = (
+                    set(state.policy_stopped_rows()) - policy_stopped
+                )
+                for row in sorted(newly_stopped):
+                    first_slot.active[row : row + 1].copy_(
+                        self._inactive, non_blocking=True
+                    )
+                policy_stopped.update(newly_stopped)
+                enqueue(slot)
+
+            return state.output(self.device)
 
 
 __all__ = ["_TdtBatchGeneratedDecoder"]

--- a/kestrel/models/parakeet_tdt/generated_decode.py
+++ b/kestrel/models/parakeet_tdt/generated_decode.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import threading
+from collections import deque
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
 import torch
 from torch import Tensor
 
+from kestrel.device import make_event, stream_context
+from kestrel.runtime.decode_graph import DecodeGraphManager
 from kestrel.runtime.generated_decode import GeneratedDecode, GeneratedDecodeSpec
+from kestrel.utils import CpuGpuBuffer
 
-from .model import ParakeetTdt, TdtOutput, _decode_batch
+from .model import ParakeetTdt, TdtOutput, _TdtBatchState
 
 
 @dataclass(slots=True)
@@ -23,7 +28,14 @@ class _TdtDecodeSlot:
     decoder_hidden: Tensor
     hidden: tuple[Tensor, ...]
     cell: tuple[Tensor, ...]
-    decisions: Tensor
+    decisions: CpuGpuBuffer
+    frames: Tensor
+    valid_lengths: Tensor
+    steps_remaining: Tensor
+    tokens_remaining: Tensor
+    batch_offsets: Tensor
+    duration_values: Tensor
+    read_done: Any
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,8 +70,8 @@ class _TdtDecodeBindings:
             "encoded": slot.encoded[:capacity].flatten(0, 1),
             "frame_indices": slot.frame_indices[:capacity],
             "active": slot.active[:capacity],
-            "token": slot.decisions[0, :capacity],
-            "duration": slot.decisions[1, :capacity],
+            "token": slot.decisions.gpu[0, :capacity],
+            "duration": slot.decisions.gpu[1, :capacity],
             **state,
             **{f"{name}_next": value for name, value in state.items()},
         }
@@ -72,7 +84,7 @@ class _TdtDecodeBindings:
 
 
 class _TdtBatchGeneratedDecoder:
-    """Run one complete TDT decision per generated kernel launch."""
+    """Pipeline generated TDT decisions over two asynchronous readback slots."""
 
     minimum_batch = 1
 
@@ -103,6 +115,18 @@ class _TdtBatchGeneratedDecoder:
         if generated is None:
             return None
         decoder._generated = generated
+        decoder._graphs = DecodeGraphManager[_TdtDecodeSlot](
+            enabled=True,
+            device=decoder.device,
+            max_batch=max_batch,
+            graph_capture_lock=threading.RLock(),
+            compute_stream=compute_stream,
+            run_forward=decoder._run_step,
+            prepare_step=lambda _slot, _batch_size: None,
+            zero_padding=decoder._zero_padding,
+            zero_for_capture=decoder._zero_for_capture,
+        )
+        decoder._graphs.ensure_ready(decoder.decode_slots)
         return decoder
 
     def __init__(
@@ -130,31 +154,134 @@ class _TdtBatchGeneratedDecoder:
         self._initial_decoder_hidden = initial_decoder_hidden[:, 0]
         self._initial_hidden = tuple(initial_hidden.unbind())
         self._initial_cell = tuple(initial_cell.unbind())
-        self.slot = _TdtDecodeSlot(
-            slot_id=0,
-            compute_stream=compute_stream,
-            encoded=torch.empty(
-                (
-                    max_batch,
-                    config.encoder.max_position_embeddings,
-                    config.decoder_hidden_size,
-                ),
-                device=self.device,
-                dtype=self.dtype,
-            ),
-            frame_indices=torch.zeros(
-                max_batch, dtype=torch.long, device=self.device
-            ),
-            active=torch.zeros(max_batch, dtype=torch.bool, device=self.device),
-            decoder_hidden=torch.empty_like(self._initial_decoder_hidden),
-            hidden=tuple(torch.empty_like(value) for value in self._initial_hidden),
-            cell=tuple(torch.empty_like(value) for value in self._initial_cell),
-            decisions=torch.empty(
-                (2, max_batch), dtype=torch.int32, device=self.device
-            ),
+        max_frames = config.encoder.max_position_embeddings
+        encoded = torch.empty(
+            (max_batch, max_frames, config.decoder_hidden_size),
+            device=self.device,
+            dtype=self.dtype,
         )
-        self.decode_slots: Sequence[_TdtDecodeSlot] = (self.slot,)
+        frame_indices = torch.zeros(
+            max_batch, dtype=torch.long, device=self.device
+        )
+        active = torch.zeros(max_batch, dtype=torch.bool, device=self.device)
+        decoder_hidden = torch.empty_like(self._initial_decoder_hidden)
+        hidden = tuple(torch.empty_like(value) for value in self._initial_hidden)
+        cell = tuple(torch.empty_like(value) for value in self._initial_cell)
+        frames = torch.zeros(max_batch, dtype=torch.long, device=self.device)
+        valid_lengths = torch.zeros(
+            max_batch, dtype=torch.long, device=self.device
+        )
+        steps_remaining = torch.zeros(
+            max_batch, dtype=torch.long, device=self.device
+        )
+        tokens_remaining = torch.zeros(
+            max_batch, dtype=torch.long, device=self.device
+        )
+        batch_offsets = (
+            torch.arange(max_batch, device=self.device, dtype=torch.long)
+            * max_frames
+        )
+        duration_values = torch.tensor(
+            config.durations, device=self.device, dtype=torch.long
+        )
+
+        # The recurrence is one shared causal device state. Only decisions are
+        # double-buffered so the host can consume step N while step N+1 runs.
+        def make_slot(slot_id: int) -> _TdtDecodeSlot:
+            return _TdtDecodeSlot(
+                slot_id=slot_id,
+                compute_stream=compute_stream,
+                encoded=encoded,
+                frame_indices=frame_indices,
+                active=active,
+                decoder_hidden=decoder_hidden,
+                hidden=hidden,
+                cell=cell,
+                decisions=CpuGpuBuffer(
+                    2,
+                    max_batch,
+                    dtype=torch.int32,
+                    device=self.device,
+                    pin_memory=True,
+                    with_numpy=False,
+                    zero=False,
+                ),
+                frames=frames,
+                valid_lengths=valid_lengths,
+                steps_remaining=steps_remaining,
+                tokens_remaining=tokens_remaining,
+                batch_offsets=batch_offsets,
+                duration_values=duration_values,
+                read_done=make_event(self.device),
+            )
+
+        self.decode_slots: Sequence[_TdtDecodeSlot] = (
+            make_slot(0),
+            make_slot(1),
+        )
         self._generated: GeneratedDecode
+        self._graphs: DecodeGraphManager[_TdtDecodeSlot]
+
+    def _advance(self, slot: _TdtDecodeSlot, batch: int) -> None:
+        config = self.model.config
+        active = slot.active[:batch]
+        token = slot.decisions.gpu[0, :batch].to(torch.long)
+        duration_index = slot.decisions.gpu[1, :batch].to(torch.long)
+        duration = slot.duration_values[duration_index]
+        duration = torch.where(
+            (token == config.blank_token_id) & (duration == 0),
+            1,
+            duration,
+        )
+        duration = torch.where(active, duration, 0)
+        emitted = active & (token != config.blank_token_id)
+        slot.frames[:batch].add_(duration)
+        slot.steps_remaining[:batch].sub_(active.to(torch.long))
+        slot.tokens_remaining[:batch].sub_(emitted.to(torch.long))
+        slot.active[:batch].copy_(
+            (slot.frames[:batch] < slot.valid_lengths[:batch])
+            & (slot.steps_remaining[:batch] > 0)
+            & (slot.tokens_remaining[:batch] > 0)
+        )
+        slot.frame_indices[:batch].copy_(
+            slot.batch_offsets[:batch]
+            + slot.frames[:batch].clamp_max(slot.encoded.shape[1] - 1)
+        )
+
+    def _run_step(self, slot: _TdtDecodeSlot, batch: int) -> None:
+        self._generated.static_launcher(slot, batch)()
+        self._advance(slot, batch)
+
+    @staticmethod
+    def _zero_padding(
+        slot: _TdtDecodeSlot, batch: int, graph_batch: int
+    ) -> None:
+        slot.active[batch:graph_batch].zero_()
+
+    @staticmethod
+    def _zero_for_capture(slot: _TdtDecodeSlot) -> None:
+        slot.encoded.zero_()
+        slot.frame_indices.zero_()
+        slot.active.zero_()
+        slot.decoder_hidden.zero_()
+        for value in (*slot.hidden, *slot.cell):
+            value.zero_()
+        slot.decisions.gpu.zero_()
+        slot.frames.zero_()
+        slot.valid_lengths.zero_()
+        slot.steps_remaining.zero_()
+        slot.tokens_remaining.zero_()
+
+    def _launch(self, slot: _TdtDecodeSlot, batch: int) -> None:
+        with stream_context(self.compute_stream):
+            self._graphs.run(slot, batch)
+            slot.decisions.copy_to_cpu()
+            slot.read_done.record(self.compute_stream)
+
+    @staticmethod
+    def _read(slot: _TdtDecodeSlot, batch: int) -> list[list[int]]:
+        slot.read_done.synchronize()
+        return slot.decisions.cpu[:, :batch].T.tolist()
 
     def generate(
         self,
@@ -166,41 +293,59 @@ class _TdtBatchGeneratedDecoder:
         batch, width, _ = encoded.shape
         if not self.minimum_batch <= batch <= self.max_batch_size:
             raise ValueError("TDT generated decode requires a supported batch")
-        if width > self.slot.encoded.shape[1]:
+        control = self.decode_slots[0]
+        if width > control.encoded.shape[1]:
             return self.model._generate_batch(
                 encoded, valid, max_tokens=max_tokens
             )
 
-        valid_lengths = valid.sum(-1).tolist()
-        slot = self.slot
-        slot.encoded[:batch, :width].copy_(encoded)
-        slot.decoder_hidden.copy_(self._initial_decoder_hidden)
-        for current, initial in zip(
-            (*slot.hidden, *slot.cell),
-            (*self._initial_hidden, *self._initial_cell),
-            strict=True,
-        ):
-            current.copy_(initial)
-        max_frames = slot.encoded.shape[1]
-        launch = self._generated.static_launcher(slot, batch)
-
-        def step(frames: list[int], active: list[bool]) -> list[list[int]]:
-            slot.frame_indices[:batch].copy_(torch.tensor(
-                [row * max_frames + min(frame, max_frames - 1)
-                 for row, frame in enumerate(frames)],
-                device=self.device,
-            ))
-            slot.active[:batch].copy_(torch.tensor(active, device=self.device))
-            launch()
-            return slot.decisions[:, :batch].T.tolist()
-
-        return _decode_batch(
-            self.model.config,
-            valid_lengths,
-            max_tokens,
-            self.device,
-            step,
+        valid_tensor = valid.sum(-1)
+        valid_lengths = valid_tensor.tolist()
+        state = _TdtBatchState.create(
+            self.model.config, valid_lengths, max_tokens
         )
+        with stream_context(self.compute_stream):
+            control.encoded[:batch, :width].copy_(encoded)
+            control.decoder_hidden.copy_(self._initial_decoder_hidden)
+            for current, initial in zip(
+                (*control.hidden, *control.cell),
+                (*self._initial_hidden, *self._initial_cell),
+                strict=True,
+            ):
+                current.copy_(initial)
+            control.frames[:batch].zero_()
+            control.valid_lengths[:batch].copy_(valid_tensor)
+            control.steps_remaining[:batch].copy_(
+                valid_tensor * self.model.config.max_symbols_per_step
+            )
+            control.tokens_remaining[:batch].fill_(
+                torch.iinfo(torch.long).max if max_tokens is None else max_tokens
+            )
+            control.active[:batch].copy_(
+                (control.valid_lengths[:batch] > 0)
+                & (control.steps_remaining[:batch] > 0)
+                & (control.tokens_remaining[:batch] > 0)
+            )
+            control.frame_indices[:batch].copy_(control.batch_offsets[:batch])
+
+        available = deque(self.decode_slots)
+        pending: deque[_TdtDecodeSlot] = deque()
+        active = state.active()
+        while any(active):
+            while len(pending) < 2:
+                slot = available.popleft()
+                self._launch(slot, batch)
+                pending.append(slot)
+            slot = pending.popleft()
+            decisions = self._read(slot, batch)
+            available.append(slot)
+            state.commit(decisions, active)
+            active = state.active()
+
+        for slot in pending:
+            slot.read_done.synchronize()
+        with stream_context(self.compute_stream):
+            return state.output(self.device)
 
 
 __all__ = ["_TdtBatchGeneratedDecoder"]

--- a/kestrel/models/parakeet_tdt/generated_decode.py
+++ b/kestrel/models/parakeet_tdt/generated_decode.py
@@ -74,6 +74,10 @@ class _TdtDecodeBindings:
 class _TdtBatchGeneratedDecoder:
     """Run one complete TDT decision per generated kernel launch."""
 
+    # Tried an outer CUDA graph around the generated step plus device recurrence:
+    # it returned an empty L4 transcript. The graph-free tensor recurrence was
+    # correct but slowed C1 from 75.4 ms to 127.2 ms; keeping host recurrence.
+
     minimum_batch = 1
 
     @classmethod

--- a/kestrel/models/parakeet_tdt/generated_decode.py
+++ b/kestrel/models/parakeet_tdt/generated_decode.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 import torch
 from torch import Tensor
@@ -188,6 +188,17 @@ class _TdtBatchGeneratedDecoder:
             for slot_id in range(2)
         )
         self._generated: GeneratedDecode
+        self._launchers: dict[int, tuple[Callable[[], None], ...]] = {}
+
+    def _launchers_for(self, batch: int) -> tuple[Callable[[], None], ...]:
+        launchers = self._launchers.get(batch)
+        if launchers is None:
+            launchers = tuple(
+                self._generated.static_launcher(slot, batch)
+                for slot in self.decode_slots
+            )
+            self._launchers[batch] = launchers
+        return launchers
 
     def generate(
         self,
@@ -231,10 +242,7 @@ class _TdtBatchGeneratedDecoder:
             ):
                 current.copy_(initial)
 
-            launchers = tuple(
-                self._generated.static_launcher(slot, batch)
-                for slot in self.decode_slots
-            )
+            launchers = self._launchers_for(batch)
             pending: deque[_TdtDecodeSlot] = deque()
 
             def enqueue(slot: _TdtDecodeSlot) -> None:

--- a/kestrel/models/parakeet_tdt/model.py
+++ b/kestrel/models/parakeet_tdt/model.py
@@ -324,56 +324,38 @@ class TdtOutput:
     encoder_frame_seconds: float = 0.08
 
 
-@dataclass(slots=True)
-class _TdtBatchState:
-    config: ParakeetTdtConfig
-    valid_lengths: list[int]
-    frames: list[int]
-    steps_remaining: list[int]
-    tokens_remaining: list[int | None]
-    sequences: list[list[int]]
-    durations: list[list[int]]
+def _decode_batch(
+    config: ParakeetTdtConfig,
+    valid_lengths: list[int],
+    max_tokens: int | None,
+    device: torch.device,
+    step: Callable[[list[int], list[bool]], list[list[int]]],
+) -> TdtOutput:
+    batch = len(valid_lengths)
+    frames = [0] * batch
+    steps_remaining = [
+        config.max_symbols_per_step * length for length in valid_lengths
+    ]
+    tokens_remaining = [max_tokens] * batch
+    sequences = [[config.blank_token_id] for _ in range(batch)]
+    durations = [[0] for _ in range(batch)]
 
-    @classmethod
-    def create(
-        cls,
-        config: ParakeetTdtConfig,
-        valid_lengths: list[int],
-        max_tokens: int | None,
-    ) -> "_TdtBatchState":
-        batch = len(valid_lengths)
-        return cls(
-            config=config,
-            valid_lengths=valid_lengths,
-            frames=[0] * batch,
-            steps_remaining=[
-                config.max_symbols_per_step * length for length in valid_lengths
-            ],
-            tokens_remaining=[max_tokens] * batch,
-            sequences=[[config.blank_token_id] for _ in range(batch)],
-            durations=[[0] for _ in range(batch)],
-        )
-
-    def active(self) -> list[bool]:
-        return [
+    while True:
+        active = [
             frame < valid_length
             and steps > 0
             and (tokens is None or tokens > 0)
             for frame, valid_length, steps, tokens in zip(
-                self.frames,
-                self.valid_lengths,
-                self.steps_remaining,
-                self.tokens_remaining,
+                frames,
+                valid_lengths,
+                steps_remaining,
+                tokens_remaining,
                 strict=True,
             )
         ]
-
-    def commit(
-        self,
-        decisions: list[list[int]],
-        active: list[bool],
-    ) -> None:
-        config = self.config
+        if not any(active):
+            break
+        decisions = step(frames, active)
         for index, ((token_id, duration_index), is_active) in enumerate(
             zip(decisions, active, strict=True)
         ):
@@ -382,51 +364,28 @@ class _TdtBatchState:
             duration = config.durations[duration_index]
             if token_id == config.blank_token_id and duration == 0:
                 duration = 1
-            self.sequences[index].append(token_id)
-            self.durations[index].append(duration)
-            self.frames[index] += duration
-            self.steps_remaining[index] -= 1
-            remaining_tokens = self.tokens_remaining[index]
+            sequences[index].append(token_id)
+            durations[index].append(duration)
+            frames[index] += duration
+            steps_remaining[index] -= 1
+            remaining_tokens = tokens_remaining[index]
             if token_id != config.blank_token_id and remaining_tokens is not None:
-                self.tokens_remaining[index] = remaining_tokens - 1
+                tokens_remaining[index] = remaining_tokens - 1
 
-    def output(self, device: torch.device) -> TdtOutput:
-        config = self.config
-        lengths = torch.tensor(
-            [len(sequence) for sequence in self.sequences], device=device
-        )
-        width = int(lengths.max())
-        sequence_tensor = torch.tensor(
-            [
-                sequence + [config.blank_token_id] * (width - len(sequence))
-                for sequence in self.sequences
-            ],
-            device=device,
-        )
-        duration_tensor = torch.tensor(
-            [
-                duration + [0] * (width - len(duration))
-                for duration in self.durations
-            ],
-            device=device,
-        )
-        return TdtOutput(sequence_tensor, duration_tensor, lengths)
-
-
-def _decode_batch(
-    config: ParakeetTdtConfig,
-    valid_lengths: list[int],
-    max_tokens: int | None,
-    device: torch.device,
-    step: Callable[[list[int], list[bool]], list[list[int]]],
-) -> TdtOutput:
-    state = _TdtBatchState.create(config, valid_lengths, max_tokens)
-    while True:
-        active = state.active()
-        if not any(active):
-            break
-        state.commit(step(state.frames, active), active)
-    return state.output(device)
+    lengths = torch.tensor([len(sequence) for sequence in sequences], device=device)
+    width = int(lengths.max())
+    sequence_tensor = torch.tensor(
+        [
+            sequence + [config.blank_token_id] * (width - len(sequence))
+            for sequence in sequences
+        ],
+        device=device,
+    )
+    duration_tensor = torch.tensor(
+        [duration + [0] * (width - len(duration)) for duration in durations],
+        device=device,
+    )
+    return TdtOutput(sequence_tensor, duration_tensor, lengths)
 
 
 class ParakeetTdt(nn.Module):

--- a/kestrel/models/parakeet_tdt/model.py
+++ b/kestrel/models/parakeet_tdt/model.py
@@ -324,38 +324,56 @@ class TdtOutput:
     encoder_frame_seconds: float = 0.08
 
 
-def _decode_batch(
-    config: ParakeetTdtConfig,
-    valid_lengths: list[int],
-    max_tokens: int | None,
-    device: torch.device,
-    step: Callable[[list[int], list[bool]], list[list[int]]],
-) -> TdtOutput:
-    batch = len(valid_lengths)
-    frames = [0] * batch
-    steps_remaining = [
-        config.max_symbols_per_step * length for length in valid_lengths
-    ]
-    tokens_remaining = [max_tokens] * batch
-    sequences = [[config.blank_token_id] for _ in range(batch)]
-    durations = [[0] for _ in range(batch)]
+@dataclass(slots=True)
+class _TdtBatchState:
+    config: ParakeetTdtConfig
+    valid_lengths: list[int]
+    frames: list[int]
+    steps_remaining: list[int]
+    tokens_remaining: list[int | None]
+    sequences: list[list[int]]
+    durations: list[list[int]]
 
-    while True:
-        active = [
+    @classmethod
+    def create(
+        cls,
+        config: ParakeetTdtConfig,
+        valid_lengths: list[int],
+        max_tokens: int | None,
+    ) -> "_TdtBatchState":
+        batch = len(valid_lengths)
+        return cls(
+            config=config,
+            valid_lengths=valid_lengths,
+            frames=[0] * batch,
+            steps_remaining=[
+                config.max_symbols_per_step * length for length in valid_lengths
+            ],
+            tokens_remaining=[max_tokens] * batch,
+            sequences=[[config.blank_token_id] for _ in range(batch)],
+            durations=[[0] for _ in range(batch)],
+        )
+
+    def active(self) -> list[bool]:
+        return [
             frame < valid_length
             and steps > 0
             and (tokens is None or tokens > 0)
             for frame, valid_length, steps, tokens in zip(
-                frames,
-                valid_lengths,
-                steps_remaining,
-                tokens_remaining,
+                self.frames,
+                self.valid_lengths,
+                self.steps_remaining,
+                self.tokens_remaining,
                 strict=True,
             )
         ]
-        if not any(active):
-            break
-        decisions = step(frames, active)
+
+    def commit(
+        self,
+        decisions: list[list[int]],
+        active: list[bool],
+    ) -> None:
+        config = self.config
         for index, ((token_id, duration_index), is_active) in enumerate(
             zip(decisions, active, strict=True)
         ):
@@ -364,28 +382,51 @@ def _decode_batch(
             duration = config.durations[duration_index]
             if token_id == config.blank_token_id and duration == 0:
                 duration = 1
-            sequences[index].append(token_id)
-            durations[index].append(duration)
-            frames[index] += duration
-            steps_remaining[index] -= 1
-            remaining_tokens = tokens_remaining[index]
+            self.sequences[index].append(token_id)
+            self.durations[index].append(duration)
+            self.frames[index] += duration
+            self.steps_remaining[index] -= 1
+            remaining_tokens = self.tokens_remaining[index]
             if token_id != config.blank_token_id and remaining_tokens is not None:
-                tokens_remaining[index] = remaining_tokens - 1
+                self.tokens_remaining[index] = remaining_tokens - 1
 
-    lengths = torch.tensor([len(sequence) for sequence in sequences], device=device)
-    width = int(lengths.max())
-    sequence_tensor = torch.tensor(
-        [
-            sequence + [config.blank_token_id] * (width - len(sequence))
-            for sequence in sequences
-        ],
-        device=device,
-    )
-    duration_tensor = torch.tensor(
-        [duration + [0] * (width - len(duration)) for duration in durations],
-        device=device,
-    )
-    return TdtOutput(sequence_tensor, duration_tensor, lengths)
+    def output(self, device: torch.device) -> TdtOutput:
+        config = self.config
+        lengths = torch.tensor(
+            [len(sequence) for sequence in self.sequences], device=device
+        )
+        width = int(lengths.max())
+        sequence_tensor = torch.tensor(
+            [
+                sequence + [config.blank_token_id] * (width - len(sequence))
+                for sequence in self.sequences
+            ],
+            device=device,
+        )
+        duration_tensor = torch.tensor(
+            [
+                duration + [0] * (width - len(duration))
+                for duration in self.durations
+            ],
+            device=device,
+        )
+        return TdtOutput(sequence_tensor, duration_tensor, lengths)
+
+
+def _decode_batch(
+    config: ParakeetTdtConfig,
+    valid_lengths: list[int],
+    max_tokens: int | None,
+    device: torch.device,
+    step: Callable[[list[int], list[bool]], list[list[int]]],
+) -> TdtOutput:
+    state = _TdtBatchState.create(config, valid_lengths, max_tokens)
+    while True:
+        active = state.active()
+        if not any(active):
+            break
+        state.commit(step(state.frames, active), active)
+    return state.output(device)
 
 
 class ParakeetTdt(nn.Module):

--- a/kestrel/models/parakeet_tdt/model.py
+++ b/kestrel/models/parakeet_tdt/model.py
@@ -324,6 +324,110 @@ class TdtOutput:
     encoder_frame_seconds: float = 0.08
 
 
+@dataclass(slots=True)
+class _TdtBatchDecodeState:
+    config: ParakeetTdtConfig
+    valid_lengths: list[int]
+    frames: list[int]
+    steps_remaining: list[int]
+    tokens_remaining: list[int | None]
+    sequences: list[list[int]]
+    durations: list[list[int]]
+
+    @classmethod
+    def create(
+        cls,
+        config: ParakeetTdtConfig,
+        valid_lengths: list[int],
+        max_tokens: int | None,
+    ) -> _TdtBatchDecodeState:
+        batch = len(valid_lengths)
+        return cls(
+            config=config,
+            valid_lengths=valid_lengths,
+            frames=[0] * batch,
+            steps_remaining=[
+                config.max_symbols_per_step * length for length in valid_lengths
+            ],
+            tokens_remaining=[max_tokens] * batch,
+            sequences=[[config.blank_token_id] for _ in range(batch)],
+            durations=[[0] for _ in range(batch)],
+        )
+
+    def active(self) -> list[bool]:
+        return [
+            frame < valid_length
+            and steps > 0
+            and (tokens is None or tokens > 0)
+            for frame, valid_length, steps, tokens in zip(
+                self.frames,
+                self.valid_lengths,
+                self.steps_remaining,
+                self.tokens_remaining,
+                strict=True,
+            )
+        ]
+
+    def commit(
+        self,
+        decisions: list[list[int]],
+        active: list[bool],
+    ) -> None:
+        for index, ((token_id, duration_index), is_active) in enumerate(
+            zip(decisions, active, strict=True)
+        ):
+            if not is_active:
+                continue
+            duration = self.config.durations[duration_index]
+            if token_id == self.config.blank_token_id and duration == 0:
+                duration = 1
+            self.sequences[index].append(token_id)
+            self.durations[index].append(duration)
+            self.frames[index] += duration
+            self.steps_remaining[index] -= 1
+            remaining_tokens = self.tokens_remaining[index]
+            if (
+                token_id != self.config.blank_token_id
+                and remaining_tokens is not None
+            ):
+                self.tokens_remaining[index] = remaining_tokens - 1
+
+    def policy_stopped_rows(self) -> tuple[int, ...]:
+        return tuple(
+            index
+            for index, (frame, valid_length, steps, tokens) in enumerate(zip(
+                self.frames,
+                self.valid_lengths,
+                self.steps_remaining,
+                self.tokens_remaining,
+                strict=True,
+            ))
+            if frame < valid_length
+            and (steps <= 0 or (tokens is not None and tokens <= 0))
+        )
+
+    def output(self, device: torch.device) -> TdtOutput:
+        length_values = [len(sequence) for sequence in self.sequences]
+        lengths = torch.tensor(length_values, device=device)
+        width = max(length_values)
+        sequence_tensor = torch.tensor(
+            [
+                sequence
+                + [self.config.blank_token_id] * (width - len(sequence))
+                for sequence in self.sequences
+            ],
+            device=device,
+        )
+        duration_tensor = torch.tensor(
+            [
+                duration + [0] * (width - len(duration))
+                for duration in self.durations
+            ],
+            device=device,
+        )
+        return TdtOutput(sequence_tensor, duration_tensor, lengths)
+
+
 def _decode_batch(
     config: ParakeetTdtConfig,
     valid_lengths: list[int],
@@ -331,61 +435,15 @@ def _decode_batch(
     device: torch.device,
     step: Callable[[list[int], list[bool]], list[list[int]]],
 ) -> TdtOutput:
-    batch = len(valid_lengths)
-    frames = [0] * batch
-    steps_remaining = [
-        config.max_symbols_per_step * length for length in valid_lengths
-    ]
-    tokens_remaining = [max_tokens] * batch
-    sequences = [[config.blank_token_id] for _ in range(batch)]
-    durations = [[0] for _ in range(batch)]
+    state = _TdtBatchDecodeState.create(config, valid_lengths, max_tokens)
 
     while True:
-        active = [
-            frame < valid_length
-            and steps > 0
-            and (tokens is None or tokens > 0)
-            for frame, valid_length, steps, tokens in zip(
-                frames,
-                valid_lengths,
-                steps_remaining,
-                tokens_remaining,
-                strict=True,
-            )
-        ]
+        active = state.active()
         if not any(active):
             break
-        decisions = step(frames, active)
-        for index, ((token_id, duration_index), is_active) in enumerate(
-            zip(decisions, active, strict=True)
-        ):
-            if not is_active:
-                continue
-            duration = config.durations[duration_index]
-            if token_id == config.blank_token_id and duration == 0:
-                duration = 1
-            sequences[index].append(token_id)
-            durations[index].append(duration)
-            frames[index] += duration
-            steps_remaining[index] -= 1
-            remaining_tokens = tokens_remaining[index]
-            if token_id != config.blank_token_id and remaining_tokens is not None:
-                tokens_remaining[index] = remaining_tokens - 1
+        state.commit(step(state.frames, active), active)
 
-    lengths = torch.tensor([len(sequence) for sequence in sequences], device=device)
-    width = int(lengths.max())
-    sequence_tensor = torch.tensor(
-        [
-            sequence + [config.blank_token_id] * (width - len(sequence))
-            for sequence in sequences
-        ],
-        device=device,
-    )
-    duration_tensor = torch.tensor(
-        [duration + [0] * (width - len(duration)) for duration in durations],
-        device=device,
-    )
-    return TdtOutput(sequence_tensor, duration_tensor, lengths)
+    return state.output(device)
 
 
 class ParakeetTdt(nn.Module):

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -821,7 +821,7 @@ class GeneratedDecode:
             raise RuntimeError(
                 f"generated {self._spec.label} launch misses {sorted(missing)}"
             )
-        return bound.invocation.prepare_launch(
+        return bound.invocation.prepare_repeated_launch(
             **{
                 name: value
                 for name, value in extents.items()

--- a/tests/test_generated_decode_static_extents.py
+++ b/tests/test_generated_decode_static_extents.py
@@ -29,6 +29,9 @@ class _Invocation:
     def prepare_launch(self, **extents):
         return lambda: self.launch(**extents)
 
+    def prepare_repeated_launch(self, **extents):
+        return lambda: self.launch(**extents)
+
 
 @dataclass(frozen=True)
 class _Program:


### PR DESCRIPTION
## Summary

- share one Parakeet host-policy state machine between native/graph and generated decode paths
- keep causal frame recurrence on device and pipeline decision readback through two pinned buffers on the existing compute stream
- cache the fixed generated launchers per batch size so steady-state requests avoid repeated binding validation and memref packing

Token and step budgets remain host policy. The pipeline permits one speculative decision, ignores it for a stopped row, and asynchronously marks that row inactive before any later launch.

## Validation

- L4 Modal generated-kernel gate: 4 passed
  - https://modal.com/apps/m87-labs/main/ap-fnGEUsKksxGYBADqEqV0nQ
- canonical L4 Parakeet qualification at this exact public head `8612915d` and private `d000591d`: transcript parity passed across every retained sample
  - https://modal.com/apps/m87-labs/main/ap-dNfwNkCLeDHtQtoJBd6auk
  - C1: 38.763 ms vs NeMo 65.880 ms (1.70x)
  - C2: 41.305 ms vs NeMo 71.420 ms (1.73x)
  - C4: 41.892 ms vs NeMo 101.047 ms (2.41x)
  - C8: 51.680 ms vs NeMo 177.356 ms (3.43x)
- versus the retained Kestrel baseline, median latency is 48.6% lower at C1, 50.1% at C2, 49.3% at C4, and 38.7% at C8

