### PR TITLE
Fuse Parakeet encoder projections

### DIFF
--- a/kestrel/models/parakeet_tdt/model.py
+++ b/kestrel/models/parakeet_tdt/model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 import torch
 import torch.nn.functional as F
@@ -44,12 +45,16 @@ class Convolution(nn.Module):
         self.pointwise_conv2 = nn.Conv1d(channels, channels, 1, bias=False)
 
     def forward(self, hidden: Tensor, valid: Tensor | None) -> Tensor:
-        hidden = F.glu(self.pointwise_conv1(hidden.transpose(1, 2)), dim=1)
+        # Treating both 1x1 convolutions as linears measured 42.87 ms vs
+        # 45.37 ms encoder wall on L4 at batch 1; keep the depthwise Conv1d.
+        hidden = F.glu(
+            F.linear(hidden, self.pointwise_conv1.weight[..., 0]), dim=-1
+        )
         if valid is not None:
-            hidden = hidden.masked_fill(~valid[:, None], 0)
-        hidden = self.depthwise_conv(hidden)
-        hidden = self.pointwise_conv2(F.silu(self.norm(hidden)))
-        return hidden.transpose(1, 2)
+            hidden = hidden.masked_fill(~valid[..., None], 0)
+        hidden = self.depthwise_conv(hidden.transpose(1, 2))
+        hidden = F.silu(self.norm(hidden)).transpose(1, 2)
+        return F.linear(hidden, self.pointwise_conv2.weight[..., 0])
 
 
 class RelativeAttention(nn.Module):
@@ -58,15 +63,46 @@ class RelativeAttention(nn.Module):
         self.num_heads = config.num_attention_heads
         self.head_dim = config.hidden_size // self.num_heads
         self.scale = self.head_dim**-0.5
-        self.q_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
-        self.k_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
-        self.v_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.qkv_proj = nn.Linear(
+            config.hidden_size, 3 * config.hidden_size, bias=False
+        )
         self.o_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
         self.relative_k_proj = nn.Linear(
             config.hidden_size, config.hidden_size, bias=False
         )
         self.bias_u = nn.Parameter(torch.zeros(self.num_heads, self.head_dim))
         self.bias_v = nn.Parameter(torch.zeros(self.num_heads, self.head_dim))
+
+    def _load_from_state_dict(
+        self,
+        state_dict: dict[str, Tensor],
+        prefix: str,
+        local_metadata: dict[str, Any],
+        strict: bool,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+        error_msgs: list[str],
+    ) -> None:
+        # One QKV GEMM measured 43.35 ms vs 45.37 ms encoder wall on L4 at
+        # batch 1. Fuse the checkpoint's separate tensors without retaining a
+        # duplicate 144 MiB BF16 copy across the 24 encoder layers.
+        fused_key = f"{prefix}qkv_proj.weight"
+        source_keys = tuple(f"{prefix}{name}_proj.weight" for name in "qkv")
+        if fused_key not in state_dict and all(
+            key in state_dict for key in source_keys
+        ):
+            state_dict[fused_key] = torch.cat(
+                tuple(state_dict.pop(key) for key in source_keys)
+            ).contiguous()
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
 
     @staticmethod
     def _relative_shift(scores: Tensor) -> Tensor:
@@ -77,9 +113,10 @@ class RelativeAttention(nn.Module):
     def forward(self, hidden: Tensor, positions: Tensor, mask: Tensor | None) -> Tensor:
         batch, length, _ = hidden.shape
         shape = (batch, length, self.num_heads, self.head_dim)
-        q = self.q_proj(hidden).view(shape).transpose(1, 2)
-        k = self.k_proj(hidden).view(shape).transpose(1, 2)
-        v = self.v_proj(hidden).view(shape).transpose(1, 2)
+        q, k, v = (
+            value.view(shape).transpose(1, 2)
+            for value in self.qkv_proj(hidden).chunk(3, dim=-1)
+        )
         if mask is not None:
             key_valid = mask[:, :1, :].transpose(1, 2)
             k = k.masked_fill(~key_valid[:, None], 0)


### PR DESCRIPTION
## Summary

- fuse the checkpoint Q/K/V tensors into one runtime projection without duplicate storage
- execute both 1x1 convolution projections as linears while retaining the depthwise convolution
- keep strict compatibility with the published checkpoint layout

## L4 results

Paired 24-round A/B on an NVIDIA L4, 8 seconds of audio features:

- C1 encoder: 40.19 ms to 37.42 ms (1.074x; paired median -2.83 ms)
- C8 encoder: 43.43 ms to 38.83 ms (1.118x; paired median -4.53 ms)
- C1 valid-row max/mean absolute delta: 0.03076 / 0.00216 (rtol=0.03, atol=0.03 passes)
- C8 valid-row output: exact
- real LibriSpeech transcript, token IDs, durations, and output length: exact

The operator profile removes 48 cuDNN convolution launches per encoder pass. The net matrix-multiply count remains 216 because QKV removes 48 GEMMs while the two pointwise projections add 48 GEMMs.

## Checks

- Modal L4 reference test: tests/asr/test_reference_models.py::test_parakeet_encoder_and_tdt_decode_match_transformers (passed)
- strict published-checkpoint load (passed)
- ruff check kestrel/models/parakeet_tdt/model.py (passed)
- git diff --check (passed)