### PR TITLE
Skip Qwen ASR streaming work for sync requests

### DIFF
--- a/kestrel/models/qwen3_asr/skill.py
+++ b/kestrel/models/qwen3_asr/skill.py
@@ -146,9 +146,14 @@ class Qwen3AsrTranscribeState(SkillState):
         self._clip_start_seconds = audio.clip_start_seconds
         self._alignment_audio = audio if self.timestamps == "word" else None
         self._token_ids: list[int] = []
-        self._stream_decoder = DecodeStream(skip_special_tokens=False)
-        self._stream_raw = ""
-        self._stream_text = ""
+        self._stream_decoder = (
+            DecodeStream(skip_special_tokens=False)
+            if request.stream_callback is not None
+            else None
+        )
+        if self._stream_decoder is not None:
+            self._stream_raw = ""
+            self._stream_text = ""
 
     def consume_step(self, runtime: Any, step: DecodeStep) -> None:
         del runtime
@@ -157,12 +162,10 @@ class Qwen3AsrTranscribeState(SkillState):
         self.append_token(step.token)
         token_id = int(step.token.token_id)
         self._token_ids.append(token_id)
-        piece = self._stream_decoder.step(self.tokenizer.backend, token_id)
-        if piece:
-            self._stream_raw += piece
-
-    def stop_token_ids(self, runtime: Any) -> Sequence[int]:
-        return tuple(int(token_id) for token_id in runtime.eos_token_ids)
+        if self._stream_decoder is not None:
+            piece = self._stream_decoder.step(self.tokenizer.backend, token_id)
+            if piece:
+                self._stream_raw += piece
 
     def _decoded(self) -> tuple[str, str | None]:
         return self.tokenizer.decode_result(
@@ -172,6 +175,8 @@ class Qwen3AsrTranscribeState(SkillState):
 
     def pop_stream_delta(self, runtime: Any) -> str | None:
         del runtime
+        if self._stream_decoder is None:
+            return None
         raw = self._stream_raw
         if self.language is None:
             marker = "<asr_text>"

--- a/tests/asr/test_qwen3_skill.py
+++ b/tests/asr/test_qwen3_skill.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+import pytest
+
+from kestrel.models.qwen3_asr import skill as skill_module
+from kestrel.models.qwen3_asr.skill import (
+    Qwen3AsrTranscribeSkill,
+    Qwen3AsrTranscribeState,
+    QwenTranscribeContext,
+)
+from kestrel.runtime.tokens import TextToken
+from kestrel.skills.base import DecodeStep
+
+
+class _Tokenizer:
+    backend = object()
+
+    def decode_result(self, token_ids, *, forced_language):
+        return " ".join(map(str, token_ids)), forced_language
+
+
+def _state(*, stream_callback):
+    audio = SimpleNamespace(
+        duration_seconds=1.0,
+        source_duration_seconds=1.0,
+        clip_start_seconds=0.0,
+    )
+    return Qwen3AsrTranscribeState(
+        Qwen3AsrTranscribeSkill(),
+        SimpleNamespace(stream_callback=stream_callback),
+        QwenTranscribeContext(language=None, timestamps="none"),
+        _Tokenizer(),
+        SimpleNamespace(audio=audio),
+    )
+
+
+def _consume(state, token_id):
+    state.consume_step(
+        object(),
+        DecodeStep(token=TextToken(token_id=token_id), position=0),
+    )
+
+
+def test_nonstream_state_skips_incremental_tokenizer_decode(monkeypatch) -> None:
+    monkeypatch.setattr(
+        skill_module,
+        "DecodeStream",
+        lambda **_kwargs: pytest.fail("constructed streaming decoder"),
+    )
+    state = _state(stream_callback=None)
+
+    _consume(state, 17)
+
+    assert state._token_ids == [17]
+    assert state.pop_stream_delta(object()) is None
+    assert state.stop_token_ids(SimpleNamespace(eos_token_ids=(1, 2))) is None
+
+
+def test_stream_state_retains_incremental_text(monkeypatch) -> None:
+    steps = []
+
+    class _Stream:
+        def __init__(self, *, skip_special_tokens):
+            assert skip_special_tokens is False
+
+        def step(self, backend, token_id):
+            steps.append((backend, token_id))
+            return "<asr_text> hello"
+
+    monkeypatch.setattr(skill_module, "DecodeStream", _Stream)
+    state = _state(stream_callback=lambda _update: None)
+
+    _consume(state, 23)
+
+    assert steps == [(_Tokenizer.backend, 23)]
+    assert state.pop_stream_delta(object()) == "hello"


### PR DESCRIPTION
## Summary
- construct Qwen-ASR incremental decode state only for requests with a stream callback
- skip per-token incremental tokenizer decode and string growth for synchronous transcription
- remove a skill EOS override that duplicated the scheduler's runtime EOS check

## Validation
- focused Modal suite: 2 passed: https://modal.com/apps/m87-labs/main/ap-WRtlW403QP1svwWKkTEMTY
- Python compile check
- git diff --check

Streaming requests retain the same DecodeStream path; final synchronous output still uses the complete token list through decode_result.