### PR TITLE
Derive SM8x Whisper support from deployed targets

### DIFF
--- a/kestrel/models/whisper/runtime.py
+++ b/kestrel/models/whisper/runtime.py
@@ -104,7 +104,7 @@ def _supports_whisper_native_target(
     major, minor = capability
     if major in (9, 10):
         return True
-    if major != 8 or minor not in (6, 9):
+    if major != 8:
         return False
 
     from kestrel_kernels.deploy_targets import GENERATED_DECODE, deploy_targets_for

--- a/tests/whisper/test_runtime.py
+++ b/tests/whisper/test_runtime.py
@@ -81,7 +81,8 @@ def test_native_whisper_ops_use_the_uniform_kernel_runtime_surface() -> None:
         ((8, 9), 24, False),  # Smaller consumer Ada.
         ((8, 9), 128, False),  # Larger consumer Ada.
         ((8, 9), 142, False),  # L40/L40S must not inherit L4 admission.
-        ((8, 0), 108, False),
+        ((8, 0), 108, True),  # A100 SXM: exact shipped Ampere target.
+        ((8, 0), 80, False),  # Other SM80 target.
         ((8, 6), 82, True),  # RTX 3090: exact shipped Ampere target.
         ((8, 6), 68, False),  # Other consumer Ampere target.
         ((12, 0), 96, False),


### PR DESCRIPTION
## Summary
- derive SM8x Whisper admission from the packaging-owned generated-decode target registry
- admit exact A100 SXM (SM80, 108 SMs) without admitting other SM80 shapes

## Validation
- Modal AWS A100-SXM: exact target matrix, 11 passed (ap-3EliqbYqTOnFWQ5SMhvxue)
- python -m py_compile kestrel/models/whisper/runtime.py tests/whisper/test_runtime.py
- git diff --check