### PR TITLE
Project Moondream logits into decode slots

### DIFF
--- a/kestrel/models/moondream/runtime.py
+++ b/kestrel/models/moondream/runtime.py
@@ -2516,10 +2516,9 @@ class MoondreamRuntime:
                 hidden = self._native_decode_hidden(slot, batch_size, embeds)
         else:
             hidden = self._native_decode_hidden(slot, batch_size, embeds)
-        logits = lm_head(hidden, self.model.text)
+        lm_head(hidden, self.model.text, out=slot.logits[:batch_size])
 
         # Write to slot output buffers (stable addresses for graph capture)
-        slot.logits[:batch_size].copy_(logits)
         slot.hidden_last[:batch_size].copy_(hidden[:, 0, :])
 
     def _megakernel_decode_hidden(

--- a/kestrel/models/moondream/text.py
+++ b/kestrel/models/moondream/text.py
@@ -281,7 +281,11 @@ def text_decoder(
 
 
 def lm_head(
-    hidden: torch.Tensor, module: nn.Module, indices: Optional[torch.Tensor] = None
+    hidden: torch.Tensor,
+    module: nn.Module,
+    indices: Optional[torch.Tensor] = None,
+    *,
+    out: Optional[torch.Tensor] = None,
 ):
     hidden_last = hidden[:, -1, :]
     post_ln = LayerNormWeights(weight=module.post_ln.weight, bias=module.post_ln.bias)
@@ -289,9 +293,14 @@ def lm_head(
     if indices is not None:
         weights = module.lm_head.weight[indices]
         bias = module.lm_head.bias[indices]
-        logits = _kestrel_linear(hidden_norm, weights, bias)
+        logits = _kestrel_linear(hidden_norm, weights, bias, out=out)
     else:
-        logits = _kestrel_linear(hidden_norm, module.lm_head.weight, module.lm_head.bias)
+        logits = _kestrel_linear(
+            hidden_norm,
+            module.lm_head.weight,
+            module.lm_head.bias,
+            out=out,
+        )
     return logits
 
 

--- a/tests/moondream/test_runtime_megakernel_fallback.py
+++ b/tests/moondream/test_runtime_megakernel_fallback.py
@@ -22,7 +22,11 @@ def _forward_runtime(monkeypatch: pytest.MonkeyPatch):
         enabled=True,
     )
     runtime._megakernel_buckets = frozenset({1})
-    monkeypatch.setattr(runtime_mod, "lm_head", lambda hidden, text: torch.ones(1, 3))
+    monkeypatch.setattr(
+        runtime_mod,
+        "lm_head",
+        lambda hidden, text, *, out: out.fill_(1),
+    )
     return runtime, slot
 
 
@@ -57,6 +61,40 @@ def test_graphs_on_genuine_megakernel_failure_remains_fatal(
 
     with pytest.raises(RuntimeError, match="kernel failed"):
         runtime._run_decode_forward(slot, 1)
+
+
+def test_decode_lm_head_writes_exact_active_logits_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, slot = _forward_runtime(monkeypatch)
+    capacity = 3
+    batch_size = 2
+    slot.decode_token_ids = torch.zeros(capacity, dtype=torch.int64)
+    slot.decode_coord_values = torch.zeros(capacity, 1)
+    slot.decode_size_values = torch.zeros(capacity, 2)
+    slot.logits = torch.full((capacity, 3), -1.0)
+    slot.hidden_last = torch.zeros(capacity, 2)
+    runtime._megakernel_buckets = frozenset({batch_size})
+    runtime._megakernel_decode_hidden = lambda *args: torch.ones(
+        batch_size, 1, 2
+    )
+    captured = {}
+
+    def fake_lm_head(hidden, text, *, out):
+        captured["out"] = out
+        out.fill_(7)
+        return torch.full_like(out, 99)
+
+    monkeypatch.setattr(runtime_mod, "lm_head", fake_lm_head)
+
+    runtime._run_decode_forward(slot, batch_size)
+
+    active_logits = slot.logits[:batch_size]
+    assert captured["out"].data_ptr() == active_logits.data_ptr()
+    assert captured["out"].shape == active_logits.shape
+    assert captured["out"].stride() == active_logits.stride()
+    assert torch.equal(active_logits, torch.full_like(active_logits, 7))
+    assert torch.equal(slot.logits[batch_size:], torch.full((1, 3), -1.0))
 
 
 def test_padding_clears_host_and_device_megakernel_metadata() -> None:

--- a/tests/moondream/test_text.py
+++ b/tests/moondream/test_text.py
@@ -12,6 +12,48 @@ class _StopAfterTau(RuntimeError):
     pass
 
 
+@pytest.mark.parametrize("indices", [None, torch.tensor([3, 1])])
+def test_lm_head_forwards_output_buffer_for_full_and_indexed_heads(
+    monkeypatch: pytest.MonkeyPatch,
+    indices: torch.Tensor | None,
+) -> None:
+    hidden = torch.arange(24, dtype=torch.float32).view(2, 1, 12)
+    weight = torch.arange(60, dtype=torch.float32).view(5, 12)
+    bias = torch.arange(5, dtype=torch.float32)
+    module = SimpleNamespace(
+        post_ln=SimpleNamespace(weight=object(), bias=object()),
+        lm_head=SimpleNamespace(weight=weight, bias=bias),
+    )
+    expected_width = weight.shape[0] if indices is None else indices.numel()
+    out = torch.empty((hidden.shape[0], expected_width), dtype=hidden.dtype)
+    captured: dict[str, object] = {}
+
+    def fake_layer_norm(inp, _weights):
+        captured["hidden_last"] = inp
+        return inp + 1
+
+    def fake_linear(inp, selected_weight, selected_bias, *, out):
+        captured["hidden_norm"] = inp
+        captured["weight"] = selected_weight
+        captured["bias"] = selected_bias
+        captured["out"] = out
+        return out.fill_(7)
+
+    monkeypatch.setattr(text_mod, "layer_norm", fake_layer_norm)
+    monkeypatch.setattr(text_mod, "_kestrel_linear", fake_linear)
+
+    result = text_mod.lm_head(hidden, module, indices=indices, out=out)
+
+    assert result is out
+    assert captured["out"] is out
+    torch.testing.assert_close(captured["hidden_last"], hidden[:, -1, :])
+    torch.testing.assert_close(captured["hidden_norm"], hidden[:, -1, :] + 1)
+    expected_weight = weight if indices is None else weight[indices]
+    expected_bias = bias if indices is None else bias[indices]
+    torch.testing.assert_close(captured["weight"], expected_weight)
+    torch.testing.assert_close(captured["bias"], expected_bias)
+
+
 def test_tau_attention_uses_moondream_tanh_gelu(monkeypatch) -> None:
     qkv_weight = object()
     tau_weight = object()


### PR DESCRIPTION
## Summary
- write Moondream decode logits directly into the persistent per-slot output buffer
- avoid allocating and copying a full vocabulary tensor every decode step
- preserve indexed and full-vocabulary lm-head behavior

## Validation
- Modal L4 focused suite: 9 passed
- real L4 BF16 output is bit-exact with the previous allocate-and-copy path
- randomized A/B (200 warmups, 12 x 100 reps): 1.0030x at B1, 1.0061x at B4, 1.0086x at B8
- removes 102400 / 409600 / 819200 bytes of device-to-device copy per token at B1 / B4 / B8
- git diff --check
- Python compile check