### PR TITLE
Reuse prepared dynamic generated launches

### DIFF
--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -123,6 +123,7 @@ class GeneratedDecodeSpec:
 @dataclass(frozen=True)
 class _BoundInvocation:
     invocation: Any
+    repeated_dynamic_launch: Callable[..., Any]
     scalar_names: frozenset[str]
     required_launch_extents: frozenset[str]
 
@@ -770,8 +771,10 @@ class GeneratedDecode:
                         f"generated {spec.label} has unknown launch extents "
                         f"{sorted(unknown)}"
                     )
+                invocation = program.bind(bindings)
                 self._slots[(int(slot.slot_id), program_index)] = _BoundInvocation(
-                    program.bind(bindings),
+                    invocation,
+                    invocation.prepare_repeated_dynamic_launch(),
                     scalar_names,
                     frozenset(launch_extents),
                 )
@@ -859,7 +862,7 @@ class GeneratedDecode:
             raise RuntimeError(
                 f"generated {self._spec.label} launch misses {sorted(missing)}"
             )
-        bound.invocation.launch(
+        bound.repeated_dynamic_launch(
             **{
                 name: value
                 for name, value in extents.items()

--- a/tests/test_generated_decode_static_extents.py
+++ b/tests/test_generated_decode_static_extents.py
@@ -1,6 +1,6 @@
 import contextlib
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as dataclass_replace
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -31,6 +31,9 @@ class _Invocation:
 
     def prepare_repeated_launch(self, **extents):
         return lambda: self.launch(**extents)
+
+    def prepare_repeated_dynamic_launch(self):
+        return self.launch
 
 
 @dataclass(frozen=True)
@@ -222,6 +225,33 @@ def test_generated_decode_constructs_and_selects_dynamic_exact_siblings(monkeypa
         ("b8", {"active_batch": 7}),
         ("b8_exact", {}),
     ]
+
+
+def test_generated_decode_repeated_dynamic_launch_keeps_step_preparations(
+    monkeypatch,
+):
+    generated, launches = _build(
+        monkeypatch,
+        _programs("b1"),
+        max_batch_size=1,
+    )
+    prepared = []
+    generated._input_preparation_plan = (
+        runtime_decode.DeviceInputPreparation("prepare", ()),
+    )
+    generated._spec = dataclass_replace(
+        generated._spec,
+        preparation_callbacks={
+            "prepare": lambda slot, batch: prepared.append((slot.slot_id, batch))
+        },
+    )
+    slot = SimpleNamespace(slot_id=0)
+
+    generated.run(slot, 1)
+    generated.run(slot, 1)
+
+    assert prepared == [(0, 1), (0, 1)]
+    assert launches == [("b1", {}), ("b1", {})]
 
 
 def test_static_launcher_resolves_capacity_once(monkeypatch):


### PR DESCRIPTION
Prepare each generated decode slot/program launcher once, then update only its live scalar extents per token. Program selection, per-step input preparation, extent validation, callbacks, device checks, locking, counters, and launch accounting remain live.\n\nValidation:\n- Exact-head generated-decode extent suite: 13 passed on Modal: https://modal.com/apps/m87-labs/main/ap-dmj4MPm1CFw1atI8Zl0Jee\n- L4 end-to-end ASR qualification: transcript parity and median wins for all Qwen-ASR and Parakeet C1/C2/C4/C8 cells: https://modal.com/apps/m87-labs/main/ap-5MmkRbj6jC36STpQXYYqZm\n\nDepends on private runtime support merged in m87-labs/kestrel-proprietary#2249.