### PR TITLE
Reuse shared RMSNorm for Qwen ASR prefill

### DIFF
--- a/kestrel/models/qwen3_asr/model.py
+++ b/kestrel/models/qwen3_asr/model.py
@@ -1,8 +1,7 @@
 """Inference-only PyTorch definition of Qwen3-ASR.
 
-This is the correctness/reference path. Production decode is bound through the
-generated backend separately; keeping the ordinary module makes checkpoint and
-kernel equivalence tests independent of Transformers.
+Production decode is bound through the generated backend separately. Prefill
+uses ordinary modules and shared operators without depending on Transformers.
 """
 
 from __future__ import annotations
@@ -13,24 +12,29 @@ from dataclasses import dataclass
 import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
+from kestrel_kernels import get_runtime
 
 from .config import AudioEncoderConfig, Qwen3AsrConfig, TextDecoderConfig
 
 
 KvCache = list[tuple[Tensor, Tensor]]
+_rmsnorm = get_runtime().dense.rmsnorm
 
 
 class RmsNorm(nn.Module):
     def __init__(self, size: int, eps: float) -> None:
         super().__init__()
         self.weight = nn.Parameter(torch.ones(size))
+        self.register_buffer("unit_weight", torch.ones(size), persistent=False)
         self.eps = eps
 
+    def reset_nonpersistent_buffers(self) -> None:
+        self.unit_weight = torch.ones_like(self.weight)
+
     def forward(self, value: Tensor) -> Tensor:
-        normalized = value.float() * torch.rsqrt(
-            value.float().square().mean(-1, keepdim=True) + self.eps
-        )
-        return self.weight * normalized.to(value.dtype)
+        # Preserve normalized-value rounding before the learned weight multiply.
+        # L4 C1 text prefill: unit RMS + BF16 multiply saved 5.9–6.4 ms.
+        return self.weight * _rmsnorm(value, self.unit_weight, self.eps)
 
 
 class AudioAttention(nn.Module):
@@ -458,6 +462,9 @@ class Qwen3AsrForConditionalGeneration(nn.Module):
     def reset_nonpersistent_buffers(self) -> None:
         self.model.audio_tower.reset_nonpersistent_buffers()
         self.model.language_model.reset_nonpersistent_buffers()
+        for module in self.modules():
+            if isinstance(module, RmsNorm):
+                module.reset_nonpersistent_buffers()
 
     def prefill(
         self,

--- a/tests/asr/test_qwen3_rmsnorm.py
+++ b/tests/asr/test_qwen3_rmsnorm.py
@@ -1,0 +1,40 @@
+import torch
+
+from kestrel.models.qwen3_asr import model as qwen_model
+
+
+def test_rmsnorm_preserves_cast_before_weight(monkeypatch):
+    norm = qwen_model.RmsNorm(128, 1e-6).to(dtype=torch.bfloat16)
+    value = torch.linspace(-2, 3, 256).reshape(2, 128).to(torch.bfloat16)
+    with torch.no_grad():
+        norm.weight.copy_(torch.linspace(0.5, 2, 128))
+
+    def shared_rms(value, unit_weight, eps):
+        assert unit_weight.dtype == value.dtype
+        assert torch.equal(unit_weight, torch.ones_like(unit_weight))
+        normalized = value.float() * torch.rsqrt(
+            value.float().square().mean(-1, keepdim=True) + eps
+        )
+        return normalized.to(value.dtype)
+
+    monkeypatch.setattr(qwen_model, "_rmsnorm", shared_rms)
+    normalized = value.float() * torch.rsqrt(
+        value.float().square().mean(-1, keepdim=True) + norm.eps
+    )
+    expected = norm.weight * normalized.to(value.dtype)
+    assert torch.equal(norm(value), expected)
+
+
+def test_rmsnorm_unit_weight_reset_and_moves():
+    with torch.device("meta"):
+        norm = qwen_model.RmsNorm(128, 1e-6)
+    norm.load_state_dict({"weight": torch.ones(128)}, assign=True)
+    norm.reset_nonpersistent_buffers()
+    assert norm.unit_weight.device.type == "cpu"
+    assert torch.equal(norm.unit_weight, torch.ones(128))
+    assert set(norm.state_dict()) == {"weight"}
+    norm.to(dtype=torch.bfloat16)
+    assert norm.unit_weight.dtype == norm.weight.dtype == torch.bfloat16
+    norm.to_empty(device="cpu")
+    norm.reset_nonpersistent_buffers()
+    assert torch.equal(norm.unit_weight, torch.ones_like(norm.weight))


### PR DESCRIPTION
## Summary

Route Qwen3-ASR RMSNorm through the existing shared dense runtime operation, using nonpersistent unit weights followed by the learned-weight multiply. This preserves rounding normalized values to the activation dtype before scaling. No new kernel, graph cache, backend-specific branch, or compiler calibration is introduced.

Reset the unit buffers after meta checkpoint assignment, before device/dtype moves. Keep independent formula and buffer-lifecycle tests.

## Evidence

L4, pinned qwen-asr[vllm], 12 retained samples per engine in AB/BA order:

| Model / concurrency | Kestrel | Incumbent | Speedup |
| --- | ---: | ---: | ---: |
| Qwen3-ASR 0.6B / C1 | 219.995 ms | 231.252 ms | 1.051x |
| Qwen3-ASR 1.7B / C1 | 530.074 ms | 539.192 ms | 1.017x |

Every retained Kestrel sample was faster than every incumbent sample for each model. Transcripts matched. These are selected C1 measurements, not a new full-concurrency qualification.

Separate same-worker prefill diagnostics saved 6.4 ms / 5.9 ms. Intermediate values are not bit-exact because reduction arithmetic differs; all generated tokens matched the independent eager reference across three speech clips at 2/5/12 seconds for both sizes (18/18 cases). This modest regression check is not a ground-truth corpus WER claim.

## Validation

- Two focused rounding/buffer lifecycle tests passed on Modal CPU.
- Native dispatch smoke passed on L4 at widths 128/1024/2048, with fallback forbidden.
- No local pytest or kernel-wheel rebuild.
- Adversarial review covered cast order, checkpoint compatibility, meta-buffer reset, state-dict exclusion, device/dtype movement, and independent reference comparisons; no remaining findings.
