### PR TITLE
Use generated Parakeet decoding for live streaming windows

### DIFF
--- a/kestrel/models/parakeet_tdt/generated_decode.py
+++ b/kestrel/models/parakeet_tdt/generated_decode.py
@@ -12,7 +12,7 @@ from torch import Tensor
 from kestrel.runtime.generated_decode import GeneratedDecode, GeneratedDecodeSpec
 from kestrel.utils import CpuGpuBuffer
 
-from .model import ParakeetTdt, TdtOutput, _TdtBatchDecodeState
+from .model import ParakeetTdt, TdtOutput, TdtState, _TdtBatchDecodeState
 
 
 @dataclass(slots=True)
@@ -73,9 +73,7 @@ class _TdtDecodeBindings:
         }
 
     @staticmethod
-    def launch_extents(
-        _slot: _TdtDecodeSlot, batch_size: int
-    ) -> Mapping[str, int]:
+    def launch_extents(_slot: _TdtDecodeSlot, batch_size: int) -> Mapping[str, int]:
         return {"active_batch": int(batch_size)}
 
 
@@ -151,19 +149,16 @@ class _TdtBatchGeneratedDecoder:
             device=self.device,
             dtype=self.dtype,
         )
-        valid_lengths = torch.zeros(
-            max_batch, dtype=torch.long, device=self.device
-        )
-        frame_indices = torch.zeros(
-            max_batch, dtype=torch.long, device=self.device
-        )
+        valid_lengths = torch.zeros(max_batch, dtype=torch.long, device=self.device)
+        frame_indices = torch.zeros(max_batch, dtype=torch.long, device=self.device)
         active = torch.zeros(max_batch, dtype=torch.bool, device=self.device)
         decoder_hidden = torch.empty_like(self._initial_decoder_hidden)
         hidden = tuple(torch.empty_like(value) for value in self._initial_hidden)
         cell = tuple(torch.empty_like(value) for value in self._initial_cell)
-        self._initial_frame_indices = torch.arange(
-            max_batch, dtype=torch.long, device=self.device
-        ) * config.encoder.max_position_embeddings
+        self._initial_frame_indices = (
+            torch.arange(max_batch, dtype=torch.long, device=self.device)
+            * config.encoder.max_position_embeddings
+        )
         self._inactive = torch.zeros(1, dtype=torch.bool, pin_memory=True)
         self.decode_slots: Sequence[_TdtDecodeSlot] = tuple(
             _TdtDecodeSlot(
@@ -212,35 +207,153 @@ class _TdtBatchGeneratedDecoder:
             raise ValueError("TDT generated decode requires a supported batch")
         first_slot = self.decode_slots[0]
         if width > first_slot.encoded.shape[1]:
-            return self.model._generate_batch(
-                encoded, valid, max_tokens=max_tokens
+            return self.model._generate_batch(encoded, valid, max_tokens=max_tokens)
+
+        state = self._run(encoded, valid, max_tokens=max_tokens)
+        return state.output(self.device)
+
+    def generate_windows(
+        self,
+        encoded: Tensor,
+        valid: Tensor,
+        *,
+        max_tokens: int | None,
+        start_frames: Sequence[int],
+        frame_counts: Sequence[int | None],
+        states: Sequence[TdtState | None],
+    ) -> tuple[TdtOutput, ...]:
+        """Decode a cohort of windows, retaining recurrent state on the GPU."""
+        batch = encoded.shape[0]
+        if not (len(start_frames) == len(frame_counts) == len(states) == batch):
+            raise ValueError("TDT windows must match the encoded batch")
+        if encoded.shape[1] > self.decode_slots[0].encoded.shape[1]:
+            return tuple(
+                self.model.generate_encoded(
+                    encoded[row : row + 1],
+                    valid[row : row + 1],
+                    max_tokens=max_tokens,
+                    start_frame=start_frames[row],
+                    frame_count=frame_counts[row],
+                    state=states[row],
+                )
+                for row in range(batch)
             )
+        with torch.cuda.stream(self.compute_stream):
+            state = self._run(
+                encoded,
+                valid,
+                max_tokens=max_tokens,
+                start_frames=start_frames,
+                frame_counts=frame_counts,
+                previous_states=states,
+            )
+            slot = self.decode_slots[0]
+            # Returned rows retain immutable cohort snapshots, independent of
+            # launch storage. Copy each state tensor once, not once per row.
+            decoder_hidden = slot.decoder_hidden[:batch].clone()
+            hidden = torch.stack([value[:batch] for value in slot.hidden], dim=0)
+            cell = torch.stack([value[:batch] for value in slot.cell], dim=0)
+            return tuple(
+                TdtOutput(
+                    sequences=torch.tensor([state.sequences[row]], device=self.device),
+                    durations=torch.tensor([state.durations[row]], device=self.device),
+                    lengths=torch.tensor(
+                        [len(state.sequences[row])], device=self.device
+                    ),
+                    state=TdtState(
+                        decoder_hidden[row : row + 1, None],
+                        hidden[:, row : row + 1],
+                        cell[:, row : row + 1],
+                        max(0, state.frames[row] - state.valid_lengths[row]),
+                    ),
+                )
+                for row in range(batch)
+            )
+
+    def _run(
+        self,
+        encoded: Tensor,
+        valid: Tensor,
+        *,
+        max_tokens: int | None,
+        start_frames: Sequence[int] | None = None,
+        frame_counts: Sequence[int | None] | None = None,
+        previous_states: Sequence[TdtState | None] | None = None,
+    ) -> _TdtBatchDecodeState:
+        batch, width, _ = encoded.shape
+        if not self.minimum_batch <= batch <= self.max_batch_size:
+            raise ValueError("TDT generated decode requires a supported batch")
+        first_slot = self.decode_slots[0]
 
         with torch.cuda.stream(self.compute_stream):
             valid_device = valid.sum(-1).to(dtype=torch.long)
             valid_lengths = valid_device.tolist()
-            state = _TdtBatchDecodeState.create(
-                self.model.config, valid_lengths, max_tokens
+            starts = [0] * batch if start_frames is None else list(start_frames)
+            counts = [None] * batch if frame_counts is None else list(frame_counts)
+            previous = (
+                [None] * batch if previous_states is None else list(previous_states)
             )
+            ends = [
+                length if count is None else min(length, start + count)
+                for length, start, count in zip(
+                    valid_lengths, starts, counts, strict=True
+                )
+            ]
+            if any(
+                not 0 <= start <= end for start, end in zip(starts, ends, strict=True)
+            ):
+                raise ValueError("TDT decode frames are outside the encoded audio")
+            state = _TdtBatchDecodeState.create(self.model.config, ends, max_tokens)
+            for row, (start, end, prior) in enumerate(
+                zip(starts, ends, previous, strict=True)
+            ):
+                carry = 0 if prior is None else prior.carry
+                state.frames[row] = start + carry
+                state.durations[row][0] = min(carry, end - start)
+                state.steps_remaining[row] = self.model.config.max_symbols_per_step * (
+                    end - start
+                )
             active = state.active()
-            if not any(active):
-                return state.output(self.device)
 
             first_slot.encoded[:batch, :width].copy_(encoded)
-            first_slot.valid_lengths[:batch].copy_(valid_device)
+            first_slot.valid_lengths[:batch].copy_(
+                torch.tensor(ends, device=self.device)
+            )
             first_slot.frame_indices[:batch].copy_(
                 self._initial_frame_indices[:batch]
+                + torch.tensor(state.frames, device=self.device).clamp_max(
+                    first_slot.encoded.shape[1] - 1
+                )
             )
-            first_slot.active[:batch].copy_(
-                torch.tensor(active, device=self.device)
+            first_slot.active[:batch].copy_(torch.tensor(active, device=self.device))
+            torch.cat(
+                [
+                    self._initial_decoder_hidden[row : row + 1]
+                    if prior is None
+                    else prior.decoder_hidden[:, 0]
+                    for row, prior in enumerate(previous)
+                ],
+                out=first_slot.decoder_hidden[:batch],
             )
-            first_slot.decoder_hidden.copy_(self._initial_decoder_hidden)
-            for current, initial in zip(
-                (*first_slot.hidden, *first_slot.cell),
-                (*self._initial_hidden, *self._initial_cell),
-                strict=True,
+            for layer, (hidden, cell) in enumerate(
+                zip(first_slot.hidden, first_slot.cell, strict=True)
             ):
-                current.copy_(initial)
+                for destination, initial, field in (
+                    (hidden, self._initial_hidden[layer], "hidden"),
+                    (cell, self._initial_cell[layer], "cell"),
+                ):
+                    torch.cat(
+                        [
+                            initial[row : row + 1]
+                            if prior is None
+                            else getattr(prior, field)[layer]
+                            for row, prior in enumerate(previous)
+                        ],
+                        out=destination[:batch],
+                    )
+
+            if not any(active):
+                return state
 
             launchers = self._launchers_for(batch)
             pending: deque[_TdtDecodeSlot] = deque()
@@ -251,16 +364,33 @@ class _TdtBatchGeneratedDecoder:
                 slot.read_done.record(self.compute_stream)
                 pending.append(slot)
 
-            enqueue(self.decode_slots[0])
-            enqueue(self.decode_slots[1])
+            def fill_pipeline() -> None:
+                # A pending decision can spend at most one token/step. Near a
+                # host policy limit, don't enqueue a decision whose state might
+                # later have to be rolled back at a streaming boundary.
+                budget = min(
+                    min(steps, tokens if tokens is not None else steps)
+                    for steps, tokens, enabled in zip(
+                        state.steps_remaining,
+                        state.tokens_remaining,
+                        active,
+                        strict=True,
+                    )
+                    if enabled
+                )
+                for candidate in self.decode_slots:
+                    if len(pending) >= min(2, budget):
+                        break
+                    if not any(item is candidate for item in pending):
+                        enqueue(candidate)
+
+            fill_pipeline()
             while pending:
                 slot = pending.popleft()
                 slot.read_done.synchronize()
-                decisions = (
-                    slot.decisions.cpu.view(2, self.max_batch_size)
-                    [:, :batch]
-                    .T.tolist()
-                )
+                decisions = slot.decisions.cpu.view(2, self.max_batch_size)[
+                    :, :batch
+                ].T.tolist()
                 newly_policy_stopped = state.commit(decisions, active)
                 active = state.active()
                 if not any(active):
@@ -270,9 +400,9 @@ class _TdtBatchGeneratedDecoder:
                     first_slot.active[row : row + 1].copy_(
                         self._inactive, non_blocking=True
                     )
-                enqueue(slot)
+                fill_pipeline()
 
-            return state.output(self.device)
+            return state
 
 
 __all__ = ["_TdtBatchGeneratedDecoder"]

--- a/kestrel/models/parakeet_tdt/generated_decode.py
+++ b/kestrel/models/parakeet_tdt/generated_decode.py
@@ -368,16 +368,19 @@ class _TdtBatchGeneratedDecoder:
                 # A pending decision can spend at most one token/step. Near a
                 # host policy limit, don't enqueue a decision whose state might
                 # later have to be rolled back at a streaming boundary.
-                budget = min(
-                    min(steps, tokens if tokens is not None else steps)
-                    for steps, tokens, enabled in zip(
-                        state.steps_remaining,
-                        state.tokens_remaining,
-                        active,
-                        strict=True,
+                # Terminal requests discard the state and retain full lookahead.
+                budget = 2
+                if previous_states is not None:
+                    budget = min(
+                        min(steps, tokens if tokens is not None else steps)
+                        for steps, tokens, enabled in zip(
+                            state.steps_remaining,
+                            state.tokens_remaining,
+                            active,
+                            strict=True,
+                        )
+                        if enabled
                     )
-                    if enabled
-                )
                 for candidate in self.decode_slots:
                     if len(pending) >= min(2, budget):
                         break

--- a/kestrel/models/parakeet_tdt/runtime.py
+++ b/kestrel/models/parakeet_tdt/runtime.py
@@ -270,23 +270,40 @@ class ParakeetTdtRuntime:
         encoded, valid = self.model.encode(features, mask)
         values = []
         factor = self.model.config.encoder.subsampling_factor
-        for row, window, request, row_encoded, row_valid in zip(
-            rows, windows, requests, encoded, valid, strict=True
+        starts = [
+            _encoder_frames(window.start_sample, factor) for window in windows
+        ]
+        counts = [
+            None
+            if window.sample_count is None
+            else _encoder_frames(window.sample_count, factor)
+            for window in windows
+        ]
+        states = [
+            None if window.state is None else window.state.decoder
+            for window in windows
+        ]
+        if isinstance(self._batch_decoder, _TdtBatchGeneratedDecoder):
+            outputs = self._batch_decoder.generate_windows(
+                encoded, valid, max_tokens=max_tokens,
+                start_frames=starts, frame_counts=counts, states=states,
+            )
+        else:
+            outputs = tuple(
+                self.model.generate_encoded(
+                    encoded[index : index + 1], valid[index : index + 1],
+                    max_tokens=max_tokens, start_frame=start,
+                    frame_count=count, state=state,
+                )
+                for index, (start, count, state) in enumerate(
+                    zip(starts, counts, states, strict=True)
+                )
+            )
+        for row, window, request, generated in zip(
+            rows, windows, requests, outputs, strict=True
         ):
             _index, audio = row
             previous = window.state
-            generated = self.model.generate_encoded(
-                row_encoded[None],
-                row_valid[None],
-                max_tokens=max_tokens,
-                start_frame=_encoder_frames(window.start_sample, factor),
-                frame_count=(
-                    None
-                    if window.sample_count is None
-                    else _encoder_frames(window.sample_count, factor)
-                ),
-                state=None if previous is None else previous.decoder,
-            )
             length = int(generated.lengths[0])
             token_ids = generated.sequences[0, 1:length].tolist()
             durations = generated.durations[0, 1:length].tolist()

--- a/tests/asr/test_parakeet_generated_windows.py
+++ b/tests/asr/test_parakeet_generated_windows.py
@@ -1,0 +1,151 @@
+"""GPU state ownership and boundary tests for the generated TDT host loop."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from kestrel.models.parakeet_tdt.generated_decode import _TdtBatchGeneratedDecoder
+from kestrel.models.parakeet_tdt.model import TdtState
+
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def _decoder():
+    device = torch.device("cuda")
+    config = SimpleNamespace(
+        blank_token_id=2,
+        decoder_hidden_size=4,
+        num_decoder_layers=2,
+        durations=(0, 1, 2, 3),
+        max_symbols_per_step=2,
+        encoder=SimpleNamespace(max_position_embeddings=8),
+    )
+
+    def initial(tokens, state):
+        batch = tokens.shape[0]
+        return torch.zeros(batch, 1, 4, device=device), (
+            torch.zeros(2, batch, 4, device=device),
+            torch.zeros(2, batch, 4, device=device),
+        )
+
+    model = SimpleNamespace(
+        config=config,
+        decoder=initial,
+        encoder_projector=SimpleNamespace(weight=torch.zeros(1, device=device)),
+    )
+    decoder = _TdtBatchGeneratedDecoder(
+        model,
+        max_batch=3,
+        compute_stream=torch.cuda.current_stream(),
+    )
+
+    def static_launcher(slot, batch):
+        def launch():
+            rows = torch.arange(batch, device=device)
+            frame = slot.frame_indices[:batch] - rows * 8
+            data = slot.encoded[rows, frame]
+            token, duration = data[:, 0].int(), data[:, 1].int()
+            slot.decisions.gpu.view(2, -1)[0, :batch].copy_(token)
+            slot.decisions.gpu.view(2, -1)[1, :batch].copy_(duration)
+            emitted = slot.active[:batch] & (token != 2)
+            for value in (slot.decoder_hidden, *slot.hidden, *slot.cell):
+                value[:batch].add_(emitted[:, None])
+            advance = torch.where((token == 2) & (duration == 0), 1, duration)
+            following = frame + advance
+            slot.frame_indices[:batch].copy_(
+                torch.where(
+                    slot.active[:batch],
+                    rows * 8 + following.clamp_max(7),
+                    slot.frame_indices[:batch],
+                )
+            )
+            slot.active[:batch].logical_and_(following < slot.valid_lengths[:batch])
+
+        return launch
+
+    decoder._generated = SimpleNamespace(static_launcher=static_launcher)
+    return decoder
+
+
+@pytest.mark.parametrize("max_tokens", [None, 0, 1, 2, 3])
+def test_stream_boundaries_budgets_and_owned_state(max_tokens):
+    decoder = _decoder()
+    encoded = torch.zeros(3, 8, 4, device="cuda")
+    # Row 0 emits with zero duration until the token/step policy stops it.
+    encoded[0, :, 0] = 1
+    # Row 1 immediately overshoots its two-frame chunk by one frame.
+    encoded[1, :, 0] = 1
+    encoded[1, :, 1] = 3
+    # Row 2 consists of blank zero-duration decisions (must advance one).
+    encoded[2, :, 0] = 2
+    valid = torch.ones(3, 8, dtype=torch.bool, device="cuda")
+    output = decoder.generate_windows(
+        encoded,
+        valid,
+        max_tokens=max_tokens,
+        start_frames=[1, 2, 0],
+        frame_counts=[2, 2, 2],
+        states=[None] * 3,
+    )
+    limit = 4 if max_tokens is None else min(4, max_tokens)
+    expected_emits = [limit, int(max_tokens is None or max_tokens > 0), 0]
+    for row, result in enumerate(output):
+        state = result.state
+        assert state is not None
+        for value in (state.decoder_hidden, state.hidden, state.cell):
+            torch.testing.assert_close(
+                value, torch.full_like(value, expected_emits[row])
+            )
+    assert output[1].state.carry == (1 if expected_emits[1] else 0)
+    assert output[2].sequences.tolist() == ([[2, 2, 2]] if max_tokens != 0 else [[2]])
+
+    snapshot = output[1].state.hidden.clone()
+    # A different cohort reuses launch storage but must not alter returned state.
+    decoder.generate_windows(
+        encoded,
+        valid,
+        max_tokens=1,
+        start_frames=[0] * 3,
+        frame_counts=[1] * 3,
+        states=[None] * 3,
+    )
+    torch.testing.assert_close(output[1].state.hidden, snapshot)
+
+    # The next chunk can occupy a different batch row and resumes exactly the
+    # saved recurrent state, including a duration that crossed its boundary.
+    (resumed,) = decoder.generate_windows(
+        encoded[1:2],
+        valid[1:2],
+        max_tokens=1,
+        start_frames=[0],
+        frame_counts=[2],
+        states=[output[1].state],
+    )
+    torch.testing.assert_close(resumed.state.hidden, snapshot + 1)
+    assert resumed.state.carry == output[1].state.carry + 1
+
+
+def test_carry_skips_window_without_mutating_state():
+    decoder = _decoder()
+    prior = TdtState(
+        torch.full((1, 1, 4), 7.0, device="cuda"),
+        torch.full((2, 1, 4), 8.0, device="cuda"),
+        torch.full((2, 1, 4), 9.0, device="cuda"),
+        carry=3,
+    )
+    encoded = torch.ones(1, 8, 4, device="cuda")
+    (result,) = decoder.generate_windows(
+        encoded,
+        torch.ones(1, 8, dtype=torch.bool, device="cuda"),
+        max_tokens=None,
+        start_frames=[7],
+        frame_counts=[1],
+        states=[prior],
+    )
+    assert result.sequences.tolist() == [[2]]
+    assert result.durations.tolist() == [[1]]
+    assert result.state.carry == 2
+    for name in ("hidden", "cell", "decoder_hidden"):
+        torch.testing.assert_close(getattr(result.state, name), getattr(prior, name))


### PR DESCRIPTION
Live Parakeet preview windows currently bypass generated decoding and run the native decoder separately for each row. Route them through the existing generated TDT decoder as a batch, preserving frame bounds, duration carry and recurrent GPU state across windows.

State is restored with batched device-to-device operations and returned as owned cohort snapshots. Decision slots continue to share recurrence and alternate output readback. Resumable windows restrict queued decisions only near host policy limits to return the exact accepted state; terminal requests retain unrestricted two-slot lookahead.

Requires corrected generated artifacts from m87-labs/kestrel-proprietary#2368: the previous compiler could deactivate a boundary row before its final recurrent commit. No scheduler or encoder changes.

Validation: all eight public boundary/bookkeeping tests passed remotely on L4. Coverage includes zero-duration tokens, blank advancement, mixed row completion, token/step limits, cross-window carry, retained-state ownership and moving a resumed stream between batch rows. Actual native/generated streaming parity and L4/H100/B200 steady-state comparisons with corrected artifacts are in progress; this PR remains draft until those complete. No local pytest was run.

---

**Status (2026-09-20, backlog review).** Still relevant on its own terms: nothing on `main` or in another PR routes live streaming windows through generated decode, and its dependency m87-labs/kestrel-proprietary#2368 merged on 2026-09-04. It now **conflicts with `main`**: `kestrel/models/parakeet_tdt/runtime.py` changed under it in #229, #242 and #244 (bounded / bucketed / retained encoder CUDA graphs), so the branch needs a rebase before review. The parity and steady-state comparisons the draft was waiting on were never posted here. It is independent of the ternary Parakeet work consolidated in #253 and not part of that stack.
