### PR TITLE
Retain bounded Parakeet encoder graphs

### DIFF
--- a/kestrel/models/parakeet_tdt/runtime.py
+++ b/kestrel/models/parakeet_tdt/runtime.py
@@ -178,9 +178,9 @@ class ParakeetTdtRuntime:
             device=self.device,
             stream=self.compute_stream,
             run_forward=self.model.encode,
-            # One graph bounds persistent pool memory; a shape transition
-            # recaptures instead of accumulating graph pools.
-            max_entries=1,
+            # Three exact B1/B4/B8 shapes retained 372 MiB on L4 and avoided
+            # 107-146 ms recaptures; cap at four independent graph pools.
+            max_entries=4,
         )
 
     @property

--- a/kestrel/models/parakeet_tdt/runtime.py
+++ b/kestrel/models/parakeet_tdt/runtime.py
@@ -10,7 +10,7 @@ from typing import Any
 import numpy as np
 import torch
 import torch.nn.functional as F
-from kestrel.device import empty_cache, resolve_device
+from kestrel.device import empty_cache, make_stream, resolve_device
 from kestrel.runtime import ExecutionShape
 from kestrel.runtime.single_pass_graph import FixedShapeSinglePassGraph
 
@@ -122,11 +122,7 @@ class ParakeetTdtRuntime:
         self.compute_stream = (
             compute_stream
             if compute_stream is not None
-            else (
-                torch.cuda.current_stream(self.device)
-                if self.device.type == "cuda" and torch.cuda.is_available()
-                else None
-            )
+            else make_stream(self.device)
         )
         if model is None or tokenizer is None:
             checkpoint = getattr(cfg, "model_path", None) or self._model_name

--- a/kestrel/models/parakeet_tdt/runtime.py
+++ b/kestrel/models/parakeet_tdt/runtime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from contextlib import ExitStack
+from contextlib import ExitStack, nullcontext
 from dataclasses import dataclass
 from typing import Any
 
@@ -12,6 +12,7 @@ import torch
 import torch.nn.functional as F
 from kestrel.device import empty_cache, resolve_device
 from kestrel.runtime import ExecutionShape
+from kestrel.runtime.single_pass_graph import FixedShapeSinglePassGraph
 
 from kestrel.models.asr.audio import AudioChunks, DecodedAudio
 from kestrel.models.asr.contract import (
@@ -118,7 +119,15 @@ class ParakeetTdtRuntime:
             if hasattr(cfg, "resolved_dtype")
             else getattr(cfg, "dtype", torch.float32)
         )
-        self.compute_stream = compute_stream
+        self.compute_stream = (
+            compute_stream
+            if compute_stream is not None
+            else (
+                torch.cuda.current_stream(self.device)
+                if self.device.type == "cuda" and torch.cuda.is_available()
+                else None
+            )
+        )
         if model is None or tokenizer is None:
             checkpoint = getattr(cfg, "model_path", None) or self._model_name
             loaded = load_parakeet_tdt(checkpoint, device=self.device, dtype=self.dtype)
@@ -139,7 +148,8 @@ class ParakeetTdtRuntime:
                 "Parakeet generated decode requires CUDA with BF16 weights"
             )
         if self.decode_path != "native" and generated_supported:
-            stream = compute_stream or torch.cuda.current_stream(self.device)
+            stream = self.compute_stream
+            assert stream is not None
             self._batch_decoder = _TdtBatchGeneratedDecoder.create(
                 self.model,
                 max_batch=self.batch_capacity,
@@ -152,12 +162,26 @@ class ParakeetTdtRuntime:
             and self.device.type == "cuda"
             and torch.cuda.is_available()
         ):
-            stream = compute_stream or torch.cuda.current_stream(self.device)
+            stream = self.compute_stream
+            assert stream is not None
             self._batch_decoder = _TdtBatchGraphDecoder(
                 self.model,
                 max_batch=self.batch_capacity,
                 compute_stream=stream,
             )
+        self._encoder_graph = FixedShapeSinglePassGraph(
+            enabled=(
+                bool(getattr(cfg, "enable_cuda_graphs", True))
+                and self.device.type == "cuda"
+                and torch.cuda.is_available()
+            ),
+            device=self.device,
+            stream=self.compute_stream,
+            run_forward=self.model.encode,
+            # One graph bounds persistent pool memory; a shape transition
+            # recaptures instead of accumulating graph pools.
+            max_entries=1,
+        )
 
     @property
     def model_name(self) -> str:
@@ -267,65 +291,65 @@ class ParakeetTdtRuntime:
         *,
         max_tokens: int,
     ) -> tuple[dict[str, object], ...]:
-        encoded, valid = self.model.encode(features, mask)
         values = []
         factor = self.model.config.encoder.subsampling_factor
-        for row, window, request, row_encoded, row_valid in zip(
-            rows, windows, requests, encoded, valid, strict=True
-        ):
-            _index, audio = row
-            previous = window.state
-            generated = self.model.generate_encoded(
-                row_encoded[None],
-                row_valid[None],
-                max_tokens=max_tokens,
-                start_frame=_encoder_frames(window.start_sample, factor),
-                frame_count=(
-                    None
-                    if window.sample_count is None
-                    else _encoder_frames(window.sample_count, factor)
-                ),
-                state=None if previous is None else previous.decoder,
-            )
-            length = int(generated.lengths[0])
-            token_ids = generated.sequences[0, 1:length].tolist()
-            durations = generated.durations[0, 1:length].tolist()
-            if previous is None:
-                all_token_ids = (self.tokenizer.blank_token_id, *token_ids)
-                all_durations = (0, *durations)
-            else:
-                all_token_ids = (*previous.token_ids, *token_ids)
-                all_durations = (*previous.durations, *durations)
-            if generated.state is None:
-                raise RuntimeError("stateful TDT decoding returned no state")
-            state = _StreamState(generated.state, all_token_ids, all_durations)
-            text_parts: list[str] = []
-            segments: list[Segment] = []
-            logical_audio = DecodedAudio(
-                audio.waveform,
-                window.duration_seconds,
-                window.duration_seconds,
-                0.0,
-            )
-            self._append_chunk_result(
-                request,
-                logical_audio,
-                list(all_token_ids),
-                list(all_durations),
-                text_parts,
-                segments,
-                frame_seconds=generated.encoder_frame_seconds,
-            )
-            value = TranscriptionResult(
-                text=" ".join(text_parts),
-                language=None,
-                duration_seconds=window.duration_seconds,
-                source_duration_seconds=window.duration_seconds,
-                clip_start_seconds=0.0,
-                segments=tuple(segments),
-            ).as_dict()
-            value["_stream_state"] = state
-            values.append(value)
+        with self._encoder_graph.launch(features, mask) as (encoded, valid):
+            for row, window, request, row_encoded, row_valid in zip(
+                rows, windows, requests, encoded, valid, strict=True
+            ):
+                _index, audio = row
+                previous = window.state
+                generated = self.model.generate_encoded(
+                    row_encoded[None],
+                    row_valid[None],
+                    max_tokens=max_tokens,
+                    start_frame=_encoder_frames(window.start_sample, factor),
+                    frame_count=(
+                        None
+                        if window.sample_count is None
+                        else _encoder_frames(window.sample_count, factor)
+                    ),
+                    state=None if previous is None else previous.decoder,
+                )
+                length = int(generated.lengths[0])
+                token_ids = generated.sequences[0, 1:length].tolist()
+                durations = generated.durations[0, 1:length].tolist()
+                if previous is None:
+                    all_token_ids = (self.tokenizer.blank_token_id, *token_ids)
+                    all_durations = (0, *durations)
+                else:
+                    all_token_ids = (*previous.token_ids, *token_ids)
+                    all_durations = (*previous.durations, *durations)
+                if generated.state is None:
+                    raise RuntimeError("stateful TDT decoding returned no state")
+                state = _StreamState(generated.state, all_token_ids, all_durations)
+                text_parts: list[str] = []
+                segments: list[Segment] = []
+                logical_audio = DecodedAudio(
+                    audio.waveform,
+                    window.duration_seconds,
+                    window.duration_seconds,
+                    0.0,
+                )
+                self._append_chunk_result(
+                    request,
+                    logical_audio,
+                    list(all_token_ids),
+                    list(all_durations),
+                    text_parts,
+                    segments,
+                    frame_seconds=generated.encoder_frame_seconds,
+                )
+                value = TranscriptionResult(
+                    text=" ".join(text_parts),
+                    language=None,
+                    duration_seconds=window.duration_seconds,
+                    source_duration_seconds=window.duration_seconds,
+                    clip_start_seconds=0.0,
+                    segments=tuple(segments),
+                ).as_dict()
+                value["_stream_state"] = state
+                values.append(value)
         return tuple(values)
 
     @torch.inference_mode()
@@ -437,30 +461,38 @@ class ParakeetTdtRuntime:
                         ):
                             results[index] = value
                         continue
-                    if (
-                        self._batch_decoder is None
-                        or features.shape[0] < self._batch_decoder.minimum_batch
-                    ):
-                        output = self.model.generate(
-                            features,
-                            mask,
-                            max_tokens=max_tokens,
-                        )
-                    else:
-                        encoded, valid = self.model.encode(features, mask)
-                        output = self._batch_decoder.generate(
-                            encoded,
-                            valid,
-                            max_tokens=max_tokens,
-                        )
-                    packed = torch.cat(
-                        (
-                            output.lengths[:, None],
-                            output.sequences,
-                            output.durations,
-                        ),
-                        dim=1,
-                    ).tolist()
+                    use_encoded_decode = (
+                        self._batch_decoder is not None
+                        and features.shape[0] >= self._batch_decoder.minimum_batch
+                    )
+                    encoder_lease = (
+                        self._encoder_graph.launch(features, mask)
+                        if use_encoded_decode
+                        else nullcontext(None)
+                    )
+                    with encoder_lease as encoded_result:
+                        if encoded_result is None:
+                            output = self.model.generate(
+                                features,
+                                mask,
+                                max_tokens=max_tokens,
+                            )
+                        else:
+                            assert self._batch_decoder is not None
+                            encoded, valid = encoded_result
+                            output = self._batch_decoder.generate(
+                                encoded,
+                                valid,
+                                max_tokens=max_tokens,
+                            )
+                        packed = torch.cat(
+                            (
+                                output.lengths[:, None],
+                                output.sequences,
+                                output.durations,
+                            ),
+                            dim=1,
+                        ).tolist()
                     for (index, audio), row in zip(valid_group, packed, strict=True):
                         length = row[0]
                         token_ids = row[1 : 1 + length]
@@ -494,6 +526,7 @@ class ParakeetTdtRuntime:
         return tuple(finalized)
 
     def shutdown(self) -> None:
+        self._encoder_graph.shutdown()
         empty_cache(self.device)
 
 

--- a/kestrel/runtime/single_pass_graph.py
+++ b/kestrel/runtime/single_pass_graph.py
@@ -46,14 +46,25 @@ class FixedShapeSinglePassGraph:
             raise ValueError("single-pass graph max_entries must be positive")
         self.enabled = bool(enabled)
         self.device = resolve_device(device)
+        if self.enabled:
+            if self.device.type != "cuda":
+                raise ValueError("single-pass graph replay requires a CUDA device")
+            with torch.cuda.device(self.device):
+                if stream is None:
+                    stream = torch.cuda.Stream(device=self.device)
+                elif stream.device != self.device:
+                    raise ValueError("single-pass graph stream must share its device")
+                if stream == torch.cuda.default_stream(self.device):
+                    raise ValueError(
+                        "single-pass graph replay requires a non-default stream"
+                    )
         self._stream = stream
         self._run_forward = run_forward
         self._max_entries = int(max_entries)
         self._entries: OrderedDict[_InputKey, _GraphEntry] = OrderedDict()
         self._lock = threading.RLock()
+        self._active_lease_thread: int | None = None
         self._closed = False
-        if self.enabled and (self.device.type != "cuda" or self._stream is None):
-            raise ValueError("single-pass graph replay requires a CUDA stream")
 
     @staticmethod
     def _outputs(value: Sequence[Tensor]) -> tuple[Tensor, ...]:
@@ -105,50 +116,80 @@ class FixedShapeSinglePassGraph:
 
     @contextmanager
     def launch(self, *inputs: Tensor) -> Iterator[tuple[Tensor, ...]]:
-        """Stage one exact-shape call and lease its outputs to the caller."""
+        """Stage one exact-shape call and lease its outputs to the caller.
+
+        CUDA inputs must be ready on the ambient stream at context entry.  The
+        session orders that stream before staging without synchronizing the host.
+        """
         values = tuple(inputs)
         with self._lock:
             if self._closed:
                 raise RuntimeError("single-pass graph session is shut down")
-            if not self.enabled:
-                yield self._outputs(self._run_forward(*values))
-                return
+            thread_id = threading.get_ident()
+            if self._active_lease_thread == thread_id:
+                raise RuntimeError("single-pass graph leases cannot be nested")
+            self._active_lease_thread = thread_id
+            try:
+                if not self.enabled:
+                    yield self._outputs(self._run_forward(*values))
+                    return
 
-            stream = self._stream
-            if stream is None:
-                raise RuntimeError("single-pass graph launch has no CUDA stream")
-            # Keep the caller in the owned stream context for the entire lease,
-            # so consumers are ordered after replay before stable outputs can be
-            # staged again by another caller.
-            with torch.cuda.device(self.device), stream_context(stream):
-                key = self._key(values)
-                entry = self._entries.get(key)
-                if entry is None:
-                    if len(self._entries) >= self._max_entries:
-                        stream.synchronize()
-                        self._entries.popitem(last=False)
-                    entry = self._capture(values)
-                    self._entries[key] = entry
-                else:
-                    self._entries.move_to_end(key)
-                    for destination, source in zip(entry.inputs, values, strict=True):
-                        destination.copy_(source)
-                    entry.graph.replay()
-                yield entry.outputs
+                stream = self._stream
+                if stream is None:
+                    raise RuntimeError("single-pass graph launch has no CUDA stream")
+                with torch.cuda.device(self.device):
+                    source_stream = torch.cuda.current_stream(self.device)
+                    ready = None
+                    if source_stream != stream:
+                        ready = torch.cuda.Event()
+                        ready.record(source_stream)
+                        stream.wait_event(ready)
+                    # Keep the caller in the owned stream context for the entire
+                    # lease, so consumers are ordered after replay before stable
+                    # outputs can be staged again by another caller.
+                    with stream_context(stream):
+                        key = self._key(values)
+                        entry = self._entries.get(key)
+                        if entry is None:
+                            if len(self._entries) >= self._max_entries:
+                                stream.synchronize()
+                                self._entries.popitem(last=False)
+                            entry = self._capture(values)
+                            self._entries[key] = entry
+                        else:
+                            self._entries.move_to_end(key)
+                            for destination, source in zip(
+                                entry.inputs, values, strict=True
+                            ):
+                                destination.copy_(source)
+                            entry.graph.replay()
+                        yield entry.outputs
+                    del ready
+            finally:
+                self._active_lease_thread = None
 
     def shutdown(self) -> None:
         """Synchronize the owned stream and release graph pools and buffers."""
         with self._lock:
             if self._closed:
                 return
+            if self._active_lease_thread == threading.get_ident():
+                raise RuntimeError(
+                    "single-pass graph cannot shut down during an active lease"
+                )
             self._closed = True
-            if self.enabled:
-                stream = self._stream
-                if stream is None:
-                    raise RuntimeError("single-pass graph shutdown has no CUDA stream")
-                stream.synchronize()
-            self._entries.clear()
-            self._run_forward = lambda *_args: ()
+            try:
+                if self.enabled:
+                    stream = self._stream
+                    if stream is None:
+                        raise RuntimeError(
+                            "single-pass graph shutdown has no CUDA stream"
+                        )
+                    stream.synchronize()
+            finally:
+                self._entries.clear()
+                self._run_forward = lambda *_args: ()
+                self._stream = None
 
 
 __all__ = ["FixedShapeSinglePassGraph"]

--- a/kestrel/runtime/single_pass_graph.py
+++ b/kestrel/runtime/single_pass_graph.py
@@ -1,0 +1,161 @@
+"""Bounded CUDA-graph replay for fixed-shape single-pass operations."""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+
+from kestrel.device import resolve_device, stream_context
+
+
+_InputKey = tuple[tuple[tuple[int, ...], tuple[int, ...], torch.dtype], ...]
+
+
+@dataclass(slots=True)
+class _GraphEntry:
+    inputs: tuple[Tensor, ...]
+    outputs: tuple[Tensor, ...]
+    graph: torch.cuda.CUDAGraph
+
+
+class FixedShapeSinglePassGraph:
+    """Capture and replay a bounded set of exact tensor-shape calls.
+
+    Returned tensors are session-owned stable buffers.  ``launch`` therefore
+    holds the session lock until its context exits; callers must submit every
+    consumer of the outputs inside that context.  This makes lazy capture and
+    replay safe even when a runtime can be entered from more than one thread.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        device: torch.device,
+        stream: torch.cuda.Stream | None,
+        run_forward: Callable[..., Sequence[Tensor]],
+        max_entries: int = 4,
+    ) -> None:
+        if max_entries <= 0:
+            raise ValueError("single-pass graph max_entries must be positive")
+        self.enabled = bool(enabled)
+        self.device = resolve_device(device)
+        self._stream = stream
+        self._run_forward = run_forward
+        self._max_entries = int(max_entries)
+        self._pool = None
+        self._entries: OrderedDict[_InputKey, _GraphEntry] = OrderedDict()
+        self._lock = threading.RLock()
+        self._closed = False
+        if self.enabled and (self.device.type != "cuda" or self._stream is None):
+            raise ValueError("single-pass graph replay requires a CUDA stream")
+
+    @staticmethod
+    def _outputs(value: Sequence[Tensor]) -> tuple[Tensor, ...]:
+        outputs = tuple(value)
+        if not outputs or any(not isinstance(output, Tensor) for output in outputs):
+            raise TypeError("single-pass graph forward must return tensors")
+        return outputs
+
+    def _key(self, inputs: tuple[Tensor, ...]) -> _InputKey:
+        if not inputs:
+            raise ValueError("single-pass graph launch requires tensor inputs")
+        for value in inputs:
+            if not isinstance(value, Tensor):
+                raise TypeError("single-pass graph inputs must be tensors")
+            if value.device != self.device:
+                raise ValueError("single-pass graph inputs must share its device")
+        return tuple(
+            (tuple(value.shape), tuple(value.stride()), value.dtype) for value in inputs
+        )
+
+    def _capture(self, inputs: tuple[Tensor, ...]) -> _GraphEntry:
+        stream = self._stream
+        if stream is None:
+            raise RuntimeError("single-pass graph capture has no CUDA stream")
+        static_inputs = tuple(
+            torch.empty_strided(
+                value.shape,
+                value.stride(),
+                dtype=value.dtype,
+                device=value.device,
+            )
+            for value in inputs
+        )
+        with (
+            torch.cuda.device(self.device),
+            stream_context(stream),
+            torch.inference_mode(),
+        ):
+            for destination, source in zip(static_inputs, inputs, strict=True):
+                destination.copy_(source)
+            # Materialize library handles and algorithm selection outside capture.
+            self._outputs(self._run_forward(*static_inputs))
+            stream.synchronize()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(
+                graph,
+                stream=stream,
+                pool=self._pool,
+            ):
+                outputs = self._outputs(self._run_forward(*static_inputs))
+            if self._pool is None:
+                self._pool = graph.pool()
+            graph.replay()
+        return _GraphEntry(static_inputs, outputs, graph)
+
+    @contextmanager
+    def launch(self, *inputs: Tensor) -> Iterator[tuple[Tensor, ...]]:
+        """Stage one exact-shape call and lease its outputs to the caller."""
+        values = tuple(inputs)
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("single-pass graph session is shut down")
+            if not self.enabled:
+                yield self._outputs(self._run_forward(*values))
+                return
+
+            stream = self._stream
+            if stream is None:
+                raise RuntimeError("single-pass graph launch has no CUDA stream")
+            # Keep the caller in the owned stream context for the entire lease,
+            # so consumers are ordered after replay before stable outputs can be
+            # staged again by another caller.
+            with torch.cuda.device(self.device), stream_context(stream):
+                key = self._key(values)
+                entry = self._entries.get(key)
+                if entry is None:
+                    if len(self._entries) >= self._max_entries:
+                        stream.synchronize()
+                        self._entries.popitem(last=False)
+                    entry = self._capture(values)
+                    self._entries[key] = entry
+                else:
+                    self._entries.move_to_end(key)
+                    for destination, source in zip(entry.inputs, values, strict=True):
+                        destination.copy_(source)
+                    entry.graph.replay()
+                yield entry.outputs
+
+    def shutdown(self) -> None:
+        """Synchronize the owned stream and release graph pools and buffers."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self.enabled:
+                stream = self._stream
+                if stream is None:
+                    raise RuntimeError("single-pass graph shutdown has no CUDA stream")
+                stream.synchronize()
+            self._entries.clear()
+            self._run_forward = lambda *_args: ()
+
+
+__all__ = ["FixedShapeSinglePassGraph"]

--- a/kestrel/runtime/single_pass_graph.py
+++ b/kestrel/runtime/single_pass_graph.py
@@ -46,15 +46,18 @@ class FixedShapeSinglePassGraph:
             raise ValueError("single-pass graph max_entries must be positive")
         self.enabled = bool(enabled)
         self.device = resolve_device(device)
-        if self.enabled:
-            if self.device.type != "cuda":
-                raise ValueError("single-pass graph replay requires a CUDA device")
+        if self.enabled and self.device.type != "cuda":
+            raise ValueError("single-pass graph replay requires a CUDA device")
+        if self.enabled and stream is None:
             with torch.cuda.device(self.device):
-                if stream is None:
-                    stream = torch.cuda.Stream(device=self.device)
-                elif stream.device != self.device:
+                stream = torch.cuda.Stream(device=self.device)
+        if stream is not None:
+            if self.device.type != "cuda":
+                raise ValueError("single-pass graph stream requires a CUDA device")
+            with torch.cuda.device(self.device):
+                if stream.device != self.device:
                     raise ValueError("single-pass graph stream must share its device")
-                if stream == torch.cuda.default_stream(self.device):
+                if self.enabled and stream == torch.cuda.default_stream(self.device):
                     raise ValueError(
                         "single-pass graph replay requires a non-default stream"
                     )
@@ -115,6 +118,24 @@ class FixedShapeSinglePassGraph:
         return _GraphEntry(static_inputs, outputs, graph)
 
     @contextmanager
+    def _ordered_stream(self) -> Iterator[None]:
+        """Order the ambient CUDA stream before the configured session stream."""
+        stream = self._stream
+        if stream is None:
+            yield
+            return
+        with torch.cuda.device(self.device):
+            source_stream = torch.cuda.current_stream(self.device)
+            ready = None
+            if source_stream != stream:
+                ready = torch.cuda.Event()
+                ready.record(source_stream)
+                stream.wait_event(ready)
+            with stream_context(stream):
+                yield
+            del ready
+
+    @contextmanager
     def launch(self, *inputs: Tensor) -> Iterator[tuple[Tensor, ...]]:
         """Stage one exact-shape call and lease its outputs to the caller.
 
@@ -130,24 +151,17 @@ class FixedShapeSinglePassGraph:
                 raise RuntimeError("single-pass graph leases cannot be nested")
             self._active_lease_thread = thread_id
             try:
-                if not self.enabled:
-                    yield self._outputs(self._run_forward(*values))
-                    return
-
-                stream = self._stream
-                if stream is None:
-                    raise RuntimeError("single-pass graph launch has no CUDA stream")
-                with torch.cuda.device(self.device):
-                    source_stream = torch.cuda.current_stream(self.device)
-                    ready = None
-                    if source_stream != stream:
-                        ready = torch.cuda.Event()
-                        ready.record(source_stream)
-                        stream.wait_event(ready)
-                    # Keep the caller in the owned stream context for the entire
-                    # lease, so consumers are ordered after replay before stable
-                    # outputs can be staged again by another caller.
-                    with stream_context(stream):
+                # Keep the caller in the configured stream context for the entire
+                # lease, so eager and replay consumers share identical ordering.
+                with self._ordered_stream():
+                    if not self.enabled:
+                        yield self._outputs(self._run_forward(*values))
+                    else:
+                        stream = self._stream
+                        if stream is None:
+                            raise RuntimeError(
+                                "single-pass graph launch has no CUDA stream"
+                            )
                         key = self._key(values)
                         entry = self._entries.get(key)
                         if entry is None:
@@ -164,12 +178,11 @@ class FixedShapeSinglePassGraph:
                                 destination.copy_(source)
                             entry.graph.replay()
                         yield entry.outputs
-                    del ready
             finally:
                 self._active_lease_thread = None
 
     def shutdown(self) -> None:
-        """Synchronize the owned stream and release graph pools and buffers."""
+        """Synchronize the configured stream and release retained state."""
         with self._lock:
             if self._closed:
                 return
@@ -179,12 +192,8 @@ class FixedShapeSinglePassGraph:
                 )
             self._closed = True
             try:
-                if self.enabled:
-                    stream = self._stream
-                    if stream is None:
-                        raise RuntimeError(
-                            "single-pass graph shutdown has no CUDA stream"
-                        )
+                stream = self._stream
+                if stream is not None:
                     stream.synchronize()
             finally:
                 self._entries.clear()

--- a/kestrel/runtime/single_pass_graph.py
+++ b/kestrel/runtime/single_pass_graph.py
@@ -49,7 +49,6 @@ class FixedShapeSinglePassGraph:
         self._stream = stream
         self._run_forward = run_forward
         self._max_entries = int(max_entries)
-        self._pool = None
         self._entries: OrderedDict[_InputKey, _GraphEntry] = OrderedDict()
         self._lock = threading.RLock()
         self._closed = False
@@ -99,14 +98,8 @@ class FixedShapeSinglePassGraph:
             self._outputs(self._run_forward(*static_inputs))
             stream.synchronize()
             graph = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(
-                graph,
-                stream=stream,
-                pool=self._pool,
-            ):
+            with torch.cuda.graph(graph, stream=stream):
                 outputs = self._outputs(self._run_forward(*static_inputs))
-            if self._pool is None:
-                self._pool = graph.pool()
             graph.replay()
         return _GraphEntry(static_inputs, outputs, graph)
 

--- a/tests/asr/test_parakeet_runtime_stream.py
+++ b/tests/asr/test_parakeet_runtime_stream.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from kestrel.models.parakeet_tdt.runtime import ParakeetTdtRuntime
+from kestrel.runtime.single_pass_graph import FixedShapeSinglePassGraph
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_disabled_encoder_graph_keeps_generated_decode_on_configured_stream() -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    compute_stream = torch.cuda.Stream(device=device)
+    producer_stream = torch.cuda.Stream(device=device)
+    streams = []
+
+    class _Model:
+        def encode(
+            self, features: torch.Tensor, mask: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            streams.append(("encode", torch.cuda.current_stream(device)))
+            return features + 1, mask
+
+    class _Decoder:
+        minimum_batch = 1
+
+        def generate(
+            self,
+            encoded: torch.Tensor,
+            valid: torch.Tensor,
+            *,
+            max_tokens: int,
+        ) -> SimpleNamespace:
+            del max_tokens
+            with torch.cuda.stream(compute_stream):
+                streams.append(("decode", torch.cuda.current_stream(device)))
+                torch.testing.assert_close(encoded, torch.full_like(encoded, 4))
+                batch = encoded.shape[0]
+                return SimpleNamespace(
+                    lengths=torch.ones(batch, dtype=torch.long, device=device),
+                    sequences=torch.zeros(
+                        (batch, 2), dtype=torch.long, device=device
+                    ),
+                    durations=torch.zeros(
+                        (batch, 2), dtype=torch.long, device=device
+                    ),
+                    encoder_frame_seconds=0.08,
+                )
+
+    class _Tokenizer:
+        def decode(self, _token_ids: list[int]) -> str:
+            return "ok"
+
+    model = _Model()
+    runtime = ParakeetTdtRuntime.__new__(ParakeetTdtRuntime)
+    runtime.device = device
+    runtime.dtype = torch.bfloat16
+    runtime.model = model
+    runtime.tokenizer = _Tokenizer()
+    runtime._batch_decoder = _Decoder()
+    runtime._encoder_graph = FixedShapeSinglePassGraph(
+        enabled=False,
+        device=device,
+        stream=compute_stream,
+        run_forward=model.encode,
+    )
+
+    features = torch.zeros((1, 4), dtype=torch.bfloat16, device=device)
+    mask = torch.ones((1, 4), dtype=torch.bool, device=device)
+    runtime._batch_audio_features = lambda _rows: (features, mask)
+    waveform = np.ones(320, dtype=np.float32)
+    with torch.cuda.stream(producer_stream):
+        torch.cuda._sleep(5_000_000)
+        features.fill_(3)
+        result = runtime.forward(
+            "transcribe",
+            (
+                {
+                    "audio": waveform,
+                    "sample_rate": 16_000,
+                    "timestamps": "none",
+                },
+            ),
+        )
+
+    assert result[0]["text"] == "ok"
+    assert streams == [("encode", compute_stream), ("decode", compute_stream)]
+    runtime.shutdown()

--- a/tests/test_single_pass_graph.py
+++ b/tests/test_single_pass_graph.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from kestrel.runtime.single_pass_graph import FixedShapeSinglePassGraph
+
+
+def test_disabled_session_runs_eager_and_refuses_after_shutdown() -> None:
+    calls = []
+
+    def forward(value: torch.Tensor) -> tuple[torch.Tensor]:
+        calls.append(value)
+        return (value + 1,)
+
+    session = FixedShapeSinglePassGraph(
+        enabled=False,
+        device=torch.device("cpu"),
+        stream=None,
+        run_forward=forward,
+        max_entries=1,
+    )
+    with session.launch(torch.tensor([2])) as (output,):
+        assert output.tolist() == [3]
+    assert len(calls) == 1
+    session.shutdown()
+    session.shutdown()
+    with pytest.raises(RuntimeError, match="shut down"):
+        with session.launch(torch.tensor([2])):
+            pass
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_cuda_session_replays_stable_outputs_and_bounds_shapes() -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    stream = torch.cuda.Stream(device=device)
+    calls = 0
+
+    def forward(value: torch.Tensor) -> tuple[torch.Tensor]:
+        nonlocal calls
+        calls += 1
+        return (value.square() + 1,)
+
+    session = FixedShapeSinglePassGraph(
+        enabled=True,
+        device=device,
+        stream=stream,
+        run_forward=forward,
+        max_entries=1,
+    )
+    first = torch.arange(4, device=device, dtype=torch.float32)
+    with session.launch(first) as (output,):
+        stream.synchronize()
+        pointer = output.data_ptr()
+        torch.testing.assert_close(output, first.square() + 1)
+    assert calls == 2
+
+    with session.launch(first + 1) as (output,):
+        stream.synchronize()
+        assert output.data_ptr() == pointer
+        torch.testing.assert_close(output, (first + 1).square() + 1)
+    assert calls == 2
+
+    with session.launch(torch.arange(5, device=device)) as (output,):
+        stream.synchronize()
+        torch.testing.assert_close(output, torch.arange(5, device=device).square() + 1)
+    assert calls == 4
+
+    with session.launch(first) as (output,):
+        stream.synchronize()
+        torch.testing.assert_close(output, first.square() + 1)
+    assert calls == 6
+    session.shutdown()

--- a/tests/test_single_pass_graph.py
+++ b/tests/test_single_pass_graph.py
@@ -91,6 +91,36 @@ def test_cuda_session_owns_nondefault_stream_and_waits_for_producer() -> None:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_cuda_disabled_session_keeps_eager_forward_and_consumers_ordered() -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    target = torch.cuda.Stream(device=device)
+    producer = torch.cuda.Stream(device=device)
+    observed_streams = []
+
+    def forward(value: torch.Tensor) -> tuple[torch.Tensor]:
+        observed_streams.append(torch.cuda.current_stream(device))
+        return (value.square() + 1,)
+
+    session = FixedShapeSinglePassGraph(
+        enabled=False,
+        device=device,
+        stream=target,
+        run_forward=forward,
+    )
+    value = torch.zeros(4096, device=device)
+    with torch.cuda.stream(producer):
+        torch.cuda._sleep(5_000_000)
+        value.fill_(3)
+        with session.launch(value) as (output,):
+            assert torch.cuda.current_stream(device) == target
+            consumed = output + 2
+            target.synchronize()
+            torch.testing.assert_close(consumed, value.square() + 3)
+    assert observed_streams == [target]
+    session.shutdown()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_cuda_session_retains_four_shapes_and_evicts_the_fifth() -> None:
     device = torch.device("cuda", torch.cuda.current_device())
     stream = torch.cuda.Stream(device=device)

--- a/tests/test_single_pass_graph.py
+++ b/tests/test_single_pass_graph.py
@@ -22,12 +22,72 @@ def test_disabled_session_runs_eager_and_refuses_after_shutdown() -> None:
     )
     with session.launch(torch.tensor([2])) as (output,):
         assert output.tolist() == [3]
+        with pytest.raises(RuntimeError, match="cannot be nested"):
+            with session.launch(torch.tensor([4])):
+                pass
+        with pytest.raises(RuntimeError, match="during an active lease"):
+            session.shutdown()
     assert len(calls) == 1
     session.shutdown()
     session.shutdown()
     with pytest.raises(RuntimeError, match="shut down"):
         with session.launch(torch.tensor([2])):
             pass
+
+
+def test_shutdown_releases_state_when_stream_synchronize_fails() -> None:
+    session = FixedShapeSinglePassGraph(
+        enabled=False,
+        device=torch.device("cpu"),
+        stream=None,
+        run_forward=lambda value: (value,),
+    )
+
+    class _FailingStream:
+        def synchronize(self) -> None:
+            raise RuntimeError("sync failed")
+
+    session.enabled = True
+    session._stream = _FailingStream()  # type: ignore[assignment]
+    session._entries[()] = object()  # type: ignore[index,assignment]
+    with pytest.raises(RuntimeError, match="sync failed"):
+        session.shutdown()
+    assert not session._entries
+    assert session._stream is None
+    assert session._run_forward(torch.tensor([1])) == ()
+    session.shutdown()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_cuda_session_owns_nondefault_stream_and_waits_for_producer() -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    session = FixedShapeSinglePassGraph(
+        enabled=True,
+        device=device,
+        stream=None,
+        run_forward=lambda value: (value.square() + 1,),
+    )
+    assert session._stream is not None
+    assert session._stream != torch.cuda.default_stream(device)
+
+    value = torch.zeros(4096, device=device)
+    producer = torch.cuda.Stream(device=device)
+    with torch.cuda.stream(producer):
+        torch.cuda._sleep(5_000_000)
+        value.fill_(3)
+        with session.launch(value) as (output,):
+            assert session._stream is not None
+            session._stream.synchronize()
+            torch.testing.assert_close(output, value.square() + 1)
+    session.shutdown()
+
+    with pytest.raises(ValueError, match="non-default stream"):
+        FixedShapeSinglePassGraph(
+            enabled=True,
+            device=device,
+            stream=torch.cuda.default_stream(device),
+            run_forward=lambda item: (item,),
+        )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/test_single_pass_graph.py
+++ b/tests/test_single_pass_graph.py
@@ -31,7 +31,7 @@ def test_disabled_session_runs_eager_and_refuses_after_shutdown() -> None:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-def test_cuda_session_replays_stable_outputs_and_bounds_shapes() -> None:
+def test_cuda_session_retains_four_shapes_and_evicts_the_fifth() -> None:
     device = torch.device("cuda", torch.cuda.current_device())
     stream = torch.cuda.Stream(device=device)
     calls = 0
@@ -46,7 +46,7 @@ def test_cuda_session_replays_stable_outputs_and_bounds_shapes() -> None:
         device=device,
         stream=stream,
         run_forward=forward,
-        max_entries=1,
+        max_entries=4,
     )
     first = torch.arange(4, device=device, dtype=torch.float32)
     with session.launch(first) as (output,):
@@ -61,13 +61,32 @@ def test_cuda_session_replays_stable_outputs_and_bounds_shapes() -> None:
         torch.testing.assert_close(output, (first + 1).square() + 1)
     assert calls == 2
 
-    with session.launch(torch.arange(5, device=device)) as (output,):
-        stream.synchronize()
-        torch.testing.assert_close(output, torch.arange(5, device=device).square() + 1)
-    assert calls == 4
+    pointers = {4: pointer}
+    for size in (1, 2, 8):
+        value = torch.arange(size, device=device, dtype=torch.float32)
+        with session.launch(value) as (output,):
+            stream.synchronize()
+            pointers[size] = output.data_ptr()
+            torch.testing.assert_close(output, value.square() + 1)
+    assert calls == 8
 
+    for size in (4, 1, 2, 8):
+        value = torch.arange(size, device=device, dtype=torch.float32) + 2
+        with session.launch(value) as (output,):
+            stream.synchronize()
+            assert output.data_ptr() == pointers[size]
+            torch.testing.assert_close(output, value.square() + 1)
+    assert calls == 8
+
+    fifth = torch.arange(6, device=device, dtype=torch.float32)
+    with session.launch(fifth) as (output,):
+        stream.synchronize()
+        torch.testing.assert_close(output, fifth.square() + 1)
+    assert calls == 10
+
+    # Shape four was the least recently used after the replay sequence above.
     with session.launch(first) as (output,):
         stream.synchronize()
         torch.testing.assert_close(output, first.square() + 1)
-    assert calls == 6
+    assert calls == 12
     session.shutdown()


### PR DESCRIPTION
## Summary
- add a bounded fixed-shape CUDA graph session for single-pass operations
- retain four Parakeet encoder shapes with independent graph pools
- keep captured and eager execution on one explicitly ordered compute stream
- fail closed on invalid streams and safely release graph state during shutdown

## L4 performance
Exact counterbalanced Parakeet vs NeMo, transcript parity true:
- C4: 30.133 ms vs 104.598 ms (3.471x)
- C8: 47.109 ms vs 190.351 ms (4.041x)

The final stream-ordering commit changes only the graphs-disabled eager route; the measured graph-enabled hot path is unchanged.

## Validation
- focused Modal L4: 6 passed (ap-raDt2M8FQAsn248XwykmA0)
- delayed cross-stream producer coverage for captured and eager sessions
- four-shape retention/fifth-shape eviction coverage
- direct Parakeet generated-decode stream-route regression
- final adversarial review: zero findings