### PR TITLE
Keep decode runtimes on caller stream

### DIFF
--- a/kestrel/models/gemma4/runtime.py
+++ b/kestrel/models/gemma4/runtime.py
@@ -1207,12 +1207,11 @@ class Gemma4Runtime(UncachedPagedRuntime):
                 "required generated Gemma decode does not cover "
                 f"active batch size {batch_size}"
             )
-        with torch.cuda.stream(slot.compute_stream):
-            if use_generated:
-                assert self.generated_decode is not None
-                self.generated_decode.run(slot, batch_size)
-            else:
-                self._run_native_decode(slot, batch_size)
+        if use_generated:
+            assert self.generated_decode is not None
+            self.generated_decode.run(slot, batch_size)
+        else:
+            self._run_native_decode(slot, batch_size)
 
     def _run_native_decode(self, slot: Any, batch_size: int) -> None:
         batch_idx = slot.meta.batch_idx.gpu[:batch_size]

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -6,7 +6,6 @@ import os
 import threading
 import warnings
 from concurrent.futures import Future, ThreadPoolExecutor
-from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, Sequence
@@ -737,11 +736,7 @@ class Qwen35Runtime(UncachedPagedRuntime):
                 "selected generated Qwen decode does not cover "
                 f"active batch size {batch_size}"
             )
-        stream = getattr(slot, "compute_stream", None)
-        stream_context = (
-            torch.cuda.stream(stream) if stream is not None else nullcontext())
-        with stream_context:
-            megakernel.run(slot, batch_size)
+        megakernel.run(slot, batch_size)
 
     def _gather_decode_rope_deltas(
         self,

--- a/kestrel/models/qwen3_asr/runtime.py
+++ b/kestrel/models/qwen3_asr/runtime.py
@@ -542,8 +542,7 @@ class Qwen3AsrRuntime(UncachedPagedRuntime):
             or self.decode_slots[slot_id] is not slot
         ):
             raise ValueError("Qwen3AsrRuntime received a foreign decode slot")
-        with stream_context(self._compute_stream):
-            self.generated_decode.run(slot, batch_size)
+        self.generated_decode.run(slot, batch_size)
 
     def align_words(
         self,

--- a/kestrel/models/whisper/runtime.py
+++ b/kestrel/models/whisper/runtime.py
@@ -1261,18 +1261,18 @@ class WhisperRuntime(UncachedPagedRuntime):
         )
         # Generated programs are compiled for B1/B2/B4/B8. Tail lanes address
         # the globally reserved no-op row/page and are ignored by the scheduler.
-        # Staging and launch share the captured compute stream, so no host sync
-        # or device-value read is introduced for non-power-of-two batches.
-        with stream_context(self._compute_stream):
-            if launch_capacity != batch_size:
-                slot.decode_token_ids[batch_size:launch_capacity].zero_()
-                slot.meta.input_pos.gpu[batch_size:launch_capacity].zero_()
-                slot.meta.batch_idx.gpu[batch_size:launch_capacity].fill_(
-                    self._padding_batch_idx
-                )
-            # Resident slot tensors were bound at session construction. The
-            # generated launch reads token_ids/input_pos/batch_idx and writes logits.
-            self._decode_session.run(slot, launch_capacity)
+        # Staging and launch share the caller-selected compute stream, so no
+        # host sync or device-value read is introduced for non-power-of-two
+        # batches.
+        if launch_capacity != batch_size:
+            slot.decode_token_ids[batch_size:launch_capacity].zero_()
+            slot.meta.input_pos.gpu[batch_size:launch_capacity].zero_()
+            slot.meta.batch_idx.gpu[batch_size:launch_capacity].fill_(
+                self._padding_batch_idx
+            )
+        # Resident slot tensors were bound at session construction. The
+        # generated launch reads token_ids/input_pos/batch_idx and writes logits.
+        self._decode_session.run(slot, launch_capacity)
 
     def _warmup_decode(self) -> None:
         slot = self._decode_slots[0]

--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -237,7 +237,14 @@ class AutoregressiveRuntime(Runtime, Protocol):
 
     def release_sequence(self, state: SequenceState) -> None: ...
 
-    def decode_with_slot(self, slot: Any, batch_size: int) -> None: ...
+    def decode_with_slot(self, slot: Any, batch_size: int) -> None:
+        """Enqueue one decode forward on the caller's current compute stream.
+
+        The scheduler owns stream selection and calls this only while already
+        inside ``slot.compute_stream``. Implementations must not re-enter that
+        same stream context on every token.
+        """
+        ...
 
 
 class SinglePassRuntime(Runtime, Protocol):

--- a/tests/test_decode_path.py
+++ b/tests/test_decode_path.py
@@ -6,6 +6,8 @@ from kestrel.models.gemma4.runtime import Gemma4Runtime
 from kestrel.models.moondream.runtime import MoondreamRuntime
 from kestrel.models.qwen35 import generated_decode as qwen_generated
 from kestrel.models.qwen35.runtime import Qwen35Runtime
+from kestrel.models.qwen3_asr.runtime import Qwen3AsrRuntime
+from kestrel.models.whisper.runtime import WhisperRuntime
 from kestrel.runtime.generated_decode import GeneratedDecode
 
 
@@ -166,13 +168,21 @@ def test_generated_requirement_covers_complete_batch_domain(
         GeneratedDecode,
         "_resolve_programs",
         classmethod(
-            lambda _cls, _runtime, _spec: (SimpleNamespace(capacity=4),)
+            lambda _cls, _runtime, _spec: (
+                SimpleNamespace(
+                    capacity=1,
+                    static_extent_bindings={"active_batch": 1},
+                ),
+                SimpleNamespace(
+                    capacity=2,
+                    static_extent_bindings={"active_batch": 2},
+                ),
+                SimpleNamespace(
+                    capacity=4,
+                    static_extent_bindings={"active_batch": 4},
+                ),
+            )
         ),
-    )
-    monkeypatch.setattr(
-        GeneratedDecode,
-        "supports",
-        lambda _self, batch_size: batch_size != 3,
     )
 
     with pytest.raises(
@@ -212,6 +222,48 @@ def test_qwen_selected_generated_failure_never_falls_back_to_native() -> None:
         runtime.decode_with_slot(object(), 2)
 
 
+def test_qwen_decode_uses_caller_selected_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.qwen35 import runtime as qwen_runtime
+
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.decode_path = "generated"
+    runtime.generated_decode = _Generated(supported=True)
+    slot = SimpleNamespace(compute_stream=object())
+    monkeypatch.setattr(
+        qwen_runtime.torch.cuda,
+        "stream",
+        lambda _stream: pytest.fail("runtime must not re-enter the caller stream"),
+    )
+
+    runtime.decode_with_slot(slot, 2)
+
+    assert runtime.generated_decode.runs == [2]
+
+
+def test_qwen_asr_decode_uses_caller_selected_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.qwen3_asr import runtime as qwen_asr_runtime
+
+    runtime = object.__new__(Qwen3AsrRuntime)
+    runtime.max_batch_size = 4
+    runtime.generated_decode = _Generated(supported=True)
+    runtime._compute_stream = object()
+    slot = SimpleNamespace(slot_id=0)
+    runtime.decode_slots = (slot,)
+    monkeypatch.setattr(
+        qwen_asr_runtime,
+        "stream_context",
+        lambda _stream: pytest.fail("runtime must not re-enter the caller stream"),
+    )
+
+    runtime.decode_with_slot(slot, 2)
+
+    assert runtime.generated_decode.runs == [2]
+
+
 def test_gemma_required_generated_never_falls_back_to_native(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -236,6 +288,60 @@ def test_gemma_required_generated_never_falls_back_to_native(
         match="required generated Gemma decode does not cover active batch size 2",
     ):
         runtime.decode_with_slot(SimpleNamespace(compute_stream=object()), 2)
+
+
+def test_gemma_decode_uses_caller_selected_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.gemma4 import runtime as gemma_runtime
+
+    runtime = object.__new__(Gemma4Runtime)
+    runtime.decode_path = "generated"
+    runtime.generated_decode = _Generated(supported=True)
+    slot = SimpleNamespace(compute_stream=object())
+    monkeypatch.setattr(
+        gemma_runtime.torch.cuda,
+        "stream",
+        lambda _stream: pytest.fail("runtime must not re-enter the caller stream"),
+    )
+
+    runtime.decode_with_slot(slot, 2)
+
+    assert runtime.generated_decode.runs == [2]
+
+
+def test_whisper_decode_uses_caller_selected_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kestrel.models.whisper import runtime as whisper_runtime
+
+    launches = []
+    runtime = object.__new__(WhisperRuntime)
+    runtime.max_batch_size = 4
+    runtime._decode_batch_capacities = (1, 2, 4)
+    runtime._padding_batch_idx = 0
+    runtime._compute_stream = object()
+    runtime._decode_session = SimpleNamespace(
+        run=lambda slot, capacity: launches.append((slot, capacity))
+    )
+    slot = SimpleNamespace(
+        slot_id=0,
+        decode_token_ids=torch.ones(4, dtype=torch.long),
+        meta=SimpleNamespace(
+            input_pos=SimpleNamespace(gpu=torch.ones(4, dtype=torch.int32)),
+            batch_idx=SimpleNamespace(gpu=torch.ones(4, dtype=torch.long)),
+        ),
+    )
+    runtime._decode_slots = (slot,)
+    monkeypatch.setattr(
+        whisper_runtime,
+        "stream_context",
+        lambda _stream: pytest.fail("runtime must not re-enter the caller stream"),
+    )
+
+    runtime.decode_with_slot(slot, 3)
+
+    assert launches == [(slot, 4)]
 
 
 def test_moondream_explicit_decode_path_refuses_before_runtime_work() -> None:


### PR DESCRIPTION
Make the existing decode_with_slot contract uniformly caller-stream-owned, matching the scheduler and Moondream implementation. Remove one redundant same-stream context entry per token from Qwen VLM, Qwen ASR, Gemma, and Whisper. Also refresh the generated-program coverage test stub to model exact B1/B2/B4 artifacts after the selector lookup change.\n\nValidation: exact full decode-path file, 15 passed on Modal: https://modal.com/apps/m87-labs/main/ap-bfmNybaajBC07XcHYAar59