### PR TITLE
Keep page table synchronization runtime-owned

### DIFF
--- a/kestrel/runtime/protocol.py
+++ b/kestrel/runtime/protocol.py
@@ -131,7 +131,8 @@ class AutoregressiveRuntime(Runtime, Protocol):
     graph_capture_lock: Any  # context manager serializing CUDA-graph capture
     kv_pool: Any  # Engine-owned KV memory pool shared with co-hosted AR runtimes
 
-    # Shared cache state used by the scheduler.
+    # Shared cache state used by the scheduler for capacity accounting. The
+    # runtime owns page mappings and their device visibility.
     page_table: Any
 
     # Capacity queries
@@ -242,7 +243,9 @@ class AutoregressiveRuntime(Runtime, Protocol):
 
         The scheduler owns stream selection and calls this only while already
         inside ``slot.compute_stream``. Implementations must not re-enter that
-        same stream context on every token.
+        same stream context on every token. If an implementation changes page
+        mappings after prefill, it must make them device-visible before the
+        decode reads them; the scheduler does not commit runtime-owned mappings.
         """
         ...
 

--- a/kestrel/scheduler/scheduler.py
+++ b/kestrel/scheduler/scheduler.py
@@ -2327,10 +2327,6 @@ class GenerationScheduler:
             if self._hooks.prepare_decode_inputs is not None:
                 self._hooks.prepare_decode_inputs(slot, batch_idx, batch_size)
 
-            # Commit page table for all batch indices before forward pass (deferred H2D sync)
-            batch_indices_list = [seq.state.batch_idx for seq in sequences]
-            self.runtime.page_table.commit_block_table(batch_indices_list)
-
             # Run forward pass - writes to slot.logits and slot.hidden_last.
             # ``inference_mode`` is applied centrally here (not left to each
             # runtime) so eager model paths can't accidentally retain

--- a/tests/moondream/test_runtime_prefill.py
+++ b/tests/moondream/test_runtime_prefill.py
@@ -111,6 +111,7 @@ def test_launch_prepared_batch_omits_paged_kv_q_lengths_for_uniform_q_lengths() 
     )
 
     assert logits.shape == (2, 8)
+    assert runtime.page_table.committed == [1, 2]
     assert captured["position_ids_contiguous"]
     assert captured["batch_idx_contiguous"]
     assert captured["paged_kv_seqlens_q"] is None

--- a/tests/scheduler/test_decode_cohort.py
+++ b/tests/scheduler/test_decode_cohort.py
@@ -97,3 +97,4 @@ def test_decode_launch_retains_maximum_staged_position() -> None:
 
     assert slot.meta.input_pos.cpu[:2].tolist() == [7, 3]
     assert slot.meta.max_input_pos == 7
+    assert runtime.page_table.commit_block_table_calls == []


### PR DESCRIPTION
## Summary
- remove the decode-loop page-table commit check from the model-agnostic scheduler
- document that autoregressive runtimes own mapping visibility before decode
- lock the scheduler/runtime boundary with tests

Every current autoregressive runtime reserves its target capacity during preparation and commits the resulting mapping in `launch_prepared_batch`; none mutates mappings per decode token.

## Measurement
Clean-row Python bookkeeping removed per decode launch, median of 9 repeats:
- B1: 0.156 us
- B8: 0.471 us
- B64: 2.948 us
- B128: 5.870 us

## Validation
- Modal CPU scheduler suite: 202 passed
- Modal CPU Moondream prefill contract tests: 3 passed