### PR TITLE
Stream Parakeet policy stop updates

### DIFF
--- a/kestrel/models/parakeet_tdt/generated_decode.py
+++ b/kestrel/models/parakeet_tdt/generated_decode.py
@@ -253,29 +253,23 @@ class _TdtBatchGeneratedDecoder:
 
             enqueue(self.decode_slots[0])
             enqueue(self.decode_slots[1])
-            policy_stopped: set[int] = set()
             while pending:
                 slot = pending.popleft()
                 slot.read_done.synchronize()
-                active = state.active()
                 decisions = (
                     slot.decisions.cpu.view(2, self.max_batch_size)
                     [:, :batch]
                     .T.tolist()
                 )
-                state.commit(decisions, active)
-                next_active = state.active()
-                if not any(next_active):
+                newly_policy_stopped = state.commit(decisions, active)
+                active = state.active()
+                if not any(active):
                     break
 
-                newly_stopped = (
-                    set(state.policy_stopped_rows()) - policy_stopped
-                )
-                for row in sorted(newly_stopped):
+                for row in newly_policy_stopped:
                     first_slot.active[row : row + 1].copy_(
                         self._inactive, non_blocking=True
                     )
-                policy_stopped.update(newly_stopped)
                 enqueue(slot)
 
             return state.output(self.device)

--- a/kestrel/models/parakeet_tdt/model.py
+++ b/kestrel/models/parakeet_tdt/model.py
@@ -372,7 +372,9 @@ class _TdtBatchDecodeState:
         self,
         decisions: list[list[int]],
         active: list[bool],
-    ) -> None:
+    ) -> list[int]:
+        """Commit decisions and return rows stopped by host-only budgets."""
+        newly_policy_stopped: list[int] = []
         for index, ((token_id, duration_index), is_active) in enumerate(
             zip(decisions, active, strict=True)
         ):
@@ -391,20 +393,16 @@ class _TdtBatchDecodeState:
                 and remaining_tokens is not None
             ):
                 self.tokens_remaining[index] = remaining_tokens - 1
-
-    def policy_stopped_rows(self) -> tuple[int, ...]:
-        return tuple(
-            index
-            for index, (frame, valid_length, steps, tokens) in enumerate(zip(
-                self.frames,
-                self.valid_lengths,
-                self.steps_remaining,
-                self.tokens_remaining,
-                strict=True,
-            ))
-            if frame < valid_length
-            and (steps <= 0 or (tokens is not None and tokens <= 0))
-        )
+            tokens = self.tokens_remaining[index]
+            if (
+                self.frames[index] < self.valid_lengths[index]
+                and (
+                    self.steps_remaining[index] <= 0
+                    or (tokens is not None and tokens <= 0)
+                )
+            ):
+                newly_policy_stopped.append(index)
+        return newly_policy_stopped
 
     def output(self, device: torch.device) -> TdtOutput:
         length_values = [len(sequence) for sequence in self.sequences]

--- a/tests/asr/test_parakeet_decode_state.py
+++ b/tests/asr/test_parakeet_decode_state.py
@@ -1,0 +1,45 @@
+"""Host policy bookkeeping for Parakeet TDT decode."""
+
+from types import SimpleNamespace
+from typing import cast
+
+from kestrel.models.parakeet_tdt.config import ParakeetTdtConfig
+from kestrel.models.parakeet_tdt.model import _TdtBatchDecodeState
+
+
+def _config(*, max_symbols_per_step: int = 2) -> ParakeetTdtConfig:
+    return cast(
+        ParakeetTdtConfig,
+        SimpleNamespace(
+            blank_token_id=0,
+            durations=(0, 1, 2),
+            max_symbols_per_step=max_symbols_per_step,
+        ),
+    )
+
+
+def test_commit_reports_only_new_host_policy_stops() -> None:
+    state = _TdtBatchDecodeState.create(
+        _config(), valid_lengths=[3, 1, 4], max_tokens=1
+    )
+
+    stopped = state.commit(
+        decisions=[[1, 0], [0, 1], [0, 0]],
+        active=state.active(),
+    )
+
+    assert stopped == [0]
+    assert state.active() == [False, False, True]
+    assert state.commit([[2, 0], [2, 0], [2, 0]], state.active()) == [2]
+    assert state.commit([[2, 0], [2, 0], [2, 0]], state.active()) == []
+
+
+def test_commit_reports_step_budget_stop_before_encoder_exhaustion() -> None:
+    state = _TdtBatchDecodeState.create(
+        _config(max_symbols_per_step=1), valid_lengths=[2], max_tokens=None
+    )
+
+    assert state.commit([[1, 0]], state.active()) == []
+    assert state.commit([[1, 0]], state.active()) == [0]
+    assert state.frames == [0]
+    assert state.active() == [False]


### PR DESCRIPTION
## Summary
- return newly policy-stopped rows from the existing host commit pass
- remove repeated row rescans, set construction/difference, sorting, and duplicate active-mask recomputation
- cover token-budget, step-budget, natural-exhaustion, and emit-once behavior

## Validation
- exact head: 2c457aca0c54a371985184acdb9d1b2d4daff251
- Modal CPU focused tests: 2 passed (https://modal.com/apps/m87-labs/main/ap-bRPHYLwRJh4JLwocl38CBR)
- Modal L4 canonical Parakeet qualification: transcript parity at C1/C2/C4/C8 (https://modal.com/apps/m87-labs/main/ap-SV68zArE64LccOaWcXtk9U)
- Kestrel median latency: 51.85 / 52.78 / 53.61 / 58.47 ms at C1/C2/C4/C8
- NeMo median latency: 83.55 / 87.90 / 104.17 / 179.98 ms (1.61x / 1.67x / 1.94x / 3.08x)
- local syntax compilation and diff checks passed; no local pytest