### PR TITLE
Bind packed Qwen weights and BF16 Moondream caches to generated decode

### DIFF
--- a/kestrel/models/moondream/generated_decode.py
+++ b/kestrel/models/moondream/generated_decode.py
@@ -57,35 +57,37 @@ class MoondreamDecodeBindings:
             runtime._lora_workspace is None
             and runtime.page_size == 1
             and len(self.layers) == len(runtime.model.text.blocks)
-            and all(layer.cache.quantized for layer in self.layers)
+            and bool(self.layers)
+            and (
+                all(layer.cache.quantized for layer in self.layers)
+                or all(
+                    not layer.cache.quantized
+                    and layer.cache.k_cache.dtype == torch.bfloat16
+                    and layer.cache.v_cache.dtype == torch.bfloat16
+                    for layer in self.layers
+                )
+            )
             and all(
                 int(layer.cache.k_cache.shape[2])
                 == int(layer.cache.v_cache.shape[2])
                 == 1
                 for layer in self.layers
             )
-            and all(
-                hasattr(block.attn, "_tau_pos_table")
-                for block in runtime.model.text.blocks
+            and (
+                not self.layers[0].cache.quantized
+                or all(
+                    hasattr(block.attn, "_tau_pos_table")
+                    for block in runtime.model.text.blocks
+                )
             )
         )
 
     def runtime_inputs(self, runtime: Any) -> Mapping[str, Any]:
         rope_cos, rope_sin = _rope_tables(runtime.model.text)
         caches = [layer.cache for layer in self.layers]
-        return {
-            "tau_pos": torch.stack([
-                block.attn._tau_pos_table.detach().float()
-                for block in runtime.model.text.blocks
-            ]).contiguous(),
+        inputs = {
             "rope_cos": rope_cos,
             "rope_sin": rope_sin,
-            "mK_dequant_scale": torch.stack([
-                cache.k_scale_tensor for cache in caches
-            ]).contiguous(),
-            "mV_dequant_scale": torch.stack([
-                cache.v_scale_tensor for cache in caches
-            ]).contiguous(),
             "mK": [cache.k_cache[:, :, 0, :] for cache in caches],
             "mV": [cache.v_cache[:, :, 0, :] for cache in caches],
             "page_table": runtime.page_table.page_table,
@@ -93,6 +95,20 @@ class MoondreamDecodeBindings:
             # ``launch_extents`` supplies the live maximum position for every run.
             "kv_len": 1,
         }
+        if caches[0].quantized:
+            inputs.update({
+                "tau_pos": torch.stack([
+                    block.attn._tau_pos_table.detach().float()
+                    for block in runtime.model.text.blocks
+                ]).contiguous(),
+                "mK_dequant_scale": torch.stack([
+                    cache.k_scale_tensor for cache in caches
+                ]).contiguous(),
+                "mV_dequant_scale": torch.stack([
+                    cache.v_scale_tensor for cache in caches
+                ]).contiguous(),
+            })
+        return inputs
 
     def slot_inputs(self, slot: Any, capacity: int) -> Mapping[str, Any]:
         return {

--- a/kestrel/models/qwen35/qwen_config.py
+++ b/kestrel/models/qwen35/qwen_config.py
@@ -34,6 +34,7 @@ class Qwen3_5TextConfig:
     num_experts_per_tok: int | None = None
     num_experts: int | None = None
     expert_weight_format: str = "bf16"
+    dense_weight_format: str = "bf16"
 
     def __post_init__(self) -> None:
         layer_types = tuple(str(kind) for kind in self.layer_types)
@@ -56,6 +57,8 @@ class Qwen3_5TextConfig:
             raise ValueError(
                 f"unsupported Qwen expert weight format {self.expert_weight_format!r}"
             )
+        if self.dense_weight_format not in {"bf16", "fp8_e4m3"}:
+            raise ValueError(f"unsupported Qwen dense weight format {self.dense_weight_format!r}")
         moe_fields = (
             self.moe_intermediate_size,
             self.shared_expert_intermediate_size,
@@ -81,6 +84,7 @@ class Qwen3_5TextConfig:
         is_moe: bool,
         tie_word_embeddings: bool,
         expert_weight_format: str,
+        dense_weight_format: str = "bf16",
     ) -> "Qwen3_5TextConfig":
         if required_config(data, "hidden_act", "Qwen text") != "silu":
             raise ValueError("Qwen text inference requires hidden_act='silu'")
@@ -141,6 +145,7 @@ class Qwen3_5TextConfig:
             ),
             layer_types=layer_types,
             expert_weight_format=expert_weight_format,
+            dense_weight_format=dense_weight_format,
         )
         if is_moe:
             for name in (
@@ -205,6 +210,8 @@ class Qwen3_5Config:
             and quantization.get("fmt") == "e4m3"
             else "bf16"
         )
+        if expert_weight_format == "fp8_e4m3" and quantization.get("weight_block_size", [128, 128]) != [128, 128]:
+            raise ValueError("Qwen FP8 requires 128 by 128 weight scale blocks")
         text = Qwen3_5TextConfig.from_dict(
             text_data,
             is_moe=model_type == "qwen3_5_moe"
@@ -213,6 +220,7 @@ class Qwen3_5Config:
                 required_config(data, "tie_word_embeddings", "Qwen")
             ),
             expert_weight_format=expert_weight_format,
+            dense_weight_format=expert_weight_format,
         )
         return cls(
             text_config=text,

--- a/kestrel/models/qwen35/qwen_config.py
+++ b/kestrel/models/qwen35/qwen_config.py
@@ -210,7 +210,10 @@ class Qwen3_5Config:
             and quantization.get("fmt") == "e4m3"
             else "bf16"
         )
-        if expert_weight_format == "fp8_e4m3" and quantization.get("weight_block_size", [128, 128]) != [128, 128]:
+        if (
+            expert_weight_format == "fp8_e4m3"
+            and quantization.get("weight_block_size", [128, 128]) != [128, 128]
+        ):
             raise ValueError("Qwen FP8 requires 128 by 128 weight scale blocks")
         text = Qwen3_5TextConfig.from_dict(
             text_data,

--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -12,6 +12,7 @@ from huggingface_hub import hf_hub_download
 from safetensors import safe_open
 
 from kestrel.ops.rotary import default_inv_freq
+from kestrel.ops.block_scaled_linear import BlockScaledLinear
 from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 
 from .qwen_config import Qwen3_5Config
@@ -258,27 +259,30 @@ def _dequantize_fp8_weight(
     return output
 
 
-def _load_fp8_expert_weight_and_scale(
+def _load_fp8_block_weight_and_scale(
     value: torch.Tensor,
     scale_inv: torch.Tensor | None,
     expected_shape: torch.Size,
     *,
     key: str,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if not _is_float8_tensor(value):
-        raise ValueError(f"Qwen FP8 expert weight {key!r} has dtype {value.dtype}")
+    if value.dtype != torch.float8_e4m3fn:
+        raise ValueError(f"Qwen FP8 block weight {key!r} has dtype {value.dtype}")
     if scale_inv is None:
-        raise ValueError(f"Qwen FP8 expert weight {key!r} is missing weight_scale_inv")
+        raise ValueError(f"Qwen FP8 block weight {key!r} is missing weight_scale_inv")
     if value.ndim != 2 or scale_inv.ndim != 2:
         raise ValueError(
-            "Qwen FP8 expert loading expects 2D weight/scale tensors, "
+            "Qwen FP8 block loading expects 2D weight/scale tensors, "
             f"got weight={tuple(value.shape)} scale={tuple(scale_inv.shape)}"
         )
     if value.shape != expected_shape:
         raise ValueError(
-            f"Qwen FP8 expert weight {key!r} has shape {tuple(value.shape)}, "
+            f"Qwen FP8 block weight {key!r} has shape {tuple(value.shape)}, "
             f"expected {tuple(expected_shape)}"
         )
+    expected_scale_shape = tuple((extent + 127) // 128 for extent in expected_shape)
+    if tuple(scale_inv.shape) != expected_scale_shape or not scale_inv.is_floating_point():
+        raise ValueError(f"Qwen FP8 block scale {key!r} must have shape {expected_scale_shape} and floating-point values")
     return value.view(torch.uint8).contiguous(), scale_inv.to(torch.float32).contiguous()
 
 
@@ -380,6 +384,62 @@ def _copy_fused_projection_part(
     seen.add(part)
     if seen == set(parts):
         loaded_keys.add(fused_key)
+
+
+def _copy_block_scaled_projection_part(
+    module: BlockScaledLinear,
+    tensor_shapes: dict[str, torch.Size],
+    *, checkpoint_key: str, target_key: str, part: str,
+    parts: tuple[str, ...], value: torch.Tensor,
+    scale: torch.Tensor | None, loaded_parts: dict[str, set[str]],
+    loaded_keys: set[str],
+) -> None:
+    prefix = checkpoint_key[:-len(part)]
+    shapes = [tensor_shapes[prefix + item] for item in parts]
+    if any(len(shape) != 2 or shape[1] != module.in_features for shape in shapes):
+        raise ValueError(f"invalid block-scaled projection parts for {target_key!r}")
+    if sum(shape[0] for shape in shapes) != module.out_features:
+        raise ValueError(f"block-scaled projection rows disagree for {target_key!r}")
+    if value.shape != tensor_shapes[checkpoint_key]:
+        raise ValueError(f"checkpoint tensor {checkpoint_key!r} changed shape")
+    seen = loaded_parts.setdefault(target_key, set())
+    if part in seen:
+        raise ValueError(f"duplicate block-scaled projection part {checkpoint_key!r}")
+    slot = parts.index(part)
+    offset = sum(shape[0] for shape in shapes[:slot])
+    rows = int(value.shape[0])
+    with torch.no_grad():
+        if module.interleaved_parts == 2:
+            if len(parts) != 2 or shapes[0] != shapes[1]:
+                raise ValueError("interleaved FP8 projections need two equal row parts")
+            weight, scales = _load_fp8_block_weight_and_scale(
+                value, scale, value.shape, key=checkpoint_key)
+            module.weight.reshape(-1, 2, 8, module.in_features)[:, slot].copy_(
+                weight.reshape(-1, 8, module.in_features))
+            module.weight_scale_inv[slot].copy_(scales)
+        elif offset < module.quantized_rows:
+            if offset % 128 or offset + rows > module.quantized_rows:
+                raise ValueError("FP8 projection parts must preserve scale-block boundaries")
+            if rows % 128 and offset + rows != module.quantized_rows:
+                raise ValueError("only the final FP8 projection part may have partial blocks")
+            weight, scales = _load_fp8_block_weight_and_scale(
+                value, scale, value.shape, key=checkpoint_key)
+            module.weight.narrow(0, offset, rows).copy_(weight)
+            module.weight_scale_inv[0].narrow(0, offset // 128, scales.shape[0]).copy_(scales)
+        else:
+            if module.weight_tail is None or value.dtype not in (
+                torch.bfloat16, torch.float16, torch.float32,
+            ) or scale is not None:
+                raise ValueError("unquantized projection tails require floating-point weights without scales")
+            module.weight_tail.narrow(0, offset - module.quantized_rows, rows).copy_(value)
+            module.weight.narrow(0, offset, rows).zero_()
+    seen.add(part)
+    if seen == set(parts):
+        loaded_keys.add(target_key)
+        module_key = target_key.removesuffix(".weight")
+        loaded_keys.add(module_key + ".weight_scale_inv")
+        if module.weight_tail is not None:
+            loaded_keys.add(module_key + ".weight_tail")
 
 
 def _copy_bf16_expert_part(
@@ -582,6 +642,16 @@ def _load_sharded_safetensors(
                 value = handle.get_tensor(key)
             if key in expected_keys:
                 scale_key = _scale_inv_key(key)
+                if key.endswith(".weight"):
+                    module = model.get_submodule(key.removesuffix(".weight"))
+                    if isinstance(module, BlockScaledLinear):
+                        _copy_block_scaled_projection_part(
+                            module, tensor_shapes, checkpoint_key=key,
+                            target_key=key, part="weight", parts=("weight",),
+                            value=value, scale=scale_inv_by_key.get(scale_key),
+                            loaded_parts=loaded_fused_parts, loaded_keys=loaded_keys,
+                        )
+                        continue
                 loaded = _loadable_tensor(
                     key,
                     value,
@@ -604,6 +674,17 @@ def _load_sharded_safetensors(
             fused_handled = False
             for fused_key, part, parts in fused_parts:
                 if fused_key in expected_keys:
+                    module = model.get_submodule(fused_key.rsplit(".", 1)[0])
+                    if isinstance(module, BlockScaledLinear) and fused_key.endswith(".weight"):
+                        _copy_block_scaled_projection_part(
+                            module, tensor_shapes, checkpoint_key=key,
+                            target_key=fused_key, part=part, parts=parts,
+                            value=value,
+                            scale=scale_inv_by_key.get(_scale_inv_key(key)),
+                            loaded_parts=loaded_fused_parts, loaded_keys=loaded_keys,
+                        )
+                        fused_handled = True
+                        break
                     loaded = _loadable_tensor(
                         key,
                         value,
@@ -641,7 +722,7 @@ def _load_sharded_safetensors(
                             expected_part_shape = torch.Size(
                                 (target_shape[1], target_shape[2])
                             )
-                        weight, scale = _load_fp8_expert_weight_and_scale(
+                        weight, scale = _load_fp8_block_weight_and_scale(
                             value,
                             scale_inv_by_key.get(_scale_inv_key(key)),
                             expected_part_shape,

--- a/kestrel/models/qwen35/qwen_loader.py
+++ b/kestrel/models/qwen35/qwen_loader.py
@@ -118,12 +118,12 @@ def _loadable_tensor(
     scale_inv: torch.Tensor | None = None,
     *,
     convert_fp8_to_bf16: bool = False,
-    exact_fp32_weight_keys: set[str] | None = None,
+    fp32_storage_weight_keys: set[str] | None = None,
 ) -> torch.Tensor:
-    if exact_fp32_weight_keys is not None and key in exact_fp32_weight_keys:
-        if value.dtype != torch.float32:
+    if fp32_storage_weight_keys is not None and key in fp32_storage_weight_keys:
+        if value.dtype not in (torch.float32, torch.bfloat16, torch.float16):
             raise ValueError(
-                f"Qwen GDN norm weight {key!r} requires an FP32 checkpoint tensor, "
+                f"Qwen GDN norm weight {key!r} requires an unquantized floating-point checkpoint tensor, "
                 f"got {value.dtype}"
             )
         if value.shape != expected_shape:
@@ -131,7 +131,9 @@ def _loadable_tensor(
                 f"Qwen GDN norm weight {key!r} has shape {tuple(value.shape)}, "
                 f"expected {tuple(expected_shape)}"
             )
-        return value
+        # Qwen 3.6 checkpoints may store this norm in BF16. Widen exactly;
+        # FP32 checkpoints must never round through the model activation dtype.
+        return value.to(torch.float32)
     if _is_float8_tensor(value):
         if not convert_fp8_to_bf16:
             raise ValueError(
@@ -659,7 +661,7 @@ def _load_sharded_safetensors(
                     expected_state[key].shape,
                     scale_inv_by_key.get(scale_key),
                     convert_fp8_to_bf16=_stores_checkpoint_fp8_as_bf16(key),
-                    exact_fp32_weight_keys=qwen_gdn_norm_weight_keys,
+                    fp32_storage_weight_keys=qwen_gdn_norm_weight_keys,
                 )
                 with torch.no_grad():
                     _copy_direct_checkpoint_tensor(

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -28,8 +28,6 @@ from kestrel.ops.rotary import default_inv_freq
 from .qwen_config import Qwen3_5Config, Qwen3_5TextConfig, Qwen3_5VisionConfig
 from .cache import Qwen35InferenceCache
 
-
-
 from kestrel_kernels import get_runtime
 from kestrel_kernels import moe as _MOE_API
 
@@ -66,7 +64,6 @@ def _text_linear(
             interleaved_parts=interleaved_parts,
         )
     return nn.Linear(in_features, out_features, bias=False)
-
 
 
 def _rmsnorm_state(dim: int, eps: float) -> nn.ModuleDict:

--- a/kestrel/models/qwen35/qwen_model.py
+++ b/kestrel/models/qwen35/qwen_model.py
@@ -22,10 +22,13 @@ import torch.nn.functional as F
 from torch import nn
 
 from kestrel.ops.attention import dense_attention, paged_attention
+from kestrel.ops.block_scaled_linear import BlockScaledLinear
 from kestrel.ops.rotary import default_inv_freq
 
 from .qwen_config import Qwen3_5Config, Qwen3_5TextConfig, Qwen3_5VisionConfig
 from .cache import Qwen35InferenceCache
+
+
 
 from kestrel_kernels import get_runtime
 from kestrel_kernels import moe as _MOE_API
@@ -51,6 +54,19 @@ _kestrel_moe_topk_fwd = _kestrel_moe_runtime.topk_fwd
 _KESTREL_MOE_DECODE_MAX_TOKENS = 16
 _KESTREL_MOE_GATE_UP_LAYOUT = "interleaved_i8"
 _KESTREL_MOE_FP8_WEIGHT_SCALE_LAYOUT = "block128_interleaved8"
+
+
+def _text_linear(
+    config: Qwen3_5TextConfig, in_features: int, out_features: int, *,
+    quantized_rows: int | None = None, interleaved_parts: int = 1,
+) -> nn.Module:
+    if config.dense_weight_format == "fp8_e4m3":
+        return BlockScaledLinear(
+            in_features, out_features, quantized_rows=quantized_rows,
+            interleaved_parts=interleaved_parts,
+        )
+    return nn.Linear(in_features, out_features, bias=False)
+
 
 
 def _rmsnorm_state(dim: int, eps: float) -> nn.ModuleDict:
@@ -297,7 +313,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
         self.norm = Qwen3_5RMSNormGated(self.head_v_dim, eps=self.layer_norm_epsilon)
 
-        self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
+        self.out_proj = _text_linear(config, self.value_dim, self.hidden_size)
 
         self.causal_conv1d_packed = _kestrel_causal_conv1d_packed
         self.allocate_packed_gdn_prefill_workspace = (
@@ -309,10 +325,10 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         self.supports_packed_gdn = _kestrel_supports_packed_gdn
         self._prefill_workspace_cache = _PackedGatedDeltaPrefillWorkspaceCache()
 
-        self.in_proj = nn.Linear(
-            self.hidden_size,
+        self.in_proj = _text_linear(
+            config, self.hidden_size,
             self.conv_dim + self.value_dim + 2 * self.num_v_heads,
-            bias=False,
+            quantized_rows=self.conv_dim + self.value_dim,
         )
 
     def forward(
@@ -464,15 +480,11 @@ class Qwen3_5Attention(nn.Module):
         self.scaling = self.head_dim**-0.5
         self.q_gate_size = config.num_attention_heads * self.head_dim * 2
         self.kv_size = config.num_key_value_heads * self.head_dim
-        self.qkv_proj = nn.Linear(
-            config.hidden_size,
-            self.q_gate_size + 2 * self.kv_size,
-            bias=False,
+        self.qkv_proj = _text_linear(
+            config, config.hidden_size, self.q_gate_size + 2 * self.kv_size,
         )
-        self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim,
-            config.hidden_size,
-            bias=False,
+        self.o_proj = _text_linear(
+            config, config.num_attention_heads * self.head_dim, config.hidden_size,
         )
         # Unlike OLMo, these normalize only the head dimension.
         self.q_norm = _rmsnorm_state(self.head_dim, config.rms_norm_eps)
@@ -574,15 +586,12 @@ class Qwen3_5MLP(nn.Module):
         super().__init__()
         self.hidden_size = config.hidden_size
         self.intermediate_size = intermediate_size
-        self.gate_up_proj = nn.Linear(
-            self.hidden_size,
-            2 * self.intermediate_size,
-            bias=False,
+        self.gate_up_proj = _text_linear(
+            config, self.hidden_size, 2 * self.intermediate_size,
+            interleaved_parts=2,
         )
-        self.down_proj = nn.Linear(
-            self.intermediate_size,
-            self.hidden_size,
-            bias=False,
+        self.down_proj = _text_linear(
+            config, self.intermediate_size, self.hidden_size,
         )
 
     def forward(self, x):

--- a/kestrel/ops/block_scaled_linear.py
+++ b/kestrel/ops/block_scaled_linear.py
@@ -1,0 +1,98 @@
+"""Inference storage for block-scaled E4M3 linear projections."""
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class BlockScaledLinear(nn.Module):
+    """Keep FP8 checkpoint bytes and an optional unquantized row suffix.
+
+    Scales are stored as [parts, row blocks, column blocks]. With two parts,
+    eight-row blocks alternate between the parts, as in a fused gated MLP.
+    The ordinary forward materializes a temporary activation-dtype weight;
+    generated decode binds the packed storage directly.
+    """
+
+    block_size = 128
+
+    def __init__(
+        self, in_features: int, out_features: int, *,
+        quantized_rows: int | None = None, interleaved_parts: int = 1,
+        bias: bool = False,
+    ) -> None:
+        super().__init__()
+        self.in_features = int(in_features)
+        self.out_features = int(out_features)
+        self.quantized_rows = (
+            self.out_features if quantized_rows is None else int(quantized_rows)
+        )
+        self.interleaved_parts = int(interleaved_parts)
+        if min(self.in_features, self.out_features, self.quantized_rows) <= 0:
+            raise ValueError("block-scaled linear dimensions must be positive")
+        if self.quantized_rows > self.out_features:
+            raise ValueError("quantized rows exceed the projection extent")
+        if self.interleaved_parts not in (1, 2):
+            raise ValueError("block-scaled linear supports one or two row parts")
+        if self.interleaved_parts == 2 and (
+            self.quantized_rows != self.out_features or self.out_features % 16
+        ):
+            raise ValueError("interleaved projections require complete eight-row pairs")
+        rows_per_part = self.quantized_rows // self.interleaved_parts
+        self.weight = nn.Parameter(
+            torch.empty(self.out_features, self.in_features, dtype=torch.uint8),
+            requires_grad=False,
+        )
+        self.register_buffer("weight_scale_inv", torch.empty(
+            self.interleaved_parts,
+            (rows_per_part + self.block_size - 1) // self.block_size,
+            (self.in_features + self.block_size - 1) // self.block_size,
+            dtype=torch.float32,
+        ))
+        tail_rows = self.out_features - self.quantized_rows
+        self.register_buffer("weight_tail", (
+            torch.empty(tail_rows, self.in_features, dtype=torch.bfloat16)
+            if tail_rows else None
+        ))
+        self.bias = (
+            nn.Parameter(torch.empty(self.out_features), requires_grad=False)
+            if bias else None
+        )
+
+    def _apply(self, fn, recurse=True):
+        # Module.to(dtype=...) must preserve the checkpoint's FP32 scales and
+        # BF16 suffix. Move their byte views so dtype conversion cannot round
+        # them before the generated binder sees the original values.
+        protected = {name: self._buffers.pop(name)
+                     for name in ("weight_scale_inv", "weight_tail")}
+        try:
+            result = super()._apply(fn, recurse=recurse)
+            for name, value in protected.items():
+                self._buffers[name] = (
+                    None if value is None else fn(value.view(torch.uint8)).view(value.dtype)
+                )
+        except BaseException:
+            self._buffers.update(protected)
+            raise
+        return result
+
+    def dequantized_weight(self, dtype: torch.dtype) -> torch.Tensor:
+        if dtype not in (torch.bfloat16, torch.float16, torch.float32):
+            raise ValueError("linear activation must be BF16, FP16, or FP32")
+        rows = torch.arange(self.quantized_rows, device=self.weight.device)
+        if self.interleaved_parts == 2:
+            part = (rows // 8) % 2
+            logical_row = (rows // 16) * 8 + rows % 8
+        else:
+            part = torch.zeros_like(rows)
+            logical_row = rows
+        scales = self.weight_scale_inv[part, logical_row // self.block_size]
+        scales = scales.repeat_interleave(self.block_size, dim=1)[:, :self.in_features]
+        prefix = (self.weight[:self.quantized_rows].view(torch.float8_e4m3fn).float() * scales).to(dtype)
+        if self.weight_tail is None:
+            return prefix
+        return torch.cat((prefix, self.weight_tail.to(dtype)), dim=0)
+
+    def forward(self, activation: torch.Tensor) -> torch.Tensor:
+        bias = None if self.bias is None else self.bias.to(activation.dtype)
+        return F.linear(activation, self.dequantized_weight(activation.dtype), bias)

--- a/tests/moondream/test_generated_decode.py
+++ b/tests/moondream/test_generated_decode.py
@@ -182,3 +182,27 @@ def test_moondream_allocates_selected_generated_program_abi_capacity(
     assert plan.slot_capacity == 8
     assert storage_capacity == 8
     assert runtime.max_batch_slots == 3
+
+
+def test_dense_moondream_binds_bf16_pool_without_tau_or_scales():
+    cache = SimpleNamespace(
+        quantized=False,
+        k_cache=torch.zeros(3, 1, 1, 2, dtype=torch.bfloat16),
+        v_cache=torch.zeros(3, 1, 1, 2, dtype=torch.bfloat16),
+    )
+    runtime = SimpleNamespace(
+        _lora_workspace=None, page_size=1,
+        model=SimpleNamespace(text=SimpleNamespace(
+            blocks=[SimpleNamespace(attn=SimpleNamespace())],
+            cos_sin_cache=torch.ones(5, 4),
+        )),
+        page_table=SimpleNamespace(page_table=torch.zeros(1, 5, dtype=torch.int32)),
+    )
+    bindings = MoondreamDecodeBindings([SimpleNamespace(cache=cache)])
+    assert bindings.is_eligible(runtime)
+    inputs = bindings.runtime_inputs(runtime)
+    assert set(inputs) == {"mK", "mV", "rope_cos", "rope_sin", "page_table", "kv_len"}
+    assert inputs["mK"][0].data_ptr() == cache.k_cache.data_ptr()
+    assert inputs["mV"][0].data_ptr() == cache.v_cache.data_ptr()
+    cache.k_cache = cache.k_cache.float()
+    assert not bindings.is_eligible(runtime)

--- a/tests/qwen35/test_loader.py
+++ b/tests/qwen35/test_loader.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 
 import torch
+import pytest
 from safetensors.torch import save_file
 
 from kestrel.models.qwen35.qwen_loader import (
@@ -17,6 +18,7 @@ from kestrel.models.qwen35.qwen_loader import (
 import kestrel.models.qwen35.qwen_loader as loader_module
 from kestrel.models.qwen35.runtime import Qwen35Runtime
 from kestrel.ops.rotary import default_inv_freq
+from kestrel.ops.block_scaled_linear import BlockScaledLinear
 from kestrel.runtime.generated_decode import materialize_remaining_meta_tensors
 
 
@@ -33,6 +35,48 @@ class _FusedExpertHolder(torch.nn.Module):
             torch.empty((2, 32, 3), dtype=torch.bfloat16),
             requires_grad=False,
         )
+
+
+@pytest.mark.parametrize("kind", ["direct", "gdn", "gated"])
+def test_sharded_loader_keeps_native_fp8_and_bf16_tail(tmp_path, kind):
+    torch.manual_seed(128)
+    model = torch.nn.Module()
+    if kind == "direct":
+        name, parts, row_counts = "out_proj", ("out_proj",), (144,)
+    elif kind == "gdn":
+        name = "in_proj"
+        parts, row_counts = ("in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a"), (128, 128, 8, 8)
+    else:
+        name, parts, row_counts = "gate_up_proj", ("gate_proj", "up_proj"), (144, 144)
+    module = BlockScaledLinear(
+        136, sum(row_counts), quantized_rows=256 if kind == "gdn" else None,
+        interleaved_parts=2 if kind == "gated" else 1,
+    )
+    model.layer = torch.nn.Module()
+    setattr(model.layer, name, module)
+    checkpoint, expected = {}, []
+    for index, (part, rows) in enumerate(zip(parts, row_counts, strict=True)):
+        key = f"layer.{part}.weight"
+        if kind == "gdn" and index >= 2:
+            weight = torch.full((rows, 136), 1.0078125, dtype=torch.bfloat16)
+            checkpoint[key] = weight
+            expected.append(weight)
+        else:
+            weight = torch.randn(rows, 136).to(torch.float8_e4m3fn)
+            scale = torch.rand((rows + 127) // 128, 2) + 0.25
+            checkpoint[key] = weight
+            checkpoint[key + "_scale_inv"] = scale
+            expected.append(_dequantize_fp8_weight(weight, scale, weight.shape, key=key))
+    save_file(checkpoint, tmp_path / "model.safetensors")
+    assert _load_sharded_safetensors(
+        model, tmp_path, ["model.safetensors"], device=torch.device("cpu"),
+    ) == ([], [])
+    expected_weight = (
+        _interleave_gate_up_weight(*expected) if kind == "gated"
+        else torch.cat(expected)
+    )
+    torch.testing.assert_close(module.dequantized_weight(torch.bfloat16), expected_weight, rtol=0, atol=0)
+    assert module.weight.dtype == torch.uint8
 
 
 def test_fp8_dequantization_chunks_without_changing_bf16_result() -> None:

--- a/tests/qwen35/test_weights.py
+++ b/tests/qwen35/test_weights.py
@@ -53,21 +53,28 @@ def test_gdn_norm_preserves_exact_fp32_checkpoint_weight_under_bf16_default(
     torch.testing.assert_close(model.norm.weight, checkpoint, rtol=0, atol=0)
 
 
-def test_gdn_norm_rejects_rounded_checkpoint_weight(tmp_path) -> None:
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_gdn_norm_widens_checkpoint_without_changing_values(tmp_path, dtype) -> None:
+    model = _gdn_norm_holder(4)
+    checkpoint = torch.tensor([0.9929, 1.0009, 1.0071, -0.125], dtype=dtype)
+    shard = tmp_path / "model.safetensors"
+    save_file({"norm.weight": checkpoint}, shard)
+    missing, unexpected = _load_sharded_safetensors(
+        model, tmp_path, [shard.name], device=torch.device("cpu"),
+    )
+    assert missing == []
+    assert unexpected == []
+    assert model.norm.weight.dtype == torch.float32
+    torch.testing.assert_close(model.norm.weight, checkpoint.float(), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.int32, torch.uint8, torch.float8_e4m3fn])
+def test_gdn_norm_rejects_quantized_checkpoint_weight(tmp_path, dtype) -> None:
     model = _gdn_norm_holder(4)
     shard = tmp_path / "model.safetensors"
-    save_file({"norm.weight": torch.full((4,), 0.5, dtype=torch.bfloat16)}, shard)
-
-    with pytest.raises(ValueError, match="requires an FP32 checkpoint tensor"):
+    save_file({"norm.weight": torch.ones(4).to(dtype)}, shard)
+    with pytest.raises(ValueError, match="requires an unquantized floating-point"):
         _load_sharded_safetensors(
-            model,
-            tmp_path,
-            [shard.name],
-            device=torch.device("cpu"),
+            model, tmp_path, [shard.name], device=torch.device("cpu"),
         )
-    torch.testing.assert_close(
-        model.norm.weight,
-        torch.ones(4, dtype=torch.float32),
-        rtol=0,
-        atol=0,
-    )
+    torch.testing.assert_close(model.norm.weight, torch.ones(4), rtol=0, atol=0)

--- a/tests/test_block_scaled_linear.py
+++ b/tests/test_block_scaled_linear.py
@@ -1,0 +1,66 @@
+import pytest
+import torch
+
+from kestrel.ops.block_scaled_linear import BlockScaledLinear
+
+
+@pytest.mark.parametrize("rows,quantized,parts", [(145, 145, 1), (146, 128, 1), (288, 288, 2)])
+@pytest.mark.parametrize("batch", [1, 8])
+def test_block_scaled_linear_preserves_blocks_and_unquantized_tail(rows, quantized, parts, batch):
+    torch.manual_seed(6000)
+    module = BlockScaledLinear(136, rows, quantized_rows=quantized, interleaved_parts=parts)
+    packed = torch.randn(rows, 136).to(torch.float8_e4m3fn)
+    module.weight.data.copy_(packed.view(torch.uint8))
+    module.weight_scale_inv.uniform_(0.25, 2.0)
+    expected = torch.empty(rows, 136)
+    for row in range(quantized):
+        part = (row // 8) % 2 if parts == 2 else 0
+        logical_row = row // 16 * 8 + row % 8 if parts == 2 else row
+        for col in range(136):
+            expected[row, col] = packed[row, col].float() * module.weight_scale_inv[
+                part, logical_row // 128, col // 128]
+    if module.weight_tail is not None:
+        module.weight_tail.fill_(1.0078125)  # BF16 value not representable in E4M3.
+        expected[quantized:] = module.weight_tail.float()
+    torch.testing.assert_close(module.dequantized_weight(torch.float32), expected, rtol=0, atol=0)
+    activation = torch.randn(batch, 136)
+    torch.testing.assert_close(module(activation), activation @ expected.T)
+    assert module.weight.dtype == torch.uint8
+    assert module.weight.element_size() == 1
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"in_features": 0, "out_features": 128},
+    {"in_features": 128, "out_features": 128, "quantized_rows": 129},
+    {"in_features": 128, "out_features": 145, "interleaved_parts": 2},
+    {"in_features": 128, "out_features": 256, "quantized_rows": 128, "interleaved_parts": 2},
+])
+def test_block_scaled_linear_rejects_ambiguous_storage(kwargs):
+    with pytest.raises(ValueError):
+        BlockScaledLinear(**kwargs)
+
+
+def test_block_scaled_linear_bias_uses_activation_precision():
+    module = BlockScaledLinear(16, 16, bias=True)
+    module.weight.data.zero_()
+    module.weight_scale_inv.fill_(1)
+    module.bias.data.fill_(1.0078125)
+    result = module(torch.zeros(2, 16, dtype=torch.bfloat16))
+    assert result.dtype == torch.bfloat16
+    torch.testing.assert_close(result, module.bias.bfloat16().expand(2, 16))
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float64])
+def test_block_scaled_linear_dtype_moves_preserve_checkpoint_precision(dtype):
+    module = BlockScaledLinear(16, 17, quantized_rows=16)
+    module.weight.data.zero_()
+    module.weight_scale_inv.fill_(1.234567)
+    module.weight_tail.fill_(1.0078125)
+    scales = module.weight_scale_inv.clone()
+    tail = module.weight_tail.clone()
+    module.to(dtype=dtype)
+    assert module.weight.dtype == torch.uint8
+    assert module.weight_scale_inv.dtype == torch.float32
+    assert module.weight_tail.dtype == torch.bfloat16
+    torch.testing.assert_close(module.weight_scale_inv, scales, rtol=0, atol=0)
+    torch.testing.assert_close(module.weight_tail, tail, rtol=0, atol=0)


### PR DESCRIPTION
Qwen 3.5/3.6 block-scaled checkpoints previously dequantized dense FP8 projections during loading, so generated decode could not bind the native bytes and scales. Preserve E4M3 weights, FP32 block scales, and mixed BF16 GDN tails in an inference-only `BlockScaledLinear`; bind that storage directly to generated decode. Moondream generated decode now also accepts homogeneous BF16 KV caches, while retaining the quantized-cache scale and tau requirements.

The loader validates every direct, fused, interleaved, and mixed-tail tensor shape and dtype before copying. Module dtype/device moves preserve the packed bytes, FP32 scales, and BF16 suffix exactly.

Validation:

- 28 packed module and loader tests
- 6 Qwen norm-loading tests
- 7 Moondream generated-decode binding tests
- Production-sized generated binding checks on SM90, SM100, and SM120
