### PR TITLE
Retain decode position extent during staging

### DIFF
--- a/kestrel/models/moondream/decode_slot.py
+++ b/kestrel/models/moondream/decode_slot.py
@@ -54,6 +54,9 @@ class DecodeMetaBuffers:
             device=device,
             pin_memory=True,
         )
+        # Scheduler-owned scalar companion to the staged positions.  This removes
+        # a per-launch host tensor reduction; end-to-end impact is not yet validated.
+        self.max_input_pos = 0
         # token-major MoE LoRA ids
         self.active_token_ids = CpuGpuBuffer(
             max_batch_slots, dtype=torch.int32, device=device, pin_memory=True

--- a/kestrel/models/moondream/generated_decode.py
+++ b/kestrel/models/moondream/generated_decode.py
@@ -105,7 +105,7 @@ class MoondreamDecodeBindings:
     def launch_extents(slot: Any, batch_size: int) -> Mapping[str, int]:
         return {
             "active_batch": int(batch_size),
-            "kv_len": int(slot.meta.input_pos.cpu[:batch_size].max()) + 1,
+            "kv_len": int(slot.meta.max_input_pos) + 1,
         }
 
 

--- a/kestrel/runtime/decode_slot.py
+++ b/kestrel/runtime/decode_slot.py
@@ -31,6 +31,9 @@ class DecodeMetaBuffers:
         self.batch_idx = self.inputs.batch_idx
         self.input_pos = self.inputs.input_pos
         self.lora_slot_ids = self.inputs.lora_slot_ids
+        # Scheduler-owned scalar companion to the staged positions.  This removes
+        # a per-launch host tensor reduction; end-to-end impact is not yet validated.
+        self.max_input_pos = 0
 
 
 @dataclass

--- a/kestrel/runtime/generated_decode.py
+++ b/kestrel/runtime/generated_decode.py
@@ -97,7 +97,7 @@ class PagedDecodeBindings:
     def launch_extents(slot: Any, batch_size: int) -> Mapping[str, int]:
         return {
             "active_batch": int(batch_size),
-            "kv_len": int(slot.meta.input_pos.cpu[:batch_size].max()) + 1,
+            "kv_len": int(slot.meta.max_input_pos) + 1,
         }
 
 

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -2304,10 +2304,15 @@ class GenerationScheduler:
             idx_np = slot.meta.batch_idx.np
             pos_np = slot.meta.input_pos.np
             lora_np = slot.meta.lora_slot_ids.np
+            max_input_pos = 0
             for i, seq in enumerate(sequences):
                 idx_np[i] = seq.state.batch_idx
-                pos_np[i] = seq.state.length
+                input_pos = seq.state.length
+                pos_np[i] = input_pos
                 lora_np[i] = seq.state.lora_slot
+                if input_pos > max_input_pos:
+                    max_input_pos = input_pos
+            slot.meta.max_input_pos = max_input_pos
 
             # One H2D copy stages batch_idx/input_pos/lora_slot_ids together
             # (they share a packed buffer) instead of three separate launches.

--- a/tests/moondream/test_generated_decode.py
+++ b/tests/moondream/test_generated_decode.py
@@ -130,6 +130,7 @@ def test_moondream_slot_bindings_use_stable_hidden_and_metadata_buffers() -> Non
     slot = SimpleNamespace(
         hidden_last=torch.zeros(8, 16),
         meta=SimpleNamespace(
+            max_input_pos=6,
             batch_idx=SimpleNamespace(gpu=torch.arange(8)),
             input_pos=SimpleNamespace(
                 gpu=torch.arange(8, dtype=torch.int32),

--- a/tests/scheduler/test_decode_cohort.py
+++ b/tests/scheduler/test_decode_cohort.py
@@ -1,9 +1,14 @@
 from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import torch
 
 from kestrel.runtime import SequenceState, TextToken
+from kestrel.runtime.decode_slot import DecodeMetaBuffers
+from kestrel.runtime.sampling import SamplingHooks
 from kestrel.scheduler.queues import RunningQueue
 from kestrel.scheduler.scheduler import GenerationScheduler
-from kestrel.scheduler.types import GenerationRequest, RequestLifecycle
+from kestrel.scheduler.types import GenerationRequest, RequestLifecycle, StepPlan
 
 from tests.scheduler._fake_runtime import FakeRuntime
 
@@ -66,3 +71,29 @@ def test_resident_tail_does_not_replace_temporarily_blocked_cohort_member() -> N
     plan = scheduler.schedule_decode_step()
 
     assert plan.sequences == [sequences[1]]
+
+
+def test_decode_launch_retains_maximum_staged_position() -> None:
+    scheduler = object.__new__(GenerationScheduler)
+    runtime = FakeRuntime(max_batch_size=2, max_batch_slots=4)
+    slot = SimpleNamespace(
+        slot_id=0,
+        meta=DecodeMetaBuffers(
+            max_batch_slots=4,
+            device=torch.device("cpu"),
+            pin_memory=False,
+        ),
+        decode_token_ids=torch.empty(4, dtype=torch.long),
+    )
+    runtime.decode_slots[0] = slot
+    scheduler.runtime = runtime
+    scheduler._pending_token_ids = torch.arange(4, dtype=torch.long)
+    scheduler._hooks = SamplingHooks()
+    sequences = [_make_lifecycle(request_id) for request_id in (1, 2)]
+    sequences[0].state.length = 7
+    sequences[1].state.length = 3
+
+    scheduler._launch_forward_on_stream(StepPlan(sequences), slot_id=0)
+
+    assert slot.meta.input_pos.cpu[:2].tolist() == [7, 3]
+    assert slot.meta.max_input_pos == 7

--- a/tests/test_generated_decode_device.py
+++ b/tests/test_generated_decode_device.py
@@ -7,10 +7,20 @@ import torch
 
 from kestrel.runtime.generated_decode import (
     GeneratedDecode,
+    PagedDecodeBindings,
     _program_lookup,
     prepare_generated_weight_storage_for_loading,
     reserve_generated_binding_storage,
 )
+
+
+def test_paged_launch_extents_use_scheduler_position_scalar() -> None:
+    slot = SimpleNamespace(meta=SimpleNamespace(max_input_pos=37))
+
+    assert PagedDecodeBindings(layers=()).launch_extents(slot, 3) == {
+        "active_batch": 3,
+        "kv_len": 38,
+    }
 
 
 def _program(capacity, *, active_batch=None, minimum_batch=1):


### PR DESCRIPTION
## Summary
- compute the maximum decode position while the scheduler already stages per-row metadata
- expose that scalar uniformly on generic and Moondream decode metadata
- avoid a separate host `torch.max` in generated-decode launch binding

## Measurement
Whole-loop CPU microbenchmark using the actual NumPy staging view, median of 9 repeats:
- B1: 2.274 us -> 0.172 us
- B8: 2.909 us -> 0.759 us
- B64: 6.718 us -> 5.149 us
- B128: 10.986 us -> 10.057 us

End-to-end impact is not yet validated.

## Validation
- Modal CPU focused tests: 21 passed
- Modal CPU scheduler + generated-decode regression tests: 220 passed