### PR TITLE
Emit updates for every decoded token

### DIFF
--- a/kestrel/scheduler/types.py
+++ b/kestrel/scheduler/types.py
@@ -151,16 +151,15 @@ class RequestLifecycle:
         if callback is not None:
             text_delta = self.skill_state.pop_stream_delta(runtime)
             reasoning_delta = self.skill_state.pop_reasoning_stream_delta(runtime)
-            if text_delta or reasoning_delta:
-                callback(
-                    StreamUpdate(
-                        request_id=self.request.request_id,
-                        token=token,
-                        text=text_delta or "",
-                        token_index=self.skill_state.token_count - 1,
-                        reasoning=reasoning_delta,
-                    )
+            callback(
+                StreamUpdate(
+                    request_id=self.request.request_id,
+                    token=token,
+                    text=text_delta or "",
+                    token_index=self.skill_state.token_count - 1,
+                    reasoning=reasoning_delta,
                 )
+            )
 
     @property
     def total_length(self) -> int:
@@ -278,7 +277,7 @@ class SchedulerResult:
 
 @dataclass
 class StreamUpdate:
-    """Incremental token update emitted while a request is decoding."""
+    """Incremental update emitted for every committed decode token."""
 
     request_id: int
     token: Token

--- a/tests/scheduler/test_logprobs.py
+++ b/tests/scheduler/test_logprobs.py
@@ -199,12 +199,31 @@ def test_stage_token_emits_reasoning_without_answer_text() -> None:
     seq.stage_token(SimpleNamespace(), TextToken(10))
     seq.stage_token(SimpleNamespace(), TextToken(11))
 
-    assert len(updates) == 1
+    assert len(updates) == 2
     assert updates[0].request_id == 7
     assert updates[0].token == TextToken(10)
     assert updates[0].token_index == 0
     assert updates[0].text == ""
     assert updates[0].reasoning == "think"
+    assert updates[1].token == TextToken(11)
+    assert updates[1].token_index == 1
+    assert updates[1].text == ""
+    assert updates[1].reasoning is None
+
+
+def test_stage_token_emits_update_without_text_or_reasoning_delta() -> None:
+    updates = []
+    seq = _make_lifecycle(return_logprobs=None)
+    seq.request.stream_callback = updates.append
+
+    seq.stage_token(SimpleNamespace(), TextToken(10))
+
+    assert len(updates) == 1
+    assert updates[0].request_id == 7
+    assert updates[0].token == TextToken(10)
+    assert updates[0].token_index == 0
+    assert updates[0].text == ""
+    assert updates[0].reasoning is None
 
 
 def test_scheduler_result_keeps_generated_prefix_logprobs_aligned() -> None:


### PR DESCRIPTION
## Summary
- emit `StreamUpdate` for every committed decode token, including buffered and special tokens with no text delta
- define the token-complete streaming contract explicitly
- cover reasoning-only and empty-delta tokens with scheduler regressions

## Validation
- `tests/scheduler/test_logprobs.py`: 46 passed
- scheduler, engine, query, and chat suites: 279 passed
- `git diff --check`
- Python compile check