### PR TITLE
fix qwen chat image accounting mismatch

### DIFF
--- a/kestrel/models/qwen35/qwen_image.py
+++ b/kestrel/models/qwen35/qwen_image.py
@@ -42,6 +42,13 @@ def _smart_resize(height: int, width: int) -> tuple[int, int]:
     return h_bar, w_bar
 
 
+def image_token_count(image: Any) -> int:
+    """Count merged image patches without resizing or materializing them."""
+    rgb = image if isinstance(image, np.ndarray) else decode_to_srgb(image)
+    height, width = _smart_resize(*rgb.shape[:2])
+    return (height // _RESIZE_FACTOR) * (width // _RESIZE_FACTOR)
+
+
 def preprocess_image(image: Any) -> tuple[torch.Tensor, torch.Tensor]:
     rgb = np.ascontiguousarray(decode_to_srgb(image))
     height, width = rgb.shape[:2]
@@ -86,4 +93,4 @@ def preprocess_image(image: Any) -> tuple[torch.Tensor, torch.Tensor]:
     return pixel_values, image_grid_thw
 
 
-__all__ = ["preprocess_image"]
+__all__ = ["image_token_count", "preprocess_image"]

--- a/kestrel/models/qwen35/runtime.py
+++ b/kestrel/models/qwen35/runtime.py
@@ -44,7 +44,7 @@ from .prompt_template import (
     _NEWLINE_ID,
     _USER_ID,
 )
-from .qwen_image import preprocess_image
+from .qwen_image import image_token_count, preprocess_image
 
 
 _PREFILL_SCRATCH_TOKENS = 1024
@@ -446,26 +446,29 @@ class Qwen35Runtime(UncachedPagedRuntime):
         image: Any,
         image_crops: Any,
     ) -> int:
-        """Return the exact Qwen vision expansion after preprocessing."""
+        """Return the exact Qwen vision expansion, including before chat preprocessing."""
         if image is None:
             return 0
-        if not isinstance(image_crops, QwenImageInputs):
-            return super().image_kv_length(prompt_tokens, image, image_crops)
 
         from kestrel.runtime.tokens import ImageMarker
 
-        num_images = int(image_crops.image_grid_thw.shape[0])
-        grid_tokens = int(image_crops.image_grid_thw.prod(-1).sum().item()) // 4
-        if grid_tokens != int(image_crops.num_image_tokens):
-            raise ValueError(
-                "Qwen preprocessed image token count does not match its grid"
-            )
+        if isinstance(image_crops, QwenImageInputs):
+            num_images = int(image_crops.image_grid_thw.shape[0])
+            num_image_tokens = int(image_crops.image_grid_thw.prod(-1).sum().item()) // 4
+            if num_image_tokens != int(image_crops.num_image_tokens):
+                raise ValueError(
+                    "Qwen preprocessed image token count does not match its grid"
+                )
+        else:
+            images = image if isinstance(image, (list, tuple)) else [image]
+            num_images = len(images)
+            num_image_tokens = sum(image_token_count(one) for one in images)
         marker_count = sum(isinstance(token, ImageMarker) for token in prompt_tokens)
         if marker_count not in (0, num_images):
             raise ValueError(
                 "Qwen image marker count must be zero or match preprocessed images"
             )
-        inserted_tokens = int(image_crops.num_image_tokens) + 2 * num_images
+        inserted_tokens = num_image_tokens + 2 * num_images
         return inserted_tokens - marker_count
 
     def _load_model(self, source: str | Path) -> nn.Module:

--- a/tests/qwen35/test_engine_integration.py
+++ b/tests/qwen35/test_engine_integration.py
@@ -1,4 +1,4 @@
-"""End-to-end engine query through Qwen35Runtime."""
+"""End-to-end engine query and chat through Qwen35Runtime."""
 
 from __future__ import annotations
 
@@ -64,6 +64,43 @@ def test_engine_image_query_returns_text() -> None:
     assert "red" in answer.lower(), f"expected an answer about red; got {answer!r}"
     assert result.metrics.output_tokens < 64
     print(f"\n[qwen35 engine image answer] {answer!r}")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_engine_image_chat_generates_multiple_tokens() -> None:
+    import asyncio
+    import base64
+    import io
+
+    Image = pytest.importorskip("PIL.Image")
+
+    image = io.BytesIO()
+    Image.new("RGB", (64, 64), "red").save(image, format="PNG")
+    image_url = "data:image/png;base64," + base64.b64encode(image.getvalue()).decode()
+
+    async def run() -> EngineResult:
+        engine = await InferenceEngine.create(RuntimeConfig(
+            device="cuda", model="Qwen/Qwen3.5-0.8B", max_batch_size=1,
+        ))
+        try:
+            stream = await engine.chat(
+                messages=[{"role": "user", "content": [
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                    {"type": "text", "text": "Describe the image in one sentence."},
+                ]}],
+                reasoning=False,
+                stream=True,
+                settings={"max_tokens": 128, "temperature": 0},
+            )
+            async for _ in stream:
+                pass
+            return await stream.result()
+        finally:
+            await engine.shutdown()
+
+    result = asyncio.run(run())
+    assert result.finish_reason == "stop"
+    assert result.metrics.output_tokens > 1
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/qwen35/test_image_kv_length.py
+++ b/tests/qwen35/test_image_kv_length.py
@@ -1,8 +1,10 @@
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 
+from kestrel.models.qwen35.qwen_image import preprocess_image
 from kestrel.models.qwen35.runtime import Qwen35Runtime, QwenImageInputs
 from kestrel.runtime import ImageMarker, TextToken
 
@@ -26,7 +28,6 @@ def test_qwen_image_kv_length_uses_preprocessed_expansion() -> None:
 
     assert runtime.image_kv_length([TextToken(1)], object(), crops) == 258
     assert runtime.image_kv_length([ImageMarker(0)], object(), crops) == 257
-    assert runtime.image_kv_length([TextToken(1)], object(), None) == 4096
 
     multi = _image_inputs(images=2, tokens=600)
     assert runtime.image_kv_length(
@@ -39,6 +40,33 @@ def test_qwen_image_kv_length_uses_preprocessed_expansion() -> None:
     inconsistent.num_image_tokens = 255
     with pytest.raises(ValueError, match="does not match its grid"):
         runtime.image_kv_length([TextToken(1)], object(), inconsistent)
+
+
+@pytest.mark.parametrize("shapes", [((64, 64),), ((333, 517),), ((64, 64), (333, 517))])
+def test_chat_image_length_matches_expanded_prompt(shapes) -> None:
+    runtime = object.__new__(Qwen35Runtime)
+    runtime.image_prefix_length = 4096
+    runtime.architecture = SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2)
+    )
+    runtime._chat_image_crops = {}
+    runtime._prepare_uncached_sequence = lambda **kwargs: kwargs
+    images = tuple(np.zeros((*shape, 3), dtype=np.uint8) for shape in shapes)
+    processed = [preprocess_image(image) for image in images]
+    grid = torch.cat([item[1] for item in processed])
+    crops = QwenImageInputs(
+        pixel_values=torch.cat([item[0] for item in processed]),
+        image_grid_thw=grid,
+        num_image_tokens=int(grid.prod(-1).sum().item()) // 4,
+    )
+    tokens = [TextToken(1), *(ImageMarker(i) for i in range(len(images)))]
+    image_length = runtime.image_kv_length(tokens, images, None)
+    prepared = runtime.prepare_sequence(
+        tokens, image=images, image_crops=crops, max_new_tokens=128,
+    )
+
+    assert image_length == len(prepared["tokens"]) - len(tokens)
+    assert len(tokens) + image_length + 128 == prepared["target_length"]
 
 
 def test_qwen_prepare_sequence_reserves_exact_expanded_length() -> None:


### PR DESCRIPTION
In the past, image chat used an estimate of 4096 tokens for admission and kv cache allocation. PR #169 updated KV cache allocation to use the actual image size, but admission still uses the estimate.

As a result, if the actual size + gen limit is greater than the estimate, the scheduler stops generation after a single token.

To resolve, calculate the image token count from resize dimensions before preprocessing