### PR TITLE
Retain Whisper no-speech score from native prefill

### DIFF
--- a/kestrel/models/whisper/prefill_decoder_prefix.py
+++ b/kestrel/models/whisper/prefill_decoder_prefix.py
@@ -41,6 +41,7 @@ _VISION = _KERNELS.vision
 CONTROL_PREFIX_CAPACITY = 4
 MAX_TARGET_POSITIONS = 448
 VOCAB_SIZE = 51866
+NO_SPEECH_TOKEN_ID = 50361
 
 
 @dataclass(frozen=True)
@@ -83,6 +84,10 @@ class WhisperDecoderPrefixWorkspace:
     mlp_hidden: torch.Tensor
     final_hidden: torch.Tensor
     last_hidden: torch.Tensor
+    projection_hidden: torch.Tensor
+    projection_logits: torch.Tensor
+    no_speech_scores: torch.Tensor
+    no_speech_normalizer: torch.Tensor
     last_indices: torch.Tensor
     kv_scale: torch.Tensor
 
@@ -104,6 +109,9 @@ class WhisperDecoderPrefixWorkspace:
             raise ValueError("Whisper decoder-prefix workspace requires a CUDA device")
         dtype = torch.bfloat16
         shape = (batch_size, CONTROL_PREFIX_CAPACITY, HIDDEN_SIZE)
+        projection_hidden = torch.empty(
+            (2 * batch_size, HIDDEN_SIZE), device=resolved_device, dtype=dtype
+        )
         return cls(
             batch_size=batch_size,
             hidden=torch.empty(shape, device=resolved_device, dtype=dtype),
@@ -134,8 +142,21 @@ class WhisperDecoderPrefixWorkspace:
                 dtype=dtype,
             ),
             final_hidden=torch.empty(shape, device=resolved_device, dtype=dtype),
-            last_hidden=torch.empty(
-                (batch_size, HIDDEN_SIZE), device=resolved_device, dtype=dtype
+            # The first projection block is also the public last-hidden view.
+            # Keeping one pointer-stable backing removes a device copy from
+            # every captured prefix graph.
+            last_hidden=projection_hidden[:batch_size],
+            projection_hidden=projection_hidden,
+            projection_logits=torch.empty(
+                (2 * batch_size, VOCAB_SIZE), device=resolved_device, dtype=dtype
+            ),
+            no_speech_scores=torch.empty(
+                (batch_size, VOCAB_SIZE),
+                device=resolved_device,
+                dtype=torch.float32,
+            ),
+            no_speech_normalizer=torch.empty(
+                (batch_size,), device=resolved_device, dtype=torch.float32
             ),
             last_indices=torch.empty(
                 (batch_size,), device=resolved_device, dtype=torch.int64
@@ -251,6 +272,7 @@ def prepare_whisper_decoder_weights(
 def _validate_prefix_inputs(
     control_token_ids: torch.Tensor,
     prefix_lengths: torch.Tensor,
+    sot_positions: torch.Tensor,
     slot_mapping: torch.Tensor,
     compact_cross_keys: torch.Tensor,
     compact_cross_values: torch.Tensor,
@@ -279,6 +301,13 @@ def _validate_prefix_inputs(
         raise ValueError(
             "prefix_lengths must be contiguous CUDA INT32 [batch] with values 1, 3, or 4"
         )
+    if (
+        tuple(sot_positions.shape) != (batch,)
+        or sot_positions.dtype != torch.int64
+        or sot_positions.device != device
+        or not sot_positions.is_contiguous()
+    ):
+        raise ValueError("sot_positions must be contiguous CUDA INT64 [batch]")
     if (
         tuple(slot_mapping.shape) != (batch, CONTROL_PREFIX_CAPACITY)
         or slot_mapping.dtype != torch.int64
@@ -472,6 +501,7 @@ def _run_decoder_layer(
 def whisper_decoder_prefix(
     control_token_ids: torch.Tensor,
     prefix_lengths: torch.Tensor,
+    sot_positions: torch.Tensor,
     slot_mapping: torch.Tensor,
     compact_cross_keys: torch.Tensor,
     compact_cross_values: torch.Tensor,
@@ -480,6 +510,7 @@ def whisper_decoder_prefix(
     self_kv: WhisperSelfKVArenas,
     *,
     logits_out: torch.Tensor,
+    separate_sot_projection: bool = True,
     require_packed: bool = False,
 ) -> WhisperDecoderPrefixOutput:
     """Prefill mixed 1/3/4-token control prefixes and seed decode logits.
@@ -492,6 +523,8 @@ def whisper_decoder_prefix(
     automatic-language and explicit-language requests.
     """
 
+    if type(separate_sot_projection) is not bool:
+        raise TypeError("separate_sot_projection must be bool")
     # Tried one native paged-decode-style step per control token: at B1/B4/B8
     # it cost 0.99-1.06x this batched graph for length 1, while this graph was
     # 3.30-3.60x faster for length 4 on H100/B200.  Keeping one Bx4 graph so
@@ -499,6 +532,7 @@ def whisper_decoder_prefix(
     _validate_prefix_inputs(
         control_token_ids,
         prefix_lengths,
+        sot_positions,
         slot_mapping,
         compact_cross_keys,
         compact_cross_values,
@@ -542,25 +576,130 @@ def whisper_decoder_prefix(
         last_indices,
         out=workspace.last_hidden.view(workspace.batch_size, 1, HIDDEN_SIZE),
     )
+    if not separate_sot_projection:
+        # The overwhelmingly common automatic-language prefix is SOT alone,
+        # so its last-token logits already are the upstream SOT distribution.
+        # Keep that graph on the original B-row projection instead of paying
+        # for the packed 2B projection used by earlier-SOT prefixes.
+        _LINEAR.linear(
+            workspace.last_hidden,
+            weights.token_embedding,
+            None,
+            out=logits_out,
+        )
+        return WhisperDecoderPrefixOutput(
+            logits=logits_out,
+            last_hidden_state=workspace.last_hidden,
+        )
+    # Project the last valid prefix row and the staged SOT row together.
+    # ``sot_positions`` is host-derived from the exact prefix. Rows whose SOT
+    # lies in the forced tail carry the safe dummy index zero here and are not
+    # marked scored by the runtime; their actual raw logits are retained from
+    # the decode step that consumes SOT.
+    sot_indices = sot_positions.view(-1, 1, 1).expand(-1, 1, HIDDEN_SIZE)
+    torch.gather(
+        workspace.final_hidden,
+        1,
+        sot_indices,
+        out=workspace.projection_hidden[workspace.batch_size :].view(
+            workspace.batch_size, 1, HIDDEN_SIZE
+        ),
+    )
     _LINEAR.linear(
-        workspace.last_hidden,
+        workspace.projection_hidden,
         weights.token_embedding,
         None,
-        out=logits_out,
+        out=workspace.projection_logits,
     )
+    logits_out.copy_(workspace.projection_logits[: workspace.batch_size])
     return WhisperDecoderPrefixOutput(
         logits=logits_out,
         last_hidden_state=workspace.last_hidden,
     )
 
 
+@torch.inference_mode()
+def whisper_no_speech_probabilities(
+    workspace: WhisperDecoderPrefixWorkspace,
+    *,
+    probabilities_out: torch.Tensor,
+) -> torch.Tensor:
+    """Retain Whisper's unfiltered SOT probability from a completed prefill."""
+
+    batch = workspace.batch_size
+    if (
+        tuple(probabilities_out.shape) != (batch,)
+        or probabilities_out.device != workspace.device
+        or probabilities_out.dtype != torch.float32
+        or not probabilities_out.is_contiguous()
+    ):
+        raise ValueError("probabilities_out must be contiguous CUDA FP32 [batch]")
+    return whisper_no_speech_probabilities_from_logits(
+        workspace.projection_logits[batch:],
+        scores=workspace.no_speech_scores,
+        normalizer=workspace.no_speech_normalizer,
+        probabilities_out=probabilities_out,
+    )
+
+
+@torch.inference_mode()
+def whisper_no_speech_probabilities_from_logits(
+    logits: torch.Tensor,
+    *,
+    scores: torch.Tensor,
+    normalizer: torch.Tensor,
+    probabilities_out: torch.Tensor,
+) -> torch.Tensor:
+    """Reduce unfiltered BF16 decoder logits into the fixed SOT probability."""
+
+    if logits.ndim != 2:
+        raise ValueError("no-speech logits must be contiguous BF16 [batch, vocab]")
+    batch, vocab = logits.shape
+    if (
+        vocab != VOCAB_SIZE
+        or logits.dtype != torch.bfloat16
+        or not logits.is_contiguous()
+        or tuple(scores.shape) != (batch, vocab)
+        or scores.device != logits.device
+        or scores.dtype != torch.float32
+        or not scores.is_contiguous()
+        or tuple(normalizer.shape) != (batch,)
+        or normalizer.device != logits.device
+        or normalizer.dtype != torch.float32
+        or not normalizer.is_contiguous()
+        or tuple(probabilities_out.shape) != (batch,)
+        or probabilities_out.device != logits.device
+        or probabilities_out.dtype != torch.float32
+        or not probabilities_out.is_contiguous()
+    ):
+        raise ValueError(
+            "no-speech reduction requires contiguous colocated logits/scratch"
+        )
+    scores.copy_(logits)
+    torch.logsumexp(
+        scores,
+        dim=1,
+        out=normalizer,
+    )
+    torch.sub(
+        scores[:, NO_SPEECH_TOKEN_ID],
+        normalizer,
+        out=probabilities_out,
+    )
+    torch.exp(probabilities_out, out=probabilities_out)
+    return probabilities_out
+
+
 __all__ = [
     "CONTROL_PREFIX_CAPACITY",
     "MAX_TARGET_POSITIONS",
+    "NO_SPEECH_TOKEN_ID",
     "VOCAB_SIZE",
     "PreparedWhisperDecoderWeights",
     "WhisperDecoderPrefixOutput",
     "WhisperDecoderPrefixWorkspace",
     "prepare_whisper_decoder_weights",
     "whisper_decoder_prefix",
+    "whisper_no_speech_probabilities",
+    "whisper_no_speech_probabilities_from_logits",
 ]

--- a/kestrel/models/whisper/prefill_session.py
+++ b/kestrel/models/whisper/prefill_session.py
@@ -13,6 +13,7 @@ from .prefill_decoder_prefix import (
     WhisperDecoderPrefixWorkspace,
     prepare_whisper_decoder_weights,
     whisper_decoder_prefix,
+    whisper_no_speech_probabilities_from_logits,
 )
 from .prefill_encoder import (
     PreparedWhisperEncoderWeights,
@@ -60,7 +61,7 @@ class NativeWhisperPrefillSession(WhisperPrefillSession):
         self._workspaces: dict[
             int, tuple[WhisperEncoderWorkspace, WhisperDecoderPrefixWorkspace]
         ] = {}
-        self._graphs: dict[tuple[int, int], torch.cuda.CUDAGraph] = {}
+        self._graphs: dict[tuple[int, int, bool], torch.cuda.CUDAGraph] = {}
         self._require_packed = bool(require_packed)
         self._artifact_receipts: tuple[dict[str, object], ...] = ()
         self._lock = threading.Lock()
@@ -79,7 +80,13 @@ class NativeWhisperPrefillSession(WhisperPrefillSession):
             self._workspaces[batch_size] = workspace
         return workspace
 
-    def _run(self, slot: WhisperPrefillBuffers, batch_size: int) -> None:
+    def _run(
+        self,
+        slot: WhisperPrefillBuffers,
+        batch_size: int,
+        *,
+        separate_sot_projection: bool,
+    ) -> None:
         weights = self._weights
         cross_kv = self._cross_kv
         self_kv = self._self_kv
@@ -102,6 +109,7 @@ class NativeWhisperPrefillSession(WhisperPrefillSession):
         whisper_decoder_prefix(
             slot.control_token_ids[:batch_size],
             slot.prefix_lengths[:batch_size],
+            slot.sot_positions[:batch_size],
             slot.slot_mapping[:batch_size],
             encoder_workspace.compact_cross_keys,
             encoder_workspace.compact_cross_values,
@@ -109,13 +117,37 @@ class NativeWhisperPrefillSession(WhisperPrefillSession):
             decoder_workspace,
             self_kv,
             logits_out=slot.logits_out[:batch_size],
+            separate_sot_projection=separate_sot_projection,
             require_packed=self._require_packed,
+        )
+
+    def _score_no_speech(
+        self,
+        slot: WhisperPrefillBuffers,
+        batch_size: int,
+        *,
+        separate_sot_projection: bool,
+    ) -> None:
+        if self._weights is None:
+            raise RuntimeError("Whisper prefill session is shut down")
+        _, decoder_workspace = self._workspace(batch_size)
+        logits = (
+            decoder_workspace.projection_logits[batch_size:]
+            if separate_sot_projection
+            else slot.logits_out[:batch_size]
+        )
+        whisper_no_speech_probabilities_from_logits(
+            logits,
+            scores=decoder_workspace.no_speech_scores,
+            normalizer=decoder_workspace.no_speech_normalizer,
+            probabilities_out=slot.no_speech_probs_out[:batch_size],
         )
 
     def _stage_warmup(self, slot: WhisperPrefillBuffers, batch_size: int) -> None:
         slot.input_features[:batch_size].zero_()
         slot.control_token_ids[:batch_size].fill_(50258)
         slot.prefix_lengths[:batch_size].fill_(1)
+        slot.sot_positions[:batch_size].zero_()
         slot.slot_mapping[:batch_size].zero_()
         slot.batch_idx[:batch_size].copy_(
             torch.arange(
@@ -143,18 +175,35 @@ class NativeWhisperPrefillSession(WhisperPrefillSession):
                 with torch.cuda.stream(self._stream):
                     for batch_size in range(1, self._max_batch_size + 1):
                         self._stage_warmup(warmup_slot, batch_size)
-                        self._run(warmup_slot, batch_size)
+                        for separate_sot_projection in (False, True):
+                            self._run(
+                                warmup_slot,
+                                batch_size,
+                                separate_sot_projection=separate_sot_projection,
+                            )
+                            self._score_no_speech(
+                                warmup_slot,
+                                batch_size,
+                                separate_sot_projection=separate_sot_projection,
+                            )
                 self._stream.synchronize()
 
                 for batch_size in range(1, self._max_batch_size + 1):
                     for slot_id, slot in self._buffers.items():
-                        with torch.cuda.stream(self._stream):
-                            self._stage_warmup(slot, batch_size)
-                        self._stream.synchronize()
-                        graph = torch.cuda.CUDAGraph()
-                        with torch.cuda.graph(graph, stream=self._stream):
-                            self._run(slot, batch_size)
-                        self._graphs[(slot_id, batch_size)] = graph
+                        for separate_sot_projection in (False, True):
+                            with torch.cuda.stream(self._stream):
+                                self._stage_warmup(slot, batch_size)
+                            self._stream.synchronize()
+                            graph = torch.cuda.CUDAGraph()
+                            with torch.cuda.graph(graph, stream=self._stream):
+                                self._run(
+                                    slot,
+                                    batch_size,
+                                    separate_sot_projection=separate_sot_projection,
+                                )
+                            self._graphs[
+                                (slot_id, batch_size, separate_sot_projection)
+                            ] = graph
                 self._stream.synchronize()
             receipts = receipt_capture.receipts
             if self._require_packed and not receipts:
@@ -165,14 +214,28 @@ class NativeWhisperPrefillSession(WhisperPrefillSession):
             self._warmed = True
 
     @torch.inference_mode()
-    def launch(self, slot_id: int, batch_size: int) -> None:
+    def launch(
+        self,
+        slot_id: int,
+        batch_size: int,
+        *,
+        separate_sot_projection: bool,
+        retain_sot_score: bool,
+    ) -> None:
         if self._closed:
             raise RuntimeError("Whisper prefill session is shut down")
         if not self._warmed:
             raise RuntimeError("Whisper prefill session must be warmed before launch")
         if not 0 < int(batch_size) <= self._max_batch_size:
             raise ValueError("Whisper prefill batch is outside session capacity")
-        key = (int(slot_id), int(batch_size))
+        if (
+            type(separate_sot_projection) is not bool
+            or type(retain_sot_score) is not bool
+        ):
+            raise TypeError("Whisper SOT projection and retention modes must be bool")
+        if separate_sot_projection and not retain_sot_score:
+            raise ValueError("separate Whisper SOT projection requires score retention")
+        key = (int(slot_id), int(batch_size), separate_sot_projection)
         try:
             graph = self._graphs[key]
         except KeyError as exc:
@@ -180,6 +243,12 @@ class NativeWhisperPrefillSession(WhisperPrefillSession):
                 f"No captured Whisper prefill graph for slot/batch {key}"
             ) from exc
         graph.replay()
+        if retain_sot_score:
+            self._score_no_speech(
+                self._buffers[int(slot_id)],
+                int(batch_size),
+                separate_sot_projection=separate_sot_projection,
+            )
 
     def shutdown(self) -> None:
         with self._lock:

--- a/kestrel/models/whisper/runtime.py
+++ b/kestrel/models/whisper/runtime.py
@@ -51,12 +51,12 @@ from .alignment import (
     TranscriptAnalysis,
     TranscriptScores,
     align_transcript_words,
-    no_speech_probability,
 )
 from .assets import CHECKPOINT_REVISION, MODEL_NAME, REPO_ID, WhisperAssets
 from .audio import AudioSource, PreparedAudio, prepare_audio
 from .config import WhisperPreprocessorConfig, WhisperTurboConfig
 from .generated_decode import create_generated_decode
+from .prefill_decoder_prefix import whisper_no_speech_probabilities_from_logits
 from .prefill_session import NativeWhisperPrefillSession
 from .runtime_abi import (
     WhisperExecutionBindings,
@@ -285,6 +285,7 @@ class WhisperPrefillSlot:
     features: CpuGpuBuffer
     metadata: PackedBuffer
     logits: Tensor
+    no_speech_probs: Tensor
 
     def execution_buffers(self) -> WhisperPrefillBuffers:
         return WhisperPrefillBuffers(
@@ -292,9 +293,11 @@ class WhisperPrefillSlot:
             input_features=self.features.gpu,
             control_token_ids=self.metadata.control_token_ids.gpu,
             prefix_lengths=self.metadata.prefix_lengths.gpu,
+            sot_positions=self.metadata.sot_positions.gpu,
             batch_idx=self.batch_idx,
             slot_mapping=self.metadata.slot_mapping.gpu,
             logits_out=self.logits,
+            no_speech_probs_out=self.no_speech_probs,
         )
 
 
@@ -530,6 +533,7 @@ class WhisperRuntime(UncachedPagedRuntime):
             process_logits=self._process_logits,
             adjust_sampling_params=self._adjust_sampling_params,
             score_sampled_tokens=self._score_sampled_tokens,
+            prepare_decode_inputs=self._prepare_decode_inputs,
             require_packed_greedy_logprobs=self._require_native,
         )
 
@@ -547,6 +551,11 @@ class WhisperRuntime(UncachedPagedRuntime):
         self._sampling_artifact_receipts: tuple[dict[str, object], ...] = ()
         self._prepared_audio: dict[int, PreparedAudio] = {}
         self._owned_cross_rows: set[int] = set()
+        self._no_speech_score_rows: set[int] = set()
+        self._pending_no_speech_score_rows: set[int] = set()
+        self._no_speech_probs = torch.empty(
+            (self.max_batch_slots,), dtype=torch.float32, device=self.device
+        )
         self.active_sequences: dict[int, Any] = {}
 
         if kv_pool is None:
@@ -629,12 +638,44 @@ class WhisperRuntime(UncachedPagedRuntime):
                 vocab_size=self.vocab_size,
                 hidden_dim=self._config.d_model,
                 position_shape=(decode_rows, 1),
+                scratch_specs={
+                    "whisper_no_speech_logits": (
+                        (self.max_batch_size, self.vocab_size),
+                        self.dtype,
+                    ),
+                    "whisper_no_speech_scores": (
+                        (self.max_batch_size, self.vocab_size),
+                        torch.float32,
+                    ),
+                    "whisper_no_speech_normalizer": (
+                        (self.max_batch_size,),
+                        torch.float32,
+                    ),
+                    "whisper_no_speech_probs": (
+                        (self.max_batch_size,),
+                        torch.float32,
+                    ),
+                },
                 compute_stream=self._compute_stream,
                 copy_stream=self._copy_stream,
             )
             for slot_id in range(_DECODE_SLOT_COUNT)
         )
         self.decode_slots: Sequence[DecodeSlot] = self._decode_slots
+        self._no_speech_decode_indices = tuple(
+            PackedBuffer(
+                [
+                    ("compact_rows", (self.max_batch_size,), torch.int64),
+                    ("batch_rows", (self.max_batch_size,), torch.int64),
+                ],
+                device=self.device,
+                pin_memory=self.device.type == "cuda",
+            )
+            for _slot in self._decode_slots
+        )
+        self._no_speech_decode_bindings: list[tuple[int, ...]] = [
+            () for _slot in self._decode_slots
+        ]
 
         # Sampling can overlap two resident pipeline slots. Each slot therefore
         # owns its own pinned constraint source and GPU destination: mutating a
@@ -779,14 +820,13 @@ class WhisperRuntime(UncachedPagedRuntime):
             max(1, int(math.ceil(duration_seconds * 50.0))),
         )
         with stream_context(self._compute_stream):
-            no_speech_prob = no_speech_probability(
-                decoder=decoder,
-                tokenizer=self.tokenizer,
-                prefix_token_ids=prefix_token_ids,
-                cross_keys=self.cross_kv.keys[:, batch_idx : batch_idx + 1],
-                cross_values=self.cross_kv.values[:, batch_idx : batch_idx + 1],
-                config=self._config,
-            )
+            if batch_idx not in self._no_speech_score_rows:
+                raise RuntimeError(
+                    "Whisper decoder analysis is missing its native SOT score"
+                )
+            no_speech_prob = float(self._no_speech_probs[batch_idx].item())
+            if not math.isfinite(no_speech_prob) or not 0.0 <= no_speech_prob <= 1.0:
+                raise RuntimeError("Whisper native SOT score is invalid")
             words = (
                 align_transcript_words(
                     decoder=decoder,
@@ -830,6 +870,7 @@ class WhisperRuntime(UncachedPagedRuntime):
                     torch.int64,
                 ),
                 ("prefix_lengths", (self.max_batch_size,), torch.int32),
+                ("sot_positions", (self.max_batch_size,), torch.int64),
                 ("batch_idx", (self.max_batch_size,), torch.int64),
                 (
                     "slot_mapping",
@@ -854,6 +895,11 @@ class WhisperRuntime(UncachedPagedRuntime):
             logits=torch.empty(
                 (self.max_batch_size, self.vocab_size),
                 dtype=self.dtype,
+                device=self.device,
+            ),
+            no_speech_probs=torch.empty(
+                (self.max_batch_size,),
+                dtype=torch.float32,
                 device=self.device,
             ),
         )
@@ -947,6 +993,62 @@ class WhisperRuntime(UncachedPagedRuntime):
             constraints,
             require_packed=self._require_native,
         )
+        # A forced-tail SOT is known on the host even while its sampled token
+        # remains device-resident. Remember that its *next* decode forward
+        # owns the upstream no-speech distribution; decode captures those raw
+        # logits before the scheduler can apply any masks in place.
+        for sequence in sequences:
+            state = sequence.skill_state
+            forced = state.allowed_token_ids(self)
+            if forced != (state.controls.decoder_start_id,):
+                continue
+            sequence_state = getattr(sequence, "state", None)
+            if sequence_state is None:
+                raise TypeError("Whisper forced SOT requires sequence state ownership")
+            row = int(sequence_state.batch_idx)
+            if row not in self._no_speech_score_rows:
+                self._pending_no_speech_score_rows.add(row)
+
+    def _prepare_decode_inputs(
+        self,
+        slot: DecodeSlot,
+        batch_idx: Tensor,
+        batch_size: int,
+    ) -> None:
+        """Bind pending forced-tail SOT rows to this decode slot's compact order."""
+
+        slot_id = int(slot.slot_id)
+        if (
+            slot_id not in range(len(self._decode_slots))
+            or self._decode_slots[slot_id] is not slot
+            or batch_idx.data_ptr() != slot.meta.batch_idx.gpu.data_ptr()
+            or not 0 < int(batch_size) <= self.max_batch_size
+        ):
+            raise ValueError("Whisper no-speech decode binding received a foreign slot")
+        if self._no_speech_decode_bindings[slot_id]:
+            raise RuntimeError("Whisper no-speech decode binding was not consumed")
+        host_rows = tuple(
+            int(value) for value in slot.meta.batch_idx.cpu[: int(batch_size)]
+        )
+        bound = tuple(
+            (compact_row, row)
+            for compact_row, row in enumerate(host_rows)
+            if row in self._pending_no_speech_score_rows
+        )
+        if not bound:
+            return
+        rows = tuple(row for _compact_row, row in bound)
+        if len(set(rows)) != len(rows):
+            raise RuntimeError(
+                "Whisper no-speech decode binding contains duplicate rows"
+            )
+        indices = self._no_speech_decode_indices[slot_id]
+        indices.compact_rows.cpu[: len(bound)] = torch.tensor(
+            [compact_row for compact_row, _row in bound], dtype=torch.int64
+        )
+        indices.batch_rows.cpu[: len(bound)] = torch.tensor(rows, dtype=torch.int64)
+        indices.copy_to_gpu()
+        self._no_speech_decode_bindings[slot_id] = rows
 
     def _score_sampled_tokens(
         self,
@@ -1155,7 +1257,12 @@ class WhisperRuntime(UncachedPagedRuntime):
         )
         row = int(prepared.state.batch_idx)
         try:
-            if row in self._owned_cross_rows or row in self._prepared_audio:
+            if (
+                row in self._owned_cross_rows
+                or row in self._prepared_audio
+                or row in self._no_speech_score_rows
+                or row in self._pending_no_speech_score_rows
+            ):
                 raise RuntimeError(f"Whisper state row {row} is already owned")
             self._owned_cross_rows.add(row)
             self._prepared_audio[row] = encoder_input
@@ -1182,18 +1289,22 @@ class WhisperRuntime(UncachedPagedRuntime):
         slot: WhisperPrefillSlot,
         prepared_sequences: Sequence[PreparedSequence],
         encoder_inputs: Sequence[object | None],
-    ) -> None:
+    ) -> tuple[tuple[int, ...], bool]:
         batch_size = len(prepared_sequences)
         controls_cpu = slot.metadata.control_token_ids.cpu
         lengths_cpu = slot.metadata.prefix_lengths.cpu
+        sot_positions_cpu = slot.metadata.sot_positions.cpu
         batch_idx_cpu = slot.metadata.batch_idx.cpu
         mapping_cpu = slot.metadata.slot_mapping.cpu
         controls_cpu.zero_()
         lengths_cpu.zero_()
+        sot_positions_cpu.zero_()
         batch_idx_cpu.zero_()
         mapping_cpu.zero_()
 
         rows: list[int] = []
+        scored_rows: list[int] = []
+        separate_sot_projection = False
         for compact_row, (prepared, supplied_audio) in enumerate(
             zip(prepared_sequences, encoder_inputs)
         ):
@@ -1220,6 +1331,17 @@ class WhisperRuntime(UncachedPagedRuntime):
                 token_ids, dtype=torch.int64
             )
             lengths_cpu[compact_row] = len(token_ids)
+            sot_positions = tuple(
+                index
+                for index, token_id in enumerate(token_ids)
+                if token_id == self.tokenizer.controls.decoder_start_id
+            )
+            if sot_positions:
+                # Match the legacy/upstream contract: the final decoder-start
+                # token in the prefix owns the no-speech distribution.
+                sot_positions_cpu[compact_row] = sot_positions[-1]
+                scored_rows.append(row)
+                separate_sot_projection |= sot_positions[-1] != len(token_ids) - 1
             batch_idx_cpu[compact_row] = row
             # page_size=1, so each physical page index is also the flat slot.
             mapping_cpu[compact_row, : len(token_ids)] = torch.tensor(
@@ -1229,6 +1351,7 @@ class WhisperRuntime(UncachedPagedRuntime):
         self.page_table.commit_block_table(rows)
         slot.features.copy_to_gpu(batch_size)
         slot.metadata.copy_to_gpu()
+        return tuple(scored_rows), separate_sot_projection
 
     @torch.inference_mode()
     def launch_prepared_batch(
@@ -1264,14 +1387,25 @@ class WhisperRuntime(UncachedPagedRuntime):
             raise RuntimeError("Whisper prefill slot must be acquired before launch")
 
         with stream_context(self._compute_stream):
-            self._stage_prefill(
+            scored_rows, separate_sot_projection = self._stage_prefill(
                 prefill_slot,
                 prepared_sequences,
                 encoder_inputs,
             )
             # Contract: this call enqueues every decoder-visible write, including
             # cross-K/V and prefix self-KV, before it returns.
-            self._prefill_session.launch(slot_id, batch_size)
+            self._prefill_session.launch(
+                slot_id,
+                batch_size,
+                separate_sot_projection=separate_sot_projection,
+                retain_sot_score=bool(scored_rows),
+            )
+            self._no_speech_probs.index_copy_(
+                0,
+                prefill_slot.batch_idx[:batch_size],
+                prefill_slot.no_speech_probs[:batch_size],
+            )
+            self._no_speech_score_rows.update(scored_rows)
         return prefill_slot.logits[:batch_size]
 
     def finalize_prepared_sequence_after_prefill(
@@ -1289,6 +1423,8 @@ class WhisperRuntime(UncachedPagedRuntime):
     def _release_runtime_state(self, batch_idx: int) -> None:
         self._prepared_audio.pop(batch_idx, None)
         self._owned_cross_rows.discard(batch_idx)
+        self._no_speech_score_rows.discard(batch_idx)
+        self._pending_no_speech_score_rows.discard(batch_idx)
 
     @torch.inference_mode()
     def decode_with_slot(self, slot: DecodeSlot, batch_size: int) -> None:
@@ -1320,7 +1456,38 @@ class WhisperRuntime(UncachedPagedRuntime):
             )
         # Resident slot tensors were bound at session construction. The
         # generated launch reads token_ids/input_pos/batch_idx and writes logits.
-        self._decode_session.run(slot, launch_capacity)
+        bound_rows = self._no_speech_decode_bindings[slot_id]
+        try:
+            self._decode_session.run(slot, launch_capacity)
+            if bound_rows:
+                count = len(bound_rows)
+                indices = self._no_speech_decode_indices[slot_id]
+                compact_rows = indices.compact_rows.gpu[:count]
+                raw_logits = slot.scratch["whisper_no_speech_logits"][:count]
+                torch.index_select(
+                    slot.logits[:batch_size],
+                    0,
+                    compact_rows,
+                    out=raw_logits,
+                )
+                probabilities = slot.scratch["whisper_no_speech_probs"][:count]
+                whisper_no_speech_probabilities_from_logits(
+                    raw_logits,
+                    scores=slot.scratch["whisper_no_speech_scores"][:count],
+                    normalizer=slot.scratch[
+                        "whisper_no_speech_normalizer"
+                    ][:count],
+                    probabilities_out=probabilities,
+                )
+                self._no_speech_probs.index_copy_(
+                    0,
+                    indices.batch_rows.gpu[:count],
+                    probabilities,
+                )
+                self._pending_no_speech_score_rows.difference_update(bound_rows)
+                self._no_speech_score_rows.update(bound_rows)
+        finally:
+            self._no_speech_decode_bindings[slot_id] = ()
 
     def _warmup_decode(self) -> None:
         slot = self._decode_slots[0]
@@ -1447,6 +1614,11 @@ class WhisperRuntime(UncachedPagedRuntime):
         self.active_sequences.clear()
         self._prepared_audio.clear()
         self._owned_cross_rows.clear()
+        self._no_speech_score_rows.clear()
+        self._pending_no_speech_score_rows.clear()
+        self._no_speech_decode_bindings[:] = [
+            () for _slot in self._no_speech_decode_bindings
+        ]
         if errors:
             raise errors[0]
 

--- a/kestrel/models/whisper/runtime_abi.py
+++ b/kestrel/models/whisper/runtime_abi.py
@@ -119,9 +119,11 @@ class WhisperPrefillBuffers:
     input_features: Tensor
     control_token_ids: Tensor
     prefix_lengths: Tensor
+    sot_positions: Tensor
     batch_idx: Tensor
     slot_mapping: Tensor
     logits_out: Tensor
+    no_speech_probs_out: Tensor
 
 
 @dataclass(frozen=True, slots=True)
@@ -162,7 +164,14 @@ class WhisperPrefillSession(Protocol):
 
     def warmup(self) -> None: ...
 
-    def launch(self, slot_id: int, batch_size: int) -> None: ...
+    def launch(
+        self,
+        slot_id: int,
+        batch_size: int,
+        *,
+        separate_sot_projection: bool,
+        retain_sot_score: bool,
+    ) -> None: ...
 
     def shutdown(self) -> None: ...
 
@@ -199,6 +208,11 @@ def validate_resident_buffers(
                 (max_batch_size,),
                 torch.int32,
             ),
+            "sot_positions": (
+                slot.sot_positions,
+                (max_batch_size,),
+                torch.int64,
+            ),
             "batch_idx": (
                 slot.batch_idx,
                 (max_batch_size,),
@@ -213,6 +227,11 @@ def validate_resident_buffers(
                 slot.logits_out,
                 (max_batch_size, config.vocab_size),
                 dtype,
+            ),
+            "no_speech_probs_out": (
+                slot.no_speech_probs_out,
+                (max_batch_size,),
+                torch.float32,
             ),
         }
         for name, (tensor, shape, expected_dtype) in expected.items():

--- a/tests/whisper/test_kernels_decoder_prefix.py
+++ b/tests/whisper/test_kernels_decoder_prefix.py
@@ -14,6 +14,7 @@ from kestrel.models.whisper.prefill_decoder_prefix import (
     WhisperDecoderPrefixWorkspace,
     prepare_whisper_decoder_weights,
     whisper_decoder_prefix,
+    whisper_no_speech_probabilities,
 )
 from kestrel.models.whisper.config import WhisperTurboConfig
 from kestrel.models.whisper.runtime_abi import WhisperSelfKVArenas
@@ -128,13 +129,15 @@ def _paged_state(config, *, state_rows):
 
 def test_mixed_prefix_matches_eager_oracle_paged_layout_and_graph() -> None:
     config, eager, weights = _eager_and_kernel_weights()
-    batch = 3
-    lengths = torch.tensor([1, 3, 4], device="cuda", dtype=torch.int32)
+    batch = 4
+    lengths = torch.tensor([1, 3, 4, 4], device="cuda", dtype=torch.int32)
+    sot_positions = torch.tensor([0, 0, 2, 0], device="cuda", dtype=torch.int64)
     token_ids = torch.tensor(
         [
             [50258, 50257, 50257, 50257],
             [50258, 50259, 50360, 50257],
-            [50258, 50259, 50360, 50364],
+            [50362, 10, 50258, 50259],
+            [50362, 10, 11, 12],
         ],
         device="cuda",
         dtype=torch.int64,
@@ -151,7 +154,7 @@ def test_mixed_prefix_matches_eager_oracle_paged_layout_and_graph() -> None:
     )
     compact_values = _random(compact_keys.shape, scale=0.02)
     expected = []
-    for row, length in enumerate((1, 3, 4)):
+    for row, length in enumerate((1, 3, 4, 4)):
         row_cross = CrossAttentionKV(
             compact_keys[:, row : row + 1].contiguous(),
             compact_values[:, row : row + 1].contiguous(),
@@ -163,19 +166,21 @@ def test_mixed_prefix_matches_eager_oracle_paged_layout_and_graph() -> None:
         )
 
     state_rows = 5
-    batch_idx = torch.tensor([4, 1, 3], device="cuda", dtype=torch.int64)
+    batch_idx = torch.tensor([4, 1, 3, 2], device="cuda", dtype=torch.int64)
     self_kv, page_table = _paged_state(config, state_rows=state_rows)
     slot_mapping = page_table.index_select(0, batch_idx)[:, :4].long().contiguous()
     positions = torch.arange(4, device="cuda").view(1, 4)
     slot_mapping.masked_fill_(positions >= lengths.view(-1, 1), 0)
     workspace = WhisperDecoderPrefixWorkspace.allocate(batch, device="cuda")
     logits = torch.empty((batch, VOCAB_SIZE), device="cuda", dtype=torch.bfloat16)
+    no_speech_probs = torch.empty((batch,), device="cuda", dtype=torch.float32)
     key_pool_ptrs = tuple(pool.data_ptr() for pool in self_kv.keys)
     value_pool_ptrs = tuple(pool.data_ptr() for pool in self_kv.values)
 
     actual = whisper_decoder_prefix(
         token_ids,
         lengths,
+        sot_positions,
         slot_mapping,
         compact_keys,
         compact_values,
@@ -184,7 +189,11 @@ def test_mixed_prefix_matches_eager_oracle_paged_layout_and_graph() -> None:
         self_kv,
         logits_out=logits,
     )
-    for row, length in enumerate((1, 3, 4)):
+    scored_no_speech = whisper_no_speech_probabilities(
+        workspace,
+        probabilities_out=no_speech_probs,
+    )
+    for row, length in enumerate((1, 3, 4, 4)):
         _assert_close(
             actual.last_hidden_state[row],
             expected[row].hidden_states[0, length - 1],
@@ -192,6 +201,20 @@ def test_mixed_prefix_matches_eager_oracle_paged_layout_and_graph() -> None:
         _assert_close(
             actual.logits[row], expected[row].logits[0, length - 1], atol=0.12
         )
+        if row < 3:
+            retained_sot_logits = workspace.projection_logits[batch + row]
+            _assert_close(
+                retained_sot_logits,
+                expected[row].logits[0, int(sot_positions[row])],
+                atol=0.12,
+            )
+            expected_no_speech = retained_sot_logits.float().softmax(dim=-1)[50361]
+            torch.testing.assert_close(
+                scored_no_speech[row],
+                expected_no_speech,
+                rtol=1e-5,
+                atol=1e-8,
+            )
         for layer in range(DECODER_LAYERS):
             for position in range(length):
                 page = int(slot_mapping[row, position])
@@ -216,12 +239,37 @@ def test_mixed_prefix_matches_eager_oracle_paged_layout_and_graph() -> None:
     assert tuple(pool.data_ptr() for pool in self_kv.values) == value_pool_ptrs
     assert actual.logits.data_ptr() == logits.data_ptr()
     assert actual.last_hidden_state.data_ptr() == workspace.last_hidden.data_ptr()
+    assert workspace.last_hidden.data_ptr() == workspace.projection_hidden.data_ptr()
+
+    # Automatic-language batches stage SOT as every row's last token. Their
+    # score comes from the ordinary B-row logits, and the 2B projection buffers
+    # must remain untouched.
+    workspace.projection_logits.fill_(float("nan"))
+    direct = whisper_decoder_prefix(
+        token_ids,
+        lengths,
+        sot_positions,
+        slot_mapping,
+        compact_keys,
+        compact_values,
+        weights,
+        workspace,
+        self_kv,
+        logits_out=logits,
+        separate_sot_projection=False,
+    )
+    assert torch.isnan(workspace.projection_logits).all()
+    for row, length in enumerate((1, 3, 4, 4)):
+        _assert_close(
+            direct.logits[row], expected[row].logits[0, length - 1], atol=0.12
+        )
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         captured = whisper_decoder_prefix(
             token_ids,
             lengths,
+            sot_positions,
             slot_mapping,
             compact_keys,
             compact_values,
@@ -231,10 +279,14 @@ def test_mixed_prefix_matches_eager_oracle_paged_layout_and_graph() -> None:
             logits_out=logits,
         )
     graph.replay()
+    whisper_no_speech_probabilities(
+        workspace,
+        probabilities_out=no_speech_probs,
+    )
     torch.cuda.synchronize()
     assert captured.logits.data_ptr() == logits.data_ptr()
     assert captured.last_hidden_state.data_ptr() == workspace.last_hidden.data_ptr()
-    for row, length in enumerate((1, 3, 4)):
+    for row, length in enumerate((1, 3, 4, 4)):
         _assert_close(
             captured.logits[row], expected[row].logits[0, length - 1], atol=0.12
         )

--- a/tests/whisper/test_runtime.py
+++ b/tests/whisper/test_runtime.py
@@ -140,6 +140,7 @@ class _FakeSession:
     warmup_failures: int = 0
     warmup_calls: int = 0
     launches: list[tuple[int, int]] = field(default_factory=list)
+    launch_modes: list[tuple[bool, bool]] = field(default_factory=list)
     shutdown_calls: int = 0
     artifact_identities: tuple[dict[str, object], ...] = ()
     artifact_receipts: tuple[dict[str, object], ...] = ()
@@ -150,10 +151,20 @@ class _FakeSession:
             self.warmup_failures -= 1
             raise RuntimeError(f"{self.kind} warmup failed")
 
-    def launch(self, slot_id: int, batch_size: int) -> None:
+    def launch(
+        self,
+        slot_id: int,
+        batch_size: int,
+        *,
+        separate_sot_projection: bool,
+        retain_sot_score: bool,
+    ) -> None:
         self.launches.append((slot_id, batch_size))
         slot = self.buffers[slot_id]
         slot.logits_out[:batch_size].fill_(7.0)
+        if retain_sot_score:
+            slot.no_speech_probs_out[:batch_size].fill_(0.25)
+        self.launch_modes.append((separate_sot_projection, retain_sot_score))
 
     def run(self, slot: Any, batch_size: int) -> None:
         self.warmup_calls += 1
@@ -392,6 +403,7 @@ def test_prepared_audio_cross_row_and_prefix_slot_lifecycle(
     )
     assert factory.prefill is not None
     assert factory.prefill.launches == [(slot.slot_id, 1)]
+    assert factory.prefill.launch_modes == [(True, True)]
     assert torch.all(logits == 7)
     assert slot.metadata.control_token_ids.gpu[0].tolist() == [
         50258,
@@ -400,6 +412,7 @@ def test_prepared_audio_cross_row_and_prefix_slot_lifecycle(
         0,
     ]
     assert slot.metadata.prefix_lengths.gpu[0].item() == 3
+    assert slot.metadata.sot_positions.gpu[0].item() == 0
     assert slot.batch_idx[0].item() == row
     assert (
         slot.metadata.slot_mapping.gpu[0, :3].tolist()
@@ -411,12 +424,175 @@ def test_prepared_audio_cross_row_and_prefix_slot_lifecycle(
     assert row in runtime.active_sequences
     assert row not in runtime._prepared_audio
     assert row in runtime._owned_cross_rows
+    analysis = runtime.analyze_transcript(
+        batch_idx=row,
+        language="en",
+        task="transcribe",
+        prefix_token_ids=(50258, 50259, 50360),
+        text_token_ids=(10,),
+        avg_logprob=-0.5,
+        duration_seconds=0.1,
+        include_words=False,
+    )
+    assert analysis.words == ()
+    assert analysis.scores.no_speech_prob == pytest.approx(0.25)
 
     runtime.release_sequence(prepared.state)
     assert row not in runtime.active_sequences
     assert row not in runtime._owned_cross_rows
+    assert row not in runtime._no_speech_score_rows
     assert row in runtime.page_table.free_batch_idx
     runtime.release_prefill_slot(slot)
+    runtime.shutdown()
+
+
+def test_prefill_stages_actual_sot_position_and_marks_only_present_rows(
+    runtime_model_config,
+    runtime_weights,
+    prepared_audio,
+) -> None:
+    factory = _FakeSessionFactory()
+    runtime = _make_runtime(runtime_model_config, runtime_weights, factory)
+    with_sot = runtime.prepare_sequence(
+        [TextToken(token_id=value) for value in (50362, 10, 50258, 50259)],
+        encoder_input=prepared_audio,
+        max_new_tokens=4,
+    )
+    forced_tail = runtime.prepare_sequence(
+        [TextToken(token_id=value) for value in (50362, 10, 11, 12)],
+        encoder_input=prepared_audio,
+        max_new_tokens=4,
+    )
+    slot = runtime.acquire_prefill_slot()
+    runtime.launch_prepared_batch(
+        [forced_tail, with_sot],
+        slot,
+        images=[None, None],
+        image_crops_list=[None, None],
+        encoder_inputs=[prepared_audio, prepared_audio],
+    )
+
+    assert slot.metadata.sot_positions.gpu[:2].tolist() == [0, 2]
+    assert factory.prefill is not None
+    assert factory.prefill.launch_modes == [(True, True)]
+    assert forced_tail.state.batch_idx not in runtime._no_speech_score_rows
+    assert with_sot.state.batch_idx in runtime._no_speech_score_rows
+
+    runtime.abort_prepared_sequence(forced_tail)
+    runtime.abort_prepared_sequence(with_sot)
+    runtime.release_prefill_slot(slot)
+    runtime.shutdown()
+
+
+def test_sot_only_prefill_reuses_last_logits_projection(
+    runtime_model_config,
+    runtime_weights,
+    prepared_audio,
+) -> None:
+    factory = _FakeSessionFactory()
+    runtime = _make_runtime(runtime_model_config, runtime_weights, factory)
+    prepared = runtime.prepare_sequence(
+        [TextToken(token_id=50258)],
+        encoder_input=prepared_audio,
+        max_new_tokens=4,
+    )
+    row = int(prepared.state.batch_idx)
+    slot = runtime.acquire_prefill_slot()
+    runtime.launch_prepared_batch(
+        [prepared],
+        slot,
+        images=[None],
+        image_crops_list=[None],
+        encoder_inputs=[prepared_audio],
+    )
+
+    assert factory.prefill is not None
+    assert factory.prefill.launch_modes == [(False, True)]
+    assert row in runtime._no_speech_score_rows
+    assert runtime._no_speech_probs[row].item() == pytest.approx(0.25)
+
+    runtime.abort_prepared_sequence(prepared)
+    runtime.release_prefill_slot(slot)
+    runtime.shutdown()
+
+
+def test_forced_tail_sot_captures_raw_decode_logits_by_global_row(
+    runtime_model_config,
+    runtime_weights,
+    prepared_audio,
+) -> None:
+    factory = _FakeSessionFactory()
+    runtime = _make_runtime(runtime_model_config, runtime_weights, factory)
+    prepared = runtime.prepare_sequence(
+        [TextToken(token_id=value) for value in (50362, 10, 11, 12)],
+        encoder_input=prepared_audio,
+        max_new_tokens=4,
+    )
+    row = int(prepared.state.batch_idx)
+    prefill_slot = runtime.acquire_prefill_slot()
+    runtime.launch_prepared_batch(
+        [prepared],
+        prefill_slot,
+        images=[None],
+        image_crops_list=[None],
+        encoder_inputs=[prepared_audio],
+    )
+    assert row not in runtime._no_speech_score_rows
+    assert factory.prefill is not None
+    assert factory.prefill.launch_modes == [(False, False)]
+
+    state = WhisperTranscribeState(
+        WhisperTranscribeSkill(),
+        SimpleNamespace(),
+        WhisperDecodeContext(
+            language="en",
+            timestamps="none",
+            max_transcript_tokens=1,
+            temperature=0.0,
+            forced_prefix_tail=(50258, 50259, 50360),
+        ),
+        runtime.tokenizer,
+        prepared_audio,
+    )
+    sequence = SimpleNamespace(skill_state=state, state=prepared.state)
+    process_logits = runtime.sampling_hooks.process_logits
+    assert process_logits is not None
+    process_logits(
+        prefill_slot.logits[:1],
+        sequences=[sequence],
+        batch_idx=prefill_slot.batch_idx[:1],
+    )
+    assert row in runtime._pending_no_speech_score_rows
+
+    decode_slot = runtime.decode_slots[1]
+    decode_slot.meta.batch_idx.cpu[0] = row
+    decode_slot.meta.input_pos.cpu[0] = prepared.state.length
+    decode_slot.meta.inputs.copy_to_gpu()
+    decode_slot.decode_token_ids[0] = 50258
+    prepare_decode = runtime.sampling_hooks.prepare_decode_inputs
+    assert prepare_decode is not None
+    prepare_decode(decode_slot, decode_slot.meta.batch_idx.gpu[:1], 1)
+    runtime.decode_with_slot(decode_slot, 1)
+
+    assert row not in runtime._pending_no_speech_score_rows
+    assert row in runtime._no_speech_score_rows
+    assert runtime._no_speech_probs[row].item() == pytest.approx(
+        1.0 / runtime.vocab_size,
+        rel=1e-5,
+    )
+    # Sampling owns and mutates the decode-slot logits after forward. The
+    # retained global score must already be independent of that storage.
+    decode_slot.logits[0].fill_(-float("inf"))
+    decode_slot.logits[0, 42] = 0
+    assert runtime._no_speech_probs[row].item() == pytest.approx(
+        1.0 / runtime.vocab_size,
+        rel=1e-5,
+    )
+
+    runtime.abort_prepared_sequence(prepared)
+    assert row not in runtime._no_speech_score_rows
+    assert row not in runtime._pending_no_speech_score_rows
+    runtime.release_prefill_slot(prefill_slot)
     runtime.shutdown()
 
 


### PR DESCRIPTION
## Summary
- retain Whisper's unfiltered no-speech probability from the native SOT forward
- remove the terminal decoder replay used only for no-speech analysis
- preserve the common SOT-only B-row projection and handle earlier/forced-tail SOT positions correctly
- keep forced-tail staging slot-local for ping-pong safety

## L4 performance
Exact counterbalanced Kestrel vs vLLM 0.28, transcript parity true:
- C1: 120.736 ms vs 175.087 ms (1.450x)
- C2: 189.096 ms vs 239.796 ms (1.268x)
- C4: 315.065 ms vs 372.709 ms (1.183x)
- C8: 593.897 ms vs 640.577 ms (1.079x)

This lowers Kestrel latency by approximately 3.5-4.8% across the four cells.

## Validation
- focused Modal L4: 5 passed (ap-VxA4jBTBZmLDvUKG6xo8Jg)
- exact L4 qualification: ap-NtwRRiUCCaUnKaNB9ddoLM
- covers mixed prefixes, forced-tail SOT capture, graph replay, row lifecycle, and slot ownership
- final adversarial review: zero findings