### PR TITLE
Enable native Whisper runtime on L4

### DIFF
--- a/kestrel/device.py
+++ b/kestrel/device.py
@@ -69,6 +69,13 @@ def get_device_capability(device: torch.device) -> tuple[int, int]:
     return (0, 0)
 
 
+def get_device_sm_count(device: torch.device) -> int:
+    """Return the physical CUDA SM count; non-CUDA devices return zero."""
+    if device.type == "cuda":
+        return int(torch.cuda.get_device_properties(device).multi_processor_count)
+    return 0
+
+
 def make_stream(device: torch.device) -> Optional[torch.cuda.Stream]:
     """Create a CUDA stream for explicit pipelining.
 
@@ -167,6 +174,7 @@ __all__ = [
     "NoopEvent",
     "empty_cache",
     "get_device_capability",
+    "get_device_sm_count",
     "materialize_blas_runtime",
     "make_event",
     "make_stream",

--- a/kestrel/models/whisper/runtime.py
+++ b/kestrel/models/whisper/runtime.py
@@ -21,7 +21,13 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from kestrel.device import make_event, make_stream, stream_context
+from kestrel.device import (
+    get_device_capability,
+    get_device_sm_count,
+    make_event,
+    make_stream,
+    stream_context,
+)
 from kestrel.kv_cache import (
     KVMemoryPool,
     PageTable,
@@ -76,6 +82,48 @@ _DECODE_SLOT_COUNT = 2
 _CONTROL_TOKEN_CAPACITY = 4
 _DEFAULT_TRANSCRIPT_TOKENS = 444
 _CONSTRAINT_PLAN_WIDTH = 8
+
+
+def _supports_whisper_native_target(
+    capability: tuple[int, int], device_sms: int
+) -> bool:
+    """Whether one CUDA target is in Whisper's native serving domain.
+
+    Hopper SM9x and data-center Blackwell SM10x preserve the existing
+    architecture-level admission; their exact packed-program coverage remains
+    fail-closed in the generated runtime. Ada is narrower: only an exact
+    packaging-owned generated-decode target is admitted, so adding L4 support
+    cannot silently admit every SM89 product.
+    """
+    if (
+        not isinstance(device_sms, int)
+        or isinstance(device_sms, bool)
+        or device_sms <= 0
+    ):
+        return False
+    major, minor = capability
+    if major in (9, 10):
+        return True
+    if (major, minor) != (8, 9):
+        return False
+
+    from kestrel_kernels.deploy_targets import GENERATED_DECODE, deploy_targets_for
+
+    return any(
+        target.arch_num == 89 and target.num_sms == device_sms
+        for target in deploy_targets_for(GENERATED_DECODE)
+    )
+
+
+def _require_whisper_native_target(device: torch.device) -> None:
+    capability = get_device_capability(device)
+    device_sms = get_device_sm_count(device)
+    if not _supports_whisper_native_target(capability, device_sms):
+        raise RuntimeError(
+            "Optimized Whisper serving supports shipped Ada generated-decode "
+            "targets, Hopper SM9x, and data-center Blackwell SM10x; got "
+            f"SM{capability[0]}{capability[1]} with {device_sms} SMs"
+        )
 
 
 def _validated_packed_receipts(
@@ -403,6 +451,14 @@ class WhisperRuntime(UncachedPagedRuntime):
         self.dtype = _resolved_dtype(cfg)
         if not isinstance(self.dtype, torch.dtype):
             raise TypeError("Whisper runtime dtype must be a torch.dtype")
+        production = _components is None
+        uses_native_sessions = production or _components.session_factory is None
+        if uses_native_sessions:
+            if self.device.type != "cuda":
+                raise ValueError("The optimized Whisper runtime requires a CUDA device")
+            if self.dtype is not torch.bfloat16:
+                raise ValueError("The optimized Whisper runtime requires bfloat16")
+            _require_whisper_native_target(self.device)
         self.max_batch_size = _positive_int(
             "max_batch_size", getattr(cfg, "max_batch_size", 1)
         )
@@ -433,7 +489,6 @@ class WhisperRuntime(UncachedPagedRuntime):
                 stacklevel=2,
             )
 
-        production = _components is None
         if production and not bool(getattr(cfg, "enable_cuda_graphs", True)):
             raise ValueError(
                 "Optimized Whisper serving requires CUDA graphs for custom prefill"
@@ -643,13 +698,6 @@ class WhisperRuntime(UncachedPagedRuntime):
         )
 
         if components.session_factory is None:
-            capability = torch.cuda.get_device_capability(self.device)
-            if capability != (8, 9) and capability[0] not in (9, 10):
-                raise RuntimeError(
-                    "Optimized Whisper serving currently supports Ada, Hopper, and "
-                    f"Blackwell, got compute capability {capability[0]}."
-                    f"{capability[1]}"
-                )
             self._prefill_session = NativeWhisperPrefillSession(
                 bindings,
                 components.weights,

--- a/kestrel/models/whisper/runtime.py
+++ b/kestrel/models/whisper/runtime.py
@@ -644,9 +644,9 @@ class WhisperRuntime(UncachedPagedRuntime):
 
         if components.session_factory is None:
             capability = torch.cuda.get_device_capability(self.device)
-            if capability[0] not in (9, 10):
+            if capability != (8, 9) and capability[0] not in (9, 10):
                 raise RuntimeError(
-                    "Optimized Whisper serving currently supports Hopper and "
+                    "Optimized Whisper serving currently supports Ada, Hopper, and "
                     f"Blackwell, got compute capability {capability[0]}."
                     f"{capability[1]}"
                 )

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -11,6 +11,7 @@ from kestrel.device import (
     NoopEvent,
     empty_cache,
     get_device_capability,
+    get_device_sm_count,
     make_event,
     make_stream,
     materialize_blas_runtime,
@@ -77,6 +78,10 @@ def test_empty_cache_cuda_targets_supplied_device(
 
 def test_get_device_capability_cpu_returns_zero_tuple() -> None:
     assert get_device_capability(CPU) == (0, 0)
+
+
+def test_get_device_sm_count_cpu_returns_zero() -> None:
+    assert get_device_sm_count(CPU) == 0
 
 
 def test_make_stream_cpu_returns_none() -> None:
@@ -210,6 +215,14 @@ def test_make_event_cuda_returns_real_event() -> None:
 @pytest.mark.skipif(not _cuda_available(), reason="CUDA not available")
 def test_get_device_capability_cuda_matches_torch() -> None:
     assert get_device_capability(CUDA) == torch.cuda.get_device_capability()
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA not available")
+def test_get_device_sm_count_cuda_matches_torch() -> None:
+    assert (
+        get_device_sm_count(CUDA)
+        == torch.cuda.get_device_properties(CUDA).multi_processor_count
+    )
 
 
 # --- MPS path: stream is None, event is NoopEvent, sync uses torch.mps.* ---

--- a/tests/whisper/test_runtime.py
+++ b/tests/whisper/test_runtime.py
@@ -16,7 +16,11 @@ from kestrel.runtime.tokens import TextToken
 from kestrel.models.whisper import MODEL_NAME, _runtime_factory
 from kestrel.models.whisper.audio import AudioSource, PreparedAudio
 from kestrel.models.whisper.config import WhisperPreprocessorConfig, WhisperTurboConfig
-from kestrel.models.whisper.runtime import WhisperRuntime, WhisperRuntimeComponents
+from kestrel.models.whisper.runtime import (
+    WhisperRuntime,
+    WhisperRuntimeComponents,
+    _supports_whisper_native_target,
+)
 from kestrel.models.whisper.runtime_abi import WhisperExecutionBindings
 from kestrel.models.whisper.skill import (
     WhisperDecodeContext,
@@ -68,6 +72,50 @@ def test_native_whisper_ops_use_the_uniform_kernel_runtime_surface() -> None:
                 for forbidden in forbidden_modules
             )
         }, name
+
+
+@pytest.mark.parametrize(
+    ("capability", "device_sms", "expected"),
+    (
+        ((8, 9), 58, True),  # L4: exact shipped Ada target.
+        ((8, 9), 24, False),  # Smaller consumer Ada.
+        ((8, 9), 128, False),  # Larger consumer Ada.
+        ((8, 9), 142, False),  # L40/L40S must not inherit L4 admission.
+        ((8, 0), 108, False),
+        ((8, 6), 82, False),
+        ((12, 0), 96, False),
+        ((9, 0), 132, True),
+        ((10, 0), 148, True),
+    ),
+)
+def test_whisper_native_target_support_is_explicit(
+    capability: tuple[int, int], device_sms: int, expected: bool
+) -> None:
+    assert _supports_whisper_native_target(capability, device_sms) is expected
+
+
+@pytest.mark.parametrize("injected_native_components", (False, True))
+def test_unsupported_native_target_fails_before_asset_loading(
+    monkeypatch, injected_native_components: bool
+) -> None:
+    import kestrel.models.whisper.runtime as runtime_module
+
+    monkeypatch.setattr(runtime_module, "get_device_capability", lambda _device: (8, 6))
+    monkeypatch.setattr(runtime_module, "get_device_sm_count", lambda _device: 82)
+    monkeypatch.setattr(
+        runtime_module,
+        "_load_production_components",
+        lambda *_args, **_kwargs: pytest.fail(
+            "unsupported target reached checkpoint loading"
+        ),
+    )
+    cfg = SimpleNamespace(device="cuda", dtype=torch.bfloat16)
+    components = (
+        SimpleNamespace(session_factory=None) if injected_native_components else None
+    )
+
+    with pytest.raises(RuntimeError, match="got SM86 with 82 SMs"):
+        WhisperRuntime(cfg, kv_pool=object(), _components=components)
 
 
 class _Encoding:


### PR DESCRIPTION
## Summary\n\n- add a backend-uniform SM-count device query\n- admit the exact shipped L4 target for native Whisper while retaining Hopper and data-center Blackwell\n- reject unsupported CUDA targets before checkpoint/component loading\n- cover L4 admission and representative unsupported architectures\n\n## Validation\n\n- L4 Modal MKL suite: 32 passed (contraction epilogue + Whisper decode)\n- exact full L4 Whisper run completed with transcript parity\n- independent adversarial review: zero issues\n