### PR TITLE
Admit Whisper devices through the generated decode target inventory

### DIFF
--- a/kestrel/models/whisper/runtime.py
+++ b/kestrel/models/whisper/runtime.py
@@ -91,9 +91,9 @@ def _supports_whisper_native_target(
 
     Hopper SM9x and data-center Blackwell SM10x preserve the existing
     architecture-level admission; their exact packed-program coverage remains
-    fail-closed in the generated runtime. Ampere and Ada are narrower: only an
-    exact packaging-owned generated-decode target is admitted, so support for
-    one device cannot silently admit every SM8x product.
+    fail-closed in the generated runtime. Other architectures require an exact
+    packaging-owned generated-decode target, so adding a target admits only
+    the architecture and SM count whose artifacts are shipped.
     """
     if (
         not isinstance(device_sms, int)
@@ -104,9 +104,6 @@ def _supports_whisper_native_target(
     major, minor = capability
     if major in (9, 10):
         return True
-    if major != 8:
-        return False
-
     from kestrel_kernels.deploy_targets import GENERATED_DECODE, deploy_targets_for
 
     return any(
@@ -120,7 +117,7 @@ def _require_whisper_native_target(device: torch.device) -> None:
     device_sms = get_device_sm_count(device)
     if not _supports_whisper_native_target(capability, device_sms):
         raise RuntimeError(
-            "Optimized Whisper serving supports shipped Ampere/Ada "
+            "Optimized Whisper serving supports shipped "
             "generated-decode targets, Hopper SM9x, and data-center "
             "Blackwell SM10x; got "
             f"SM{capability[0]}{capability[1]} with {device_sms} SMs"

--- a/tests/whisper/test_runtime.py
+++ b/tests/whisper/test_runtime.py
@@ -96,6 +96,18 @@ def test_whisper_native_target_support_is_explicit(
     assert _supports_whisper_native_target(capability, device_sms) is expected
 
 
+def test_whisper_admits_exact_packaging_target_on_a_new_architecture(monkeypatch):
+    import kestrel_kernels.deploy_targets as targets
+
+    monkeypatch.setattr(
+        targets, "deploy_targets_for",
+        lambda family: (SimpleNamespace(arch_num=120, num_sms=188),),
+    )
+    assert _supports_whisper_native_target((12, 0), 188)
+    assert not _supports_whisper_native_target((12, 0), 170)
+    assert not _supports_whisper_native_target((12, 1), 188)
+
+
 @pytest.mark.parametrize("injected_native_components", (False, True))
 def test_unsupported_native_target_fails_before_asset_loading(
     monkeypatch, injected_native_components: bool


### PR DESCRIPTION
Whisper currently rejects compute capability 12.0 before consulting the generated-decode deployment inventory. Allow architectures outside the existing Hopper and datacenter Blackwell paths when their exact compute capability and SM count are present in that inventory. This enables RTX PRO 6000 Blackwell packages without admitting unshipped devices.

Validated with all 31 Whisper runtime tests, including an exact SM120/188-SM admission test and rejection of unmatched devices. The generated runtime continues to require matching packed-program coverage.
