### PR TITLE
Admit packed Whisper on RTX 3090

### DIFF
--- a/kestrel/models/whisper/runtime.py
+++ b/kestrel/models/whisper/runtime.py
@@ -91,9 +91,9 @@ def _supports_whisper_native_target(
 
     Hopper SM9x and data-center Blackwell SM10x preserve the existing
     architecture-level admission; their exact packed-program coverage remains
-    fail-closed in the generated runtime. Ada is narrower: only an exact
-    packaging-owned generated-decode target is admitted, so adding L4 support
-    cannot silently admit every SM89 product.
+    fail-closed in the generated runtime. Ampere and Ada are narrower: only an
+    exact packaging-owned generated-decode target is admitted, so support for
+    one device cannot silently admit every SM8x product.
     """
     if (
         not isinstance(device_sms, int)
@@ -104,13 +104,13 @@ def _supports_whisper_native_target(
     major, minor = capability
     if major in (9, 10):
         return True
-    if (major, minor) != (8, 9):
+    if major != 8 or minor not in (6, 9):
         return False
 
     from kestrel_kernels.deploy_targets import GENERATED_DECODE, deploy_targets_for
 
     return any(
-        target.arch_num == 89 and target.num_sms == device_sms
+        target.arch_num == major * 10 + minor and target.num_sms == device_sms
         for target in deploy_targets_for(GENERATED_DECODE)
     )
 
@@ -120,8 +120,9 @@ def _require_whisper_native_target(device: torch.device) -> None:
     device_sms = get_device_sm_count(device)
     if not _supports_whisper_native_target(capability, device_sms):
         raise RuntimeError(
-            "Optimized Whisper serving supports shipped Ada generated-decode "
-            "targets, Hopper SM9x, and data-center Blackwell SM10x; got "
+            "Optimized Whisper serving supports shipped Ampere/Ada "
+            "generated-decode targets, Hopper SM9x, and data-center "
+            "Blackwell SM10x; got "
             f"SM{capability[0]}{capability[1]} with {device_sms} SMs"
         )
 

--- a/tests/whisper/test_runtime.py
+++ b/tests/whisper/test_runtime.py
@@ -82,7 +82,8 @@ def test_native_whisper_ops_use_the_uniform_kernel_runtime_surface() -> None:
         ((8, 9), 128, False),  # Larger consumer Ada.
         ((8, 9), 142, False),  # L40/L40S must not inherit L4 admission.
         ((8, 0), 108, False),
-        ((8, 6), 82, False),
+        ((8, 6), 82, True),  # RTX 3090: exact shipped Ampere target.
+        ((8, 6), 68, False),  # Other consumer Ampere target.
         ((12, 0), 96, False),
         ((9, 0), 132, True),
         ((10, 0), 148, True),
@@ -101,7 +102,7 @@ def test_unsupported_native_target_fails_before_asset_loading(
     import kestrel.models.whisper.runtime as runtime_module
 
     monkeypatch.setattr(runtime_module, "get_device_capability", lambda _device: (8, 6))
-    monkeypatch.setattr(runtime_module, "get_device_sm_count", lambda _device: 82)
+    monkeypatch.setattr(runtime_module, "get_device_sm_count", lambda _device: 68)
     monkeypatch.setattr(
         runtime_module,
         "_load_production_components",
@@ -114,7 +115,7 @@ def test_unsupported_native_target_fails_before_asset_loading(
         SimpleNamespace(session_factory=None) if injected_native_components else None
     )
 
-    with pytest.raises(RuntimeError, match="got SM86 with 82 SMs"):
+    with pytest.raises(RuntimeError, match="got SM86 with 68 SMs"):
         WhisperRuntime(cfg, kv_pool=object(), _components=components)
 
 


### PR DESCRIPTION
Extends the existing exact packaging-owned SM8x admission rule to the shipped RTX 3090 SM86/82 target while preserving fail-closed rejection for other Ampere/Ada devices.\n\nLive RTX 3090 proof used current public 1f2b32d with a current private packed B1 archive, KESTREL_CUTE_JIT=0. All seven required packed keys resolved; generated AOT telemetry reported 37 launches/request; normalized transcript exactly matched vLLM 0.28.0 across 18 retained samples. Counterbalanced C1 medians: vLLM 101.020 ms pooled, Kestrel 64.345 ms, 1.56997x.